### PR TITLE
RavenDB-786 - Fix Index Replication Bundle

### DIFF
--- a/Bundles/Raven.Bundles.IndexReplication/IndexReplicationIndexUpdateTrigger.cs
+++ b/Bundles/Raven.Bundles.IndexReplication/IndexReplicationIndexUpdateTrigger.cs
@@ -182,7 +182,20 @@ namespace Raven.Bundles.IndexReplication
 
 			private string GetParameterName(string paramName)
 			{
-				return GetParameterNameFromBuilder(_commandBuilder, paramName);
+				switch (_providerFactory.GetType().Name)
+				{
+					case "SqlClientFactory":
+					case "MySqlClientFactory":
+						return "@" + paramName;
+
+					case "OracleClientFactory":
+					case "NpgsqlFactory":
+						return ":" + paramName;
+
+					default:
+						// If we don't know, try to get it from the CommandBuilder.
+						return GetParameterNameFromBuilder(_commandBuilder, paramName);
+				}
 			}
 
 			public override void Dispose()


### PR DESCRIPTION
Generically get the parameter name so it works with other providers, such as mysql.  Don't assume we know about the parameter prefix ourselves.  Also, put table and field names into quoted identifiers in case they use reserved keywords.
