### PR TITLE
.Load(ids[]) and related for non-string ids

### DIFF
--- a/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
+++ b/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
@@ -124,14 +124,14 @@ namespace Raven.Client.Document.Async
 		}
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Begins the async load operation, with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
 		/// This method allows you to call:
-		/// Load{Post}(1)
+		/// LoadAsync{Post}(1)
 		/// And that call will internally be translated to 
-		/// Load{Post}("posts/1");
+		/// LoadAsync{Post}("posts/1");
 		/// 
 		/// Or whatever your conventions specify.
 		/// </remarks>
@@ -139,6 +139,42 @@ namespace Raven.Client.Document.Async
 		{
 			var documentKey = Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
 			return LoadAsync<T>(documentKey);
+		}
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public Task<T[]> LoadAsync<T>(params ValueType[] ids)
+		{
+			var documentKeys = ids.Select(id => Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return LoadAsync<T>(documentKeys);
+		}
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public Task<T[]> LoadAsync<T>(IEnumerable<ValueType> ids)
+		{
+			var documentKeys = ids.Select(id => Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return LoadAsync<T>(documentKeys);
 		}
 
 		/// <summary>
@@ -183,9 +219,14 @@ namespace Raven.Client.Document.Async
 		/// </summary>
 		/// <param name="ids">The ids.</param>
 		/// <returns></returns>
-		public Task<T[]> LoadAsync<T>(string[] ids)
+		public Task<T[]> LoadAsync<T>(params string[] ids)
 		{
 			return LoadAsyncInternal<T>(ids, new string[0]);
+		}
+
+		public Task<T[]> LoadAsync<T>(IEnumerable<string> ids)
+		{
+			return LoadAsyncInternal<T>(ids.ToArray(), new string[0]);
 		}
 
 		/// <summary>

--- a/Raven.Client.Lightweight/Document/AsyncMultiLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/AsyncMultiLoaderWithInclude.cs
@@ -13,8 +13,7 @@ using Raven.Abstractions.Extensions;
 namespace Raven.Client.Document
 {
 	/// <summary>
-	/// Fluent implementation for specifying include paths
-	/// for loading documents
+	/// Fluent implementation for specifying include paths for loading documents
 	/// </summary>
 	public class AsyncMultiLoaderWithInclude<T> : IAsyncLoaderWithInclude<T>
 	{
@@ -22,9 +21,10 @@ namespace Raven.Client.Document
 		private readonly List<string> includes = new List<string>();
 
 		/// <summary>
-		/// Includes the specified path.
+		/// Begin a load while including the specified path 
 		/// </summary>
 		/// <param name="path">The path.</param>
+		/// <returns></returns>
 		public AsyncMultiLoaderWithInclude<T> Include(string path)
 		{
 			includes.Add(path);
@@ -32,9 +32,10 @@ namespace Raven.Client.Document
 		}
 
 		/// <summary>
-		/// Includes the specified path.
+		/// Begin a load while including the specified path 
 		/// </summary>
 		/// <param name="path">The path.</param>
+		/// <returns></returns>
 		public AsyncMultiLoaderWithInclude<T> Include(Expression<Func<T, object>> path)
 		{
 			return Include(path.ToPropertyPath());
@@ -47,7 +48,7 @@ namespace Raven.Client.Document
 		public AsyncMultiLoaderWithInclude<T> Include<TInclude>(Expression<Func<T, object>> path)
 		{
 			var type = path.ExtractTypeFromPath();
-			var fullId = this.session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(-1, typeof(TInclude), false);
+			var fullId = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(-1, typeof(TInclude), false);
 
 			var id = path.ToPropertyPath();
 
@@ -62,39 +63,87 @@ namespace Raven.Client.Document
 		}
 
 		/// <summary>
-		/// Loads the specified ids.
+		/// Begins the async multi-load operation
 		/// </summary>
 		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
 		public Task<T[]> LoadAsync(params string[] ids)
 		{
 			return session.LoadAsyncInternal<T>(ids, includes.ToArray());
 		}
 
 		/// <summary>
-		/// Loads the specified id.
+		/// Begins the async multi-load operation
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		public Task<T[]> LoadAsync(IEnumerable<string> ids)
+		{
+			return session.LoadAsyncInternal<T>(ids.ToArray(), includes.ToArray());
+		}
+
+		/// <summary>
+		/// Begins the async load operation
 		/// </summary>
 		/// <param name="id">The id.</param>
+		/// <returns></returns>
 		public Task<T> LoadAsync(string id)
 		{
 			return session.LoadAsyncInternal<T>(new[] { id }, includes.ToArray()).ContinueWith(x => x.Result.FirstOrDefault());
 		}
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Begins the async load operation, with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
 		/// This method allows you to call:
-		/// Load{Post}(1)
+		/// LoadAsync{Post}(1)
 		/// And that call will internally be translated to 
-		/// Load{Post}("posts/1");
+		/// LoadAsync{Post}("posts/1");
 		/// 
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		public Task<T> LoadAsync(ValueType id)
 		{
-			var idAsStr = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
-			return LoadAsync(idAsStr);
+			var documentKey = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
+			return LoadAsync(documentKey);
+		}
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public Task<T[]> LoadAsync(params ValueType[] ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return LoadAsync(documentKeys);
+		}
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public Task<T[]> LoadAsync(IEnumerable<ValueType> ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return LoadAsync(documentKeys);
 		}
 
 		/// <summary>
@@ -107,13 +156,23 @@ namespace Raven.Client.Document
 		}
 
 		/// <summary>
-		/// Loads the specified ids.
+		/// Begins the async multi-load operation
 		/// </summary>
-		/// <typeparam name="TResult"></typeparam>
 		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
 		public Task<TResult[]> LoadAsync<TResult>(params string[] ids)
 		{
 			return session.LoadAsyncInternal<TResult>(ids, includes.ToArray());
+		}
+
+		/// <summary>
+		/// Begins the async multi-load operation
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		public Task<TResult[]> LoadAsync<TResult>(IEnumerable<string> ids)
+		{
+			return session.LoadAsyncInternal<TResult>(ids.ToArray(), includes.ToArray());
 		}
 
 		/// <summary>
@@ -127,21 +186,57 @@ namespace Raven.Client.Document
 		}
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Begins the async load operation, with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
 		/// This method allows you to call:
-		/// Load{Post}(1)
+		/// LoadAsync{Post}(1)
 		/// And that call will internally be translated to 
-		/// Load{Post}("posts/1");
+		/// LoadAsync{Post}("posts/1");
 		/// 
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		public Task<TResult> LoadAsync<TResult>(ValueType id)
 		{
-			var idAsStr = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
-			return LoadAsync<TResult>(new[] { idAsStr }).ContinueWith(x => x.Result.FirstOrDefault());
+			var documentKey = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
+			return LoadAsync<TResult>(documentKey);
+		}
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public Task<TResult[]> LoadAsync<TResult>(params ValueType[] ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return LoadAsync<TResult>(documentKeys);
+		}
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public Task<TResult[]> LoadAsync<TResult>(IEnumerable<ValueType> ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return LoadAsync<TResult>(documentKeys);
 		}
 	}
 }

--- a/Raven.Client.Lightweight/Document/Batches/ILazyLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/Batches/ILazyLoaderWithInclude.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Raven.Client.Document.Batches
@@ -31,6 +32,13 @@ namespace Raven.Client.Document.Batches
 		Lazy<T[]> Load(params string[] ids);
 
 		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		Lazy<T[]> Load(IEnumerable<string> ids);
+
+		/// <summary>
 		/// Loads the specified id.
 		/// </summary>
 		/// <param name="id">The id.</param>
@@ -38,7 +46,7 @@ namespace Raven.Client.Document.Batches
 		Lazy<T> Load(string id);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -52,11 +60,46 @@ namespace Raven.Client.Document.Batches
 		Lazy<T> Load(ValueType id);
 
 		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Lazy<T[]> Load(params ValueType[] ids);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Lazy<T[]> Load(IEnumerable<ValueType> ids);
+
+		/// <summary>
 		/// Loads the specified ids.
 		/// </summary>
 		/// <param name="ids">The ids.</param>
 		/// <returns></returns>
 		Lazy<TResult[]> Load<TResult>(params string[] ids);
+
+		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		Lazy<TResult[]> Load<TResult>(IEnumerable<string> ids);
 
 		/// <summary>
 		/// Loads the specified id.
@@ -67,7 +110,7 @@ namespace Raven.Client.Document.Batches
 		Lazy<TResult> Load<TResult>(string id);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -79,5 +122,33 @@ namespace Raven.Client.Document.Batches
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		Lazy<TResult> Load<TResult>(ValueType id);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Lazy<TResult[]> Load<TResult>(params ValueType[] ids);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Lazy<TResult[]> Load<TResult>(IEnumerable<ValueType> ids);
 	}
 }

