### PR TITLE
Fix for restoring tenant dbs when using non-default paths for indexes and logs.

### DIFF
--- a/Raven.Database/Server/Responders/Admin/AdminRestore.cs
+++ b/Raven.Database/Server/Responders/Admin/AdminRestore.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System;
 using System.IO;
 using Raven.Abstractions.Data;
 using Raven.Database.Config;
@@ -19,19 +20,52 @@ namespace Raven.Database.Server.Responders.Admin
 
 			var restoreRequest = context.ReadJsonObject<RestoreRequest>();
 
-			var ravenConfiguration = new RavenConfiguration();
+			DatabaseDocument databaseDocument = null;
+
+			if (File.Exists(Path.Combine(restoreRequest.RestoreLocation, "Database.Document")))
+			{
+				var databaseDocumentText = File.ReadAllText(Path.Combine(restoreRequest.RestoreLocation, "Database.Document"));
+				databaseDocument = RavenJObject.Parse(databaseDocumentText).JsonDeserialization<DatabaseDocument>();
+			}
+
+			var databaseName = !string.IsNullOrWhiteSpace(restoreRequest.DatabaseName) ? restoreRequest.DatabaseName
+								   : databaseDocument == null ? null : databaseDocument.Id;
+
+			if (string.IsNullOrWhiteSpace(databaseName))
+			{
+				context.SetStatusToBadRequest();
+				context.WriteJson(new
+				{
+					Error = "A database name must be supplied if the restore location does not contain a valid Database.Document file"
+				});
+				return;
+			}
+
+			var ravenConfiguration = new RavenConfiguration()
+			{
+				DatabaseName = databaseName,
+				IsTenantDatabase = true
+			};
+
 			if (File.Exists(Path.Combine(restoreRequest.RestoreLocation, "Raven.ravendb")))
 			{
-				ravenConfiguration.DefaultStorageTypeName = "Raven.Storage.Managed.TransactionalStorage, Raven.Storage.Managed";
+				ravenConfiguration.DefaultStorageTypeName = typeof(Raven.Storage.Managed.TransactionalStorage).AssemblyQualifiedName;
+
 			}
 			else if (Directory.Exists(Path.Combine(restoreRequest.RestoreLocation, "new")))
 			{
-				ravenConfiguration.DefaultStorageTypeName = "Raven.Storage.Esent.TransactionalStorage, Raven.Storage.Esent";
+				ravenConfiguration.DefaultStorageTypeName = typeof(Raven.Storage.Esent.TransactionalStorage).AssemblyQualifiedName;
 			}
+
+			ravenConfiguration.CustomizeValuesForTenant(databaseName);
+			ravenConfiguration.Initialize();
+
+			string documentDataDir;
+			ravenConfiguration.DataDirectory = ResolveTenantDataDirectory(restoreRequest.DatabaseLocation, databaseName, out documentDataDir);
 
 			var restoreStatus = new List<string>();
 
-			DocumentDatabase.Restore(ravenConfiguration, restoreRequest.RestoreLocation, restoreRequest.DatabaseLocation,
+			DocumentDatabase.Restore(ravenConfiguration, restoreRequest.RestoreLocation, null,
 			                         msg =>
 			                         {
 				                         restoreStatus.Add(msg);
@@ -39,23 +73,45 @@ namespace Raven.Database.Server.Responders.Admin
 											 RavenJObject.FromObject(new {restoreStatus}), new RavenJObject(), null);
 			                         });
 
