### PR TITLE
Master unstable

### DIFF
--- a/Raven.Database/Json/JsonPatcher.cs
+++ b/Raven.Database/Json/JsonPatcher.cs
@@ -73,7 +73,7 @@ namespace Raven.Database.Json
 		{
 			EnsurePreviousValueMatchCurrentValue(patchCmd, property);
 			if (property == null)
-				throw new InvalidOperationException("Cannot copy value from  '" + propName + "' because it was not found");
+				return;
 
 			document[patchCmd.Value.Value<string>()] = property.Value;
 			document.Remove(propName);
@@ -83,7 +83,7 @@ namespace Raven.Database.Json
     	{
 			EnsurePreviousValueMatchCurrentValue(patchCmd, property);
 			if (property == null)
-				throw new InvalidOperationException("Cannot copy value from  '" + propName + "' because it was not found");
+                return;
 
 			document[patchCmd.Value.Value<string>()] = property.Value;
     	}
@@ -220,8 +220,9 @@ namespace Raven.Database.Json
         	EnsurePreviousValueMatchCurrentValue(patchCmd, property);
             if (property == null)
             {
-                property = new JProperty(propName);
+                property = new JProperty(propName, patchCmd.Value);
                 document.Add(property);
+                return;
             }
             if (property.Value == null || property.Value.Type == JTokenType.Null)
                 property.Value = patchCmd.Value;

--- a/Raven.Tests/Patching/SimplePatchApplication.cs
+++ b/Raven.Tests/Patching/SimplePatchApplication.cs
@@ -47,6 +47,24 @@ namespace Raven.Tests.Patching
 			Assert.Equal(@"{""title"":""A Blog Post"",""body"":""html markup"",""comments"":[{""author"":""ayende"",""text"":""good post""}],""cmts"":[{""author"":""ayende"",""text"":""good post""}]}",
 				patchedDoc.ToString(Formatting.None));
 		}
+        
+        [Fact]
+		public void PropertyCopyNonExistingProperty()
+		{
+			var patchedDoc = new JsonPatcher(doc).Apply(
+				new[]
+        		{
+        			new PatchRequest
+        			{
+        				Type = PatchCommandType.Copy,
+        				Name = "non-existing",
+        				Value = new JValue("irrelevant")
+        			},
+        		});
+
+			Assert.Equal(@"{""title"":""A Blog Post"",""body"":""html markup"",""comments"":[{""author"":""ayende"",""text"":""good post""}]}",
+				patchedDoc.ToString(Formatting.None));
+		}
 
 		[Fact]
 		public void PropertyMove()
@@ -63,6 +81,24 @@ namespace Raven.Tests.Patching
         		});
 
 			Assert.Equal(@"{""title"":""A Blog Post"",""body"":""html markup"",""cmts"":[{""author"":""ayende"",""text"":""good post""}]}",
+				patchedDoc.ToString(Formatting.None));
+		}
+        
+        [Fact]
+		public void PropertyRenameNonExistingProperty()
+		{
+			var patchedDoc = new JsonPatcher(doc).Apply(
+				new[]
+        		{
+        			new PatchRequest
+        			{
+        				Type = PatchCommandType.Rename,
+        				Name = "doesnotexist",
+        				Value = new JValue("irrelevant")
+        			},
+        		});
+
+			Assert.Equal(@"{""title"":""A Blog Post"",""body"":""html markup"",""comments"":[{""author"":""ayende"",""text"":""good post""}]}",
 				patchedDoc.ToString(Formatting.None));
 		}
 
@@ -94,7 +130,25 @@ namespace Raven.Tests.Patching
             Assert.Equal(@"{""title"":""A Blog Post"",""body"":""html markup"",""comments"":[{""author"":""ayende"",""text"":""good post""}],""blog_id"":2}",
                 patchedDoc.ToString(Formatting.None));
         }
+        
+        [Fact]
+        public void PropertyIncrementOnNonExistingProperty()
+        {
+            var patchedDoc = new JsonPatcher(doc).Apply(
+                new[]
+        		{
+        			new PatchRequest
+        			{
+        				Type = PatchCommandType.Inc,
+        				Name = "blog_id",
+        				Value = new JValue(1)
+        			},
+        		});
 
+            Assert.Equal(@"{""title"":""A Blog Post"",""body"":""html markup"",""comments"":[{""author"":""ayende"",""text"":""good post""}],""blog_id"":1}",
+                patchedDoc.ToString(Formatting.None));
+        }
+        
         [Fact]
         public void PropertyAddition_WithConcurrenty_MissingProp()
         {


### PR DESCRIPTION
As talked about in this thread https://groups.google.com/d/msg/ravendb/qE9nFhlBDnQ/Q5ocmrlDxesJ here's a pull request for patches which don't throw exceptions when a property doesn't exist.

I did it for copy, rename and increment.

Would a modify command on a non-existing property create it? Or should it still fail with an exception?