--- a/Raven.Client.Lightweight/Document/Batches/ILazySessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/Batches/ILazySessionOperations.cs
@@ -19,13 +19,18 @@ namespace Raven.Client.Document.Batches
 		/// Begin a load while including the specified path 
 		/// </summary>
 		/// <param name="path">The path.</param>
-		ILazyLoaderWithInclude<T> Include<T>(Expression<Func<T, object>> path);
+		ILazyLoaderWithInclude<TResult> Include<TResult>(Expression<Func<TResult, object>> path);
 
 		/// <summary>
 		/// Loads the specified ids.
 		/// </summary>
 		/// <param name="ids">The ids.</param>
 		Lazy<TResult[]> Load<TResult>(params string[] ids);
+
+		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		Lazy<TResult[]> Load<TResult>(IEnumerable<string> ids);
 
 		/// <summary>
 		/// Loads the specified ids and a function to call when it is evaluated
@@ -43,7 +48,7 @@ namespace Raven.Client.Document.Batches
 		Lazy<TResult> Load<TResult>(string id, Action<TResult> onEval);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -57,7 +62,7 @@ namespace Raven.Client.Document.Batches
 		Lazy<TResult> Load<TResult>(ValueType id);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -70,7 +75,52 @@ namespace Raven.Client.Document.Batches
 		/// </remarks>
 		Lazy<TResult> Load<TResult>(ValueType id, Action<TResult> onEval);
 
