### PR TITLE
Add support for virtually limitless terms for facets

### DIFF
--- a/Raven.Abstractions/Data/Facet.cs
+++ b/Raven.Abstractions/Data/Facet.cs
@@ -7,10 +7,14 @@ namespace Raven.Abstractions.Data
 		public FacetMode Mode { get; set; }
 		public string Name { get; set; }
 		public List<string> Ranges { get; set; }
+		public int? MaxResults { get; set; }
+		public FacetTermSortMode TermSortMode { get; set; }
+		public bool InclueRemainingTerms { get; set; }
 
 		public Facet()
 		{
 			Ranges = new List<string>();
+			TermSortMode = FacetTermSortMode.ValueAsc;
 		}
 	}
 }

--- a/Raven.Abstractions/Data/FacetResult.cs
+++ b/Raven.Abstractions/Data/FacetResult.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Raven.Abstractions.Data
+{
+	public class FacetResult
+	{
+		/// <summary>
+		/// The facet terms and hits up to a limit of MaxResults items (as specified in the facet setup document), sorted
+		/// in TermSortMode order (as indiciated in the facet setup document).
+		/// </summary>
+		public List<FacetValue> Values { get; set; }
+		/// <summary>
+		/// A list of remaining terms in term sort order for terms that are outside of the MaxResults count.
+		/// </summary>
+		public List<string> RemainingTerms { get; set; }
+		/// <summary>
+		/// The number of remaining terms outside of those covered by the Values terms.
+		/// </summary>
+		public int RemainingTermsCount { get; set; }
+		/// <summary>
+		/// The number of remaining hits outside of those covered by the Values terms.
+		/// </summary>
+		public int RemainingHits { get; set; }
+
+		public FacetResult()
+		{
+			Values = new List<FacetValue>();
+		}
+	}
+}

--- a/Raven.Abstractions/Data/FacetResults.cs
+++ b/Raven.Abstractions/Data/FacetResults.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Raven.Abstractions.Data
+{
+	public class FacetResults
+	{
+		/// <summary>
+		/// A list of results for the facet.  One entry for each term/range as specified in the facet setup document.
+		/// </summary>
+		public Dictionary<string, FacetResult> Results { get; set; }
+
+		public FacetResults()
+		{
+			Results = new Dictionary<string, FacetResult>();
+		}
+	}
+}

--- a/Raven.Abstractions/Data/FacetTermSortMode.cs
+++ b/Raven.Abstractions/Data/FacetTermSortMode.cs
@@ -1,0 +1,10 @@
+namespace Raven.Abstractions.Data
+{
+	public enum FacetTermSortMode
+	{
+		ValueAsc,
+		ValueDesc,
+		HitsAsc,
+		HitsDesc,
+	}
+}

--- a/Raven.Abstractions/Data/FacetValue.cs
+++ b/Raven.Abstractions/Data/FacetValue.cs
@@ -3,6 +3,6 @@
 	public class FacetValue
 	{
 		public string Range { get; set; }
-		public int Count { get; set; }
+		public int Hits { get; set; }
 	}
 }

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -75,6 +75,9 @@
     <Compile Include="Data\BuildNumber.cs" />
     <Compile Include="Data\ConnectionStringParser.cs" />
     <Compile Include="Data\Constants.cs" />
+    <Compile Include="Data\FacetTermSortMode.cs" />
+    <Compile Include="Data\FacetResults.cs" />
+    <Compile Include="Data\FacetResult.cs" />
     <Compile Include="Data\DatabaseDocument.cs" />
     <Compile Include="Data\DatabaseStatistics.cs" />
     <Compile Include="Commands\ICommandData.cs" />

--- a/Raven.Client.Embedded/EmbeddedDatabaseCommands.cs
+++ b/Raven.Client.Embedded/EmbeddedDatabaseCommands.cs
@@ -603,7 +603,7 @@ namespace Raven.Client.Embedded
 	    /// <param name="query"></param>
 	    /// <param name="facetSetupDoc"></param>
 	    /// <returns></returns>
