### PR TITLE
We weren't using entity name, so I made sure we were

### DIFF
--- a/Raven.Client.Tests/Querying/UsingDynamicQueryWithLocalServer.cs
+++ b/Raven.Client.Tests/Querying/UsingDynamicQueryWithLocalServer.cs
@@ -108,6 +108,27 @@ namespace Raven.Client.Tests.Querying
         }
 
         [Fact]
+        public void QueryForASpecificTypeDoesNotBringBackOtherTypes()
+        {
+            using (var store = this.NewDocumentStore())
+            {
+                using (var s = store.OpenSession())
+                {
+                    s.Store(new BlogTag());
+                    s.SaveChanges();
+                }
+
+                using (var s = store.OpenSession())
+                {
+                    var results = s.Query<Blog>()
+                        .Select(b=> new { b.Category})
+                        .ToArray();
+                    Assert.Equal(0, results.Length);
+                }
+            }
+        }
+
+        [Fact]
         public void CanPerformDynamicQueryUsingClientLuceneQuery()
         {
             var blogOne = new Blog

--- a/Raven.Client.Tests/Querying/UsingDynamicQueryWithRemoteServer.cs
+++ b/Raven.Client.Tests/Querying/UsingDynamicQueryWithRemoteServer.cs
@@ -168,6 +168,29 @@ namespace Raven.Client.Tests.Querying
             }
         }
 
+        [Fact]
+        public void QueryForASpecificTypeDoesNotBringBackOtherTypes()
+        {
+            using (var server = GetNewServer(port, path))
+            {
+                var store = new DocumentStore { Url = "http://localhost:" + port };
+                store.Initialize();
+
+                using (var s = store.OpenSession())
+                {
+                    s.Store(new Tag());
+                    s.SaveChanges();
+                }
+
+                using (var s = store.OpenSession())
+                {
+                    var results = s.Query<Blog>()
+                        .Select(b => new { b.Category })
+                        .ToArray();
+                    Assert.Equal(0, results.Length);
+                }
+            }
+        }
 
         [Fact]
         public void CanPerformLinqOrderByOnNumericField()

--- a/Raven.Client/Document/DocumentSession.cs
+++ b/Raven.Client/Document/DocumentSession.cs
@@ -322,8 +322,13 @@ namespace Raven.Client.Document
         /// <typeparam name="T">The result of the query</typeparam>
         public IRavenQueryable<T> Query<T>()
         {
+            string indexName = "dynamic";
+            if (typeof(T) != typeof(object))
+            {
+                indexName += "/" + Conventions.GetTypeTagName(typeof(T));
+            }
             var ravenQueryStatistics = new RavenQueryStatistics();
-            return new RavenQueryable<T>(new DynamicRavenQueryProvider<T>(this, ravenQueryStatistics), ravenQueryStatistics);
+            return new RavenQueryable<T>(new DynamicRavenQueryProvider<T>(this, indexName, ravenQueryStatistics), ravenQueryStatistics);
         }
 
         /// <summary>

--- a/Raven.Client/Linq/DynamicQueryProviderProcessor.cs
+++ b/Raven.Client/Linq/DynamicQueryProviderProcessor.cs
@@ -16,8 +16,8 @@ namespace Raven.Client.Linq
         /// Creates a dynamic query proivder around the provided session
         /// </summary>
        public DynamicQueryProviderProcessor(IDocumentSession session,
-            Action<IDocumentQueryCustomization> customizeQuery, Action<QueryResult> afterQueryExecuted) 
-            : base(session, customizeQuery, afterQueryExecuted, "dynamic")
+            Action<IDocumentQueryCustomization> customizeQuery, Action<QueryResult> afterQueryExecuted, string indexName) 
+            : base(session, customizeQuery, afterQueryExecuted, indexName)
         {
 
         }

--- a/Raven.Client/Linq/DynamicRavenQueryProvider.cs
+++ b/Raven.Client/Linq/DynamicRavenQueryProvider.cs
@@ -18,13 +18,14 @@ namespace Raven.Client.Linq
         private Action<QueryResult> afterQueryExecuted;
 		private readonly IDocumentSession session;
         private readonly RavenQueryStatistics ravenQueryStatistics;
+        private string indexName;
 
         /// <summary>
-        /// Gets the IndexName for this dynamic query provider (always "dynamic" in this case)
+        /// Gets the IndexName for this dynamic query provider
         /// </summary>
         public string IndexName
         {
-            get { return "dynamic"; }
+            get { return indexName; }
         }
 
         /// <summary>
@@ -32,9 +33,11 @@ namespace Raven.Client.Linq
         /// </summary>
         /// <param name="session"></param>
         /// <param name="ravenQueryStatistics"></param>
-        public DynamicRavenQueryProvider(IDocumentSession session, RavenQueryStatistics ravenQueryStatistics)
+        /// <param name="indexName"></param>
+        public DynamicRavenQueryProvider(IDocumentSession session, string indexName, RavenQueryStatistics ravenQueryStatistics)
         {
             this.session = session;
+            this.indexName = indexName;
             this.ravenQueryStatistics = ravenQueryStatistics;
         }
 
@@ -63,7 +66,7 @@ namespace Raven.Client.Linq
             if (typeof(T) == typeof(S))
                 return this;
 
-	        var ravenQueryProvider = new DynamicRavenQueryProvider<S>(session, ravenQueryStatistics);
+	        var ravenQueryProvider = new DynamicRavenQueryProvider<S>(session, this.indexName, ravenQueryStatistics);
 	        ravenQueryProvider.Customize(customizeQuery);
 	        return ravenQueryProvider;
 	    }
@@ -77,7 +80,7 @@ namespace Raven.Client.Linq
 		/// </returns>
 		public virtual object Execute(Expression expression)
 		{
-			return new DynamicQueryProviderProcessor<T>(session, customizeQuery, afterQueryExecuted).Execute(expression);
+			return new DynamicQueryProviderProcessor<T>(session, customizeQuery, afterQueryExecuted, this.IndexName).Execute(expression);
 		}
 
 		IQueryable<S> IQueryProvider.CreateQuery<S>(Expression expression)

--- a/Raven.Database/Data/DynamicQueryMapping.cs
+++ b/Raven.Database/Data/DynamicQueryMapping.cs
@@ -35,8 +35,15 @@ namespace Raven.Database.Data
         {
             var fromClauses = new HashSet<string>();
             var realMappings = new List<string>();
-
-            fromClauses.Add("from doc in docs");
+            
+            if (!string.IsNullOrEmpty(this.ForEntityName))
+            {
+                fromClauses.Add("from doc in docs." + this.ForEntityName);
+            }
+            else
+            {
+                fromClauses.Add("from doc in docs");
+            }
 
             foreach (var map in Items)
             {


### PR DESCRIPTION
I don't think our problems with autoclrf are gone yet either, judging by the diff.

To save you some hassle, what I've done is started using "indexName" in the client, generating the relevant index name when Query<T>() is first called and passing it around  the various LINQ classes.

On the server I've modified DynamicQueryMapping to use the ForEntityNAme when generating the intial 'from' clause

I've also added a couple of tests to make sure this works
