### PR TITLE
Fixing the advanced facet api (strongly typed version)

### DIFF
--- a/Raven.Abstractions/Data/Facet.cs
+++ b/Raven.Abstractions/Data/Facet.cs
@@ -69,14 +69,12 @@ namespace Raven.Abstractions.Data
 		{
 			Expression body = expr.Body;
 
-			var param = (ParameterExpression)expr.Parameters[0];
 			var operation = (BinaryExpression)expr.Body;
 
 			if (operation.Left is MemberExpression)
 			{
 				var subExpressionValue = ParseSubExpression(operation);
-				var left = (MemberExpression)operation.Left;
-				var expression = GetStringRepresentation(left.Member.Name, operation.NodeType, subExpressionValue);                
+				var expression = GetStringRepresentation(operation.NodeType, subExpressionValue);
 				return expression;
 			}
 
@@ -96,8 +94,7 @@ namespace Raven.Abstractions.Data
 										leftMember.Member.Name == rightMember.Member.Name;
 				if (validOperators && validMemberNames)
 				{
-					return GetStringRepresentation(leftMember.Member.Name, right.NodeType, 
-													ParseSubExpression(left), ParseSubExpression(right));
+					return GetStringRepresentation(right.NodeType, ParseSubExpression(left), ParseSubExpression(right));
 				}
 			}
 			throw new InvalidOperationException("Members in sub-expression(s) are not the correct types (expected \"<\" and \">\")");
@@ -133,9 +130,9 @@ namespace Raven.Abstractions.Data
 					var property = right.Member as PropertyInfo;
 					if (property != null && right.Member != null)
 					{
-						//This chokes on annonomyous types!?													
+						//This chokes on annonomyous types!?
 						var value = property.GetValue(property, null);
-						return value;						
+						return value;
 					}
 				}
 			}
@@ -153,24 +150,22 @@ namespace Raven.Abstractions.Data
 									operation.Left.GetType().Name, operation.NodeType, operation.Right.GetType().Name));
 		}
 
-		private static string GetStringRepresentation<U>(string fieldName, ExpressionType op, U value)
+		private static string GetStringRepresentation<U>(ExpressionType op, U value)
 		{
 			var valueAsStr = GetStringValue(value);
-			var fullFieldName = value.GetType().FullName == "System.String" ? fieldName : fieldName + "_Range";
 			if (op == ExpressionType.LessThan)
-				return String.Format("{0}:[NULL TO {1}]", fullFieldName, valueAsStr);
+				return String.Format("[NULL TO {0}]", valueAsStr);
 			if (op == ExpressionType.GreaterThan)
-				return String.Format("{0}:[{1} TO NULL]", fullFieldName, valueAsStr);
+				return String.Format("[{0} TO NULL]", valueAsStr);
 			throw new InvalidOperationException("Unable to parse the given operation " + op + ", into a facet range!!! ");
 		}
 
-		private static string GetStringRepresentation<U, V>(string fieldName, ExpressionType op, U lValue, V rValue)
+		private static string GetStringRepresentation<U, V>(ExpressionType op, U lValue, V rValue)
 		{
 			var lValueAsStr = GetStringValue(lValue);
 			var rValueAsStr = GetStringValue(rValue);
-			var fullFieldName = lValue.GetType().FullName == "System.String" ? fieldName : fieldName + "_Range";
 			if (lValueAsStr != null && rValueAsStr != null)
-				return String.Format("{0}:[{1} TO {2}]", fullFieldName, lValueAsStr, rValueAsStr);            
+				return String.Format("[{0} TO {1}]", lValueAsStr, rValueAsStr);
 			throw new InvalidOperationException("Unable to parse the given operation " + op + ", into a facet range!!! ");
 		}
 

--- a/Raven.Tests/Faceted/FacetAdvancedAPI.cs
+++ b/Raven.Tests/Faceted/FacetAdvancedAPI.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Raven.Abstractions.Data;
 using Xunit;
 
@@ -31,11 +30,11 @@ namespace Raven.Tests.Faceted
 					Mode = FacetMode.Ranges,
 					Ranges =
 					{
-						"[NULL TO Dx200.0]",
-						"[Dx200.0 TO Dx400.0]",
-						"[Dx400.0 TO Dx600.0]",
-						"[Dx600.0 TO Dx800.0]",
-						"[Dx800.0 TO NULL]",
+						"[NULL TO Dx200]",
+						"[Dx200 TO Dx400]",
+						"[Dx400 TO Dx600]",
+						"[Dx600 TO Dx800]",
+						"[Dx800 TO NULL]",
 					}
 				},
 				new Facet
@@ -139,7 +138,7 @@ namespace Raven.Tests.Faceted
 			var facet = TriggerConversion(edgeCaseFacet);
 			Assert.Equal(2, facet.Ranges.Count);
 			Assert.False(String.IsNullOrWhiteSpace(facet.Ranges[0]));
-			Assert.Equal("Date_Range:[20101205000000000 TO 20011205000000000]", facet.Ranges[1]);
+			Assert.Equal("[20101205000000000 TO 20011205000000000]", facet.Ranges[1]);
 		}
 
 		private bool AreFacetsEqual(Facet left, Facet right)
@@ -147,7 +146,7 @@ namespace Raven.Tests.Faceted
 			return left.Name == right.Name &&
 				left.Mode == right.Mode &&
 				left.Ranges.Count == right.Ranges.Count &&
-				left.Ranges.All(x => left.Ranges.Contains(x));
+				left.Ranges.All(x => right.Ranges.Contains(x));
 		}
 
 		private Facet TriggerConversion(Facet<Test> facet)


### PR DESCRIPTION
This is a fix for the issue here https://groups.google.com/d/msg/ravendb/bwCVpLC6Lhw/gNcPccvmdDAJ, well at least the error, if not the nullable type handling.

I know you've already fixed it (https://github.com/ayende/ravendb/commit/d603b181ba651a969f1eefba4f295906122a0272), but maybe the unit tests are useful?