-		Lazy<T[]> LoadStartingWith<T>(string keyPrefix, string matches = null, int start = 0, int pageSize = 25);
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Lazy<TResult[]> Load<TResult>(params ValueType[] ids);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Lazy<TResult[]> Load<TResult>(IEnumerable<ValueType> ids);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Lazy<TResult[]> Load<TResult>(IEnumerable<ValueType> ids, Action<TResult[]> onEval);
+
+		/// <summary>
+		/// Load documents with the specified key prefix
+		/// </summary>
+		Lazy<TResult[]> LoadStartingWith<TResult>(string keyPrefix, string matches = null, int start = 0, int pageSize = 25);
 	}
 
 	/// <summary>

--- a/Raven.Client.Lightweight/Document/Batches/LazyMultiLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/Batches/LazyMultiLoaderWithInclude.cs
@@ -50,6 +50,16 @@ namespace Raven.Client.Document.Batches
 		}
 
 		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		public Lazy<T[]> Load(IEnumerable<string> ids)
+		{
+			return session.LazyLoadInternal<T>(ids.ToArray(), includes.ToArray(), null);
+		}
+
+		/// <summary>
 		/// Loads the specified id.
 		/// </summary>
 		public Lazy<T> Load(string id)
@@ -59,7 +69,7 @@ namespace Raven.Client.Document.Batches
 		}
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -72,8 +82,44 @@ namespace Raven.Client.Document.Batches
 		/// </remarks>
 		public Lazy<T> Load(ValueType id)
 		{
-			var idAsStr = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
-			return Load(idAsStr);
+			var documentKey = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
+			return Load(documentKey);
+		}
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public Lazy<T[]> Load(params ValueType[] ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return Load(documentKeys);
+		}
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public Lazy<T[]> Load(IEnumerable<ValueType> ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return Load(documentKeys);
 		}
 
 		/// <summary>
@@ -84,6 +130,16 @@ namespace Raven.Client.Document.Batches
 		public Lazy<TResult[]> Load<TResult>(params string[] ids)
 		{
 			return session.LazyLoadInternal<TResult>(ids, includes.ToArray(), null);
+		}
+
+		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		public Lazy<TResult[]> Load<TResult>(IEnumerable<string> ids)
+		{
+			return session.LazyLoadInternal<TResult>(ids.ToArray(), includes.ToArray(), null);
 		}
 
 		/// <summary>
