### PR TITLE
should this test pass?  indexing nested objects

### DIFF
--- a/Raven.Tests/Bugs/Indexing/CanIndexNestedObjects.cs
+++ b/Raven.Tests/Bugs/Indexing/CanIndexNestedObjects.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Raven.Client.Indexes;
+using Xunit;
+
+namespace Raven.Tests.Bugs.Indexing
+{
+    public class CanIndexNestedObjects : LocalClientTest
+    {
+        public class NestedObject
+        {
+            public string Name;
+            public int Quantity;
+        }
+
+        public class ContainerObject
+        {
+            public string ContainerName;
+            public IEnumerable<NestedObject> Items;
+        }
+
+        public class IndexEntry
+        {
+            public string ContainerName;
+            public string Name;
+            public int Quantity;
+        }
+
+        public class NestedObjectIndex : AbstractIndexCreationTask<ContainerObject, IndexEntry>
+        {
+            public override Abstractions.Indexing.IndexDefinition CreateIndexDefinition()
+            {
+                return new IndexDefinitionBuilder<ContainerObject, IndexEntry>()
+                {
+                    Map = docs => from doc in docs
+                                  from item in doc.Items
+                                  select new
+                                  {
+                                      ContainerName = doc.ContainerName,
+                                      Name = item.Name,
+                                      Quantity = item.Quantity
+                                  }
+
+                }.ToIndexDefinition(Conventions);
+            }
+        }
+
+        [Fact]
+        public void SimpleInsertAndRead()
+        {
+            string expectedContainerName = "someContainer123098";
+            string expectedItemName = "someItem456";
+            int expectedQuantity = 123;
+
+            using (var store = NewDocumentStore())
+            {
+                IndexCreation.CreateIndexes(typeof(NestedObjectIndex).Assembly, store);
+                
+
+                using (var s = store.OpenSession())
+                {
+                    s.Store(new ContainerObject()
+                    {
+                        ContainerName = expectedContainerName,
+                        Items = new[]
+                        {
+                            new NestedObject()
+                            {
+                                Name = expectedItemName,
+                                Quantity = expectedQuantity
+                            },
+                            new NestedObject()
+                            {
+                                Name = "something Else",
+                                Quantity = 345
+                            }
+		                }
+                    });
+
+                    s.SaveChanges();
+                }
+
+                //  the index has two objects
+                using (var s = store.OpenSession())
+                {
+                    var result = s.Query<IndexEntry, NestedObjectIndex>()
+                        .Customize(q => q.WaitForNonStaleResultsAsOfNow())
+                        .ToArray();
+
+                    Assert.Equal(2, result.Count());
+                }
+
+                //  and the index can be queried
+                using (var s = store.OpenSession())
+                {
+                    var result = s.Query<IndexEntry, NestedObjectIndex>()
+                        .Customize(q => q.WaitForNonStaleResultsAsOfNow())
+                        .Where(o => o.Name == expectedItemName)
+                        .Single();
+
+                    Assert.Equal(expectedContainerName, result.ContainerName);
+                    Assert.Equal(expectedItemName, result.Name);
+                    Assert.Equal(expectedQuantity, result.Quantity);
+                }
+            }
+        }
+    }
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Bugs\ComplexDynamicQuery.cs" />
     <Compile Include="Bugs\ConnectionStringParsing.cs" />
     <Compile Include="Bugs\DuplicatedFiledNames.cs" />
+    <Compile Include="Bugs\Indexing\CanIndexNestedObjects.cs" />
     <Compile Include="Bugs\IntegerIds.cs" />
     <Compile Include="Bugs\IteratingTwice.cs" />
     <Compile Include="Bugs\Iulian\CanReadEntityWithUrlId.cs" />


### PR DESCRIPTION
I added a test isolating a problem I'm having indexing nested objects.  Here is the test output:

CanIndexNestedObjects.SimpleInsertAndRead : FailedSaving 1 changes to memory #9185816
    PUT containerobjects/1
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Stale query results on non stable query '' on index 'NestedObjectIndex' in 'memory #9185816', query will be retried
Executing query '' on index 'NestedObjectIndex' in 'memory #9185816'
Query returned 1/2 results

System.InvalidCastException: Unable to cast object of type 'ContainerObject' to type 'IndexedObject'.
at Raven.Client.Document.InMemoryDocumentSessionOperations.ConvertToEntity(String id, RavenJObject documentFound, RavenJObject metadata) in InMemoryDocumentSessionOperations.cs: line 405
at Raven.Client.Document.InMemoryDocumentSessionOperations.TrackEntity(String key, RavenJObject document, RavenJObject metadata) in InMemoryDocumentSessionOperations.cs: line 331
at Raven.Client.Document.AbstractDocumentQuery`2.Deserialize(RavenJObject result) in AbstractDocumentQuery.cs: line 1329
at System.Linq.Enumerable.WhereSelectListIterator`2.MoveNext()
at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
at System.Linq.Enumerable.ToList(IEnumerable`1 source)
at Raven.Client.Document.AbstractDocumentQuery`2.GetEnumerator() in AbstractDocumentQuery.cs: line 444
at Raven.Client.Linq.RavenQueryInspector`1.GetEnumerator() in RavenQueryInspector.cs: line 100
at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
at System.Linq.Enumerable.ToArray(IEnumerable`1 source)
at Raven.Tests.Bugs.Indexing.CanIndexNestedObjects.SimpleInsertAndRead() in CanIndexNestedObjects.cs: line 88 
