### PR TITLE
More robust updating of last indexed ETag in managed storage. This shoul...

### DIFF
--- a/Raven.Tests/Bugs/MultiOutputReduce.cs
+++ b/Raven.Tests/Bugs/MultiOutputReduce.cs
@@ -12,7 +12,7 @@ namespace Raven.Tests.Bugs
 		{
 			for (int xx = 0; xx < 50; xx++)
 			{
-				using (var store = NewDocumentStore(requestedStorage: "esent"))
+				using (var store = NewDocumentStore(requestedStorage: "munin"))
 				{
 					new Orders_Search().Execute(store);
 


### PR DESCRIPTION
...d fix race condition in map/reduce indexing (RavenDB-767) when using Munin.

Ayende,

this commit should fix the race condition in Munin during map/reduce indexing. Generally the problem that I've observed during working with this issue was that Raven did too many map operations (mapped already mapped documents) while the reduce results was inconsistent (if the test failed the count of reduce results always was less that expected). 

The problem with too many maps was caused by invalid updating of last indexed ETag (IndexingStorageActions.UpdateLastIndexed method). We ignored that 'storage.IndexingStats.UpdateKey' can return 'false' what means that update operation didn't succeeded (because of another thread that wanted to modified this key as well - see Table.keysModifiedInTx) what resulted in non-updated ETag value. Now the operation is retried (for 1 second)

I've fixed that but I could not be able to determine the direct influence of too many map operations on too less count of reduce results. However after this commit the failing test has never failed (it was run thousands of times). I believe that fixes the problem but as always in race condition I'm not 100% sure.
