### PR TITLE
RegisterListener should be available from IDocumentStore

### DIFF
--- a/Raven.Client.Lightweight/DocumentStoreBase.cs
+++ b/Raven.Client.Lightweight/DocumentStoreBase.cs
@@ -207,7 +207,7 @@ namespace Raven.Client
 		/// </summary>
 		/// <param name="documentStoreListener">The document store listener.</param>
 		/// <returns></returns>
-		public IDocumentStore RegisterListener(IDocumentStoreListener documentStoreListener)
+        public DocumentStoreBase RegisterListener(IDocumentStoreListener documentStoreListener)
 		{
 			listeners.StoreListeners = listeners.StoreListeners.Concat(new[] { documentStoreListener }).ToArray();
 			return this;

--- a/Raven.Client.Lightweight/IDocumentStore.cs
+++ b/Raven.Client.Lightweight/IDocumentStore.cs
@@ -177,6 +177,6 @@ namespace Raven.Client
 	    /// </summary>
 	    /// <param name="documentStoreListener">The document store listener.</param>
 	    /// <returns></returns>
-	    IDocumentStore RegisterListener(IDocumentStoreListener documentStoreListener);
+        DocumentStoreBase RegisterListener(IDocumentStoreListener documentStoreListener);
 	}
 }


### PR DESCRIPTION
Since it is available on all DocStore implementations, and to allow for a simple generic use, e.g.

```
        IDocumentStore docStore = new DocumentStore { ConnectionStringName = "RavenDB" }.Initialize();
        docStore.RegisterListener(...);
```
