### PR TITLE
Search and Where are not producing expected outcome

### DIFF
--- a/Raven.Tests/Bugs/FullTextSearchOnTags.cs
+++ b/Raven.Tests/Bugs/FullTextSearchOnTags.cs
@@ -321,5 +321,39 @@ namespace Raven.Tests.Bugs
 			}
 		}
 
+        [Fact]
+        public void Can_search_inner_words_with_extra_condition()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image { Id = "1", Name = "Great Photo buddy" });
+                    session.Store(new Image { Id = "2", Name = "Nice Photo of the sky" });
+                    session.SaveChanges();
+                }
+
+                store.DatabaseCommands.PutIndex("test", new IndexDefinition
+                {
+                    Map = "from doc in docs.Images select new { doc.Name }",
+                    Indexes = {
+					    { "Name", FieldIndexing.Analyzed }
+				    }
+
+                });
+
+                using (var session = store.OpenSession())
+                {
+                    var images = session.Query<Image>("test")
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .OrderBy(x => x.Name)
+                        .Search(x => x.Name, "Photo")
+                        .Where(x => x.Id == "1")
+                        .ToList();
+                    Assert.NotEmpty(images);
+                    Assert.True(images.Count == 1);
+                }
+            }
+        }
 	}
 }


### PR DESCRIPTION
var images = session.Query<Image>("test")
                        .Customize(x => x.WaitForNonStaleResults())
                        .OrderBy(x => x.Name)
                        .Search(x => x.Name, "Photo")
                        .Where(x => x.Id == "1")
                        .ToList();
                    Assert.NotEmpty(images);
                    Assert.True(images.Count == 1);
