### PR TITLE
Facet Paging - Added Start and PageSize

### DIFF
--- a/Raven.Client.Embedded/EmbeddedAsyncServerClient.cs
+++ b/Raven.Client.Embedded/EmbeddedAsyncServerClient.cs
@@ -282,9 +282,12 @@ namespace Raven.Client.Embedded
 			return new CompletedTask();
 		}
 
-		public Task<FacetResults> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc)
-		{
-			return new CompletedTask<FacetResults>(databaseCommands.GetFacets(index, query, facetSetupDoc));
+		public Task<FacetResults> GetFacetsAsync( string index, IndexQuery query, string facetSetupDoc ) {
+			return GetFacetsAsync( index, query, facetSetupDoc, 0, null );
+		}
+
+		public Task<FacetResults> GetFacetsAsync( string index, IndexQuery query, string facetSetupDoc, int start, int? pageSize ) {
+			return new CompletedTask<FacetResults>( databaseCommands.GetFacets( index, query, facetSetupDoc, start, pageSize ) );
 		}
 
 		public Task<LogItem[]> GetLogsAsync(bool errorsOnly)

--- a/Raven.Client.Embedded/EmbeddedDatabaseCommands.cs
+++ b/Raven.Client.Embedded/EmbeddedDatabaseCommands.cs
@@ -704,10 +704,22 @@ namespace Raven.Client.Embedded
 		/// <param name="query"></param>
 		/// <param name="facetSetupDoc"></param>
 		/// <returns></returns>
-		public FacetResults GetFacets(string index, IndexQuery query, string facetSetupDoc)
-		{
+		public FacetResults GetFacets( string index, IndexQuery query, string facetSetupDoc ) {
+			return GetFacets( index, query, facetSetupDoc, 0, null );
+		}
+
+		/// <summary>
+		/// Using the given Index, calculate the facets as per the specified doc with the given start and pageSize
+		/// </summary>
+		/// <param name="index"></param>
+		/// <param name="query"></param>
+		/// <param name="facetSetupDoc"></param>
+		/// <param name="start"></param>
+		/// <param name="pageSize"></param>
+		/// <returns></returns>
+		public FacetResults GetFacets( string index, IndexQuery query, string facetSetupDoc, int start, int? pageSize ) {
 			CurrentOperationContext.Headers.Value = OperationsHeaders;
-			return database.ExecuteGetTermsQuery(index, query, facetSetupDoc);
+			return database.ExecuteGetTermsQuery( index, query, facetSetupDoc, start, pageSize );
 		}
 
 		/// <summary>

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -590,29 +590,36 @@ namespace Raven.Client.Connection.Async
 		/// <summary>
 		/// Using the given Index, calculate the facets as per the specified doc
 		/// </summary>
-		public Task<FacetResults> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc)
-		{
-			return ExecuteWithReplication("GET", operationUrl =>
-			{
-				var requestUri = operationUrl + string.Format("/facets/{0}?facetDoc={1}&query={2}",
-				Uri.EscapeUriString(index),
-				Uri.EscapeDataString(facetSetupDoc),
-				Uri.EscapeUriString(Uri.EscapeDataString(query.Query)));
+		public Task<FacetResults> GetFacetsAsync( string index, IndexQuery query, string facetSetupDoc ) {
+			return GetFacetsAsync( index, query, facetSetupDoc, 0, null );
+		}
+
+		/// <summary>
+		/// Using the given Index, calculate the facets as per the specified doc with the given start and pageSize
+		/// </summary>
+		public Task<FacetResults> GetFacetsAsync( string index, IndexQuery query, string facetSetupDoc, int start, int? pageSize ) {
+			return ExecuteWithReplication( "GET", operationUrl => {
+				var requestUri = operationUrl + string.Format( "/facets/{0}?facetDoc={1}&query={2}&facetStart={3}&facetPageSize={4}",
+				Uri.EscapeUriString( index ),
+				Uri.EscapeDataString( facetSetupDoc ),
+				Uri.EscapeUriString( Uri.EscapeDataString( query.Query ) ),
+				start,
+				pageSize );
 
 				var request = jsonRequestFactory.CreateHttpJsonRequest(
-					new CreateHttpJsonRequestParams(this, requestUri.NoCache(), "GET", credentials, convention)
-						.AddOperationHeaders(OperationsHeaders));
+					new CreateHttpJsonRequestParams( this, requestUri.NoCache(), "GET", credentials, convention )
+						.AddOperationHeaders( OperationsHeaders ) );
 
-				request.AddReplicationStatusHeaders(url, operationUrl, replicationInformer, convention.FailoverBehavior, HandleReplicationStatusChanges);
+				request.AddReplicationStatusHeaders( url, operationUrl, replicationInformer, convention.FailoverBehavior, HandleReplicationStatusChanges );
 
 				return request.ReadResponseJsonAsync()
-					.ContinueWith(task =>
-					{
-						var json = (RavenJObject)task.Result;
+					.ContinueWith( task => {
+						var json = ( RavenJObject )task.Result;
 						return json.JsonDeserialization<FacetResults>();
-					});
-			});
+					} );
+			} );
 		}
+
 
 		public Task<LogItem[]> GetLogsAsync(bool errorsOnly)
 		{

--- a/Raven.Client.Lightweight/Connection/Async/IAsyncDatabaseCommands.cs
+++ b/Raven.Client.Lightweight/Connection/Async/IAsyncDatabaseCommands.cs
@@ -233,7 +233,20 @@ namespace Raven.Client.Connection.Async
 		/// <summary>
 		/// Using the given Index, calculate the facets as per the specified doc
 		/// </summary>
-		Task<FacetResults> GetFacetsAsync(string index, IndexQuery query, string facetSetupDoc);
+		/// <param name="index">Name of the index.</param>
+		/// <param name="query">Query to build facet results.</param>
+		/// <param name="facetSetupDoc">Name of the FacetSetup document.</param>
+		Task<FacetResults> GetFacetsAsync( string index, IndexQuery query, string facetSetupDoc );
+
+		/// <summary>
+		/// Using the given Index, calculate the facets as per the specified doc with the given start and pageSize
+		/// </summary>
+		/// <param name="index">Name of the index.</param>
+		/// <param name="query">Query to build facet results.</param>
+		/// <param name="facetSetupDoc">Name of the FacetSetup document.</param>
+		/// <param name="start">Start index for paging.</param>
+		/// <param name="pageSize">Paging PageSize. Overrides Facet.MaxResults if set.</param>
+		Task<FacetResults> GetFacetsAsync( string index, IndexQuery query, string facetSetupDoc, int start, int? pageSize );
 
 		/// <summary>
 		/// Gets the Logs

--- a/Raven.Client.Lightweight/Connection/IDatabaseCommands.cs
+++ b/Raven.Client.Lightweight/Connection/IDatabaseCommands.cs
@@ -335,7 +335,12 @@ namespace Raven.Client.Connection
 		/// <summary>
 		/// Using the given Index, calculate the facets as per the specified doc
 		/// </summary>
-		FacetResults GetFacets(string index, IndexQuery query, string facetSetupDoc);
+		FacetResults GetFacets( string index, IndexQuery query, string facetSetupDoc );
+
+		/// <summary>
+		/// Using the given Index, calculate the facets as per the specified doc with the given start and pageSize
+		/// </summary>
+		FacetResults GetFacets( string index, IndexQuery query, string facetSetupDoc, int start, int? pageSize );
 
 		/// <summary>
 		/// Sends a patch request for a specific document, ignoring the document's Etag

--- a/Raven.Client.Lightweight/Connection/ServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/ServerClient.cs
@@ -1594,24 +1594,37 @@ namespace Raven.Client.Connection
 		/// <param name="query"></param>
 		/// <param name="facetSetupDoc"></param>
 		/// <returns></returns>
-		public FacetResults GetFacets(string index, IndexQuery query, string facetSetupDoc)
-		{
-			return ExecuteWithReplication("GET", operationUrl =>
-			{
-				var requestUri = operationUrl + string.Format("/facets/{0}?facetDoc={1}&{2}",
-															  Uri.EscapeUriString(index),
-															  Uri.EscapeDataString(facetSetupDoc),
-															  query.GetMinimalQueryString());
+		public FacetResults GetFacets( string index, IndexQuery query, string facetSetupDoc ) {
+			return GetFacets( index, query, facetSetupDoc, 0, null );
+		}
+
+		/// <summary>
+		/// Using the given Index, calculate the facets as per the specified doc with the given start and pageSize
+		/// </summary>
+		/// <param name="index"></param>
+		/// <param name="query"></param>
+		/// <param name="facetSetupDoc"></param>
+		/// <param name="start"></param>
+		/// <param name="pageSize"></param>
+		/// <returns></returns>
+		public FacetResults GetFacets( string index, IndexQuery query, string facetSetupDoc, int start, int? pageSize ) {
+			return ExecuteWithReplication( "GET", operationUrl => {
+				var requestUri = operationUrl + string.Format( "/facets/{0}?facetDoc={1}&{2}&facetStart={3}&facetPageSize={4}",
+																Uri.EscapeUriString( index ),
+																Uri.EscapeDataString( facetSetupDoc ),
+																query.GetMinimalQueryString(),
+																start,
+																pageSize );
 
 				var request = jsonRequestFactory.CreateHttpJsonRequest(
-					new CreateHttpJsonRequestParams(this, requestUri, "GET", credentials, convention)
-						.AddOperationHeaders(OperationsHeaders))
-						.AddReplicationStatusHeaders(Url, operationUrl, replicationInformer, convention.FailoverBehavior, HandleReplicationStatusChanges);
+					new CreateHttpJsonRequestParams( this, requestUri, "GET", credentials, convention )
+						.AddOperationHeaders( OperationsHeaders ) )
+						.AddReplicationStatusHeaders( Url, operationUrl, replicationInformer, convention.FailoverBehavior, HandleReplicationStatusChanges );
 
-				
-				var json = (RavenJObject)request.ReadResponseJson();
+
+				var json = ( RavenJObject )request.ReadResponseJson();
 				return json.JsonDeserialization<FacetResults>();
-			});
+			} );
 		}
 
 		/// <summary>

--- a/Raven.Client.Lightweight/Document/Batches/LazyFacetsOperation.cs
+++ b/Raven.Client.Lightweight/Document/Batches/LazyFacetsOperation.cs
@@ -15,12 +15,24 @@ namespace Raven.Client.Document.Batches
 		private readonly string index;
 		private readonly string facetSetupDoc;
 		private readonly IndexQuery query;
+		private readonly int start;
+		private readonly int? pageSize;
 
 		public LazyFacetsOperation(string index, string facetSetupDoc, IndexQuery query)
 		{
 			this.index = index;
 			this.facetSetupDoc = facetSetupDoc;
 			this.query = query;
+			start = 0;
+			pageSize = null;
+		}
+
+		public LazyFacetsOperation( string index, string facetSetupDoc, IndexQuery query, int start, int? pageSize ) {
+			this.index = index;
+			this.facetSetupDoc = facetSetupDoc;
+			this.query = query;
+			this.start = start;
+			this.pageSize = pageSize;
 		}
 
 		public GetRequest CreateRequest()
@@ -28,9 +40,11 @@ namespace Raven.Client.Document.Batches
 			return new GetRequest
 			{
 				Url = "/facets/" + index,
-				Query = string.Format("facetDoc={0}&query={1}",
-									  facetSetupDoc,
-									  query.Query)
+				Query = string.Format( "facetDoc={0}&query={1}&facetStart={2}&facetPageSize={3}",
+										facetSetupDoc,
+										query.Query,
+										start,
+										pageSize )
 			};
 		}
 
@@ -102,7 +116,7 @@ namespace Raven.Client.Document.Batches
 #if !SILVERLIGHT
 		public object ExecuteEmbedded(IDatabaseCommands commands)
 		{
-			return commands.GetFacets(index, query, facetSetupDoc);
+			return commands.GetFacets( index, query, facetSetupDoc, start, pageSize );
 		}
 
 		public void HandleEmbeddedResponse(object result)

--- a/Raven.Client.Lightweight/PublicExtensions/LinqExtensions.cs
+++ b/Raven.Client.Lightweight/PublicExtensions/LinqExtensions.cs
@@ -53,37 +53,52 @@ namespace Raven.Client
 		/// <summary>
 		/// Query the facets results for this query using the specified facet document
 		/// </summary>
-		public static FacetResults ToFacets<T>(this IQueryable<T> queryable, string facetDoc)
-		{
-			var ravenQueryInspector = ((IRavenQueryInspector)queryable);
+		public static FacetResults ToFacets<T>( this IQueryable<T> queryable, string facetDoc ) {
+			return queryable.ToFacets( facetDoc, 0, null );
+		}
+
+		/// <summary>
+		/// Query the facets results for this query using the specified facet document with the given start and pageSize
+		/// </summary>
+		public static FacetResults ToFacets<T>( this IQueryable<T> queryable, string facetDoc, int start, int? pageSize ) {
+			var ravenQueryInspector = ( ( IRavenQueryInspector )queryable );
 			var query = ravenQueryInspector.GetIndexQuery();
 
-			return ravenQueryInspector.DatabaseCommands.GetFacets(ravenQueryInspector.IndexQueried, query, facetDoc);
+			return ravenQueryInspector.DatabaseCommands.GetFacets( ravenQueryInspector.IndexQueried, query, facetDoc, start, pageSize );
 		}
 #endif
 
 #if !SILVERLIGHT
-		public static Lazy<FacetResults> ToFacetsLazy<T>(this IQueryable<T> queryable, string facetDoc)
-		{
-			var ravenQueryInspector = ((IRavenQueryInspector)queryable);
+		public static Lazy<FacetResults> ToFacetsLazy<T>( this IQueryable<T> queryable, string facetDoc ) {
+			return queryable.ToFacetsLazy( facetDoc, 0, null );
+		}
+
+		public static Lazy<FacetResults> ToFacetsLazy<T>( this IQueryable<T> queryable, string facetDoc, int start, int? pageSize ) {
+			var ravenQueryInspector = ( ( IRavenQueryInspector )queryable );
 			var query = ravenQueryInspector.ToString();
 
-			var lazyOperation = new LazyFacetsOperation(ravenQueryInspector.IndexQueried, facetDoc, new IndexQuery { Query = query });
+			var lazyOperation = new LazyFacetsOperation( ravenQueryInspector.IndexQueried, facetDoc, new IndexQuery { Query = query }, start, pageSize );
 
-			var documentSession = ((DocumentSession)ravenQueryInspector.Session);
-			return documentSession.AddLazyOperation<FacetResults>(lazyOperation, null);
+			var documentSession = ( ( DocumentSession )ravenQueryInspector.Session );
+			return documentSession.AddLazyOperation<FacetResults>( lazyOperation, null );
 		}
 #endif
 
 		/// <summary>
 		/// Query the facets results for this query using the specified facet document
 		/// </summary>
-		public static Task<FacetResults> ToFacetsAsync<T>(this IQueryable<T> queryable, string facetDoc)
-		{
-			var ravenQueryInspector = ((RavenQueryInspector<T>)queryable);
+		public static Task<FacetResults> ToFacetsAsync<T>( this IQueryable<T> queryable, string facetDoc ) {
+			return queryable.ToFacetsAsync( facetDoc, 0, null );
+		}
+
+		/// <summary>
+		/// Query the facets results for this query using the specified facet document with the given start and pageSize
+		/// </summary>
+		public static Task<FacetResults> ToFacetsAsync<T>( this IQueryable<T> queryable, string facetDoc, int start, int? pageSize ) {
+			var ravenQueryInspector = ( ( RavenQueryInspector<T> )queryable );
 			var query = ravenQueryInspector.ToAsyncString();
 
-			return ravenQueryInspector.AsyncDatabaseCommands.GetFacetsAsync(ravenQueryInspector.AsyncIndexQueried, new IndexQuery { Query = query }, facetDoc);
+			return ravenQueryInspector.AsyncDatabaseCommands.GetFacetsAsync( ravenQueryInspector.AsyncIndexQueried, new IndexQuery { Query = query }, facetDoc, start, pageSize );
 		}
 
 		/// <summary>

--- a/Raven.Database/Extensions/HttpContextExtensions.cs
+++ b/Raven.Database/Extensions/HttpContextExtensions.cs
@@ -57,7 +57,17 @@ namespace Raven.Database.Extensions
 			return context.Request.QueryString["facetDoc"] ?? "";
 		}
 
-		public static IndexQuery GetIndexQueryFromHttpContext(this IHttpContext context, int maxPageSize)
+		public static int GetFacetStartFromHttpContext( this IHttpContext context ) {
+			int start;
+			return int.TryParse( context.Request.QueryString[ "facetStart" ], out start ) ? start : 0;
+		}
+
+		public static int? GetFacetPageSizeFromHttpContext( this IHttpContext context ) {
+			int pageSize;
+			return int.TryParse( context.Request.QueryString[ "facetPageSize" ], out pageSize ) ? pageSize : new int?();
+		}
+
+		public static IndexQuery GetIndexQueryFromHttpContext( this IHttpContext context, int maxPageSize )
 		{
 			var query = new IndexQuery
 			{

--- a/Raven.Database/Queries/FacetedQueryRunnerExtensions.cs
+++ b/Raven.Database/Queries/FacetedQueryRunnerExtensions.cs
@@ -11,10 +11,16 @@ namespace Raven.Database.Queries
 {
 	public static class FacetedQueryRunnerExtensions
 	{
-		public static FacetResults ExecuteGetTermsQuery(this DocumentDatabase self,
-			string index, IndexQuery query, string facetSetupDoc)
+    public static FacetResults ExecuteGetTermsQuery( this DocumentDatabase self,
+      string index, IndexQuery query, string facetSetupDoc )
 		{
-			return new FacetedQueryRunner(self).GetFacets(index, query, facetSetupDoc);
-		}
+      return self.ExecuteGetTermsQuery( index, query, facetSetupDoc, 0, null );
+    }
+
+    public static FacetResults ExecuteGetTermsQuery( this DocumentDatabase self,
+    string index, IndexQuery query, string facetSetupDoc, int start, int? pageSize )
+		{
+      return new FacetedQueryRunner( self ).GetFacets( index, query, facetSetupDoc, start, pageSize );
+    }
 	}
 }

--- a/Raven.Database/Server/Responders/Facets.cs
+++ b/Raven.Database/Server/Responders/Facets.cs
@@ -27,6 +27,8 @@ namespace Raven.Database.Server.Responders
 
 			var facetSetupDoc = context.GetFacetSetupDocFromHttpContext();
 			var indexQuery = context.GetIndexQueryFromHttpContext(Database.Configuration.MaxPageSize);
+			var facetStart = context.GetFacetStartFromHttpContext();
+			var facetPageSize = context.GetFacetPageSizeFromHttpContext();
 
 			var jsonDocument = Database.Get(facetSetupDoc, null);
 			if(jsonDocument == null)
@@ -44,7 +46,7 @@ namespace Raven.Database.Server.Responders
 				return;
 			}
 			context.WriteETag(etag);
-			context.WriteJson(Database.ExecuteGetTermsQuery(index, indexQuery, facetSetupDoc));
+			context.WriteJson( Database.ExecuteGetTermsQuery( index, indexQuery, facetSetupDoc, facetStart, facetPageSize ) );
 		}
 
 		private Guid GetFacetsEtag(JsonDocument jsonDocument, string index)

--- a/Raven.Tests/Faceted/FacetPaging.cs
+++ b/Raven.Tests/Faceted/FacetPaging.cs
@@ -1,0 +1,499 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Indexing;
+using Raven.Client;
+using Xunit;
+
+namespace Raven.Tests.Faceted {
+	public class FacetPaging : RavenTest {
+
+		private readonly IList<Camera> _data;
+		private const int NumCameras = 1000;
+
+		public FacetPaging() {
+			_data = FacetedIndexTestHelper.GetCameras( NumCameras );
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithNoPageSizeNoMaxResults_HitsDesc() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = null, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, null );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Skip( 2 ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+					Assert.Equal( camerasByHits[ 2 ], facetResults.Results[ "Manufacturer" ].Values[ 2 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithNoPageSizeNoMaxResults_HitsDesc_WithRemoteDocumentStore() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = null, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, null );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Skip( 2 ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+					Assert.Equal( camerasByHits[ 2 ], facetResults.Results[ "Manufacturer" ].Values[ 2 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithNoPageSizeWithMaxResults_HitsDesc() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 2, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, null );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithNoPageSizeWithMaxResults_HitsDesc_WithRemoteDocumentStore() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 2, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, null );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_HitsDesc() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_HitsDesc_WithRemoteDocumentStore() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_HitsAsc() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.HitsAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_HitsAsc_WithRemoteDocumentStore() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.HitsAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_TermDesc() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_TermDesc_WithRemoteDocumentStore() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_TermAsc() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_TermAsc_WithRemoteDocumentStore() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		private void Setup( IDocumentStore store ) {
+			using( var s = store.OpenSession() ) {
+				store.DatabaseCommands.PutIndex( "CameraCost",
+												new IndexDefinition {
+													Map =
+														@"from camera in docs 
+                                                        select new 
+                                                        { 
+                                                            camera.Manufacturer, 
+                                                            camera.Model, 
+                                                            camera.Cost,
+                                                            camera.DateOfListing,
+                                                            camera.Megapixels
+                                                        }"
+												} );
+
+				var counter = 0;
+				foreach( var camera in _data ) {
+					s.Store( camera );
+					counter++;
+
+					if( counter % ( NumCameras / 25 ) == 0 )
+						s.SaveChanges();
+				}
+				s.SaveChanges();
+
+				s.Query<Camera>( "CameraCost" )
+					.Customize( x => x.WaitForNonStaleResults() )
+					.ToList();
+			}
+		}
+
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -502,6 +502,7 @@
     <Compile Include="Bundles\SqlReplication\CanReplicate.cs" />
     <Compile Include="Bundles\SqlReplication\FactIfSqlServerIsAvailable.cs" />
     <Compile Include="Bundles\Versioning\Bugs\MultiTenant.cs" />
+    <Compile Include="Faceted\FacetPaging.cs" />
     <Compile Include="Issues\BulkInsertAuth.cs" />
     <Compile Include="Issues\BulkInsertClient.cs" />
     <Compile Include="Issues\RavenDB741.cs" />


### PR DESCRIPTION
Here is the work on adding Facet paging using Start and PageSize. If you specify paging, it will override the MaxResults as your page may be smaller or larger depending on the scenario.

If you specify a Start but no PageSize, Facet.MaxResults will be honored if that is null, then Database.Configuration.MaxPageSize.
