### PR TITLE
Fixe strongly typed LuceneQuery<T>

### DIFF
--- a/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
@@ -499,7 +499,7 @@ namespace Raven.Client.Document
 		///   You can prefix a field name with '-' to indicate sorting by descending or '+' to sort by ascending
 		/// </summary>
 		/// <param name = "propertySelectors">Property selectors for the fields.</param>
-		public IAsyncDocumentQuery<T> OrderBy(params Expression<Func<T, object>>[] propertySelectors)
+		public IAsyncDocumentQuery<T> OrderBy<TValue>(params Expression<Func<T, TValue>>[] propertySelectors)
 		{
 			OrderBy(propertySelectors.Select(x => x.GetPropertyName()).ToArray());
 			return this;
@@ -646,7 +646,7 @@ namespace Raven.Client.Document
 		/// </summary>
 		/// <param name = "propertySelector">Property selector for the field.</param>
 		/// <param name = "descending">if set to <c>true</c> [descending].</param>
-		public IAsyncDocumentQuery<T> AddOrder(Expression<Func<T, object>> propertySelector, bool descending)
+		public IAsyncDocumentQuery<T> AddOrder<TValue>(Expression<Func<T, TValue>> propertySelector, bool descending)
 		{
 			AddOrder(propertySelector.GetPropertyName(), descending);
 			return this;
@@ -707,7 +707,7 @@ namespace Raven.Client.Document
 		/// Perform a search for documents which fields that match the searchTerms.
 		/// If there is more than a single term, each of them will be checked independently.
 		/// </summary>
-		public IAsyncDocumentQuery<T> Search(Expression<Func<T, object>> propertySelector, string searchTerms)
+		public IAsyncDocumentQuery<T> Search<TValue>(Expression<Func<T, TValue>> propertySelector, string searchTerms)
 		{
 			Search(propertySelector.GetPropertyName(), searchTerms);
 			return this;
@@ -729,7 +729,7 @@ namespace Raven.Client.Document
 		///<remarks>
 		///  This is only valid on dynamic indexes queries
 		///</remarks>
-		public IAsyncDocumentQuery<T> GroupBy(AggregationOperation aggregationOperation, params Expression<Func<T, object>>[] groupPropertySelectors)
+		public IAsyncDocumentQuery<T> GroupBy<TValue>(AggregationOperation aggregationOperation, params Expression<Func<T, TValue>>[] groupPropertySelectors)
 		{
 			GroupBy(aggregationOperation, groupPropertySelectors.Select(x => x.GetPropertyName()).ToArray());
 			return this;

--- a/Raven.Client.Lightweight/Document/DocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/DocumentQuery.cs
@@ -121,7 +121,7 @@ namespace Raven.Client.Document
 		/// </summary>
 		/// <param name = "propertySelector">Property selector for the field.</param>
 		/// <param name = "descending">if set to <c>true</c> [descending].</param>
-		public IDocumentQuery<T> AddOrder(Expression<Func<T, object>> propertySelector, bool descending)
+		public IDocumentQuery<T> AddOrder<TValue>(Expression<Func<T, TValue>> propertySelector, bool descending)
 		{
 			AddOrder(propertySelector.GetPropertyName(), descending);
 			return this;
@@ -192,7 +192,7 @@ namespace Raven.Client.Document
 		/// Perform a search for documents which fields that match the searchTerms.
 		/// If there is more than a single term, each of them will be checked independently.
 		/// </summary>
-		public IDocumentQuery<T> Search(Expression<Func<T, object>> propertySelector, string searchTerms)
+		public IDocumentQuery<T> Search<TValue>(Expression<Func<T, TValue>> propertySelector, string searchTerms)
 		{
 			Search(propertySelector.GetPropertyName(), searchTerms);
 			return this;
@@ -216,7 +216,7 @@ namespace Raven.Client.Document
 		///<remarks>
 		///  This is only valid on dynamic indexes queries
 		///</remarks>
-		public IDocumentQuery<T> GroupBy(AggregationOperation aggregationOperation, params Expression<Func<T, object>>[] groupPropertySelectors)
+		public IDocumentQuery<T> GroupBy<TValue>(AggregationOperation aggregationOperation, params Expression<Func<T, TValue>>[] groupPropertySelectors)
 		{
 			GroupBy(aggregationOperation, groupPropertySelectors.Select(x => x.GetPropertyName()).ToArray());
 			return this;
@@ -706,7 +706,7 @@ namespace Raven.Client.Document
 		///   You can prefix a field name with '-' to indicate sorting by descending or '+' to sort by ascending
 		/// </summary>
 		/// <param name = "propertySelectors">Property selectors for the fields.</param>
-		public IDocumentQuery<T> OrderBy(params Expression<Func<T, object>>[] propertySelectors)
+		public IDocumentQuery<T> OrderBy<TValue>(params Expression<Func<T, TValue>>[] propertySelectors)
 		{
 			OrderBy(propertySelectors.Select(x => x.GetPropertyName()).ToArray());
 			return this;

--- a/Raven.Client.Lightweight/IDocumentQueryBase.cs
+++ b/Raven.Client.Lightweight/IDocumentQueryBase.cs
@@ -353,7 +353,7 @@ If you really want to do in memory filtering on the data returned from the query
 		///   You can prefix a field name with '-' to indicate sorting by descending or '+' to sort by ascending
 		/// </summary>
 		/// <param name = "propertySelectors">Property selectors for the fields.</param>
-		TSelf OrderBy(params Expression<Func<T, object>>[] propertySelectors);
+		TSelf OrderBy<TValue>(params Expression<Func<T, TValue>>[] propertySelectors);
 
 		/// <summary>
 		///   Instructs the query to wait for non stale results as of now.
@@ -436,7 +436,7 @@ If you really want to do in memory filtering on the data returned from the query
 		/// </summary>
 		/// <param name = "propertySelector">Property selector for the field.</param>
 		/// <param name = "descending">if set to <c>true</c> [descending].</param>
-		TSelf AddOrder(Expression<Func<T, object>> propertySelector, bool descending);
+		TSelf AddOrder<TValue>(Expression<Func<T, TValue>> propertySelector, bool descending);
 
 		/// <summary>
 		///   Adds an ordering for a specific field to the query and specifies the type of field for sorting purposes
@@ -468,7 +468,7 @@ If you really want to do in memory filtering on the data returned from the query
 		/// Perform a search for documents which fields that match the searchTerms.
 		/// If there is more than a single term, each of them will be checked independently.
 		/// </summary>
-		TSelf Search(Expression<Func<T, object>> propertySelector, string searchTerms);
+		TSelf Search<TValue>(Expression<Func<T, TValue>> propertySelector, string searchTerms);
 
 		///<summary>
 		///  Instruct the index to group by the specified fields using the specified aggregation operation
@@ -484,7 +484,7 @@ If you really want to do in memory filtering on the data returned from the query
 		///<remarks>
 		///  This is only valid on dynamic indexes queries
 		///</remarks>
-		TSelf GroupBy(AggregationOperation aggregationOperation, params Expression<Func<T, object>>[] groupPropertySelectors);
+		TSelf GroupBy<TValue>(AggregationOperation aggregationOperation, params Expression<Func<T, TValue>>[] groupPropertySelectors);
 
 		/// <summary>
 		/// Partition the query so we can intersect different parts of the query

--- a/Raven.Tests/Querying/UsingStronglyTypedDocumentQuery.cs
+++ b/Raven.Tests/Querying/UsingStronglyTypedDocumentQuery.cs
@@ -1,4 +1,5 @@
 using System;
+using Raven.Abstractions.Data;
 using Raven.Client;
 using Raven.Client.Document;
 using Xunit;
@@ -89,6 +90,30 @@ namespace Raven.Tests.Querying
 		{
 			Assert.Equal(CreateUserQuery().Search("Name", "ayende").ToString(),
 				CreateUserQuery().Search(x => x.Name, "ayende").ToString());
+		}
+	
+		[Fact]
+		public void CanUseStronglyTypedAddOrder()
+		{
+			CreateUserQuery().AddOrder(x => x.Birthday, false);
+		}
+
+		[Fact]
+		public void CanUseStronglyTypedOrderBy()
+		{
+			CreateUserQuery().OrderBy(x => x.Birthday);
+		}
+
+		[Fact]
+		public void CanUseStronglyTypedSearch()
+		{
+			CreateUserQuery().Search(x => x.Birthday, "1975");
+		}
+	
+		[Fact]
+		public void CanUseStronglyTypedGroupBy()
+		{
+			CreateUserQuery().GroupBy(AggregationOperation.None, x => x.Birthday);
 		}
 	}
 }


### PR DESCRIPTION
Sorry, my fault - haven't tested this with properties that would result in a Convert expression
