### PR TITLE
Error message for facet setup doc

### DIFF
--- a/Raven.Database/Queries/FacetedQueryRunner.cs
+++ b/Raven.Database/Queries/FacetedQueryRunner.cs
@@ -20,6 +20,10 @@ namespace Raven.Database.Queries
 		public IDictionary<string, IEnumerable<FacetValue>> GetFacets(string index, IndexQuery indexQuery, string facetSetupDoc)
 		{
 			var facetSetup = database.Get(facetSetupDoc, null);
+			if (facetSetup == null)
+			{
+				throw new ArgumentException(String.Format("Facet document '{0}' not found.", facetSetupDoc));
+			}
 			var facets = facetSetup.DataAsJson.JsonDeserialization<FacetSetup>().Facets;
 
 			var results = new Dictionary<string, IEnumerable<FacetValue>>();


### PR DESCRIPTION
A tiny change to throw a nicer error message if you have not saved a facet setup document.
I think this could be a fairly common mistake and the null reference is difficult to trace if you do not have ready access to the source.
