### PR TITLE
backup status messages now include a severity value, to explicit allow de

### DIFF
--- a/Raven.Database/Backup/BackupStatus.cs
+++ b/Raven.Database/Backup/BackupStatus.cs
@@ -12,6 +12,12 @@ namespace Raven.Database.Backup
 	{
 		public const string RavenBackupStatusDocumentKey = "Raven/Backup/Status";
 
+		public enum BackupMessageSeverity
+		{
+			Informational,
+			Error
+		}
+
 		public DateTime Started { get; set; }
 		public DateTime? Completed { get; set; }
 		public bool IsRunning { get; set; }
@@ -21,6 +27,7 @@ namespace Raven.Database.Backup
 		{
 			public string Message { get; set; }
 			public DateTime Timestamp { get; set; }
+			public BackupMessageSeverity Severity { get; set; }
 		}
 
 		public BackupStatus()

--- a/Raven.Database/Backup/DirectoryBackup.cs
+++ b/Raven.Database/Backup/DirectoryBackup.cs
@@ -23,7 +23,7 @@ namespace Raven.Database.Backup
 
         public const int MoveFileDelayUntilReboot = 0x4;
 
-        public event Action<string> Notify = delegate { };
+        public event Action<string, BackupStatus.BackupMessageSeverity> Notify = delegate { };
 
         private Dictionary<string, long> fileToSize = new Dictionary<string, long>();
     	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
@@ -56,10 +56,10 @@ namespace Raven.Database.Backup
         {
             foreach (var file in Directory.EnumerateFiles(tempPath))
             {
-                Notify("Copying " + Path.GetFileName(file));
+                Notify("Copying " + Path.GetFileName(file), BackupStatus.BackupMessageSeverity.Informational);
                 var fullName = new FileInfo(file).FullName;
                 FileCopy(file, Path.Combine(destination, Path.GetFileName(file)), fileToSize[fullName]);
-                Notify("Copied " + Path.GetFileName(file));
+                Notify("Copied " + Path.GetFileName(file), BackupStatus.BackupMessageSeverity.Informational);
             }
 
             try
@@ -127,7 +127,7 @@ namespace Raven.Database.Backup
             // of all the files
             foreach (var sourceFile in sourceFilesSnapshot)
             {
-                Notify("Hard linked " + sourceFile);
+                Notify("Hard linked " + sourceFile, BackupStatus.BackupMessageSeverity.Informational);
             }
 
         }

--- a/Raven.Storage.Esent/Backup/BackupOperation.cs
+++ b/Raven.Storage.Esent/Backup/BackupOperation.cs
@@ -30,8 +30,8 @@ namespace Raven.Storage.Esent.Backup
 		{
 			instance = ((TransactionalStorage)database.TransactionalStorage).Instance;
 			this.database = database;
-            this.to = to.ToFullPath();
-            this.src = src.ToFullPath();
+			this.to = to.ToFullPath();
+			this.src = src.ToFullPath();
 		}
 
 		public void Execute(object ignored)
@@ -45,9 +45,9 @@ namespace Raven.Storage.Esent.Backup
 				};
 				directoryBackups.AddRange(from index in Directory.GetDirectories(database.Configuration.IndexStoragePath)
 										  let fromIndex = Path.Combine(database.Configuration.IndexStoragePath, Path.GetFileName(index))
-				                          let toIndex = Path.Combine(to, "Indexes", Path.GetFileName(index))
+										  let toIndex = Path.Combine(to, "Indexes", Path.GetFileName(index))
 										  let tempIndex = Path.Combine(src, Path.Combine("BackupTempDirectories",Guid.NewGuid().ToString("N")))
-				                          select new DirectoryBackup(fromIndex, toIndex, tempIndex));
+										  select new DirectoryBackup(fromIndex, toIndex, tempIndex));
 
 				foreach (var directoryBackup in directoryBackups)
 				{
@@ -67,7 +67,7 @@ namespace Raven.Storage.Esent.Backup
 			catch (Exception e)
 			{
 				log.ErrorException("Failed to complete backup", e);
-				UpdateBackupStatus("Failed to complete backup because: " + e.Message);
+				UpdateBackupStatus("Failed to complete backup because: " + e.Message, BackupStatus.BackupMessageSeverity.Error);
 			}
 			finally
 			{
@@ -88,8 +88,8 @@ namespace Raven.Storage.Esent.Backup
 				backupStatus.IsRunning = false;
 				backupStatus.Completed = DateTime.UtcNow;
 				database.Put(BackupStatus.RavenBackupStatusDocumentKey, null, RavenJObject.FromObject(backupStatus),
-				             jsonDocument.Metadata,
-				             null);
+							 jsonDocument.Metadata,
+							 null);
 			}
 			catch (Exception e)
 			{
@@ -105,7 +105,7 @@ namespace Raven.Storage.Esent.Backup
 			}
 		}
 