@@ -98,7 +154,7 @@ namespace Raven.Client.Document.Batches
 		}
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -111,9 +167,20 @@ namespace Raven.Client.Document.Batches
 		/// </remarks>
 		public Lazy<TResult> Load<TResult>(ValueType id)
 		{
-			var idAsStr = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
-			var lazy = Load<TResult>(new[] { idAsStr });
-			return new Lazy<TResult>(() => lazy.Value.FirstOrDefault());
+			var documentKey = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
+			return Load<TResult>(documentKey);
+		}
+
+		public Lazy<TResult[]> Load<TResult>(params ValueType[] ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return Load<TResult>(documentKeys);
+		}
+
+		public Lazy<TResult[]> Load<TResult>(IEnumerable<ValueType> ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return Load<TResult>(documentKeys);
 		}
 	}
 }

--- a/Raven.Client.Lightweight/Document/IAsyncLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/IAsyncLoaderWithInclude.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 
@@ -11,56 +12,98 @@ namespace Raven.Client.Document
 	public interface IAsyncLoaderWithInclude<T>
 	{
 		/// <summary>
-		/// Includes the specified path.
+		/// Begin a load while including the specified path 
 		/// </summary>
 		/// <param name="path">The path.</param>
 		/// <returns></returns>
 		AsyncMultiLoaderWithInclude<T> Include(string path);
 
 		/// <summary>
-		/// Includes the specified path.
+		/// Begin a load while including the specified path 
 		/// </summary>
 		/// <param name="path">The path.</param>
 		/// <returns></returns>
 		AsyncMultiLoaderWithInclude<T> Include(Expression<Func<T, object>> path);
 
 		/// <summary>
-		/// Loads the specified ids.
+		/// Begins the async multi-load operation
 		/// </summary>
 		/// <param name="ids">The ids.</param>
 		/// <returns></returns>
 		Task<T[]> LoadAsync(params string[] ids);
 
 		/// <summary>
-		/// Loads the specified id.
+		/// Begins the async multi-load operation
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		Task<T[]> LoadAsync(IEnumerable<string> ids);
+
+		/// <summary>
+		/// Begins the async load operation
 		/// </summary>
 		/// <param name="id">The id.</param>
 		/// <returns></returns>
 		Task<T> LoadAsync(string id);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Begins the async load operation, with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
 		/// This method allows you to call:
-		/// Load{Post}(1)
+		/// LoadAsync{Post}(1)
 		/// And that call will internally be translated to 
-		/// Load{Post}("posts/1");
+		/// LoadAsync{Post}("posts/1");
 		/// 
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		Task<T> LoadAsync(ValueType id);
 
 		/// <summary>
-		/// Loads the specified ids.
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Task<T[]> LoadAsync(params ValueType[] ids);
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Task<T[]> LoadAsync(IEnumerable<ValueType> ids);
+
+		/// <summary>
+		/// Begins the async multi-load operation
 		/// </summary>
 		/// <param name="ids">The ids.</param>
 		/// <returns></returns>
 		Task<TResult[]> LoadAsync<TResult>(params string[] ids);
 
 		/// <summary>
-		/// Loads the specified id.
+		/// Begins the async multi-load operation
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		Task<TResult[]> LoadAsync<TResult>(IEnumerable<string> ids);
+
+		/// <summary>
+		/// Begins the async load operation
 		/// </summary>
 		/// <typeparam name="TResult"></typeparam>
 		/// <param name="id">The id.</param>
@@ -68,17 +111,45 @@ namespace Raven.Client.Document
 		Task<TResult> LoadAsync<TResult>(string id);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Begins the async load operation, with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
 		/// This method allows you to call:
-		/// Load{Post}(1)
+		/// LoadAsync{Post}(1)
 		/// And that call will internally be translated to 
-		/// Load{Post}("posts/1");
+		/// LoadAsync{Post}("posts/1");
 		/// 
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		Task<TResult> LoadAsync<TResult>(ValueType id);
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Task<TResult[]> LoadAsync<TResult>(params ValueType[] ids);
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Task<TResult[]> LoadAsync<TResult>(IEnumerable<ValueType> ids);
 	}
 }

--- a/Raven.Client.Lightweight/Document/ILoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/ILoaderWithInclude.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Raven.Client.Document
@@ -44,6 +45,13 @@ namespace Raven.Client.Document
 		T[] Load(params string[] ids);
 
 		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		T[] Load(IEnumerable<string> ids);
+
+		/// <summary>
 		/// Loads the specified id.
 		/// </summary>
 		/// <param name="id">The id.</param>