-			if (File.Exists(Path.Combine(restoreRequest.RestoreLocation, "Database.Document")))
+			if (databaseDocument == null)
+				return;
+
+			databaseDocument.Settings[Constants.RavenDataDir] = documentDataDir;
+			databaseDocument.Id = databaseName;
+			SystemDatabase.Put("Raven/Databases/" + databaseName, null, RavenJObject.FromObject(databaseDocument), new RavenJObject(), null);
+
+			restoreStatus.Add("The new database was created");
+			SystemDatabase.Put(RestoreStatus.RavenRestoreStatusDocumentKey, null,
+				RavenJObject.FromObject(new { restoreStatus }), new RavenJObject(), null);
+
+		}
+
+		private string ResolveTenantDataDirectory(string databaseLocation, string databaseName, out string documentDataDir)
+		{
+			if (Path.IsPathRooted(databaseLocation))
 			{
-				var databaseDocumentText = File.ReadAllText(Path.Combine(restoreRequest.RestoreLocation, "Database.Document"));
-				var databaseDocument = RavenJObject.Parse(databaseDocumentText).JsonDeserialization<DatabaseDocument>();
-				if (databaseDocument == null)
-					return;
-
-				if (!string.IsNullOrWhiteSpace(restoreRequest.DatabaseLocation))
-					databaseDocument.Settings[Constants.RavenDataDir] = restoreRequest.DatabaseLocation;
-				if (!string.IsNullOrWhiteSpace(restoreRequest.DatabaseName))
-					databaseDocument.Id = "Raven/Databases/" + restoreRequest.DatabaseName;
-				SystemDatabase.Put(databaseDocument.Id, null, RavenJObject.FromObject(databaseDocument), new RavenJObject(), null);
-
-				restoreStatus.Add("The new database was created");
-				SystemDatabase.Put(RestoreStatus.RavenRestoreStatusDocumentKey, null,
-					RavenJObject.FromObject(new { restoreStatus }), new RavenJObject(), null);
+				documentDataDir = databaseLocation;
+				return databaseLocation;
 			}
+
+			var baseDataPath = Path.GetDirectoryName(SystemDatabase.Configuration.DataDirectory);
+			if (baseDataPath == null)
+				throw new InvalidOperationException("Could not find root data path");
+
+			if (string.IsNullOrWhiteSpace(databaseLocation))
+			{
+				documentDataDir = "~/Databases/" + databaseName;
+				return Path.Combine(baseDataPath, documentDataDir.Substring(2));
+			}
+
+			documentDataDir = databaseLocation;
+
+			if (!documentDataDir.StartsWith("~/") && !documentDataDir.StartsWith(@"~\"))
+			{
+				documentDataDir = "~/" + documentDataDir.TrimStart(new char[] { '/', '\\' });
+			}
+
+			return Path.Combine(baseDataPath, documentDataDir.Substring(2));
 		}
 	}
 }

--- a/Raven.Database/Storage/Esent/Backup/RestoreOperation.cs
+++ b/Raven.Database/Storage/Esent/Backup/RestoreOperation.cs
@@ -9,6 +9,7 @@ using Microsoft.Isam.Esent.Interop;
 using Raven.Database;
 using Raven.Database.Config;
 using Raven.Database.Extensions;
+using Raven.Abstractions.Data;
 using System.Linq;
 
 namespace Raven.Storage.Esent.Backup
@@ -20,16 +21,20 @@ namespace Raven.Storage.Esent.Backup
 		private readonly Action<string> output;
 		private readonly bool defrag;
 		private readonly string backupLocation;
-		private readonly string databaseLocation;
 
 		private bool defragmentationCompleted;
 
-		public RestoreOperation(string backupLocation, string databaseLocation, Action<string> output, bool defrag)
+
+		private readonly InMemoryRavenConfiguration configuration;
+		private string databaseLocation { get { return configuration.DataDirectory.ToFullPath(); } }
+		private string indexLocation { get { return configuration.IndexStoragePath.ToFullPath(); } }
+
+		public RestoreOperation(string backupLocation, InMemoryRavenConfiguration configuration, Action<string> output, bool defrag)
 		{
 			this.output = output;
 			this.defrag = defrag;
 			this.backupLocation = backupLocation.ToFullPath();
-			this.databaseLocation = databaseLocation.ToFullPath();
+			this.configuration = configuration;
 		}
 
 		public void Execute()
@@ -49,9 +54,24 @@ namespace Raven.Storage.Esent.Backup
 			if (Directory.Exists(databaseLocation) == false)
 				Directory.CreateDirectory(databaseLocation);
 
-			Directory.CreateDirectory(Path.Combine(databaseLocation, "logs"));
-			Directory.CreateDirectory(Path.Combine(databaseLocation, "temp"));
-			Directory.CreateDirectory(Path.Combine(databaseLocation, "system"));
+			if (Directory.Exists(indexLocation) == false)
+				Directory.CreateDirectory(indexLocation);
+
+			var logsPath = databaseLocation;
+
+			if (!string.IsNullOrWhiteSpace(configuration.Settings[Constants.RavenLogsPath]))
+			{
+				logsPath = configuration.Settings[Constants.RavenLogsPath].ToFullPath();
+
+				if (Directory.Exists(logsPath) == false)
+				{
+					Directory.CreateDirectory(logsPath);
+				}
+			}
+
+			Directory.CreateDirectory(Path.Combine(logsPath, "logs"));
+			Directory.CreateDirectory(Path.Combine(logsPath, "temp"));
+			Directory.CreateDirectory(Path.Combine(logsPath, "system"));
 
 			CombineIncrementalBackups();
 
