### PR TITLE
Issue #250: Dynamic Index Query can select wrong index under certain circumstances.

### DIFF
--- a/Raven.Database/Queries/DynamicQueryOptimizer.cs
+++ b/Raven.Database/Queries/DynamicQueryOptimizer.cs
@@ -42,6 +42,9 @@ namespace Raven.Database.Queries
 						if (abstractViewGenerator.ViewText.Contains("where")) // without a where clause
 							return false;
 
+						if (abstractViewGenerator.ViewText.Contains("IEnumerable")) // we can't choose an index that flattens the document
+							return false;
+
 						if (abstractViewGenerator.ForEntityName != entityName) // for the specified entity name
 							return false;
 						var items = SimpleQueryParser.GetFieldsForDynamicQuery(indexQuery.Query).Select(x => x.Item2);

--- a/Raven.Tests/Bugs/IndexSelectionForMapReduce.cs
+++ b/Raven.Tests/Bugs/IndexSelectionForMapReduce.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Client;
+using Raven.Client.Linq;
+using Xunit;
+
+namespace Raven.Tests.Bugs
+{
+	public class IndexSelectionForMapReduce : LocalClientTest
+	{
+		[Fact]
+		public void TestIndexSelectionForMapReduce()
+		{
+			using (var store = NewDocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					CreateTestData(session);
+
+					RavenQueryStatistics stats1;
+					RavenQueryStatistics stats2;
+					RavenQueryStatistics stats3;
+
+					// We expect each product to come back as they all have category-1 assigned
+					session.Query<Product>()
+						.Customize(x=>x.WaitForNonStaleResults())
+						.Where(d=>d.Categories.Any(e=>e.Id == "category-1"))
+						.Statistics(out stats1)
+						.ToList();
+					Assert.Equal(10, stats1.TotalResults);
+					
+
+					// We expect each product to come back as there is no filter. Initial failing test is using the index created by the first query and returning a cartesian product
+					session.Query<Product>()
+						.Customize(x => x.WaitForNonStaleResults())
+						.Statistics(out stats2)
+						.ToList();
+					Assert.Equal(10, stats2.TotalResults);
+					Assert.NotEqual(stats1.IndexName, stats2.IndexName);
+
+					// We expect a second query similar to the original to re-use the index
+					session.Query<Product>()
+						.Customize(x => x.WaitForNonStaleResults())
+						.Where(d => d.Categories.Any(e => e.Id == "category-2"))
+						.Statistics(out stats3)
+						.ToList();
+					Assert.Equal(10, stats3.TotalResults);
+					Assert.Equal(stats1.IndexName, stats3.IndexName);
+				}
+			}
+		}
+
+		private static void CreateTestData(IDocumentSession session)
+		{
+			var categories = Enumerable.Range(1, 5).Select(j => new Category { Id = "category-" + j }).ToList();
+			for (var i = 1; i <= 10; i++)
+			{
+				var product = new Product {
+					Id = "product-" + i,
+					Categories = categories
+				};
+
+				session.Store(product);
+			}
+
+			session.SaveChanges();
+		}
+	}
+
+	public class Product
+	{
+		public string Id { get; set; }
+		public IEnumerable<Category> Categories { get; set; }
+	}
+
+	public class Category
+	{
+		public string Id { get; set; }
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Bugs\EntitiesWithAttributes.cs" />
     <Compile Include="Bugs\Indexing\CanIndexNestedObjects.cs" />
     <Compile Include="Bugs\Indexing\CanIndexWithCharLiteral.cs" />
+    <Compile Include="Bugs\IndexSelectionForMapReduce.cs" />
     <Compile Include="Bugs\IntegerIds.cs" />
     <Compile Include="Bugs\IteratingTwice.cs" />
     <Compile Include="Bugs\Iulian\CanReadEntityWithUrlId.cs" />


### PR DESCRIPTION
Took a look at issue #250 where a user reported doing two different dynamic queries and having them choose the same index.
I created a failing test for the issue, then made what I believe to be a fix for it. All other tests still passed, but you might want to take a look to be sure there are no side-effects I have missed.
Basically I just added another failing condition to the code that decides if an index is appropriate to be used for another query.

I created this pull request to your personal fork because pointing it at the master fork was trying to include my last set of changes as well. Is this the best way to go about it, or should I always create the pull against the master?