@@ -51,7 +59,7 @@ namespace Raven.Client.Document
 		T Load(string id);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -65,11 +73,46 @@ namespace Raven.Client.Document
 		T Load(ValueType id);
 
 		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		T[] Load(params ValueType[] ids);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		T[] Load(IEnumerable<ValueType> ids);
+
+		/// <summary>
 		/// Loads the specified ids.
 		/// </summary>
 		/// <param name="ids">The ids.</param>
 		/// <returns></returns>
 		TResult[] Load<TResult>(params string[] ids);
+
+		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		TResult[] Load<TResult>(IEnumerable<string> ids);
 
 		/// <summary>
 		/// Loads the specified id.
@@ -80,7 +123,7 @@ namespace Raven.Client.Document
 		TResult Load<TResult>(string id);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -92,6 +135,34 @@ namespace Raven.Client.Document
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		TResult Load<TResult>(ValueType id);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		TResult[] Load<TResult>(params ValueType[] ids);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		TResult[] Load<TResult>(IEnumerable<ValueType> ids);
 	}
 }
 

--- a/Raven.Client.Lightweight/Document/MultiLoaderWithInclude.cs
+++ b/Raven.Client.Lightweight/Document/MultiLoaderWithInclude.cs
@@ -47,7 +47,7 @@ namespace Raven.Client.Document
 		public MultiLoaderWithInclude<T> Include<TInclude>(Expression<Func<T, object>> path)
 		{
 			var type = path.ExtractTypeFromPath();
-			var fullId = this.session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(-1, typeof(TInclude), false);
+			var fullId = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(-1, typeof(TInclude), false);
 
 			var id = path.ToPropertyPath();
 
@@ -65,9 +65,20 @@ namespace Raven.Client.Document
 		/// Loads the specified ids.
 		/// </summary>
 		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
 		public T[] Load(params string[] ids)
 		{
 			return session.LoadInternal<T>(ids, includes.ToArray());
+		}
+
+		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		public T[] Load(IEnumerable<string> ids)
+		{
+			return session.LoadInternal<T>(ids.ToArray(), includes.ToArray());
 		}
 
 		/// <summary>
@@ -80,7 +91,7 @@ namespace Raven.Client.Document
 		}
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -93,8 +104,44 @@ namespace Raven.Client.Document
 		/// </remarks>
 		public T Load(ValueType id)
 		{
-			var idAsStr = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
-			return Load(idAsStr);
+			var documentKey = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
+			return Load(documentKey);
+		}
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public T[] Load(params ValueType[] ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return Load(documentKeys);
+		}
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		public T[] Load(IEnumerable<ValueType> ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return Load(documentKeys);
 		}
 
 		/// <summary>
@@ -114,6 +161,16 @@ namespace Raven.Client.Document
 		public TResult[] Load<TResult>(params string[] ids)
 		{
 			return session.LoadInternal<TResult>(ids, includes.ToArray());
+		}
+
+		/// <summary>
+		/// Loads the specified ids.
+		/// </summary>
+		/// <typeparam name="TResult"></typeparam>
+		/// <param name="ids">The ids.</param>
+		public TResult[] Load<TResult>(IEnumerable<string> ids)
+		{
+			return session.LoadInternal<TResult>(ids.ToArray(), includes.ToArray());
 		}
 
 		/// <summary>
@@ -140,8 +197,20 @@ namespace Raven.Client.Document
 		/// </remarks>
 		public TResult Load<TResult>(ValueType id)
 		{
-			var idAsStr = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(TResult), false);
-			return Load<TResult>(new[] { idAsStr }).FirstOrDefault();
+			var documentKey = session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(TResult), false);
+			return Load<TResult>(documentKey);
+		}
+
+		public TResult[] Load<TResult>(params ValueType[] ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return Load<TResult>(documentKeys);
+		}
+
+		public TResult[] Load<TResult>(IEnumerable<ValueType> ids)
+		{
+			var documentKeys = ids.Select(id => session.Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return Load<TResult>(documentKeys);
 		}
 	}
 }

--- a/Raven.Client.Lightweight/IAsyncDocumentSession.cs
+++ b/Raven.Client.Lightweight/IAsyncDocumentSession.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Raven.Client.Document;
@@ -84,25 +85,60 @@ namespace Raven.Client
 		Task<T> LoadAsync<T>(string id);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Begins the async multi-load operation
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		Task<T[]> LoadAsync<T>(params string[] ids);
+
+		/// <summary>
+		/// Begins the async multi-load operation
+		/// </summary>
+		/// <param name="ids">The ids.</param>
+		/// <returns></returns>
+		Task<T[]> LoadAsync<T>(IEnumerable<string> ids);
+
+		/// <summary>
+		/// Begins the async load operation, with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
 		/// This method allows you to call:
