### PR TITLE
Optional creation of plugins and analyzers directory if they do not exist

### DIFF
--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -45,6 +45,9 @@ namespace Raven.Database.Config
 
 			CreateTemporaryIndexesForAdHocQueriesIfNeeded = true;
 
+		    CreatePluginsDirectoryIfNotExisting = true;
+		    CreateAnalyzersDirectoryIfNotExisting = true;
+
 			AvailableMemoryForRaisingIndexBatchSizeLimit = Math.Min(768, MemoryStatistics.TotalPhysicalMemory / 2);
 			MaxNumberOfParallelIndexTasks = 8;
 
@@ -646,6 +649,9 @@ namespace Raven.Database.Config
 				}
 			}
 		}
+
+        public bool CreatePluginsDirectoryIfNotExisting { get; set; }
+        public bool CreateAnalyzersDirectoryIfNotExisting { get; set; }
 
 		public string OAuthTokenServer { get; set; }
 

--- a/Raven.Database/Server/HttpServer.cs
+++ b/Raven.Database/Server/HttpServer.cs
@@ -117,8 +117,14 @@ namespace Raven.Database.Server
 
 			if (configuration.RunInMemory == false)
 			{
-				TryCreateDirectory(configuration.PluginsDirectory);
-				TryCreateDirectory(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Analyzers"));
+			    if (configuration.CreatePluginsDirectoryIfNotExisting)
+			    {
+			        TryCreateDirectory(configuration.PluginsDirectory);
+			    }
+			    if (configuration.CreateAnalyzersDirectoryIfNotExisting)
+			    {
+			        TryCreateDirectory(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Analyzers"));
+			    }
 			}
 
 			SystemDatabase = resourceStore;


### PR DESCRIPTION
We have serious problem with raven automatically creating these two directories without asking for our permissions. The reason is, that we're deploying it embedded with our application and that the directory structure actually is important for us and our users. 
