### PR TITLE
Fixed culture depended issue in parsing spatial radius

### DIFF
--- a/Raven.Database/Indexing/SpatialIndex.cs
+++ b/Raven.Database/Indexing/SpatialIndex.cs
@@ -111,7 +111,7 @@ namespace Raven.Database.Indexing
 				return shapeWKT;
 
 			var radCapture = match.Groups[3];
-			var radius = double.Parse(radCapture.Value);
+			var radius = double.Parse(radCapture.Value, CultureInfo.InvariantCulture);
 
 			radius = (radius / EarthMeanRadiusKm) * RadiansToDegrees;
 

--- a/Raven.Tests/Spatial/Afif.cs
+++ b/Raven.Tests/Spatial/Afif.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using FizzWare.NBuilder;
 using Raven.Abstractions.Data;
@@ -9,6 +10,7 @@ using Raven.Client.Embedded;
 using Raven.Client.Indexes;
 using Raven.Client.Linq;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Raven.Tests.Spatial
 {
@@ -65,11 +67,13 @@ namespace Raven.Tests.Spatial
 
 		public class CanGetFacetsOnVehicleSpatialSearch :UsingEmbeddedRavenStoreWithVehicles
 		{
-			[Fact]
-			public void ShouldMatchMakeFacetsOnLocation()
+			[Theory]
+			[CriticalCultures]
+			public void ShouldMatchMakeFacetsOnLocation(CultureInfo criticalCulture)
 			{
 				FacetResults facetvalues;
 
+				using(new TemporaryCulture(criticalCulture))
 				using (var s = Store.OpenSession())
 				{
 					var index = typeof(ByVehicle).Name;


### PR DESCRIPTION
I'm kinda late in the game of testing 2.0, but here's a minor issue I stumbled upon during the build.