-		/// Load{Post}(1)
+		/// LoadAsync{Post}(1)
 		/// And that call will internally be translated to 
-		/// Load{Post}("posts/1");
+		/// LoadAsync{Post}("posts/1");
 		/// 
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		Task<T> LoadAsync<T>(ValueType id);
 
 		/// <summary>
-		/// Begins the async multi load operation
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
 		/// </summary>
-		/// <param name="ids">The ids.</param>
-		/// <returns></returns>
-		Task<T[]> LoadAsync<T>(string[] ids);
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Task<T[]> LoadAsync<T>(params ValueType[] ids);
+
+		/// <summary>
+		/// Begins the async multi-load operation, with the specified ids after applying
+		/// conventions on the provided ids to get the real document ids.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// LoadAsync{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// LoadAsync{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		Task<T[]> LoadAsync<T>(IEnumerable<ValueType> ids);
 
 		/// <summary>
 		/// Begins the async save changes operation

--- a/Raven.Client.Lightweight/IDocumentSession.cs
+++ b/Raven.Client.Lightweight/IDocumentSession.cs
@@ -53,7 +53,7 @@ namespace Raven.Client
 		T[] Load<T>(IEnumerable<string> ids);
 
 		/// <summary>
-		/// Loads the specified entities with the specified id after applying
+		/// Loads the specified entity with the specified id after applying
 		/// conventions on the provided id to get the real document id.
 		/// </summary>
 		/// <remarks>
@@ -65,6 +65,34 @@ namespace Raven.Client
 		/// Or whatever your conventions specify.
 		/// </remarks>
 		T Load<T>(ValueType id);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(1,2,3)
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		T[] Load<T>(params ValueType[] ids);
+
+		/// <summary>
+		/// Loads the specified entities with the specified id after applying
+		/// conventions on the provided id to get the real document id.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you to call:
+		/// Load{Post}(new List&lt;int&gt;(){1,2,3})
+		/// And that call will internally be translated to 
+		/// Load{Post}("posts/1","posts/2","posts/3");
+		/// 
+		/// Or whatever your conventions specify.
+		/// </remarks>
+		T[] Load<T>(IEnumerable<ValueType> ids);
 
 		/// <summary>
 		/// Queries the specified index using Linq.

--- a/Raven.Client.Lightweight/Shard/AsyncShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/AsyncShardedDocumentSession.cs
@@ -106,15 +106,32 @@ namespace Raven.Client.Shard
 			});
 		}
 
+		public Task<T[]> LoadAsync<T>(params string[] ids)
+		{
+			return LoadAsyncInternal<T>(ids);
+		}
+
+		public Task<T[]> LoadAsync<T>(IEnumerable<string> ids)
+		{
+			return LoadAsyncInternal<T>(ids.ToArray());
+		}
+
 		public Task<T> LoadAsync<T>(ValueType id)
 		{
 			var documentKey = Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false);
 			return LoadAsync<T>(documentKey);
 		}
 
-		public Task<T[]> LoadAsync<T>(string[] ids)
+		public Task<T[]> LoadAsync<T>(params ValueType[] ids)
 		{
-			return LoadAsyncInternal<T>(ids);
+			var documentKeys = ids.Select(id => Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return LoadAsyncInternal<T>(documentKeys.ToArray());
+		}
+
+		public Task<T[]> LoadAsync<T>(IEnumerable<ValueType> ids)
+		{
+			var documentKeys = ids.Select(id => Conventions.FindFullDocumentKeyFromNonStringIdentifier(id, typeof(T), false));
+			return LoadAsyncInternal<T>(documentKeys.ToArray());
 		}
 
 		public Task<T[]> LoadAsyncInternal<T>(string[] ids)


### PR DESCRIPTION
There are lots of examples of loading multiple documents at once, but none of them work if you are using non-string identifiers.

Added:
.Load(params ValueType[] ids)
.Load(IEnumerable&lt;ValueType&gt; ids)

and related methods for async, loaderwithincludes, lazy, etc...

Also found a few misc things along the way, such as some places that had .Load(params string[]) but not .Load(IEnumerable&lt;string&gt;)
