### PR TITLE
Disallow SystemTime.UtcNow in index definition

### DIFF
--- a/Raven.Database/Linq/Ast/ThrowOnInvalidMethodCalls.cs
+++ b/Raven.Database/Linq/Ast/ThrowOnInvalidMethodCalls.cs
@@ -34,7 +34,7 @@ namespace Raven.Database.Linq.Ast
 		{
 			new ForbiddenMethod(
 				names: new[] { "Now", "UtcNow" },
-				typeAliases: new[] { "DateTime", "System.DateTime", "DateTimeOffset", "System.DateTimeOffset" },
+				typeAliases: new[] { "DateTime", "System.DateTime", "DateTimeOffset", "System.DateTimeOffset", "SystemTime", "Abstractions.SystemTime", "Raven.Abstractions.SystemTime" },
 				error: @"Cannot use {0} during a map or reduce phase.
 The map or reduce functions must be referentially transparent, that is, for the same set of values, they always return the same results.
 Using {0} invalidate that premise, and is not allowed"),


### PR DESCRIPTION
Just like DateTime.Now and DateTime.UtcNow, we should not allow SystemTime.UtcNow either.
