### PR TITLE
An Index with a Map property of String.Reverse doesn't work.

### DIFF
--- a/Raven.Tests/Bugs/Indexing/WithStringReverse.cs
+++ b/Raven.Tests/Bugs/Indexing/WithStringReverse.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using Raven.Abstractions.Indexing;
+using Raven.Client;
+using Raven.Client.Document;
+using Raven.Client.Embedded;
+using Xunit;
+
+namespace Raven.Tests.Bugs.Indexing
+{
+	public class WithStringReverse : LocalClientTest
+	{
+		[Fact]
+		public void GivenSomeUsers_QueryWithAnIndex_ReturnsUsersWithNamesReversed()
+		{
+			using (EmbeddableDocumentStore store = NewDocumentStore())
+			{
+				// Wait for all indexes to finish indexing.
+				store.Conventions.DefaultQueryingConsistency = ConsistencyOptions.QueryYourWrites;
+
+				store.DatabaseCommands.PutIndex("StringReverseIndex",
+				                                new IndexDefinition
+				                                	{
+				                                		Map =
+				                                			"from doc in docs select new { doc.Name, ReverseName = new string(doc.Name.Reverse().ToArray())}"
+				                                	});
+
+				using (IDocumentSession documentSession = store.OpenSession())
+				{
+					documentSession.Store(new User {Name = "Ayende"});
+					documentSession.Store(new User {Name = "Itamar"});
+					documentSession.Store(new User {Name = "Pure Krome"});
+					documentSession.Store(new User {Name = "John Skeet"});
+					documentSession.Store(new User {Name = "StackOverflow"});
+					documentSession.Store(new User {Name = "Wow"});
+					documentSession.SaveChanges();
+				}
+
+				using (IDocumentSession documentSession = store.OpenSession())
+				{
+					var users = documentSession
+						.Query<User>("StringReverseIndex")
+						.ToList();
+					Assert.NotNull(users);
+					Assert.True(users.Count > 0);
+
+					// Should I also test that the first result is reversed?
+					// If so, then i would need a result class .. not sure how to do that..
+				}
+			}
+		}
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Bugs\HiLoToMaxTests.cs" />
     <Compile Include="Bugs\IndexesWithDateTimeMin.cs" />
     <Compile Include="Bugs\Indexing\CanHaveAnIndexNameThatStartsWithDynamic.cs" />
+    <Compile Include="Bugs\Indexing\WithStringReverse.cs" />
     <Compile Include="Bugs\Indexing\InvalidIndexes.cs" />
     <Compile Include="Bugs\Issue355.cs" />
     <Compile Include="Bugs\JsonReferences.cs" />

--- a/contributing.txt
+++ b/contributing.txt
@@ -18,7 +18,7 @@ If you want to contribute to Raven source:
     specific for a particular version.
   * Please take care of the code formatting. We don't reject contributions 
     because of a different coding style, but it would be nice if you would take
-    care of the code formatting to match the RavenDB source. On major thing to
+    care of the code formatting to match the RavenDB source. One major thing to
     take care of: We use tabs for indentation, not spaces!
     You can use the "Productivity Power Tools" extension for VisualStudio to
     enforce a consistent indentation.


### PR DESCRIPTION
- Added a unit test, testing for an index with a string Reverse() extension method inside the Map.
