### PR TITLE
Making implementation of GetReduceTypesPerKeys in munin compatible with esent impl.

### DIFF
--- a/Raven.Database/Storage/Managed/MappedResultsStorageAction.cs
+++ b/Raven.Database/Storage/Managed/MappedResultsStorageAction.cs
@@ -356,10 +356,8 @@ namespace Raven.Storage.Managed
 
 			foreach (var reduction in storage.ScheduleReductions["ByViewLevelReduceKeyAndBucket"].SkipTo(new RavenJObject
 			{
-				{"view", indexName},
-				{"level", 0}
-			}).TakeWhile(x => string.Equals(indexName, x.Value<string>("view"), StringComparison.InvariantCultureIgnoreCase) &&
-								x.Value<int>("level") == 0)
+				{"view", indexName}
+			}).TakeWhile(x => string.Equals(indexName, x.Value<string>("view"), StringComparison.InvariantCultureIgnoreCase))
 								.Take(take))
 			{
 				allKeysToReduce.Add(reduction.Value<string>("reduceKey"));


### PR DESCRIPTION
Ayende,

please review this changes. This makes sure that we would never miss any scheduled reduce key from higher level. I'm not sure if after the changes that you already did to fix RavenDB-863 this could ever happen but I'm sure that the implementation in Munin and Esent should be consistent. 
