### PR TITLE
Failing test for loading document with id containing an url

### DIFF
--- a/Raven.Tests/Bugs/Iulian/CanReadEntityWithUrlId.cs
+++ b/Raven.Tests/Bugs/Iulian/CanReadEntityWithUrlId.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using Raven.Client.Document;
+
+namespace Raven.Tests.Bugs.Iulian
+{
+    public class CanReadEntityWithUrlId : RemoteClientTest
+    {
+        public class Event
+        {
+            public string Id { get; set; }
+            public string Tag { get; set; }
+        }
+
+        [Fact]
+        public void Can_Load_entities_with_id_containing_url()
+        {
+            var id = @"mssage@msmq://local/Sample.AppService";
+
+            using (GetNewServer())
+            using (var store = new DocumentStore { Url = "http://localhost:8080" }.Initialize())
+            {
+                using (var s = store.OpenSession())
+                {
+                    Event e = new Event { Id = id, Tag = "tag" };
+                    s.Store(e);
+                    s.SaveChanges();
+                }
+
+                using (var s = store.OpenSession())
+                {
+                    Event loaded = s.Query<Event>().Where(e => e.Id == id).Single();
+                    // this passes
+                    Assert.NotNull(loaded);
+                    Assert.Equal("tag",loaded.Tag);
+                }
+
+                using (var s = store.OpenSession())
+                {
+                    Event loaded = s.Load<Event>(id);
+                    // this fails
+                    Assert.NotNull(loaded);
+                    Assert.Equal("tag", loaded.Tag);
+                }
+            }
+        }        
+    }
+}


### PR DESCRIPTION
Hi,

I've added a failing test for what i think is a bug in raven client.

When a document's id contains an url ( ex: var id = @"mssage@msmq://local/Sample.AppService"; ) the Raven Client seems to be unable to load(id) the document.

Query().Where( d=>  d.id == id) works as expected.

I haven't looked for a solution yet as i'm not familiar with the raven code. 

Thanks for your time,
Iulian
