### PR TITLE
If database is provided don't open the "Create a new database" dialog automatically

### DIFF
--- a/Raven.Studio/Models/ServerModel.cs
+++ b/Raven.Studio/Models/ServerModel.cs
@@ -116,13 +116,13 @@ namespace Raven.Studio.Models
 				                   	            }
 				                   	        });
 
-				                   		if (names.Length == 0 || (names.Length == 1 && names[0] == Constants.SystemDatabase))
+				                   		var url = new UrlParser(UrlUtil.Url);
+
+				                   		if (url.QueryParams.ContainsKey("database") == false && (names.Length == 0 || (names.Length == 1 && names[0] == Constants.SystemDatabase)))
 				                   			CreateNewDatabase = true;
 
 				                   		if (string.IsNullOrEmpty(Settings.Instance.SelectedDatabase)) 
 											return;
-
-				                   		var url = new UrlParser(UrlUtil.Url);
 
 										if (Settings.Instance.SelectedDatabase != null && names.Contains(Settings.Instance.SelectedDatabase))
 										{


### PR DESCRIPTION
For embedded scenario I usually only have a single database (<system>) and when providing this as a query parameter, I don't want the "create a new database" dialog to pop up.
