### PR TITLE
Raven/OAuthTokenCertificatePath relative path

### DIFF
--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -171,6 +171,7 @@ namespace Raven.Database.Config
 			var path = Settings["Raven/OAuthTokenCertificatePath"];
 			if (string.IsNullOrEmpty(path) == false)
 			{
+			    path = path.ToFullPath();
 				var pwd = Settings["Raven/OAuthTokenCertificatePassword"];
 				if (string.IsNullOrEmpty(pwd) == false)
 				{


### PR DESCRIPTION
Exception Details: System.Security.Cryptography.CryptographicException: The system cannot find the path specified.

<add key="Raven/OAuthTokenCertificatePath" value="~\Certificate.pfx" />

This occurred when running under IIS.
