### PR TITLE
fix to admin authentication

### DIFF
--- a/Raven.Database/Server/Responders/AdminBackup.cs
+++ b/Raven.Database/Server/Responders/AdminBackup.cs
@@ -27,7 +27,7 @@ namespace Raven.Database.Server.Responders
 		{
 			if(context.IsAdministrator() == false)
 			{
-				context.SetStatusToForbidden();
+				context.SetStatusToUnauthorized();
 				context.WriteJson(new
 				{
 					Error = "Only administrators can initiate a backup procedure"

--- a/Raven.Database/Server/Responders/AdminStartIndexing.cs
+++ b/Raven.Database/Server/Responders/AdminStartIndexing.cs
@@ -20,7 +20,7 @@ namespace Raven.Database.Server.Responders
         {
             if (context.IsAdministrator() == false)
             {
-                context.SetStatusToForbidden();
+                context.SetStatusToUnauthorized();
                 context.WriteJson(new
                 {
                     Error = "Only administrators can start indexing"

--- a/Raven.Database/Server/Responders/AdminStopIndexing.cs
+++ b/Raven.Database/Server/Responders/AdminStopIndexing.cs
@@ -20,14 +20,13 @@ namespace Raven.Database.Server.Responders
         {
             if (context.IsAdministrator() == false)
             {
-                context.SetStatusToForbidden();
+                context.SetStatusToUnauthorized();
                 context.WriteJson(new
                 {
                     Error = "Only administrators can stop indexing"
                 });
                 return;
             }
-
 
             Database.StopBackgroundWokers();
         }


### PR DESCRIPTION
given:
  RavenDB running on IIS
  AnonymousAccess configured to "All"
  IIS configured to allow anonymous and windows auth

when:
  running raven-startbackup.ps1 as administrator

then:
  receiving "403", request fails though current user has sufficient permissions

With this change, the user will receive a 401 instead, allowing them to authenticate and the backup command to succeed.
Raven-StartBackup.ps1 is set to preauthenticate, but I guess its not trying that hard.
With this fix, I am able to backup in the given scenario.
