### PR TITLE
should this work?

### DIFF
--- a/Raven.Tests/Indexes/ReduceCanUseExtensionMethods.cs
+++ b/Raven.Tests/Indexes/ReduceCanUseExtensionMethods.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Raven.Abstractions.Indexing;
+using Raven.Client.Indexes;
+using Raven.Client.Linq;
+using Raven.Database;
+using Raven.Database.Config;
+using Raven.Tests.Storage;
+using Xunit;
+
+namespace Raven.Tests.Indexes
+{
+    public class ReduceCanUseExtensionMethods : RavenTest
+    {
+        public class PainfulInputData
+        {
+            public string Name;
+            public string Tags;
+        }
+
+        public class IndexedFields
+        {
+            public string[] Tags;
+        }
+
+        [Fact]
+        public void CanUseExtensionMethods()
+        {
+            using (var store = NewDocumentStore())
+            {
+                store.Initialize();
+
+                store.DatabaseCommands.PutIndex("Hi", new IndexDefinitionBuilder<PainfulInputData, IndexedFields>()
+                    {
+                        Map = documents => from doc in documents
+                                           let tags = doc.Tags.Split(',').Select(s => s.Trim()).Where(s => !string.IsNullOrEmpty(s))
+                                           select new IndexedFields()
+                                               {
+                                                   Tags = tags.ToArray()
+                                               }
+                    });
+
+                using(var session = store.OpenSession())
+                {
+                    session.Store(new PainfulInputData()
+                        {
+                            Name = "Hello, universe",
+                            Tags = "Little, orange, comment"
+                        });
+
+                    session.Store(new PainfulInputData()
+                        {
+                            Name = "Highlander",
+                            Tags = "only-one"
+                        });
+                    
+                    session.SaveChanges();
+                }
+
+                //  How to assert no indexing errors?  
+                //  When I create a similur index, the UI shows an indexing error related to using .Select().
+
+                using(var session = store.OpenSession())
+                {
+                    var results = session.Query<IndexedFields>("Hi")
+                        .Customize(a => a.WaitForNonStaleResults())
+                        .Search(d => d.Tags, "only-one")
+                        .ToList();
+
+                    Assert.Single(results);
+                }
+            }
+        }
+    
+    }
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -529,6 +529,7 @@
     <Compile Include="Indexes\MapReduceIndexOnLargeDataSet.cs" />
     <Compile Include="Indexes\QueryingOnDefaultIndex.cs" />
     <Compile Include="Indexes\QueryingOnStaleIndexes.cs" />
+    <Compile Include="Indexes\ReduceCanUseExtensionMethods.cs" />
     <Compile Include="Indexes\ShoppingCartEventsToShopingCart.cs" />
     <Compile Include="Indexes\UsingCustomLuceneAnalyzer.cs" />
     <Compile Include="Indexes\WithDecimalValue.cs" />


### PR DESCRIPTION
I was indexing some post objects from WordPress.  To do things quickly, I store the original object which stores multiple tags in a single string field.  To fix the data in a projection, I wanted to split the tags string in the map step.  Indexing fails when using Select() in this manner.
I suppose I am doing this wrong/hard, as it would be simpler to just run the text analyzr on the original Tags string as it will split them for searching.  But maybe a case can be made that .Select() should still work in the Map part of an index when used this way.
When I check the GUI for a similar index I see indexing failed on Select(), so I'm also curious how I can check indexing errors within the test.