-	    public IDictionary<string, IEnumerable<FacetValue>> GetFacets(string index, IndexQuery query, string facetSetupDoc)
+	    public FacetResults GetFacets(string index, IndexQuery query, string facetSetupDoc)
 		{
 			CurrentOperationContext.Headers.Value = OperationsHeaders;
 			return database.ExecuteGetTermsQuery(index, query, facetSetupDoc);

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -415,7 +415,7 @@ namespace Raven.Client.Connection.Async
 		/// <summary>
 		/// Using the given Index, calculate the facets as per the specified doc
 		/// </summary>
-		public Task<IDictionary<string, IEnumerable<FacetValue>>> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc)
+		public Task<FacetResults> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc)
 		{
 			var requestUri = url + string.Format("/facets/{0}?facetDoc={1}&query={2}",
 			Uri.EscapeUriString(index),
@@ -430,7 +430,7 @@ namespace Raven.Client.Connection.Async
 				.ContinueWith(task =>
 				{
 					var json = (RavenJObject) task.Result;
-					return json.JsonDeserialization<IDictionary<string, IEnumerable<FacetValue>>>();
+					return json.JsonDeserialization<FacetResults>();
 				});
 		}
 

--- a/Raven.Client.Lightweight/Connection/Async/IAsyncDatabaseCommands.cs
+++ b/Raven.Client.Lightweight/Connection/Async/IAsyncDatabaseCommands.cs
@@ -228,7 +228,7 @@ namespace Raven.Client.Connection.Async
 		/// <summary>
 		/// Using the given Index, calculate the facets as per the specified doc
 		/// </summary>
-		Task<IDictionary<string, IEnumerable<FacetValue>>> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc);
+		Task<FacetResults> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc);
 
 		Task<LogItem[]> GetLogsAsync(bool errorsOnly);
 

--- a/Raven.Client.Lightweight/Connection/IDatabaseCommands.cs
+++ b/Raven.Client.Lightweight/Connection/IDatabaseCommands.cs
@@ -286,7 +286,7 @@ namespace Raven.Client.Connection
 		/// <summary>
 		/// Using the given Index, calculate the facets as per the specified doc
 		/// </summary>
-		IDictionary<string, IEnumerable<FacetValue>> GetFacets(string index, IndexQuery query, string facetSetupDoc);
+		FacetResults GetFacets(string index, IndexQuery query, string facetSetupDoc);
 
 		/// <summary>
 		/// Sends a patch request for a specific document, ignoring the document's Etag

--- a/Raven.Client.Lightweight/Connection/ServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/ServerClient.cs
@@ -1340,7 +1340,7 @@ Failed to get in touch with any of the " + (1 + threadSafeCopy.Count) + " Raven 
 		/// <param name="query"></param>
 		/// <param name="facetSetupDoc"></param>
 		/// <returns></returns>
-		public IDictionary<string, IEnumerable<FacetValue>> GetFacets(string index, IndexQuery query, string facetSetupDoc)
+		public FacetResults GetFacets(string index, IndexQuery query, string facetSetupDoc)
 		{
 			return ExecuteWithReplication("GET", operationUrl =>
 			{
@@ -1354,7 +1354,7 @@ Failed to get in touch with any of the " + (1 + threadSafeCopy.Count) + " Raven 
 						.AddOperationHeaders(OperationsHeaders));
 				
 				var json = (RavenJObject)request.ReadResponseJson();
-				return json.JsonDeserialization<IDictionary<string, IEnumerable<FacetValue>>>();
+				return json.JsonDeserialization<FacetResults>();
 			});
 		}
 

--- a/Raven.Client.Lightweight/Document/Batches/LazyFacetsOperation.cs
+++ b/Raven.Client.Lightweight/Document/Batches/LazyFacetsOperation.cs
@@ -48,27 +48,39 @@ namespace Raven.Client.Document.Batches
 			}
 
 			var result = RavenJObject.Parse(response.Result);