@@ -67,7 +87,7 @@ namespace Raven.Storage.Esent.Backup
 			Api.JetCreateInstance(out instance, "restoring " + Guid.NewGuid());
 			try
 			{
-				new TransactionalStorageConfigurator(new RavenConfiguration(), null).ConfigureInstance(instance, databaseLocation);
+				new TransactionalStorageConfigurator(configuration, null).ConfigureInstance(instance, databaseLocation);
 				Api.JetRestoreInstance(instance, backupLocation, databaseLocation, StatusCallback);
 				var fileThatGetsCreatedButDoesntSeemLikeItShould =
 					new FileInfo(
@@ -112,12 +132,9 @@ namespace Raven.Storage.Esent.Backup
 			if (directories.Count == 0)
 			{
 				CopyAll(new DirectoryInfo(Path.Combine(backupLocation, "Indexes")),
-				        new DirectoryInfo(Path.Combine(databaseLocation, "Indexes")));
+						new DirectoryInfo(indexLocation));
 				return;
 			}
-
-			if (Directory.Exists(Path.Combine(databaseLocation, "Indexes")) == false)
-				Directory.CreateDirectory(Path.Combine(databaseLocation, "Indexes"));
 
 			var latestIncrementalBackupDirectory = directories.First();
 			if(Directory.Exists(Path.Combine(latestIncrementalBackupDirectory, "Indexes")) == false)
@@ -131,7 +148,7 @@ namespace Raven.Storage.Esent.Backup
 				var filesList = File.ReadAllLines(Path.Combine(index, "index-files.required-for-index-restore"))
 					.Where(x=>string.IsNullOrEmpty(x) == false)
 					.Reverse();
-				var indexPath = Path.Combine(databaseLocation, "Indexes", indexName);
+				var indexPath = Path.Combine(indexLocation, indexName);
 				output("Copying Index: " + indexName);
 
 				if (Directory.Exists(indexPath) == false)

--- a/Raven.Database/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorage.cs
@@ -148,7 +148,12 @@ namespace Raven.Storage.Esent
 
 		public void Restore(string backupLocation, string databaseLocation, Action<string> output, bool defrag)
 		{
-			new RestoreOperation(backupLocation, databaseLocation, output, defrag).Execute();
+			if (!string.IsNullOrWhiteSpace(databaseLocation))
+			{
+				configuration.DataDirectory = databaseLocation;
+			}
+
+			new RestoreOperation(backupLocation, configuration, output, defrag).Execute();
 		}
 
 		public long GetDatabaseSizeInBytes()

--- a/Raven.Server/Program.cs
+++ b/Raven.Server/Program.cs
@@ -280,13 +280,11 @@ Configuration options:
 				var ravenConfiguration = new RavenConfiguration();
 				if (File.Exists(Path.Combine(backupLocation, "Raven.ravendb")))
 				{
-					ravenConfiguration.DefaultStorageTypeName =
-						"Raven.Storage.Managed.TransactionalStorage, Raven.Storage.Managed";
+					ravenConfiguration.DefaultStorageTypeName = typeof(Raven.Storage.Managed.TransactionalStorage).AssemblyQualifiedName;
 				}
 				else if (Directory.Exists(Path.Combine(backupLocation, "new")))
 				{
-					ravenConfiguration.DefaultStorageTypeName = "Raven.Storage.Esent.TransactionalStorage, Raven.Storage.Esent";
-
+					ravenConfiguration.DefaultStorageTypeName = typeof(Raven.Storage.Esent.TransactionalStorage).AssemblyQualifiedName;
 				}
 				DocumentDatabase.Restore(ravenConfiguration, backupLocation, databaseLocation, Console.WriteLine, defrag);
 			}


### PR DESCRIPTION
/admin/restore always treats the restore as a tenant database (system
doesn't make sense here) and uses the appropriate paths for data, logs,
and indexes.  Kept the db destination folder param with support for relative paths
as an override for backwards compatibility with Raven.Server and Tests.
