### PR TITLE
Allowing patches to remove by value instead of index

### DIFF
--- a/Raven.Database/Json/JsonPatcher.cs
+++ b/Raven.Database/Json/JsonPatcher.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Threading;
 using Newtonsoft.Json.Linq;
 using Raven.Database.Exceptions;
 using Raven.Http.Exceptions;
+using System.Linq;
 
 namespace Raven.Database.Json
 {
@@ -134,12 +136,26 @@ namespace Raven.Database.Json
             if (array == null)
                 throw new InvalidOperationException("Cannot remove value from  '" + propName + "' because it is not an array");
 			var position = patchCmd.Position;
-			if (position == null)
-                throw new InvalidOperationException("Cannot remove value from  '" + propName + "' because position element does not exists or not an integer");
+            var value = patchCmd.Value as JValue;
+			if (position == null && value == null)
+                throw new InvalidOperationException("Cannot remove value from  '" + propName + "' because position element does not exists or not an integer and no value was present");
+            if (position != null && value != null)
+                throw new InvalidOperationException("Cannot remove value from  '" + propName + "' because both a position and a value are set");
             if (position < 0 || position >= array.Count)
                 throw new IndexOutOfRangeException("Cannot remove value from  '" + propName +
                                                    "' because position element is out of bound bounds");
-            array.RemoveAt(position.Value);
+
+            if (value != null)
+            {
+                var singleOrDefault = array.SingleOrDefault(t => t.Equals(value));
+                if (singleOrDefault == null)
+                    throw new ArgumentOutOfRangeException("Cannot remove value from '" + propName +
+                                                          "' because it wasn't in the array");
+                array.Remove(singleOrDefault);
+            }
+            else
+                array.RemoveAt(position.Value);
+           
         }
 
 		private void InsertValue(PatchRequest patchCmd, string propName, JProperty property)


### PR DESCRIPTION
I'm not so sure of the implementation. It seems a bit awkward because I needed to compare JValues with equals and not just use array.remove(value).

(I'll also email the list in the case someone else is interested)
