### PR TITLE
Fix for possible integer overflow during calculation

### DIFF
--- a/Raven.Storage.Esent/TransactionalStorageConfigurator.cs
+++ b/Raven.Storage.Esent/TransactionalStorageConfigurator.cs
@@ -59,7 +59,7 @@ namespace Raven.Storage.Esent
 		public void LimitSystemCache()
 		{
 			var defaultCacheSize = Environment.Is64BitProcess ? 1024 : 256;
-			int cacheSizeMaxInMegabytes = GetValueFromConfiguration("Raven/Esent/CacheSizeMax",defaultCacheSize);
+			int cacheSizeMaxInMegabytes = GetValueFromConfiguration("Raven/Esent/CacheSizeMax", defaultCacheSize);
 			int cacheSizeMax = TranslateToSizeInDatabasePages(cacheSizeMaxInMegabytes, 1024 * 1024);
 			if (SystemParameters.CacheSizeMax > cacheSizeMax)
 			{
@@ -69,8 +69,10 @@ namespace Raven.Storage.Esent
 
 		private static int TranslateToSizeInDatabasePages(int sizeInMegabytes, int multiply)
 		{
-			var sizeInBytes = sizeInMegabytes * multiply;
-			return sizeInBytes / SystemParameters.DatabasePageSize;
+			//This doesn't suffer from overflow, do the division first (to make the number smaller) then multiply afterwards
+			double tempAmt = (double)sizeInMegabytes / SystemParameters.DatabasePageSize;
+			int finalSize = (int)(tempAmt * multiply);
+			return finalSize;
 		}
 
 		private int GetValueFromConfiguration(string name, int defaultValue)


### PR DESCRIPTION
This is a bit of a wierd one, but if you set "Raven/Esent/CacheSizeMax" to 2048 or larger it'll cause an overflow in "TranslateToSizeInDatabasePages". I know that setting the esent cache this high is unusual, but this function is used in other places.

I've put up a gist that better shows the problem, see https://gist.github.com/2780720. Also this will show up in 32-bit and 64-bit as int is 32-bit in both see http://stackoverflow.com/questions/651956/sizeofint-on-x64 (you probably knew this, but just in case!)
