### PR TITLE
Expiration bundle fails to delete more than 1024 documents

### DIFF
--- a/Bundles/Raven.Bundles.Expiration/ExpiredDocumentsCleaner.cs
+++ b/Bundles/Raven.Bundles.Expiration/ExpiredDocumentsCleaner.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using NLog;
@@ -48,7 +47,7 @@ namespace Raven.Bundles.Expiration
 
 			var deleteFrequencyInSeconds = database.Configuration.GetConfigurationValue<int>("Raven/Expiration/DeleteFrequencySeconds") ?? 300;
 			logger.Info("Initialied expired document cleaner, will check for expired documents every {0} seconds",
-			            deleteFrequencyInSeconds);
+						deleteFrequencyInSeconds);
 			timer = new Timer(TimerCallback, null, TimeSpan.FromSeconds(deleteFrequencyInSeconds), TimeSpan.FromSeconds(deleteFrequencyInSeconds));
 
 		}
@@ -61,11 +60,11 @@ namespace Raven.Bundles.Expiration
 			executing = true;
 			try
 			{
-				var currentTime = ExpirationReadTrigger.GetCurrentUtcDate();
-				var nowAsStr = DateTools.DateToString(currentTime, DateTools.Resolution.SECOND);
-
 				while (true)
 				{
+					var currentTime = ExpirationReadTrigger.GetCurrentUtcDate();
+					var nowAsStr = DateTools.DateToString(currentTime, DateTools.Resolution.SECOND);
+
 					var queryResult = Database.Query(RavenDocumentsByExpirationDate, new IndexQuery
 					{
 						PageSize = 1024,
@@ -87,7 +86,7 @@ namespace Raven.Bundles.Expiration
 
 					logger.Debug(()=> string.Format("Deleting {0} expired documents: [{1}]", queryResult.Results.Count, string.Join(", ", docIds)));
 
-					 var deleted = false;
+					var deleted = false;
 					Database.TransactionalStorage.Batch(accessor => // delete all expired items in a single tx
 					{
 						deleted = docIds.Aggregate(deleted, (current, docId) => current | Database.Delete(docId, null, null));


### PR DESCRIPTION
The ExpiredDocumentsCleaner selects 1024 documents, deletes them and if they are deleted, tries to select another 1024 for deletion. It does however select exactly the same 1024 documents (queryResult.IsStale is false  - bug?) causing deleted to be false and the loop exits.

Moving generation of the Cutoff time into the while loop seems to fix the problem, and all documents are now removed.
