### PR TITLE
Add the Raven.Client.Lightweight.FSharp project to RavenDB.sln

### DIFF
--- a/Raven.Client.Lightweight.FSharp/Raven.Client.Lightweight.FSharp.fsproj
+++ b/Raven.Client.Lightweight.FSharp/Raven.Client.Lightweight.FSharp.fsproj
@@ -63,8 +63,12 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\FSharp\1.0\Microsoft.FSharp.Targets" Condition="!Exists('$(MSBuildBinPath)\Microsoft.Build.Tasks.v4.0.dll')" />
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft F#\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildBinPath)\Microsoft.Build.Tasks.v4.0.dll')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft F#\v4.0\Microsoft.FSharp.Targets" Condition="(!Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')) And (Exists('$(MSBuildExtensionsPath32)\..\Microsoft F#\v4.0\Microsoft.FSharp.Targets'))" />
+  <Import Project="$(MSBuildExtensionsPath32)\FSharp\1.0\Microsoft.FSharp.Targets" Condition="(!Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')) And (!Exists('$(MSBuildExtensionsPath32)\..\Microsoft F#\v4.0\Microsoft.FSharp.Targets')) And (Exists('$(MSBuildExtensionsPath32)\FSharp\1.0\Microsoft.FSharp.Targets'))" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
 	     Other similar extension points exist, see Microsoft.Common.targets.
 	<Target Name="BeforeBuild">

--- a/RavenDB.sln
+++ b/RavenDB.sln
@@ -53,6 +53,8 @@ Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Raven.Client.VisualBasic.Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.VisualHost", "Raven.VisualHost\Raven.VisualHost.csproj", "{D3485301-AA81-4F7A-BB78-CC0AD3C8BEDC}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Raven.Client.Lightweight.FSharp", "Raven.Client.Lightweight.FSharp\Raven.Client.Lightweight.FSharp.fsproj", "{6996133D-EE21-4CC8-B29B-F6222EE476BB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -213,6 +215,16 @@ Global
 		{D3485301-AA81-4F7A-BB78-CC0AD3C8BEDC}.Release|Mixed Platforms.Build.0 = Release|x86
 		{D3485301-AA81-4F7A-BB78-CC0AD3C8BEDC}.Release|x86.ActiveCfg = Release|x86
 		{D3485301-AA81-4F7A-BB78-CC0AD3C8BEDC}.Release|x86.Build.0 = Release|x86
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6996133D-EE21-4CC8-B29B-F6222EE476BB}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
A modification was performed on the project by VS such that it will no longer open in VS2010. 

It also allows the build script to work on computer that doesn't have VS2010 installed.