-		private void UpdateBackupStatus(string newMsg)
+		private void UpdateBackupStatus(string newMsg, BackupStatus.BackupMessageSeverity severity)
 		{
 			try
 			{
@@ -117,10 +117,11 @@ namespace Raven.Storage.Esent.Backup
 				backupStatus.Messages.Add(new BackupStatus.BackupMessage
 				{
 					Message = newMsg,
-					Timestamp = DateTime.UtcNow
+					Timestamp = DateTime.UtcNow,
+					Severity = severity
 				});
 				database.Put(BackupStatus.RavenBackupStatusDocumentKey, null, RavenJObject.FromObject(backupStatus), jsonDocument.Metadata,
-				             null);
+							 null);
 			}
 			catch (Exception e)
 			{

--- a/Raven.Storage.Esent/Backup/EsentBackup.cs
+++ b/Raven.Storage.Esent/Backup/EsentBackup.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 using System;
 using Microsoft.Isam.Esent.Interop;
+using Raven.Database.Backup;
 
 namespace Raven.Storage.Esent.Backup
 {
@@ -12,7 +13,7 @@ namespace Raven.Storage.Esent.Backup
 	{
 		private readonly JET_INSTANCE instance;
 		private readonly string destination;
-		public event Action<string> Notify = delegate { };
+		public event Action<string,BackupStatus.BackupMessageSeverity> Notify = delegate { };
 
 		public EsentBackup(JET_INSTANCE instance, string destination)
 		{
@@ -30,7 +31,7 @@ namespace Raven.Storage.Esent.Backup
 
 		private JET_err StatusCallback(JET_SESID sesid, JET_SNP snp, JET_SNT snt, object data)
 		{
-			Notify(string.Format("Esent {0} {1} {2}", snp, snt, data).Trim());
+			Notify(string.Format("Esent {0} {1} {2}", snp, snt, data).Trim(), BackupStatus.BackupMessageSeverity.Informational);
 			return JET_err.Success;
 		}
 	}


### PR DESCRIPTION
Adding some stuff to automate backups, from the documentation it wasn't clear how to detect failures.
Looking at the code, it didn't seem to be written to the final status.  So I thought I'd add something.
At this point I saw in the tests there is the means by checking if any messages starts with "Failed".  I figured checking what the string starts with is kind of fragile.  So I continued to add severity value to the messages.

Sorry my last pull request included test breaks.  This request includes tests,...  I ran the tests, there were failures, but they look unrelated.  I include them below in case you want to review.

Raven.Tests.Bugs.CompiledIndexes.UsingNetworkEventsToNetworkTemp.CanGetGoodResults [FAIL]
   Assert.Empty() failure
   Stack Trace:
      c:\src\ravendb\Raven.Tests\Bugs\CompiledIndexes\UsingNetworkEventsToNetworkTemp.cs(31,0): at Raven.Tests.Bugs.CompiledIndexes.UsingNetworkEventsToNetworkTemp.CanGetGoodResults()

Raven.Tests.Bugs.DocumentUrl.CanGetFullUrl [FAIL]
   System.InvalidOperationException : <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
   <HTML><HEAD><TITLE>Bad Request</TITLE>
   <META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
   <BODY><h2>Bad Request - Invalid Hostname</h2>
   <hr><p>HTTP Error 400. The request hostname is invalid.</p>
   </BODY></HTML>

   ---- System.Net.WebException : The remote server returned an error: (400) Bad Request.
   Stack Trace:
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(202,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(131,0): at Raven.Client.Connection.HttpJsonRequest.ReadResponseString()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(204,0): at Raven.Client.Connection.ServerClient.DirectGet(String serverUrl, String key)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(169,0): at Raven.Client.Connection.ReplicationInformer.RefreshReplicationInformation(ServerClient commands)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(66,0): at Raven.Client.Connection.ReplicationInformer.UpdateReplicationInformationIfNeeded(ServerClient serverClient)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(65,0): at Raven.Client.Connection.ServerClient..ctor(String url, DocumentConvention convention, ICredentials credentials, ReplicationInformer replicationInformer, HttpJsonRequestFactory jsonRequestFactory, Nullable`1 currentSessionId)
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(469,0): at Raven.Client.Document.DocumentStore.<>c__DisplayClass5.<InitializeInternal>b__3()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(77,0): at Raven.Client.Document.DocumentStore.get_DatabaseCommands()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(297,0): at Raven.Client.Document.DocumentStore.OpenSession()
      c:\src\ravendb\Raven.Tests\Bugs\DocumentUrl.cs(27,0): at Raven.Tests.Bugs.DocumentUrl.CanGetFullUrl()
   ----- Inner Stack Trace -----
      at System.Net.HttpWebRequest.GetResponse()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(139,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)

Raven.Tests.Bugs.DocumentUrl.CanGetFullUrlWithSlashOnTheEnd [FAIL]
   System.InvalidOperationException : <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
   <HTML><HEAD><TITLE>Bad Request</TITLE>
   <META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
   <BODY><h2>Bad Request - Invalid Hostname</h2>
   <hr><p>HTTP Error 400. The request hostname is invalid.</p>
   </BODY></HTML>

   ---- System.Net.WebException : The remote server returned an error: (400) Bad Request.
   Stack Trace:
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(202,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(131,0): at Raven.Client.Connection.HttpJsonRequest.ReadResponseString()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(204,0): at Raven.Client.Connection.ServerClient.DirectGet(String serverUrl, String key)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(169,0): at Raven.Client.Connection.ReplicationInformer.RefreshReplicationInformation(ServerClient commands)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(66,0): at Raven.Client.Connection.ReplicationInformer.UpdateReplicationInformationIfNeeded(ServerClient serverClient)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(65,0): at Raven.Client.Connection.ServerClient..ctor(String url, DocumentConvention convention, ICredentials credentials, ReplicationInformer replicationInformer, HttpJsonRequestFactory jsonRequestFactory, Nullable`1 currentSessionId)
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(469,0): at Raven.Client.Document.DocumentStore.<>c__DisplayClass5.<InitializeInternal>b__3()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(77,0): at Raven.Client.Document.DocumentStore.get_DatabaseCommands()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(297,0): at Raven.Client.Document.DocumentStore.OpenSession()
      c:\src\ravendb\Raven.Tests\Bugs\DocumentUrl.cs(50,0): at Raven.Tests.Bugs.DocumentUrl.CanGetFullUrlWithSlashOnTheEnd()
   ----- Inner Stack Trace -----
      at System.Net.HttpWebRequest.GetResponse()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(139,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)

Raven.Tests.Bugs.OperationHeaders.CanPassOperationHeadersUsingServer [FAIL]
   System.InvalidOperationException : <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
   <HTML><HEAD><TITLE>Bad Request</TITLE>
   <META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
   <BODY><h2>Bad Request - Invalid Hostname</h2>
   <hr><p>HTTP Error 400. The request hostname is invalid.</p>
   </BODY></HTML>

   ---- System.Net.WebException : The remote server returned an error: (400) Bad Request.
   Stack Trace:
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(202,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(131,0): at Raven.Client.Connection.HttpJsonRequest.ReadResponseString()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(204,0): at Raven.Client.Connection.ServerClient.DirectGet(String serverUrl, String key)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(169,0): at Raven.Client.Connection.ReplicationInformer.RefreshReplicationInformation(ServerClient commands)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(66,0): at Raven.Client.Connection.ReplicationInformer.UpdateReplicationInformationIfNeeded(ServerClient serverClient)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(65,0): at Raven.Client.Connection.ServerClient..ctor(String url, DocumentConvention convention, ICredentials credentials, ReplicationInformer replicationInformer, HttpJsonRequestFactory jsonRequestFactory, Nullable`1 currentSessionId)
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(469,0): at Raven.Client.Document.DocumentStore.<>c__DisplayClass5.<InitializeInternal>b__3()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(77,0): at Raven.Client.Document.DocumentStore.get_DatabaseCommands()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(297,0): at Raven.Client.Document.DocumentStore.OpenSession()
      c:\src\ravendb\Raven.Tests\Bugs\OperationHeaders.cs(87,0): at Raven.Tests.Bugs.OperationHeaders.CanPassOperationHeadersUsingServer()
   ----- Inner Stack Trace -----
      at System.Net.HttpWebRequest.GetResponse()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(139,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)

Raven.Tests.Bugs.OperationHeaders.CanPassOperationHeadersSetBeforeSessionUsingServer [FAIL]
   System.InvalidOperationException : <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
   <HTML><HEAD><TITLE>Bad Request</TITLE>
   <META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
   <BODY><h2>Bad Request - Invalid Hostname</h2>
   <hr><p>HTTP Error 400. The request hostname is invalid.</p>
   </BODY></HTML>

   ---- System.Net.WebException : The remote server returned an error: (400) Bad Request.
   Stack Trace:
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(202,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(131,0): at Raven.Client.Connection.HttpJsonRequest.ReadResponseString()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(204,0): at Raven.Client.Connection.ServerClient.DirectGet(String serverUrl, String key)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(169,0): at Raven.Client.Connection.ReplicationInformer.RefreshReplicationInformation(ServerClient commands)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(66,0): at Raven.Client.Connection.ReplicationInformer.UpdateReplicationInformationIfNeeded(ServerClient serverClient)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(65,0): at Raven.Client.Connection.ServerClient..ctor(String url, DocumentConvention convention, ICredentials credentials, ReplicationInformer replicationInformer, HttpJsonRequestFactory jsonRequestFactory, Nullable`1 currentSessionId)
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(469,0): at Raven.Client.Document.DocumentStore.<>c__DisplayClass5.<InitializeInternal>b__3()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(77,0): at Raven.Client.Document.DocumentStore.get_DatabaseCommands()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(297,0): at Raven.Client.Document.DocumentStore.OpenSession()
      c:\src\ravendb\Raven.Tests\Bugs\OperationHeaders.cs(119,0): at Raven.Tests.Bugs.OperationHeaders.CanPassOperationHeadersSetBeforeSessionUsingServer()
   ----- Inner Stack Trace -----
      at System.Net.HttpWebRequest.GetResponse()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(139,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)

Raven.Tests.Bugs.ReadDataFromServer.CanReadDataProperly [FAIL]
   System.Net.WebException : The remote server returned an error: (400) Bad Request.
   Stack Trace:
      at System.Net.WebClient.DownloadDataInternal(Uri address, WebRequest& request)
      at System.Net.WebClient.DownloadData(Uri address)
      c:\src\ravendb\Raven.Tests\Bugs\ReadDataFromServer.cs(24,0): at Raven.Tests.Bugs.ReadDataFromServer.CanReadDataProperly()

Raven.Tests.Bugs.SerializingEntities.Daniil_CanSaveProperly [FAIL]
   System.InvalidOperationException : <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
   <HTML><HEAD><TITLE>Bad Request</TITLE>
   <META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
   <BODY><h2>Bad Request - Invalid Hostname</h2>
   <hr><p>HTTP Error 400. The request hostname is invalid.</p>
   </BODY></HTML>

   ---- System.Net.WebException : The remote server returned an error: (400) Bad Request.
   Stack Trace:
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(202,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(131,0): at Raven.Client.Connection.HttpJsonRequest.ReadResponseString()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(204,0): at Raven.Client.Connection.ServerClient.DirectGet(String serverUrl, String key)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(169,0): at Raven.Client.Connection.ReplicationInformer.RefreshReplicationInformation(ServerClient commands)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(66,0): at Raven.Client.Connection.ReplicationInformer.UpdateReplicationInformationIfNeeded(ServerClient serverClient)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(65,0): at Raven.Client.Connection.ServerClient..ctor(String url, DocumentConvention convention, ICredentials credentials, ReplicationInformer replicationInformer, HttpJsonRequestFactory jsonRequestFactory, Nullable`1 currentSessionId)
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(469,0): at Raven.Client.Document.DocumentStore.<>c__DisplayClass5.<InitializeInternal>b__3()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(77,0): at Raven.Client.Document.DocumentStore.get_DatabaseCommands()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(297,0): at Raven.Client.Document.DocumentStore.OpenSession()
      c:\src\ravendb\Raven.Tests\Bugs\SerializingEntities.cs(88,0): at Raven.Tests.Bugs.SerializingEntities.Daniil_CanSaveProperly()
   ----- Inner Stack Trace -----
      at System.Net.HttpWebRequest.GetResponse()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(139,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)

Raven.Tests.Bugs.WillNotFailSystemIfServerIsNotAvailableOnStartup.CanStartWithoutServer [FAIL]
   Assert.Throws() Failure
   Expected: System.Net.WebException
   Actual:   System.InvalidOperationException: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
             <HTML><HEAD><TITLE>Bad Request</TITLE>
             <META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
             <BODY><h2>Bad Request - Invalid Hostname</h2>
             <hr><p>HTTP Error 400. The request hostname is invalid.</p>
             </BODY></HTML>
   Stack Trace:
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(202,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(131,0): at Raven.Client.Connection.HttpJsonRequest.ReadResponseString()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(204,0): at Raven.Client.Connection.ServerClient.DirectGet(String serverUrl, String key)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(169,0): at Raven.Client.Connection.ReplicationInformer.RefreshReplicationInformation(ServerClient commands)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(66,0): at Raven.Client.Connection.ReplicationInformer.UpdateReplicationInformationIfNeeded(ServerClient serverClient)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(65,0): at Raven.Client.Connection.ServerClient..ctor(String url, DocumentConvention convention, ICredentials credentials, ReplicationInformer replicationInformer, HttpJsonRequestFactory jsonRequestFactory, Nullable`1 currentSessionId)
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(469,0): at Raven.Client.Document.DocumentStore.<>c__DisplayClass5.<InitializeInternal>b__3()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(77,0): at Raven.Client.Document.DocumentStore.get_DatabaseCommands()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(297,0): at Raven.Client.Document.DocumentStore.OpenSession()
      c:\src\ravendb\Raven.Tests\Bugs\WillNotFailSystemIfServerIsNotAvailableOnStartup.cs(48,0): at Raven.Tests.Bugs.WillNotFailSystemIfServerIsNotAvailableOnStartup.<>c__DisplayClass3.<CanStartWithoutServer>b__1()
      at Xunit.Record.Exception(ThrowsDelegateWithReturn code)

Raven.Tests.Document.DocumentStoreServerTests_DifferentProcess.Can_promote_transactions [FAIL]
   System.InvalidOperationException : <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
   <HTML><HEAD><TITLE>Bad Request</TITLE>
   <META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
   <BODY><h2>Bad Request - Invalid Hostname</h2>
   <hr><p>HTTP Error 400. The request hostname is invalid.</p>
   </BODY></HTML>

   ---- System.Net.WebException : The remote server returned an error: (400) Bad Request.
   Stack Trace:
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(202,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(131,0): at Raven.Client.Connection.HttpJsonRequest.ReadResponseString()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(204,0): at Raven.Client.Connection.ServerClient.DirectGet(String serverUrl, String key)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(169,0): at Raven.Client.Connection.ReplicationInformer.RefreshReplicationInformation(ServerClient commands)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ReplicationInformer.cs(66,0): at Raven.Client.Connection.ReplicationInformer.UpdateReplicationInformationIfNeeded(ServerClient serverClient)
      C:\src\ravendb\Raven.Client.Lightweight\Connection\ServerClient.cs(65,0): at Raven.Client.Connection.ServerClient..ctor(String url, DocumentConvention convention, ICredentials credentials, ReplicationInformer replicationInformer, HttpJsonRequestFactory jsonRequestFactory, Nullable`1 currentSessionId)
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(469,0): at Raven.Client.Document.DocumentStore.<>c__DisplayClass5.<InitializeInternal>b__3()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(77,0): at Raven.Client.Document.DocumentStore.get_DatabaseCommands()
      C:\src\ravendb\Raven.Client.Lightweight\Document\DocumentStore.cs(297,0): at Raven.Client.Document.DocumentStore.OpenSession()
      c:\src\ravendb\Raven.Tests\Document\DocumentStoreServerTests_DifferentProcess.cs(37,0): at Raven.Tests.Document.DocumentStoreServerTests_DifferentProcess.Can_promote_transactions()
   ----- Inner Stack Trace -----
      at System.Net.HttpWebRequest.GetResponse()
      C:\src\ravendb\Raven.Client.Lightweight\Connection\HttpJsonRequest.cs(139,0): at Raven.Client.Connection.HttpJsonRequest.ReadStringInternal(Func`1 getResponse)

980 total, 9 failed, 0 skipped, took 349.014 seconds
System.Management.Automation.RuntimeException
