### PR TITLE
Add DestinationStats.LastEtagCheckedForReplication and update even when no docs need to be replicated

### DIFF
--- a/Raven.Abstractions/Replication/ReplicationStatistics.cs
+++ b/Raven.Abstractions/Replication/ReplicationStatistics.cs
@@ -21,6 +21,7 @@ namespace Raven.Abstractions.Replication
 		public int FailureCountInternal = 0;
 		public string Url { get; set; }
 		public DateTime? LastHeartbeatReceived { get; set; }
+		public Guid? LastEtagCheckedForReplication { get; set; }
 		public Guid? LastReplicatedEtag { get; set; }
 		public DateTime? LastReplicatedLastModified { get; set; }
 		public DateTime? LastSuccessTimestamp { get; set; }


### PR DESCRIPTION
In environments with more than 2 Raven servers in master-master replication, servers that aren't written to may (correctly) never replicate to a destination.  Tracking the last etag that was checked for potential replication lets us know if the replication task is up to date, by comparing it with that server's last etag.
