### PR TITLE
Dynamic fields bug

### DIFF
--- a/Raven.Tests/Bugs/Indexing/DynamicFields.cs
+++ b/Raven.Tests/Bugs/Indexing/DynamicFields.cs
@@ -12,65 +12,111 @@ using Xunit;
 
 namespace Raven.Tests.Bugs.Indexing
 {
-    public class DynamicFields : LocalClientTest
-    {
-        public class Product
-        {
-            public string Id { get; set; }
-            public List<Attribute> Attributes { get; set; }
-        }
+	public class DynamicFields : LocalClientTest
+	{
+		public class Product
+		{
+			public string Id { get; set; }
+			public List<Attribute> Attributes { get; set; }
+		}
 
-        public class Attribute
-        {
-            public string Name { get; set; }
-            public string Value { get; set; }
-        }
+		public class Attribute
+		{
+			public string Name { get; set; }
+			public string Value { get; set; }
+			public double NumericValue { get; set; }
+		}
 
-        public class Product_ByAttribute : AbstractIndexCreationTask<Product>
-        {
-            public Product_ByAttribute()
-            {
-                Map = products =>
-                    from p in products
-                    select new
-                    {
-                        _ = Project(p.Attributes, attribute => new Field(attribute.Name, attribute.Value, Field.Store.NO, Field.Index.ANALYZED))
-                    };
-            }
-        }
+		public class Product_ByAttribute : AbstractIndexCreationTask<Product>
+		{
+			public Product_ByAttribute()
+			{
+				Map = products =>
+					from p in products
+					select new
+					{
+						_ = Project(p.Attributes, attribute => new Field(attribute.Name, attribute.Value, Field.Store.NO, Field.Index.ANALYZED))
+					};
+			}
+		}
 
-        [Fact]
-        public void CanCreateCompletelyDynamicFields()
-        {
-            using (var store = NewDocumentStore())
-            {
-                new Product_ByAttribute().Execute(store);
+		public class Product_ByNumericAttribute : AbstractIndexCreationTask<Product>
+		{
+			public Product_ByNumericAttribute()
+			{
+				Map = products =>
+					from p in products
+					select new
+					{
+						_ = Project(p.Attributes, attribute => new NumericField(attribute.Name, Field.Store.NO, true).SetDoubleValue(attribute.NumericValue))
+					};
+			}
+		}
 
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new Product
-                    {
-                        Attributes = new List<Attribute>
+		[Fact]
+		public void CanCreateCompletelyDynamicFields()
+		{
+			using (var store = NewDocumentStore())
+			{
+				new Product_ByAttribute().Execute(store);
+
+				using (var session = store.OpenSession())
+				{
+					session.Store(new Product
+					{
+						Attributes = new List<Attribute>
                         {
                             new Attribute{Name = "Color", Value = "Red"}
                         }
-                    });
+					});
 
-                    session.SaveChanges();
-                }
+					session.SaveChanges();
+				}
 
-                using (var session = store.OpenSession())
-                {
-                    var products = session.Advanced.LuceneQuery<Product>("Product/ByAttribute")
-                        .WhereEquals("Color", "Red")
-                        .WaitForNonStaleResults(TimeSpan.FromMinutes(3))
-                        .ToList();
+				using (var session = store.OpenSession())
+				{
+					var products = session.Advanced.LuceneQuery<Product>("Product/ByAttribute")
+						.WhereEquals("Color", "Red")
+						.WaitForNonStaleResults(TimeSpan.FromMinutes(3))
+						.ToList();
 
-                    Assert.NotEmpty(products);
-                }
-            }
-        }
-    }
+					Assert.NotEmpty(products);
+				}
+			}
+		}
+
+		[Fact]
+		public void CanCreateCompletelyDynamicNumericFields()
+		{
+			using (var store = NewDocumentStore())
+			{
+				new Product_ByNumericAttribute().Execute(store);
+
+				using (var session = store.OpenSession())
+				{
+					session.Store(new Product
+					{
+						Attributes = new List<Attribute>
+                        {
+                            new Attribute{Name = "Color", Value = "Red", NumericValue = 30}
+                        }
+					});
+
+					session.SaveChanges();
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var products = session.Advanced.LuceneQuery<Product, Product_ByNumericAttribute>()
+						.WhereGreaterThan("Color", 20d)
+						.WaitForNonStaleResults(TimeSpan.FromMinutes(3))
+						.ToList();
+
+					Assert.NotEmpty(products);
+				}
+			}
+		}
+	}
 
 
 }


### PR DESCRIPTION
I need to use .WhereGreaterThan on a numeric value generated from the Project function in an index.  In order to accomplish this, I believe I need to use something like this:
Project(p.Properties, prop=> new NumericField(prop.Key, Field.Store.NO, true).SetDoubleValue(prop.Value.Value))

When you generate the text (tmp file) of the index to compile, the text is changing the text to:
Project(p.Properties, prop=> new NumericField(prop.Key, Field.Store.NO, True).SetDoubleValue(prop.Value.Value))

Note the capital "T" in true for the parameter in NumericField.  This causes a compilation error at runtime.
