### PR TITLE
Map functions don't need to return _exactly_ the same types

### DIFF
--- a/Raven.Database/Indexing/SimpleIndex.cs
+++ b/Raven.Database/Indexing/SimpleIndex.cs
@@ -39,7 +39,6 @@ namespace Raven.Database.Indexing
 			Write(context, (indexWriter, analyzer) =>
 			{
 				bool madeChanges = false;
-				PropertyDescriptorCollection properties = null;
 				var processedKeys = new HashSet<string>();
 				var batchers = context.IndexUpdateTriggers.Select(x => x.CreateBatcher(name))
 					.Where(x => x != null)
@@ -77,7 +76,7 @@ namespace Raven.Database.Indexing
 					count++;
 
 					float boost;
-					var indexingResult = GetIndexingResult(ref properties, doc, anonymousObjectToLuceneDocumentConverter, out boost);
+					var indexingResult = GetIndexingResult(doc, anonymousObjectToLuceneDocumentConverter, out boost);
 
 					if (indexingResult.NewDocId != null && indexingResult.ShouldSkip == false)
 					{
@@ -121,7 +120,7 @@ namespace Raven.Database.Indexing
 			logIndexing.Debug("Indexed {0} documents for {1}", count, name);
 		}
 
-		private IndexingResult GetIndexingResult(ref PropertyDescriptorCollection properties, object doc, AnonymousObjectToLuceneDocumentConverter anonymousObjectToLuceneDocumentConverter, out float boost)
+		private IndexingResult GetIndexingResult(object doc, AnonymousObjectToLuceneDocumentConverter anonymousObjectToLuceneDocumentConverter, out float boost)
 		{
 			boost = 1;
 
@@ -136,7 +135,7 @@ namespace Raven.Database.Indexing
 			if (doc is DynamicJsonObject)
 				indexingResult = ExtractIndexDataFromDocument(anonymousObjectToLuceneDocumentConverter, (DynamicJsonObject) doc);
 			else
-				indexingResult = ExtractIndexDataFromDocument(anonymousObjectToLuceneDocumentConverter, ref properties, doc);
+				indexingResult = ExtractIndexDataFromDocument(anonymousObjectToLuceneDocumentConverter, doc);
 
 			if (Math.Abs(boost - 1) > float.Epsilon)
 			{
@@ -168,12 +167,10 @@ namespace Raven.Database.Indexing
 			};
 		}
 
-		private IndexingResult ExtractIndexDataFromDocument(AnonymousObjectToLuceneDocumentConverter anonymousObjectToLuceneDocumentConverter, ref PropertyDescriptorCollection properties, object doc)
+		private IndexingResult ExtractIndexDataFromDocument(AnonymousObjectToLuceneDocumentConverter anonymousObjectToLuceneDocumentConverter, object doc)
 		{
-			if (properties == null)
-			{
-				properties = TypeDescriptor.GetProperties(doc);
-			}
+		    var properties = TypeDescriptor.GetProperties(doc);
+			
 			var abstractFields = anonymousObjectToLuceneDocumentConverter.Index(doc, properties, indexDefinition, Field.Store.NO).ToList();
 			return new IndexingResult()
 			{

--- a/Raven.Tests/Bugs/MultiMap/MultiMapWithCustomProperties.cs
+++ b/Raven.Tests/Bugs/MultiMap/MultiMapWithCustomProperties.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+using Raven.Client.Indexes;
+using Xunit;
+
+namespace Raven.Tests.Bugs.MultiMap
+{
+    public class MultiMapWithCustomProperties : RavenTest
+    {
+        [Fact]
+        public void Can_create_index()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Cat { Name = "Tom", CatsOnlyProperty = "Miau"});
+                    session.Store(new Dog { Name = "Oscar" });
+
+                    session.SaveChanges();
+                }
+
+                new CatsAndDogs().Execute(store);
+
+                WaitForIndexing(store);
+
+                Assert.Empty(store.DocumentDatabase.Statistics.Errors);
+            }
+        }
+
+        public class CatsAndDogs : AbstractMultiMapIndexCreationTask
+        {
+            public CatsAndDogs()
+            {
+                AddMap<Cat>(cats => from cat in cats
+                                    select new { cat.Name, cat.CatsOnlyProperty });
+
+                AddMap<Dog>(dogs => from dog in dogs
+                                    select new { dog.Name, CatsOnlyProperty = (string)null });
+            }
+        }
+
+        public interface IHaveName
+        {
+            string Name { get; }
+        }
+
+        public class Cat : IHaveName
+        {
+            public string Name { get; set; }
+            public string CatsOnlyProperty { get; set; }
+        }
+
+        public class Dog : IHaveName
+        {
+            public string Name { get; set; }
+        }
+    }
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Bugs\Metadata\Querying.cs" />
     <Compile Include="Bugs\MultiMap\Errors.cs" />
     <Compile Include="Bugs\MultiMap\MultiMapReduce.cs" />
+    <Compile Include="Bugs\MultiMap\MultiMapWithCustomProperties.cs" />
     <Compile Include="Bugs\MultiMap\SimpleMultiMap.cs" />
     <Compile Include="Bugs\NestedProjection.cs" />
     <Compile Include="Bugs\NestedTransactions.cs" />


### PR DESCRIPTION
People will never understand why this test fails, so I removed the caching of the property descriptor of the indexing results.

Oren, this is a follow-up to my email. I doesn't make any sense to force these scary explicit castings as they will raise a lot of issues.
