### PR TITLE
Fixing non-string id includes on async session.

### DIFF
--- a/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
+++ b/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
@@ -115,6 +115,15 @@ namespace Raven.Client.Document.Async
 		}
 
 		/// <summary>
+		/// Begin a load while including the specified path 
+		/// </summary>
+		/// <param name="path">The path.</param>
+		public IAsyncLoaderWithInclude<T> Include<T, TInclude>(Expression<Func<T, object>> path)
+		{
+			return new AsyncMultiLoaderWithInclude<T>(this).Include<TInclude>(path);
+		}
+
+		/// <summary>
 		/// Loads the specified entities with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>

--- a/Raven.Client.Lightweight/Document/AsyncMultiLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/AsyncMultiLoaderWithInclude.cs
@@ -41,6 +41,27 @@ namespace Raven.Client.Document
 		}
 
 		/// <summary>
+		/// Includes the specified path.
+		/// </summary>
+		/// <param name="path">The path.</param>
+		public AsyncMultiLoaderWithInclude<T> Include<TInclude>(Expression<Func<T, object>> path)
+		{
+			var type = path.ExtractTypeFromPath();
+			var fullId = this.session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(-1, typeof(TInclude), false);
+
+			var id = path.ToPropertyPath();
+
+			if (type != typeof(string))
+			{
+				var idPrefix = fullId.Replace("-1", string.Empty);
+
+				id += "(" + idPrefix + ")";
+			}
+
+			return Include(id);
+		}
+
+		/// <summary>
 		/// Loads the specified ids.
 		/// </summary>
 		/// <param name="ids">The ids.</param>

--- a/Raven.Client.Lightweight/Document/DocumentSession.cs
+++ b/Raven.Client.Lightweight/Document/DocumentSession.cs
@@ -389,7 +389,11 @@ namespace Raven.Client.Document
 			return new MultiLoaderWithInclude<T>(this).Include(path);
 		}
 
-
+		/// <summary>
+		/// Begin a load while including the specified path
+		/// </summary>
+		/// <param name="path">The path.</param>
+		/// <returns></returns>
 		public ILoaderWithInclude<T> Include<T, TInclude>(Expression<Func<T, object>> path)
 		{
 			return new MultiLoaderWithInclude<T>(this).Include<TInclude>(path);

--- a/Raven.Client.Lightweight/Document/MultiLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/MultiLoaderWithInclude.cs
@@ -42,6 +42,10 @@ namespace Raven.Client.Document
 			return Include(path.ToPropertyPath());
 		}
 
+		/// <summary>
+		/// Includes the specified path.
+		/// </summary>
+		/// <param name="path">The path.</param>
 		public MultiLoaderWithInclude<T> Include<TInclude>(Expression<Func<T, object>> path)
 		{
 			var type = path.ExtractTypeFromPath();

--- a/Raven.Client.Lightweight/IAsyncDocumentSession.cs
+++ b/Raven.Client.Lightweight/IAsyncDocumentSession.cs
@@ -39,13 +39,18 @@ namespace Raven.Client
 		/// <param name="path">The path.</param>
 		IAsyncLoaderWithInclude<T> Include<T>(Expression<Func<T, object>> path);
 
+		/// <summary>
+		/// Begin a load while including the specified path 
+		/// </summary>
+		/// <param name="path">The path.</param>
+		IAsyncLoaderWithInclude<T> Include<T, TInclude>(Expression<Func<T, object>> path);
 
 		/// <summary>
 		/// Stores the specified entity with the specified etag.
 		/// The entity will be saved when <see cref="SaveChangesAsync"/> is called.
 		/// </summary>
 		void Store(object entity, Guid etag);
-	
+
 		/// <summary>
 		/// Stores the specified entity in the session. The entity will be saved when <see cref="SaveChangesAsync"/> is called.
 		/// </summary>
@@ -98,7 +103,7 @@ namespace Raven.Client
 		/// <param name="ids">The ids.</param>
 		/// <returns></returns>
 		Task<T[]> LoadAsync<T>(string[] ids);
-		
+
 		/// <summary>
 		/// Begins the async save changes operation
 		/// </summary>

--- a/Raven.Client.Lightweight/Shard/AsyncShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/AsyncShardedDocumentSession.cs
@@ -199,6 +199,11 @@ namespace Raven.Client.Shard
 			return new AsyncMultiLoaderWithInclude<T>(this).Include(path);
 		}
 
+		public IAsyncLoaderWithInclude<T> Include<T, TInclude>(Expression<Func<T, object>> path)
+		{
+			return new AsyncMultiLoaderWithInclude<T>(this).Include<TInclude>(path);
+		}
+
 		#endregion
 
 		#region Queries

--- a/Raven.Client.Lightweight/Shard/ShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/ShardedDocumentSession.cs
@@ -237,6 +237,11 @@ namespace Raven.Client.Shard
 			return new MultiLoaderWithInclude<T>(this).Include(path);
 		}
 
+		public ILoaderWithInclude<T> Include<T, TInclude>(Expression<Func<T, object>> path)
+		{
+			return new MultiLoaderWithInclude<T>(this).Include<TInclude>(path);
+		}
+
 		#endregion
 
 		#region Lazy loads
@@ -477,15 +482,6 @@ namespace Raven.Client.Shard
 		public IDocumentQuery<T> LuceneQuery<T>()
 		{
 			return LuceneQuery<T>(GetDynamicIndexName<T>());
-		}
-
-		#endregion
-
-		#region DatabaseCommands (not supported)
-
-		public ILoaderWithInclude<T> Include<T, TInclude>(Expression<Func<T, object>> path)
-		{
-			return new MultiLoaderWithInclude<T>(this).Include<TInclude>(path);
 		}
 
 		#endregion


### PR DESCRIPTION
asyncSession.Include<Foo, Bar>(...) was missing.  Copied implementation details from synchronous version.

Some minor code comments fixed also.
