### PR TITLE
Fixes a bug in the Document Count Quotas bundle, and cleans up the naming of the triggers

### DIFF
--- a/Bundles/Raven.Bundles.Quotas/Documents/Triggers/DocumentCountQuotaForDocumentDeleteTrigger.cs
+++ b/Bundles/Raven.Bundles.Quotas/Documents/Triggers/DocumentCountQuotaForDocumentDeleteTrigger.cs
@@ -1,13 +1,12 @@
-using Raven.Bundles.Quotas.Size;
 using Raven.Database.Plugins;
 
 namespace Raven.Bundles.Quotas.Documents.Triggers
 {
-	public class DatabaseCountDocumentDeleteTrigger : AbstractDeleteTrigger
+	public class DocumentCountQuotaForDocumentDeleteTrigger : AbstractDeleteTrigger
 	{
 		public override void AfterDelete(string key, Abstractions.Data.TransactionInformation transactionInformation)
 		{
-			SizeQuotaConfiguration.GetConfiguration(Database).AfterDelete();
+			DocQuotaConfiguration.GetConfiguration(Database).AfterDelete();
 		}
 	}
 }

--- a/Bundles/Raven.Bundles.Quotas/Documents/Triggers/DocumentCountQuotaForDocumentsPutTrigger.cs
+++ b/Bundles/Raven.Bundles.Quotas/Documents/Triggers/DocumentCountQuotaForDocumentsPutTrigger.cs
@@ -2,16 +2,14 @@ using Raven.Abstractions.Data;
 using Raven.Database.Plugins;
 using Raven.Json.Linq;
 
