### PR TITLE
Strongly typed lucene syntax

### DIFF
--- a/Raven.Client/Document/DocumentSession.cs
+++ b/Raven.Client/Document/DocumentSession.cs
@@ -224,6 +224,19 @@ namespace Raven.Client.Document
 			UpdateBatchResults(DatabaseCommands.Batch(data.Commands.ToArray()), data.Entities);
 		}
 
+
+        /// <summary>
+        /// Queries the index specified by <typeparamref name="TIndexCreator"/> using lucene syntax.
+        /// </summary>
+        /// <typeparam name="T">The result of the query</typeparam>
+        /// <typeparam name="TIndexCreator">The type of the index creator.</typeparam>
+        /// <returns></returns>
+        public IDocumentQuery<T> LuceneQuery<T, TIndexCreator>() where TIndexCreator : AbstractIndexCreationTask, new()
+        {
+            var index = new TIndexCreator();
+            return LuceneQuery<T>(index.IndexName);
+        }
+
 		/// <summary>
 		/// Query the specified index using Lucene syntax
 		/// </summary>

--- a/Raven.Client/IDocumentSession.cs
+++ b/Raven.Client/IDocumentSession.cs
@@ -57,6 +57,14 @@ namespace Raven.Client
 		/// <returns></returns>
 		IRavenQueryable<T> Query<T, TIndexCreator>() where TIndexCreator : AbstractIndexCreationTask, new();
 
+        /// <summary>
+        /// Queries the index specified by <typeparamref name="TIndexCreator"/> using lucene syntax.
+        /// </summary>
+        /// <typeparam name="T">The result of the query</typeparam>
+        /// <typeparam name="TIndexCreator">The type of the index creator.</typeparam>
+        /// <returns></returns>
+        IDocumentQuery<T> LuceneQuery<T, TIndexCreator>() where TIndexCreator : AbstractIndexCreationTask, new();
+
 		/// <summary>
 		/// Query the specified index using Lucene syntax
 		/// </summary>

--- a/Raven.Client/Shard/ShardedDocumentSession.cs
+++ b/Raven.Client/Shard/ShardedDocumentSession.cs
@@ -392,6 +392,18 @@ namespace Raven.Client.Shard
 											   GetAppropriateShardedSessions<T>(null));
 		}
 
+        /// <summary>
+        /// Queries the index specified by <typeparamref name="TIndexCreator"/> using lucene syntax.
+        /// </summary>
+        /// <typeparam name="T">The result of the query</typeparam>
+        /// <typeparam name="TIndexCreator">The type of the index creator.</typeparam>
+        /// <returns></returns>
+        public IDocumentQuery<T> LuceneQuery<T, TIndexCreator>() where TIndexCreator : AbstractIndexCreationTask, new()
+        {
+            var index = new TIndexCreator();
+            return LuceneQuery<T>(index.IndexName);
+        }
+
 		private IDocumentSession[] GetAppropriateShardedSessions<T>(string key)
 		{
 			var sessionIds =


### PR DESCRIPTION
Just a tiny change, adding support for

session.LuceneQuery<T, TIndexCreator>

I've checked my autoclrf setting and it's set to 'true', so I can only assume that the files were already in a weird state before I got access to them, please advise if this is not the case so I can investigate my git config.
