### PR TITLE
Adding Session.Advanced.ChangedEntities

### DIFF
--- a/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
@@ -301,6 +301,17 @@ namespace Raven.Client.Document
 			return EntityChanged(entity, value);
 		}
 
+		/// <summary>
+		/// Gets the entities tracked by the session that have changes.
+		/// </summary>
+		public IEnumerable<object> ChangedEntities
+		{
+			get
+			{
+				return entitiesByKey.Values.Where(HasChanged);
+			}
+		}
+
 		public void IncrementRequestCount()
 		{
 			if (++NumberOfRequests > MaxNumberOfRequestsPerSession)

--- a/Raven.Client.Lightweight/IAdvancedDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/IAdvancedDocumentSessionOperations.cs
@@ -143,5 +143,10 @@ namespace Raven.Client
 		/// </summary>
 		/// <param name="commands">The commands to be executed</param>
 		void Defer(params ICommandData[] commands);
+
+		/// <summary>
+		/// Gets the entities tracked by the session that have changes.
+		/// </summary>
+		IEnumerable<object> ChangedEntities { get; }
 	}
 }


### PR DESCRIPTION
Exposes the tracked entities that have been changed but not yet committed by the session.

This is useful when additional activities need to be performed for each changed entity before committing.  I need it for dispatching events in a CQRS (without ES) architecture.  It could also be useful for other global client-side infrastructure such as logging changes, or if you need to evaluate changes for potential eviction from the session.

Without this exposed, the only way to get at the changed entities is via reflection on the protect data.