-namespace Raven.Bundles.Quotas.Size.Triggers
+namespace Raven.Bundles.Quotas.Documents.Triggers
 {
-	public class DatabaseSizeQoutaForDocumentsPutTrigger : AbstractPutTrigger
+	public class DocumentCountQuotaForDocumentsPutTrigger : AbstractPutTrigger
 	{
-		
-		
 		public override VetoResult AllowPut(string key, RavenJObject document, RavenJObject metadata,
 		                                    TransactionInformation transactionInformation)
 		{
-			return SizeQuotaConfiguration.GetConfiguration(Database).AllowPut();
+			return DocQuotaConfiguration.GetConfiguration(Database).AllowPut();
 		}
 
 	}

--- a/Bundles/Raven.Bundles.Quotas/Raven.Bundles.Quotas.csproj
+++ b/Bundles/Raven.Bundles.Quotas/Raven.Bundles.Quotas.csproj
@@ -51,13 +51,13 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Documents\DocQuotaConfiguration.cs" />
-    <Compile Include="Documents\Triggers\DatabaseCountDocumentDeleteTrigger.cs" />
-    <Compile Include="Documents\Triggers\DatabaseCountQoutaForDocumentsPutTrigger.cs" />
+    <Compile Include="Documents\Triggers\DocumentCountQuotaForDocumentDeleteTrigger.cs" />
+    <Compile Include="Documents\Triggers\DocumentCountQuotaForDocumentsPutTrigger.cs" />
     <Compile Include="Size\SizeQuotaConfiguration.cs" />
-    <Compile Include="Size\Triggers\DatabaseSizeAttachmentDeleteTrigger.cs" />
-    <Compile Include="Size\Triggers\DatabaseSizeDocumentDeleteTrigger.cs" />
-    <Compile Include="Size\Triggers\DatabaseSizeQoutaForAttachmentsPutTrigger.cs" />
-    <Compile Include="Size\Triggers\DatabaseSizeQoutaForDocumentsPutTrigger.cs" />
+    <Compile Include="Size\Triggers\DatabaseSizeQuotaForAttachmentDeleteTrigger.cs" />
+    <Compile Include="Size\Triggers\DatabaseSizeQuotaForDocumentDeleteTrigger.cs" />
+    <Compile Include="Size\Triggers\DatabaseSizeQuotaForAttachmentsPutTrigger.cs" />
+    <Compile Include="Size\Triggers\DatabaseSizeQuotaForDocumentsPutTrigger.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Raven.Abstractions\Raven.Abstractions.csproj">

--- a/Bundles/Raven.Bundles.Quotas/Size/Triggers/DatabaseSizeQuotaForAttachmentDeleteTrigger.cs
+++ b/Bundles/Raven.Bundles.Quotas/Size/Triggers/DatabaseSizeQuotaForAttachmentDeleteTrigger.cs
@@ -2,7 +2,7 @@
 
 namespace Raven.Bundles.Quotas.Size.Triggers
 {
-	public class DatabaseSizeAttachmentDeleteTrigger : AbstractDeleteTrigger
+	public class DatabaseSizeQuotaForAttachmentDeleteTrigger : AbstractDeleteTrigger
 	{
 		public override void AfterDelete(string key, Abstractions.Data.TransactionInformation transactionInformation)
 		{

--- a/Bundles/Raven.Bundles.Quotas/Size/Triggers/DatabaseSizeQuotaForAttachmentsPutTrigger.cs
+++ b/Bundles/Raven.Bundles.Quotas/Size/Triggers/DatabaseSizeQuotaForAttachmentsPutTrigger.cs
@@ -4,7 +4,7 @@ using Raven.Json.Linq;
 
 namespace Raven.Bundles.Quotas.Size.Triggers
 {
-	public class DatabaseSizeQoutaForAttachmentsPutTrigger : AbstractAttachmentPutTrigger
+	public class DatabaseSizeQuotaForAttachmentsPutTrigger : AbstractAttachmentPutTrigger
 	{
 		public override VetoResult AllowPut(string key, Stream data, RavenJObject metadata)
 		{

--- a/Bundles/Raven.Bundles.Quotas/Size/Triggers/DatabaseSizeQuotaForDocumentDeleteTrigger.cs
+++ b/Bundles/Raven.Bundles.Quotas/Size/Triggers/DatabaseSizeQuotaForDocumentDeleteTrigger.cs
@@ -2,7 +2,7 @@ using Raven.Database.Plugins;
 
 namespace Raven.Bundles.Quotas.Size.Triggers
 {
-	public class DatabaseSizeDocumentDeleteTrigger : AbstractDeleteTrigger
+	public class DatabaseSizeQuotaForDocumentDeleteTrigger : AbstractDeleteTrigger
 	{
 		public override void AfterDelete(string key, Abstractions.Data.TransactionInformation transactionInformation)
 		{

--- a/Bundles/Raven.Bundles.Quotas/Size/Triggers/DatabaseSizeQuotaForDocumentsPutTrigger.cs
+++ b/Bundles/Raven.Bundles.Quotas/Size/Triggers/DatabaseSizeQuotaForDocumentsPutTrigger.cs
@@ -1,12 +1,13 @@
 using Raven.Abstractions.Data;
-using Raven.Bundles.Quotas.Size;
 using Raven.Database.Plugins;
 using Raven.Json.Linq;
 
-namespace Raven.Bundles.Quotas.Documents.Triggers
+namespace Raven.Bundles.Quotas.Size.Triggers
 {
-	public class DatabaseCountQoutaForDocumentsPutTrigger : AbstractPutTrigger
+	public class DatabaseSizeQuotaForDocumentsPutTrigger : AbstractPutTrigger
 	{
+		
+		
 		public override VetoResult AllowPut(string key, RavenJObject document, RavenJObject metadata,
 		                                    TransactionInformation transactionInformation)
 		{


### PR DESCRIPTION
The bug was that the DatabaseCountQoutaForDocumentsPutTrigger and DatabaseCountDocumentDeleteTrigger were using the SizeQuotaConfiguration, not the DocQuotaConfiguration.

I also corrected the typo "Qoutas" ==> "Quotas" and made the name of all the triggers in the Quotas bundle consistent with each other. 
