### PR TITLE
Support for multiple session AJAX calls

### DIFF
--- a/Raven.Client.MvcIntegration/RavenProfilingHandler.cs
+++ b/Raven.Client.MvcIntegration/RavenProfilingHandler.cs
@@ -144,8 +144,11 @@ namespace Raven.Client.MvcIntegration
 		private void OnSessionCreated(InMemoryDocumentSessionOperations operations)
 		{
 			RavenProfiler.ContextualSessionList.Add(operations.Id);
-			if (HttpContext.Current != null && HttpContext.Current.Response != null)
-				HttpContext.Current.Response.AddHeader("X-RavenDb-Profiling-Id", operations.Id.ToString());
+			if (HttpContext.Current != null && HttpContext.Current.Response != null) {
+				string ids = HttpContext.Current.Response.Headers["X-RavenDb-Profiling-Id"] ?? "";
+				ids = ids + (ids.Length == 0 ? "" : ",") + operations.Id.ToString();
+				HttpContext.Current.Response.Headers.Set("X-RavenDb-Profiling-Id", ids);
+			}
 		}
 
 		private static string ravenDbProfilerScripts;

--- a/Raven.Client.MvcIntegration/ravendb-profiler-scripts.js
+++ b/Raven.Client.MvcIntegration/ravendb-profiler-scripts.js
@@ -138,7 +138,7 @@ var RavenDBProfiler = (function ($) {
 			$('body').ajaxComplete(function (event, xhrRequest, ajaxOptions) {
 				var id = xhrRequest.getResponseHeader('X-RavenDb-Profiling-Id');
 				if (id)
-					fetchResults(id);
+					fetchResults(id.split(','));
 			});
 			load();
 		}


### PR DESCRIPTION
I updated the AJAX tracking to handle when multiple sessions are created in a single call. They will now all be sent back in the header and added to the results.