-			Result = result.JsonDeserialization<IDictionary<string, IEnumerable<FacetValue>>>();
+			Result = result.JsonDeserialization<FacetResults>();
 		}
 
 #if !SILVERLIGHT
 		public void HandleResponses(GetResponse[] responses, ShardStrategy shardStrategy)
 		{
-			var result = new Dictionary<string, IEnumerable<FacetValue>>();
+			var result = new FacetResults();
 
-			IEnumerable<IGrouping<string, KeyValuePair<string, IEnumerable<FacetValue>>>> list = responses.Select(response => RavenJObject.Parse(response.Result))
-				.SelectMany(jsonResult => jsonResult.JsonDeserialization<IDictionary<string, IEnumerable<FacetValue>>>())
-				.GroupBy(x => x.Key);
-
-			foreach (var facet in list)
+			foreach(var response in responses.Select(response => RavenJObject.Parse(response.Result)))
 			{
-				var individualFacet = facet.SelectMany(x=>x.Value).GroupBy(x=>x.Range)
-					.Select(g=>new FacetValue
+				var facet = response.JsonDeserialization<FacetResults>();
+				foreach(var facetResult in facet.Results)
+				{
+					if (!result.Results.ContainsKey(facetResult.Key))
+						result.Results[facetResult.Key] = new FacetResult();
+
+					var newFacetResult = result.Results[facetResult.Key];
+
+					foreach (var facetValue in facetResult.Value.Values)
 					{
-						Count = g.Sum(y=>y.Count),
-						Range = g.Key
-					});
-				result[facet.Key] = individualFacet.ToList();
+						var existingFacetValueRange = newFacetResult.Values.Find((x) => x.Range == facetValue.Range);
+						if(existingFacetValueRange != null)
+							existingFacetValueRange.Hits += facetValue.Hits;
+						else
+							newFacetResult.Values.Add(new FacetValue() { Hits = facetValue.Hits, Range = facetValue.Range });
+					}
+
+					foreach (var facetTerm in facetResult.Value.RemainingTerms)
+					{
+						if(!newFacetResult.RemainingTerms.Contains(facetTerm))
+							newFacetResult.RemainingTerms.Add(facetTerm);
+					}
+				}
 			}
 
 			Result = result;

--- a/Raven.Client.Lightweight/Linq/LinqExtensions.cs
+++ b/Raven.Client.Lightweight/Linq/LinqExtensions.cs
@@ -28,7 +28,7 @@ namespace Raven.Client.Linq
 		/// <summary>
 		/// Query the facets results for this query using the specified facet document
 		/// </summary>
