### PR TITLE
minor discrepancy in Last-Modified tracking

### DIFF
--- a/Raven.Tests/Bugs/Metadata/LastModifiedLocal.cs
+++ b/Raven.Tests/Bugs/Metadata/LastModifiedLocal.cs
@@ -32,7 +32,7 @@ namespace Raven.Tests.Bugs.Metadata
                     var user = session.Load<User>("users/1");
                     var lastModified = session.Advanced.GetMetadataFor(user).Value<DateTime>("Last-Modified");
                     Assert.NotNull(lastModified);
-                    Assert.InRange(lastModified.ToUniversalTime().Ticks, before.Ticks, after.Ticks);
+                    Assert.InRange(lastModified.ToUniversalTime(), before, after);
                     Assert.Equal(DateTimeKind.Utc, lastModified.Kind);
                 }
             }

--- a/Raven.Tests/Bugs/Metadata/LastModifiedRemote.cs
+++ b/Raven.Tests/Bugs/Metadata/LastModifiedRemote.cs
@@ -34,7 +34,8 @@ namespace Raven.Tests.Bugs.Metadata
                     var user = session.Load<User>("users/1");
                     var lastModified = session.Advanced.GetMetadataFor(user).Value<DateTime>("Last-Modified");
                     Assert.NotNull(lastModified);
-                    Assert.InRange(lastModified.ToUniversalTime().Ticks, before.Ticks, after.Ticks);
+                    int msPrecision = 1000;
+                    Assert.InRange(lastModified.ToUniversalTime(), before.AddMilliseconds(-msPrecision), after.AddMilliseconds(msPrecision));
                     Assert.Equal(DateTimeKind.Utc, lastModified.Kind);
                 }
             }


### PR DESCRIPTION
Here are some test changes show a slight difference between metadata Last-Modified when running raven remotely or locally.  The severity of the difference is quite small, but I thought you might want to consider if it need be that way.

First, an assertion checking the time's accuracy fails when connected remotely.  Based on the assertion there is some rounding error:

```
Test 'Raven.Tests.Bugs.Metadata.LastModifiedRemote.CanAccessLastModifiedAsMetadata' failed: Assert.InRange() Failure
Range:  (634470024880198732 - 634470024880718762)
Actual: 634470024880000000
    Bugs\Metadata\LastModifiedRemote.cs(37,0): at Raven.Tests.Bugs.Metadata.LastModifiedRemote.CanAccessLastModifiedAsMetadata()
```

Second, when using the remote client the Last-Modified time is DateTimeKind.Local, while when using local client the result is DateTimeKind.Utc.  Whoever consumes the DateTime can call ToUniversalTime() to address this.
