### PR TITLE
Added Extensions ToFacets and ToFacetsLazily to LuceneQuery - See note below about ToFacetsAsync

### DIFF
--- a/Raven.Client.Lightweight/PublicExtensions/LinqExtensions.cs
+++ b/Raven.Client.Lightweight/PublicExtensions/LinqExtensions.cs
@@ -56,9 +56,21 @@ namespace Raven.Client
 		/// <param name="facetSetupDoc">Name of the FacetSetup document</param>
 		/// <param name="start">Start index for paging</param>
 		/// <param name="pageSize">Paging PageSize. If set, overrides Facet.MaxResults</param>
-		public static FacetResults ToFacets<T>( this IQueryable<T> queryable, string facetSetupDoc, int start = 0, int? pageSize = null )
-		{
-			var ravenQueryInspector = ((IRavenQueryInspector)queryable);
+		public static FacetResults ToFacets<T>( this IQueryable<T> queryable, string facetSetupDoc, int start = 0, int? pageSize = null ) {
+			var ravenQueryInspector = ( ( IRavenQueryInspector )queryable );
+			var query = ravenQueryInspector.GetIndexQuery();
+
+			return ravenQueryInspector.DatabaseCommands.GetFacets( ravenQueryInspector.IndexQueried, query, facetSetupDoc, start, pageSize );
+		}
+
+		/// <summary>
+		/// Query the facets results for this query using the specified facet document with the given start and pageSize
+		/// </summary>
+		/// <param name="facetSetupDoc">Name of the FacetSetup document</param>
+		/// <param name="start">Start index for paging</param>
+		/// <param name="pageSize">Paging PageSize. If set, overrides Facet.MaxResults</param>
+		public static FacetResults ToFacets<T>( this IDocumentQuery<T> queryable, string facetSetupDoc, int start = 0, int? pageSize = null ) {
+			var ravenQueryInspector = ( ( IRavenQueryInspector )queryable );
 			var query = ravenQueryInspector.GetIndexQuery();
 
 			return ravenQueryInspector.DatabaseCommands.GetFacets( ravenQueryInspector.IndexQueried, query, facetSetupDoc, start, pageSize );
@@ -72,15 +84,30 @@ namespace Raven.Client
 		/// <param name="facetSetupDoc">Name of the FacetSetup document</param>
 		/// <param name="start">Start index for paging</param>
 		/// <param name="pageSize">Paging PageSize. If set, overrides Facet.MaxResults</param>
-		public static Lazy<FacetResults> ToFacetsLazy<T>( this IQueryable<T> queryable, string facetSetupDoc, int start = 0, int? pageSize = null )
-		{
-			var ravenQueryInspector = ((IRavenQueryInspector)queryable);
+		public static Lazy<FacetResults> ToFacetsLazy<T>( this IQueryable<T> queryable, string facetSetupDoc, int start = 0, int? pageSize = null ) {
+			var ravenQueryInspector = ( ( IRavenQueryInspector )queryable );
 			var query = ravenQueryInspector.ToString();
 
 			var lazyOperation = new LazyFacetsOperation( ravenQueryInspector.IndexQueried, facetSetupDoc, new IndexQuery { Query = query }, start, pageSize );
 
-			var documentSession = ((DocumentSession)ravenQueryInspector.Session);
-			return documentSession.AddLazyOperation<FacetResults>(lazyOperation, null);
+			var documentSession = ( ( DocumentSession )ravenQueryInspector.Session );
+			return documentSession.AddLazyOperation<FacetResults>( lazyOperation, null );
+		}
+
+		/// <summary>
+		/// Lazily Query the facets results for this query using the specified facet document with the given start and pageSize
+		/// </summary>
+		/// <param name="facetSetupDoc">Name of the FacetSetup document</param>
+		/// <param name="start">Start index for paging</param>
+		/// <param name="pageSize">Paging PageSize. If set, overrides Facet.MaxResults</param>
+		public static Lazy<FacetResults> ToFacetsLazy<T>( this IDocumentQuery<T> queryable, string facetSetupDoc, int start = 0, int? pageSize = null ) {
+			var ravenQueryInspector = ( ( IRavenQueryInspector )queryable );
+			var query = ravenQueryInspector.ToString();
+
+			var lazyOperation = new LazyFacetsOperation( ravenQueryInspector.IndexQueried, facetSetupDoc, new IndexQuery { Query = query }, start, pageSize );
+
+			var documentSession = ( ( DocumentSession )ravenQueryInspector.Session );
+			return documentSession.AddLazyOperation<FacetResults>( lazyOperation, null );
 		}
 #endif
 
@@ -90,9 +117,8 @@ namespace Raven.Client
 		/// <param name="facetSetupDoc">Name of the FacetSetup document</param>
 		/// <param name="start">Start index for paging</param>
 		/// <param name="pageSize">Paging PageSize. If set, overrides Facet.MaxResults</param>
-		public static Task<FacetResults> ToFacetsAsync<T>( this IQueryable<T> queryable, string facetSetupDoc, int start = 0, int? pageSize = null )
-		{
-			var ravenQueryInspector = ((RavenQueryInspector<T>)queryable);
+		public static Task<FacetResults> ToFacetsAsync<T>( this IQueryable<T> queryable, string facetSetupDoc, int start = 0, int? pageSize = null ) {
+			var ravenQueryInspector = ( ( RavenQueryInspector<T> )queryable );
 			var query = ravenQueryInspector.ToAsyncString();
 
 			return ravenQueryInspector.AsyncDatabaseCommands.GetFacetsAsync( ravenQueryInspector.AsyncIndexQueried, new IndexQuery { Query = query }, facetSetupDoc, start, pageSize );

--- a/Raven.Database/Queries/FacetedQueryRunner.cs
+++ b/Raven.Database/Queries/FacetedQueryRunner.cs
@@ -19,12 +19,7 @@ namespace Raven.Database.Queries
 			this.database = database;
 		}
 
-		public FacetResults GetFacets(string index, IndexQuery indexQuery, string facetSetupDoc)
-		{
-			return GetFacets(index, indexQuery, facetSetupDoc, 0, null);
-		}
-
-		public FacetResults GetFacets(string index, IndexQuery indexQuery, string facetSetupDoc, int start, int? pageSize)
+		public FacetResults GetFacets(string index, IndexQuery indexQuery, string facetSetupDoc, int start = 0, int? pageSize = null)
 		{
 			var facetSetup = database.Get(facetSetupDoc, null);
 			if (facetSetup == null)

--- a/Raven.Tests/Faceted/FacetPaging.cs
+++ b/Raven.Tests/Faceted/FacetPaging.cs
@@ -474,45 +474,488 @@ namespace Raven.Tests.Faceted
 		}
 
 		[Fact]
-		public void CanPerformFacetedPagingSearchWithPageSize_TermAsc_WithRemoteDocumentStore()
-		{
+		public void CanPerformFacetedPagingSearchWithPageSize_TermAsc_WithRemoteDocumentStore() {
 			//also specify more results than we have
 			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueAsc, InclueRemainingTerms = true } };
 
-			using (var store = NewRemoteDocumentStore())
-			{
-				Setup(store);
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
 
-				using (var s = store.OpenSession())
-				{
-					s.Store(new FacetSetup { Id = "facets/CameraFacets", Facets = facets });
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
 					s.SaveChanges();
 
-					var facetResults = s.Query<Camera>("CameraCost")
-						.ToFacets("facets/CameraFacets", 2, 2);
+					var facetResults = s.Query<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
 
 					var cameraCounts = from d in _data
-									   group d by d.Manufacturer
-										   into result
-										   select new { Manufacturer = result.Key, Count = result.Count() };
-					var camerasByHits = cameraCounts.OrderBy(x => x.Manufacturer.ToLower()).Select(x => x.Manufacturer.ToLower()).Skip(2).Take(2).ToList();
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
 
-					Assert.Equal(2, facetResults.Results["Manufacturer"].Values.Count());
-					Assert.Equal(camerasByHits[0], facetResults.Results["Manufacturer"].Values[0].Range);
-					Assert.Equal(camerasByHits[1], facetResults.Results["Manufacturer"].Values[1].Range);
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
 
-					foreach (var facet in facetResults.Results["Manufacturer"].Values)
-					{
-						var inMemoryCount = _data.Where(x => x.Manufacturer.ToLower() == facet.Range).Count();
-						Assert.Equal(inMemoryCount, facet.Hits);
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
 					}
 
-					Assert.Equal(1, facetResults.Results["Manufacturer"].RemainingTermsCount);
-					Assert.Equal(1, facetResults.Results["Manufacturer"].RemainingTerms.Count());
-					Assert.Equal(cameraCounts.OrderBy(x => x.Manufacturer.ToLower()).Last().Count, facetResults.Results["Manufacturer"].RemainingHits);
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
 				}
 			}
 		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_HitsDesc_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_HitsDesc_WithRemoteDocumentStore_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_HitsAsc_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.HitsAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_HitsAsc_WithRemoteDocumentStore_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.HitsAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_TermDesc_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_TermDesc_WithRemoteDocumentStore_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+		
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_TermAsc_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+		
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithPageSize_TermAsc_WithRemoteDocumentStore_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>("CameraCost")
+						.ToFacets( "facets/CameraFacets", 2, 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithNoPageSizeNoMaxResults_HitsDesc_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = null, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Skip( 2 ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+					Assert.Equal( camerasByHits[ 2 ], facetResults.Results[ "Manufacturer" ].Values[ 2 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithNoPageSizeNoMaxResults_HitsDesc_WithRemoteDocumentStore_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = null, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Skip( 2 ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+					Assert.Equal( camerasByHits[ 2 ], facetResults.Results[ "Manufacturer" ].Values[ 2 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithNoPageSizeWithMaxResults_HitsDesc_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 2, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedPagingSearchWithNoPageSizeWithMaxResults_HitsDesc_WithRemoteDocumentStore_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 2, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewRemoteDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets", 2 );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Skip( 2 ).Take( 2 ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 1, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Last().Count, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
 
 		private void Setup(IDocumentStore store)
 		{

--- a/Raven.Tests/Faceted/FacetedIndexLimit.cs
+++ b/Raven.Tests/Faceted/FacetedIndexLimit.cs
@@ -256,6 +256,217 @@ namespace Raven.Tests.Faceted
 			}
 		}
 
+		[Fact]
+		public void CanPerformSearchWithTwoDefaultFacets_LuceneQuery() {
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer" }, new Facet { Name = "Model" } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets" );
+
+					Assert.Equal( 5, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( "canon", facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( "jessops", facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+					Assert.Equal( "nikon", facetResults.Results[ "Manufacturer" ].Values[ 2 ].Range );
+					Assert.Equal( "phillips", facetResults.Results[ "Manufacturer" ].Values[ 3 ].Range );
+					Assert.Equal( "sony", facetResults.Results[ "Manufacturer" ].Values[ 4 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( null, facetResults.Results[ "Manufacturer" ].RemainingTerms );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingHits );
+
+					Assert.Equal( 5, facetResults.Results[ "Model" ].Values.Count() );
+					Assert.Equal( "model1", facetResults.Results[ "Model" ].Values[ 0 ].Range );
+					Assert.Equal( "model2", facetResults.Results[ "Model" ].Values[ 1 ].Range );
+					Assert.Equal( "model3", facetResults.Results[ "Model" ].Values[ 2 ].Range );
+					Assert.Equal( "model4", facetResults.Results[ "Model" ].Values[ 3 ].Range );
+					Assert.Equal( "model5", facetResults.Results[ "Model" ].Values[ 4 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Model" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Model.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( null, facetResults.Results[ "Model" ].RemainingTerms );
+					Assert.Equal( 0, facetResults.Results[ "Model" ].RemainingTermsCount );
+					Assert.Equal( 0, facetResults.Results[ "Model" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedLimitSearch_TermAsc_LuceneQuery() {
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 2, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.WhereGreaterThan( x => x.DateOfListing, new DateTime( 2000, 1, 1 ) )
+						.ToFacets( "facets/CameraFacets" );
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( "canon", facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( "jessops", facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.DateOfListing > new DateTime( 2000, 1, 1 ) ).Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( "nikon", facetResults.Results[ "Manufacturer" ].RemainingTerms[ 0 ] );
+					Assert.Equal( "phillips", facetResults.Results[ "Manufacturer" ].RemainingTerms[ 1 ] );
+					Assert.Equal( "sony", facetResults.Results[ "Manufacturer" ].RemainingTerms[ 2 ] );
+
+					Assert.Equal( _data.Count( x => x.DateOfListing > new DateTime( 2000, 1, 1 ) ),
+						facetResults.Results[ "Manufacturer" ].Values[ 0 ].Hits +
+						facetResults.Results[ "Manufacturer" ].Values[ 1 ].Hits +
+						facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedLimitSearch_TermDesc_LuceneQuery() {
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 3, TermSortMode = FacetTermSortMode.ValueDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.WhereGreaterThan( x => x.DateOfListing, new DateTime( 2000, 1, 1 ) )
+						.ToFacets( "facets/CameraFacets" );
+
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( "sony", facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( "phillips", facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+					Assert.Equal( "nikon", facetResults.Results[ "Manufacturer" ].Values[ 2 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.DateOfListing > new DateTime( 2000, 1, 1 ) ).Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( "jessops", facetResults.Results[ "Manufacturer" ].RemainingTerms[ 0 ] );
+					Assert.Equal( "canon", facetResults.Results[ "Manufacturer" ].RemainingTerms[ 1 ] );
+
+					Assert.Equal( _data.Count( x => x.DateOfListing > new DateTime( 2000, 1, 1 ) ),
+						facetResults.Results[ "Manufacturer" ].Values[ 0 ].Hits +
+						facetResults.Results[ "Manufacturer" ].Values[ 1 ].Hits +
+						facetResults.Results[ "Manufacturer" ].Values[ 2 ].Hits +
+						facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedLimitSearch_HitsAsc_LuceneQuery() {
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 2, TermSortMode = FacetTermSortMode.HitsAsc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets" );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderBy( x => x.Count ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 2, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 3, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( camerasByHits[ 2 ], facetResults.Results[ "Manufacturer" ].RemainingTerms[ 0 ] );
+					Assert.Equal( camerasByHits[ 3 ], facetResults.Results[ "Manufacturer" ].RemainingTerms[ 1 ] );
+					Assert.Equal( camerasByHits[ 4 ], facetResults.Results[ "Manufacturer" ].RemainingTerms[ 2 ] );
+
+					Assert.Equal( _data.Count(),
+						facetResults.Results[ "Manufacturer" ].Values[ 0 ].Hits +
+						facetResults.Results[ "Manufacturer" ].Values[ 1 ].Hits +
+						facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
+		[Fact]
+		public void CanPerformFacetedLimitSearch_HitsDesc_LuceneQuery() {
+			//also specify more results than we have
+			var facets = new List<Facet> { new Facet { Name = "Manufacturer", MaxResults = 20, TermSortMode = FacetTermSortMode.HitsDesc, InclueRemainingTerms = true } };
+
+			using( var store = NewDocumentStore() ) {
+				Setup( store );
+
+				using( var s = store.OpenSession() ) {
+					s.Store( new FacetSetup { Id = "facets/CameraFacets", Facets = facets } );
+					s.SaveChanges();
+
+					var facetResults = s.Advanced.LuceneQuery<Camera>( "CameraCost" )
+						.ToFacets( "facets/CameraFacets" );
+
+					var cameraCounts = from d in _data
+														 group d by d.Manufacturer
+															 into result
+															 select new { Manufacturer = result.Key, Count = result.Count() };
+					var camerasByHits = cameraCounts.OrderByDescending( x => x.Count ).ThenBy( x => x.Manufacturer.ToLower() ).Select( x => x.Manufacturer.ToLower() ).ToList();
+
+					Assert.Equal( 5, facetResults.Results[ "Manufacturer" ].Values.Count() );
+					Assert.Equal( camerasByHits[ 0 ], facetResults.Results[ "Manufacturer" ].Values[ 0 ].Range );
+					if( camerasByHits[ 1 ] != facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range )
+						WaitForUserToContinueTheTest( store, debug: false );
+					Assert.Equal( camerasByHits[ 1 ], facetResults.Results[ "Manufacturer" ].Values[ 1 ].Range );
+					Assert.Equal( camerasByHits[ 2 ], facetResults.Results[ "Manufacturer" ].Values[ 2 ].Range );
+					Assert.Equal( camerasByHits[ 3 ], facetResults.Results[ "Manufacturer" ].Values[ 3 ].Range );
+					Assert.Equal( camerasByHits[ 4 ], facetResults.Results[ "Manufacturer" ].Values[ 4 ].Range );
+
+					foreach( var facet in facetResults.Results[ "Manufacturer" ].Values ) {
+						var inMemoryCount = _data.Where( x => x.Manufacturer.ToLower() == facet.Range ).Count();
+						Assert.Equal( inMemoryCount, facet.Hits );
+					}
+
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTermsCount );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingTerms.Count() );
+					Assert.Equal( 0, facetResults.Results[ "Manufacturer" ].RemainingHits );
+				}
+			}
+		}
+
 		private void Setup(IDocumentStore store)
 		{
 			using (var s = store.OpenSession())


### PR DESCRIPTION
To ease use of Facets within a LuceneQuery, I added the extensions of
ToFacets and ToFacetsLazily for convenience. Added additional tests around these new
extensions - all passing.

Was not sure how to cast IAsyncDocumentQuery as ( (
RavenQueryInspector<T> )queryable ) so I did not implement ToFacetsAsync.
If you would like to comment and indicate the right way to get IAsyncDocumentQuery into RevenQueryInspector<T> or some alternative, I could add
that before you commit this pull request.