-		public static IDictionary<string, IEnumerable<FacetValue>> ToFacets<T>(this IQueryable<T> queryable, string facetDoc)
+		public static FacetResults ToFacets<T>(this IQueryable<T> queryable, string facetDoc)
 		{
 			var ravenQueryInspector = ((IRavenQueryInspector)queryable);
 			var query = ravenQueryInspector.ToString();
@@ -40,7 +40,7 @@ namespace Raven.Client.Linq
 #endif
 
 #if !NET_3_5 && !SILVERLIGHT
-		public static Lazy<IDictionary<string, IEnumerable<FacetValue>>> ToFacetsLazy<T>(this IQueryable<T> queryable, string facetDoc)
+		public static Lazy<FacetResults> ToFacetsLazy<T>(this IQueryable<T> queryable, string facetDoc)
 		{
 			var ravenQueryInspector = ((IRavenQueryInspector)queryable);
 			var query = ravenQueryInspector.ToString();
@@ -48,7 +48,7 @@ namespace Raven.Client.Linq
 			var lazyOperation = new LazyFacetsOperation(ravenQueryInspector.IndexQueried, facetDoc, new IndexQuery { Query = query });
 
 			var documentSession = ((DocumentSession)ravenQueryInspector.Session);
-			return documentSession.AddLazyOperation<IDictionary<string, IEnumerable<FacetValue>>>(lazyOperation, null);
+			return documentSession.AddLazyOperation<FacetResults>(lazyOperation, null);
 		}
 #endif
 
@@ -59,7 +59,7 @@ namespace Raven.Client.Linq
 		/// <summary>
 		/// Query the facets results for this query using the specified facet document
 		/// </summary>
-		public static Task<IDictionary<string, IEnumerable<FacetValue>>> ToFacetsAsync<T>(this IQueryable<T> queryable, string facetDoc)
+		public static Task<FacetResults> ToFacetsAsync<T>(this IQueryable<T> queryable, string facetDoc)
 		{
 			var ravenQueryInspector = ((RavenQueryInspector<T>)queryable);
 			var query = ravenQueryInspector.ToString();

--- a/Raven.Client.Silverlight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Silverlight/Connection/Async/AsyncServerClient.cs
@@ -348,7 +348,7 @@ namespace Raven.Client.Silverlight.Connection.Async
 		/// <summary>
 		/// Using the given Index, calculate the facets as per the specified doc
 		/// </summary>
-		public Task<IDictionary<string, IEnumerable<FacetValue>>> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc)
+		public Task<FacetResults> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc)
 		{
 			var requestUri = url + string.Format("/facets/{0}?facetDoc={1}&query={2}",
 			Uri.EscapeUriString(index),
@@ -362,7 +362,7 @@ namespace Raven.Client.Silverlight.Connection.Async
 				.ContinueWith(task =>
 				{
 					var json = (RavenJObject)task.Result;
-					return json.JsonDeserialization<IDictionary<string, IEnumerable<FacetValue>>>();
+					return json.JsonDeserialization<FacetResults>();
 				});
 		}
 

--- a/Raven.Client.Silverlight/Raven.Client.Silverlight.csproj
+++ b/Raven.Client.Silverlight/Raven.Client.Silverlight.csproj
@@ -106,8 +106,17 @@
     <Compile Include="..\Raven.Abstractions\Data\FacetMode.cs">
       <Link>Imports\Data\FacetMode.cs</Link>
     </Compile>
+    <Compile Include="..\Raven.Abstractions\Data\FacetResult.cs">
+      <Link>Imports\Data\FacetResult.cs</Link>
+    </Compile>
+    <Compile Include="..\Raven.Abstractions\Data\FacetResults.cs">
+      <Link>Imports\Data\FacetResults.cs</Link>
+    </Compile>
     <Compile Include="..\Raven.Abstractions\Data\FacetSetup.cs">
       <Link>Imports\Data\FacetSetup.cs</Link>
+    </Compile>
+    <Compile Include="..\Raven.Abstractions\Data\FacetTermSortMode.cs">
+      <Link>Imports\Data\FacetTermSortMode.cs</Link>
     </Compile>
     <Compile Include="..\Raven.Abstractions\Data\FacetValue.cs">
       <Link>Imports\Data\FacetValue.cs</Link>

--- a/Raven.Database/Queries/FacetedQueryRunnerExtensions.cs
+++ b/Raven.Database/Queries/FacetedQueryRunnerExtensions.cs
@@ -11,7 +11,7 @@ namespace Raven.Database.Queries
 {
 	public static class FacetedQueryRunnerExtensions
 	{
-		public static IDictionary<string, IEnumerable<FacetValue>> ExecuteGetTermsQuery(this DocumentDatabase self,
+		public static FacetResults ExecuteGetTermsQuery(this DocumentDatabase self,
 			string index, IndexQuery query, string facetSetupDoc)
 		{
 			return new FacetedQueryRunner(self).GetFacets(index, query, facetSetupDoc);

--- a/Raven.Database/Queries/TermsQueryRunner.cs
+++ b/Raven.Database/Queries/TermsQueryRunner.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using Lucene.Net.Index;

--- a/Raven.Tests/Faceted/FacetedIndexLimit.cs
+++ b/Raven.Tests/Faceted/FacetedIndexLimit.cs
@@ -1,0 +1,297 @@
+//-----------------------------------------------------------------------
+// <copyright file="FacetedIndex.cs" company="Hibernating Rhinos LTD">
+//     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Abstractions.Data;
+using Raven.Client;
+using Raven.Client.Linq;
+using Xunit;
+using Raven.Abstractions.Indexing;
+using System.Threading;
+using System.Linq.Expressions;
+using Raven.Client.Document;
+
+namespace Raven.Tests.Faceted
+{
+	public class FacetedIndexLimit : RavenTest
+	{
+		private readonly IList<Camera> _data;
+		private const int NumCameras = 1000;
+
+		public FacetedIndexLimit()
+		{
+			_data = FacetedIndexTestHelper.GetCameras(NumCameras);
+		}
+
+		[Fact]
+		public void CanPerformSearchWithTwoDefaultFacets()
+		{
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer" }, new Facet { Name = "Model" } };
+
+			using (var store = NewDocumentStore())
+			{
+				Setup(store);
+
+				using(var s = store.OpenSession())
+				{
+					s.Store(new FacetSetup { Id = "facets/CameraFacets", Facets = facets });
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>("CameraCost")
+						.ToFacets("facets/CameraFacets");
+
+					Assert.Equal(5, facetResults.Results["Manufacturer"].Values.Count());
+					Assert.Equal("canon", facetResults.Results["Manufacturer"].Values[0].Range);
+					Assert.Equal("jessops", facetResults.Results["Manufacturer"].Values[1].Range);
+					Assert.Equal("nikon", facetResults.Results["Manufacturer"].Values[2].Range);
+					Assert.Equal("phillips", facetResults.Results["Manufacturer"].Values[3].Range);
+					Assert.Equal("sony", facetResults.Results["Manufacturer"].Values[4].Range);
+
+					foreach (var facet in facetResults.Results["Manufacturer"].Values)
+					{
+						var inMemoryCount = _data.Where(x => x.Manufacturer.ToLower() == facet.Range).Count();
+						Assert.Equal(inMemoryCount, facet.Hits);
+					}
+
+					Assert.Equal(null, facetResults.Results["Manufacturer"].RemainingTerms);
+					Assert.Equal(0, facetResults.Results["Manufacturer"].RemainingTermsCount);
+					Assert.Equal(0, facetResults.Results["Manufacturer"].RemainingHits);
+
+					Assert.Equal(5, facetResults.Results["Model"].Values.Count());
+					Assert.Equal("model1", facetResults.Results["Model"].Values[0].Range);
+					Assert.Equal("model2", facetResults.Results["Model"].Values[1].Range);
+					Assert.Equal("model3", facetResults.Results["Model"].Values[2].Range);
+					Assert.Equal("model4", facetResults.Results["Model"].Values[3].Range);
+					Assert.Equal("model5", facetResults.Results["Model"].Values[4].Range);
+
+					foreach (var facet in facetResults.Results["Model"].Values)
+					{
+						var inMemoryCount = _data.Where(x => x.Model.ToLower() == facet.Range).Count();
+						Assert.Equal(inMemoryCount, facet.Hits);
+					}
+
+					Assert.Equal(null, facetResults.Results["Model"].RemainingTerms);
+					Assert.Equal(0, facetResults.Results["Model"].RemainingTermsCount);
+					Assert.Equal(0, facetResults.Results["Model"].RemainingHits);
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedLimitSearch_TermAsc()
+		{
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 2, InclueRemainingTerms = true } };
+
+			using (var store = NewDocumentStore())
+			{
+				Setup(store);
+
+				using(var s = store.OpenSession())
+				{
+					s.Store(new FacetSetup { Id = "facets/CameraFacets", Facets = facets });
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>("CameraCost")
+						.Where(x => x.DateOfListing > new DateTime(2000, 1, 1))
+						.ToFacets("facets/CameraFacets");
+
+					Assert.Equal(2, facetResults.Results["Manufacturer"].Values.Count());
+					Assert.Equal("canon", facetResults.Results["Manufacturer"].Values[0].Range);
+					Assert.Equal("jessops", facetResults.Results["Manufacturer"].Values[1].Range);
+
+					foreach (var facet in facetResults.Results["Manufacturer"].Values)
+					{
+						var inMemoryCount = _data.Where(x => x.DateOfListing > new DateTime(2000, 1, 1)).Where(x => x.Manufacturer.ToLower() == facet.Range).Count();
+						Assert.Equal(inMemoryCount, facet.Hits);
+					}
+
+					Assert.Equal(3, facetResults.Results["Manufacturer"].RemainingTermsCount);
+					Assert.Equal(3, facetResults.Results["Manufacturer"].RemainingTerms.Count());
+					Assert.Equal("nikon", facetResults.Results["Manufacturer"].RemainingTerms[0]);
+					Assert.Equal("phillips", facetResults.Results["Manufacturer"].RemainingTerms[1]);
+					Assert.Equal("sony", facetResults.Results["Manufacturer"].RemainingTerms[2]);
+
+					Assert.Equal(_data.Count(x => x.DateOfListing > new DateTime(2000, 1, 1)),
+						facetResults.Results["Manufacturer"].Values[0].Hits +
+						facetResults.Results["Manufacturer"].Values[1].Hits +
+						facetResults.Results["Manufacturer"].RemainingHits);
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedLimitSearch_TermDesc()
+		{
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueDesc, InclueRemainingTerms = true } };
+
+			using (var store = NewDocumentStore())
+			{
+				Setup(store);
+
+				using(var s = store.OpenSession())
+				{
+					s.Store(new FacetSetup { Id = "facets/CameraFacets", Facets = facets });
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>("CameraCost")
+						.Where(x => x.DateOfListing > new DateTime(2000, 1, 1))
+						.ToFacets("facets/CameraFacets");
+
+					Assert.Equal(3, facetResults.Results["Manufacturer"].Values.Count());
+					Assert.Equal("sony", facetResults.Results["Manufacturer"].Values[0].Range);
+					Assert.Equal("phillips", facetResults.Results["Manufacturer"].Values[1].Range);
+					Assert.Equal("nikon", facetResults.Results["Manufacturer"].Values[2].Range);
+
+					foreach (var facet in facetResults.Results["Manufacturer"].Values)
+					{
+						var inMemoryCount = _data.Where(x => x.DateOfListing > new DateTime(2000, 1, 1)).Where(x => x.Manufacturer.ToLower() == facet.Range).Count();
+						Assert.Equal(inMemoryCount, facet.Hits);
+					}
+
+					Assert.Equal(2, facetResults.Results["Manufacturer"].RemainingTermsCount);
+					Assert.Equal(2, facetResults.Results["Manufacturer"].RemainingTerms.Count());
+					Assert.Equal("jessops", facetResults.Results["Manufacturer"].RemainingTerms[0]);
+					Assert.Equal("canon", facetResults.Results["Manufacturer"].RemainingTerms[1]);
+
+					Assert.Equal(_data.Count(x => x.DateOfListing > new DateTime(2000, 1, 1)),
+						facetResults.Results["Manufacturer"].Values[0].Hits +
+						facetResults.Results["Manufacturer"].Values[1].Hits +
+						facetResults.Results["Manufacturer"].Values[2].Hits +
+						facetResults.Results["Manufacturer"].RemainingHits);
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedLimitSearch_HitsAsc()
+		{
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 2, TermSortMode = FacetTermSortMode.HitsAsc, InclueRemainingTerms = true } };
+
+			using (var store = NewDocumentStore())
+			{
+				Setup(store);
+
+				using(var s = store.OpenSession())
+				{
+					s.Store(new FacetSetup { Id = "facets/CameraFacets", Facets = facets });
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>("CameraCost")
+						.ToFacets("facets/CameraFacets");
+
+					var cameraCounts = from d in _data
+					                  group d by d.Manufacturer
+					                  into result
+					                  select new {Manufacturer = result.Key, Count = result.Count()};
+					var camerasByHits = cameraCounts.OrderBy(x => x.Count).Select(x => x.Manufacturer.ToLower()).ToList();
+
+					Assert.Equal(2, facetResults.Results["Manufacturer"].Values.Count());
+					Assert.Equal(camerasByHits[0], facetResults.Results["Manufacturer"].Values[0].Range);
+					Assert.Equal(camerasByHits[1], facetResults.Results["Manufacturer"].Values[1].Range);
+
+					foreach (var facet in facetResults.Results["Manufacturer"].Values)
+					{
+						var inMemoryCount = _data.Where(x => x.Manufacturer.ToLower() == facet.Range).Count();
+						Assert.Equal(inMemoryCount, facet.Hits);
+					}
+
+					Assert.Equal(3, facetResults.Results["Manufacturer"].RemainingTermsCount);
+					Assert.Equal(3, facetResults.Results["Manufacturer"].RemainingTerms.Count());
+					Assert.Equal(camerasByHits[2], facetResults.Results["Manufacturer"].RemainingTerms[0]);
+					Assert.Equal(camerasByHits[3], facetResults.Results["Manufacturer"].RemainingTerms[1]);
+					Assert.Equal(camerasByHits[4], facetResults.Results["Manufacturer"].RemainingTerms[2]);
+
+					Assert.Equal(_data.Count(),
+						facetResults.Results["Manufacturer"].Values[0].Hits +
+						facetResults.Results["Manufacturer"].Values[1].Hits +
+						facetResults.Results["Manufacturer"].RemainingHits);
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedLimitSearch_HitsDesc()
+		{
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 20, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using (var store = NewDocumentStore())
+			{
+				Setup(store);
+
+				using(var s = store.OpenSession())
+				{
+					s.Store(new FacetSetup { Id = "facets/CameraFacets", Facets = facets });
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>("CameraCost")
+						.ToFacets("facets/CameraFacets");
+
+					var cameraCounts = from d in _data
+					                  group d by d.Manufacturer
+					                  into result
+					                  select new {Manufacturer = result.Key, Count = result.Count()};
+					var camerasByHits = cameraCounts.OrderByDescending(x => x.Count).Select(x => x.Manufacturer.ToLower()).ToList();
+
+					Assert.Equal(5, facetResults.Results["Manufacturer"].Values.Count());
+					Assert.Equal(camerasByHits[0], facetResults.Results["Manufacturer"].Values[0].Range);
+					Assert.Equal(camerasByHits[1], facetResults.Results["Manufacturer"].Values[1].Range);
+					Assert.Equal(camerasByHits[2], facetResults.Results["Manufacturer"].Values[2].Range);
+					Assert.Equal(camerasByHits[3], facetResults.Results["Manufacturer"].Values[3].Range);
+					Assert.Equal(camerasByHits[4], facetResults.Results["Manufacturer"].Values[4].Range);
+
+					foreach (var facet in facetResults.Results["Manufacturer"].Values)
+					{
+						var inMemoryCount = _data.Where(x => x.Manufacturer.ToLower() == facet.Range).Count();
+						Assert.Equal(inMemoryCount, facet.Hits);
+					}
+
+					Assert.Equal(0, facetResults.Results["Manufacturer"].RemainingTermsCount);
+					Assert.Equal(0, facetResults.Results["Manufacturer"].RemainingTerms.Count());
+					Assert.Equal(0, facetResults.Results["Manufacturer"].RemainingHits);
+				}
+			}
+		}
+
+		private void Setup(IDocumentStore store)
+		{
+			using (var s = store.OpenSession())
+			{
+				store.DatabaseCommands.PutIndex("CameraCost",
+												new IndexDefinition
+												{
+													Map =
+														@"from camera in docs 
+                                                        select new 
+                                                        { 
+                                                            camera.Manufacturer, 
+                                                            camera.Model, 
+                                                            camera.Cost,
+                                                            camera.DateOfListing,
+                                                            camera.Megapixels
+                                                        }"
+												});
+
+				var counter = 0;
+				foreach (var camera in _data)
+				{
+					s.Store(camera);
+					counter++;
+
+					if (counter % (NumCameras / 25) == 0)
+						s.SaveChanges();
+				}
+				s.SaveChanges();
+
+				s.Query<Camera>("CameraCost")
+					.Customize(x => x.WaitForNonStaleResults())
+					.ToList();
+			}
+		}
+	}
+}

--- a/Raven.Tests/Faceted/FacetedIndexTestHelper.cs
+++ b/Raven.Tests/Faceted/FacetedIndexTestHelper.cs
@@ -28,6 +28,15 @@ namespace Raven.Tests.Faceted
 						"Jessops"
 					};
 
+		private static readonly List<string> Models = new List<string> 
+					{ 
+						"Model1", 
+						"Model2",
+						"Model3",
+						"Model4",
+						"Model5"
+					};
+
 		private static readonly Random random = new Random(1337);
 
 		public static IList<Camera> GetCameras(int numCameras)
@@ -41,7 +50,7 @@ namespace Raven.Tests.Faceted
 					Id = i,
 					DateOfListing = new DateTime(1980 + random.Next(1, 30), random.Next(1, 12), random.Next(1, 27)),
 					Manufacturer = Manufacturers[(int)(random.NextDouble() * Manufacturers.Count)],
-					Model = "blah",
+					Model = Models[(int)(random.NextDouble() * Models.Count)],
 					Cost = (decimal)((random.NextDouble() * 900.0) + 100.0),    //100.0 to 1000.0
 					Zoom = (int)(random.NextDouble() * 12) + 2,                 //2.0 to 12.0
 					Megapixels = (decimal)((random.NextDouble() * 10.0) + 1.0), //1.0 to 11.0

--- a/Raven.Tests/MailingList/Afif.cs
+++ b/Raven.Tests/MailingList/Afif.cs
@@ -67,7 +67,7 @@ namespace Raven.Tests.MailingList
 			[Fact]
 			public void ShouldMatchMakeFacetsOnLocation()
 			{
-				IDictionary<string, IEnumerable<FacetValue>> facetvalues;
+				FacetResults facetvalues;
 
 				using (var s = Store.OpenSession())
 				{
@@ -85,7 +85,7 @@ namespace Raven.Tests.MailingList
 				}
 
 				Assert.NotNull(facetvalues);
-				Assert.Equal(2, facetvalues["Make"].Count());
+				Assert.Equal(2, facetvalues.Results["Make"].Values.Count());
 			}
 		}
 

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -519,6 +519,7 @@
     <Compile Include="Document\TotalCountServerTest.cs" />
     <Compile Include="Document\WhenUsingMultipleUnshardedServers.cs" />
     <Compile Include="Document\ZoneCountResult.cs" />
+    <Compile Include="Faceted\FacetedIndexLimit.cs" />
     <Compile Include="IISExpressTestClient.cs" />
     <Compile Include="Bugs\IndexDefinitions.cs" />
     <Compile Include="Indexes\AnalyzerResolution.cs" />


### PR DESCRIPTION
Instead of issuing a query per facet term and searching through all of the facet terms for the index regardless whether they are in the baseQuery or not, this issues the baseQuery with a custom Lucene Collector. Doing this allows direct access to the terms (and counts) associated with that query.

Add support for limiting the number of returned FacetValues with a MaxResults field Facet document, and returning all terms that match the query as well.

Adds supprort for a FacetValue sort mode added that allows you to decide what "MaxResults" facet values to return (term ASC, term DESC, number of hits ASC, number of hits DESC).
