### PR TITLE
Add TermVector support to index fields

### DIFF
--- a/Raven.Abstractions/Indexing/FieldTermVector.cs
+++ b/Raven.Abstractions/Indexing/FieldTermVector.cs
@@ -1,0 +1,30 @@
+﻿namespace Raven.Abstractions.Indexing
+{
+    /// <summary>
+    /// Specifies whether to include term vectors for a field
+    /// </summary>
+    public enum FieldTermVector
+    {
+        /// <summary>
+        /// Do not store term vectors
+        /// </summary>
+        No,
+        /// <summary>
+        /// Store the term vectors of each document. A term vector is a list of the document's
+        /// terms and their number of occurrences in that document.
+        /// </summary>
+        Yes,        
+        /// <summary>
+        /// Store the term vector + token position information
+        /// </summary>
+        WithPositions,
+        /// <summary>
+        /// Store the term vector + Token offset information
+        /// </summary>
+        WithOffsets,
+        /// <summary>
+        /// Store the term vector + Token position and offset information
+        /// </summary>
+        WithPositionsAndOffsets
+    }
+}

--- a/Raven.Abstractions/Indexing/IndexDefinition.cs
+++ b/Raven.Abstractions/Indexing/IndexDefinition.cs
@@ -27,6 +27,7 @@ namespace Raven.Abstractions.Indexing
 			SortOptions = new Dictionary<string, SortOptions>();
 			Fields = new List<string>();
 			Suggestions = new Dictionary<string, SuggestionOptions>();
+			TermVectors = new Dictionary<string, FieldTermVector>();
 		}
 
 		/// <summary>
@@ -126,6 +127,12 @@ namespace Raven.Abstractions.Indexing
 		public IDictionary<string, SuggestionOptions> Suggestions { get; set; }
 
 		/// <summary>
+		/// Gets or sets the term vectors options
+		/// </summary>
+		/// <value>The term vectors.</value>
+		public IDictionary<string, FieldTermVector> TermVectors { get; set; }
+
+		/// <summary>
 		/// Equals the specified other.
 		/// </summary>
 		/// <param name="other">The other.</param>
@@ -137,14 +144,15 @@ namespace Raven.Abstractions.Indexing
 			if (ReferenceEquals(this, other))
 				return true;
 			return Maps.SequenceEqual(other.Maps) &&
-			       Equals(other.Name, Name) &&
-			       Equals(other.Reduce, Reduce) &&
-			       Equals(other.TransformResults, TransformResults) &&
-			       DictionaryEquals(other.Stores, Stores) &&
-			       DictionaryEquals(other.Indexes, Indexes) &&
-			       DictionaryEquals(other.Analyzers, Analyzers) &&
-				   DictionaryEquals(other.SortOptions, SortOptions) &&
-				   DictionaryEquals(other.Suggestions, Suggestions);
+					Equals(other.Name, Name) &&
+					Equals(other.Reduce, Reduce) &&
+					Equals(other.TransformResults, TransformResults) &&
+					DictionaryEquals(other.Stores, Stores) &&
+					DictionaryEquals(other.Indexes, Indexes) &&
+					DictionaryEquals(other.Analyzers, Analyzers) &&
+					DictionaryEquals(other.SortOptions, SortOptions) &&
+					DictionaryEquals(other.Suggestions, Suggestions) &&
+					DictionaryEquals(other.TermVectors, TermVectors);
 		}
 
 		private static bool DictionaryEquals<TKey, TValue>(IDictionary<TKey, TValue> x, IDictionary<TKey, TValue> y)
@@ -226,6 +234,7 @@ namespace Raven.Abstractions.Indexing
 				result = (result * 397) ^ DictionaryHashCode(Analyzers);
 				result = (result * 397) ^ DictionaryHashCode(SortOptions);
 				result = (result * 397) ^ DictionaryHashCode(Suggestions);
+				result = (result * 397) ^ DictionaryHashCode(TermVectors);
 				return result;
 			}
 		}
@@ -273,6 +282,10 @@ namespace Raven.Abstractions.Indexing
 			{
 				Suggestions.Remove(toRemove);
 			}
+			foreach (var toRemove in TermVectors.Where(x => x.Value == FieldTermVector.No).ToArray())
+			{
+				TermVectors.Remove(toRemove);
+			}
 		}
 
 		public IndexDefinition Clone()
@@ -299,6 +312,8 @@ namespace Raven.Abstractions.Indexing
 				indexDefinition.Stores = new Dictionary<string, FieldStorage>(Stores);
 			if (Suggestions != null)
 				indexDefinition.Suggestions = new Dictionary<string, SuggestionOptions>(Suggestions);
+			if (TermVectors != null)
+				indexDefinition.TermVectors = new Dictionary<string, FieldTermVector>(TermVectors);
 			return indexDefinition;
 		}
 	}

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -628,6 +628,7 @@
     <Compile Include="Default.cs" />
     <Compile Include="Extensions\ListExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
+    <Compile Include="Indexing\FieldTermVector.cs" />
     <Compile Include="Indexing\SpatialOptions.cs" />
     <Compile Include="Indexing\SuggestionOptions.cs" />
     <Compile Include="Json\ConflictsResolver.cs" />

--- a/Raven.Client.Lightweight/Indexes/AbstractGenericIndexCreationTask.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractGenericIndexCreationTask.cs
@@ -26,6 +26,8 @@ namespace Raven.Client.Indexes
 			Analyzers = new Dictionary<Expression<Func<TReduceResult, object>>, string>();
 			AnalyzersStrings = new Dictionary<string, string>();
 			IndexSuggestions = new Dictionary<Expression<Func<TReduceResult, object>>, SuggestionOptions>();
+			TermVectors = new Dictionary<Expression<Func<TReduceResult, object>>, FieldTermVector>();
+			TermVectorsStrings = new Dictionary<string, FieldTermVector>();
 		}
 
 		public override bool IsMapReduce
@@ -81,6 +83,17 @@ namespace Raven.Client.Indexes
 		/// Index sort options
 		/// </summary>
 		protected IDictionary<string, string> AnalyzersStrings { get; set; }
+
+		/// <summary>
+		/// Index term vector options
+		/// </summary>		
+		protected IDictionary<Expression<Func<TReduceResult, object>>, FieldTermVector> TermVectors { get; set; }
+
+		/// <summary>
+		/// Index term vector options
+		/// </summary>		
+		protected IDictionary<string, FieldTermVector> TermVectorsStrings { get; set; }
+
 
 		/// <summary>
 		/// Indexing options
@@ -143,6 +156,22 @@ namespace Raven.Client.Indexes
 		protected void Analyze(string field, string analyzer)
 		{
 			AnalyzersStrings.Add(field, analyzer);
+		}
+
+		/// <summary>
+		/// Register a field to have term vectors
+		/// </summary>
+		protected void TermVector(Expression<Func<TReduceResult, object>> field, FieldTermVector termVector)
+		{
+			TermVectors.Add(field, termVector);
+		}
+
+		/// <summary>
+		/// Register a field to have term vectors
+		/// </summary>
+		protected void TermVector(string field, FieldTermVector termVector)
+		{
+			TermVectorsStrings.Add(field, termVector);
 		}
 
 		/// <summary>

--- a/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
@@ -403,6 +403,7 @@ namespace Raven.Client.Indexes
 				Stores = Stores,
 				StoresStrings = StoresStrings,
 				Suggestions = IndexSuggestions,
+				TermVectors = TermVectors
 			}.ToIndexDefinition(Conventions);
 		}
 

--- a/Raven.Client.Lightweight/Indexes/IndexDefinitionBuilder.cs
+++ b/Raven.Client.Lightweight/Indexes/IndexDefinitionBuilder.cs
@@ -85,6 +85,19 @@ namespace Raven.Client.Indexes
 		public IDictionary<Expression<Func<TReduceResult, object>>, SuggestionOptions> Suggestions { get; set; }
 
 		/// <summary>
+		/// Gets or sets the term vector options
+		/// </summary>
+		/// <value>The term vectors.</value>
+		public IDictionary<Expression<Func<TReduceResult, object>>, FieldTermVector> TermVectors { get; set; }
+
+		/// <summary>
+		/// Gets or sets the term vector options
+		/// </summary>
+		/// <value>The term vectors.</value>
+		public IDictionary<string, FieldTermVector> TermVectorsStrings { get; set; }
+
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="IndexDefinitionBuilder{TDocument,TReduceResult}"/> class.
 		/// </summary>
 		public IndexDefinitionBuilder()
@@ -97,6 +110,8 @@ namespace Raven.Client.Indexes
 			Suggestions = new Dictionary<Expression<Func<TReduceResult, object>>, SuggestionOptions>();
 			Analyzers = new Dictionary<Expression<Func<TReduceResult, object>>, string>();
 			AnalyzersStrings = new Dictionary<string, string>();
+			TermVectors = new Dictionary<Expression<Func<TReduceResult, object>>, FieldTermVector>();
+			TermVectorsStrings = new Dictionary<string, FieldTermVector>();
 		}
 
 		/// <summary>
@@ -121,6 +136,7 @@ namespace Raven.Client.Indexes
 				SortOptions = ConvertToStringDictionary(SortOptions),
 				Analyzers = ConvertToStringDictionary(Analyzers),
 				Suggestions = ConvertToStringDictionary(Suggestions),
+                TermVectors =  ConvertToStringDictionary(TermVectors)
 			};
 
 			foreach (var indexesString in IndexesStrings)
@@ -140,8 +156,15 @@ namespace Raven.Client.Indexes
 			foreach (var analyzerString in AnalyzersStrings)
 			{
 				if (indexDefinition.Analyzers.ContainsKey(analyzerString.Key))
-					throw new InvalidOperationException("There is a duplicate key in stores: " + analyzerString.Key);
+					throw new InvalidOperationException("There is a duplicate key in analyzers: " + analyzerString.Key);
 				indexDefinition.Analyzers.Add(analyzerString);
+			}
+
+			foreach (var termVectorString in TermVectorsStrings)
+			{
+				if (indexDefinition.TermVectors.ContainsKey(termVectorString.Key))
+					throw new InvalidOperationException("There is a duplicate key in term vectors: " + termVectorString.Key);
+				indexDefinition.TermVectors.Add(termVectorString);
 			}
 
 			if (Map != null)

--- a/Raven.Client.Lightweight/Indexes/RavenDocumentsByEntityName.cs
+++ b/Raven.Client.Lightweight/Indexes/RavenDocumentsByEntityName.cs
@@ -39,6 +39,11 @@ select new { Tag, LastModified = (DateTime)doc[""@metadata""][""Last-Modified""]
 					{
 						{"Tag", FieldStorage.No},
 						{"LastModified", FieldStorage.No}
+					},
+				TermVectors =
+					{
+						{"Tag", FieldTermVector.No},
+						{"LastModified", FieldTermVector.No}
 					}
 			};
 		}

--- a/Raven.Client.Silverlight/Raven.Client.Silverlight.csproj
+++ b/Raven.Client.Silverlight/Raven.Client.Silverlight.csproj
@@ -685,6 +685,9 @@
     <Compile Include="..\Raven.Abstractions\Extensions\TaskExtensions.cs">
       <Link>Imports\Extensions\Absdtractions\TaskExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Raven.Abstractions\Indexing\FieldTermVector.cs">
+      <Link>Imports\Indexing\FieldTermVector.cs</Link>
+    </Compile>
     <Compile Include="..\Raven.Abstractions\Indexing\SpatialOptions.cs">
       <Link>Imports\Indexing\SpatialOptions.cs</Link>
     </Compile>

--- a/Raven.Database/Data/DynamicQueryMapping.cs
+++ b/Raven.Database/Data/DynamicQueryMapping.cs
@@ -137,6 +137,7 @@ namespace Raven.Database.Data
 			{
 				index.Stores[field] = FieldStorage.Yes;
 				index.Indexes[field] = FieldIndexing.Analyzed;
+				index.TermVectors[field] = FieldTermVector.WithPositionsAndOffsets;
 			}
 			return index;
 		}

--- a/Raven.Database/Extensions/IndexingExtensions.cs
+++ b/Raven.Database/Extensions/IndexingExtensions.cs
@@ -104,6 +104,37 @@ namespace Raven.Database.Extensions
 			}
 		}
 
+		public static Field.TermVector GetTermVector(this IndexDefinition self, string name, Field.TermVector defaultTermVector)
+		{
+			if (self.TermVectors == null)
+				return defaultTermVector;
+
+			FieldTermVector value;
+			if (self.TermVectors.TryGetValue(name, out value) == false)
+				return defaultTermVector;
+
+			if (value != FieldTermVector.No && self.GetIndex(name, null) == Field.Index.NO)
+			{
+				throw new InvalidOperationException(string.Format("TermVectors cannot be enabled for the field {0} because Indexing is set to No", name));
+			}
+
+			switch (value)
+			{
+				case FieldTermVector.No:
+					return Field.TermVector.NO;
+				case FieldTermVector.WithOffsets:
+					return Field.TermVector.WITH_OFFSETS;
+				case FieldTermVector.WithPositions:
+					return Field.TermVector.WITH_POSITIONS;
+				case FieldTermVector.WithPositionsAndOffsets:
+					return Field.TermVector.WITH_POSITIONS_OFFSETS;
+				case FieldTermVector.Yes:
+					return Field.TermVector.YES;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
+
 		public static Sort GetSort(this IndexQuery self, IndexDefinition indexDefinition)
 		{
 			var spatialQuery = self as SpatialIndexQuery;

--- a/Raven.Database/Indexing/AnonymousObjectToLuceneDocumentConverter.cs
+++ b/Raven.Database/Indexing/AnonymousObjectToLuceneDocumentConverter.cs
@@ -74,7 +74,7 @@ namespace Raven.Database.Indexing
 		///		1. with the supplied name, containing the numeric value as an unanalyzed string - useful for direct queries
 		///		2. with the name: name +'_Range', containing the numeric value in a form that allows range queries
 		/// </summary>
-		public IEnumerable<AbstractField> CreateFields(string name, object value, Field.Store defaultStorage, bool nestedArray = false)
+		public IEnumerable<AbstractField> CreateFields(string name, object value, Field.Store defaultStorage, bool nestedArray = false, Field.TermVector defaultTermVector = Field.TermVector.NO)
 		{
 			if (string.IsNullOrWhiteSpace(name))
 				throw new ArgumentException("Field must be not null, not empty and cannot contain whitespace", "name");
@@ -87,16 +87,18 @@ namespace Raven.Database.Indexing
 
 			var fieldIndexingOptions = indexDefinition.GetIndex(name, null);
 			var storage = indexDefinition.GetStorage(name, defaultStorage);
+			var termVector = indexDefinition.GetTermVector(name, defaultTermVector);
+
 			if (value == null)
 			{
 				yield return CreateFieldWithCaching(name, Constants.NullValue, storage,
-								 Field.Index.NOT_ANALYZED_NO_NORMS);
+								 Field.Index.NOT_ANALYZED_NO_NORMS, Field.TermVector.NO);
 				yield break;
 			}
 			if (Equals(value, string.Empty))
 			{
 				yield return CreateFieldWithCaching(name, Constants.EmptyString, storage,
-							 Field.Index.NOT_ANALYZED_NO_NORMS);
+							 Field.Index.NOT_ANALYZED_NO_NORMS, Field.TermVector.NO);
 				yield break;
 			}
 			if (value is DynamicNullObject)
@@ -109,14 +111,14 @@ namespace Raven.Database.Indexing
 						yield break; // we don't emit null for sorting	
 					}
 					yield return CreateFieldWithCaching(name, Constants.NullValue, storage,
-														Field.Index.NOT_ANALYZED_NO_NORMS);
+														Field.Index.NOT_ANALYZED_NO_NORMS, Field.TermVector.NO);
 				}
 				yield break;
 			}
 			var boostedValue = value as BoostedValue;
 			if (boostedValue != null)
 			{
-				foreach (var field in CreateFields(name, boostedValue.Value, storage))
+				foreach (var field in CreateFields(name, boostedValue.Value, storage, false, termVector))
 				{
 					field.Boost = boostedValue.Boost;
 					field.OmitNorms = false;
@@ -135,7 +137,7 @@ namespace Raven.Database.Indexing
 			var bytes = value as byte[];
 			if (bytes != null)
 			{
-				yield return CreateBinaryFieldWithCaching(name, bytes, storage, fieldIndexingOptions);
+				yield return CreateBinaryFieldWithCaching(name, bytes, storage, fieldIndexingOptions, termVector);
 				yield break;
 			}
 
@@ -149,7 +151,7 @@ namespace Raven.Database.Indexing
 					if (nestedArray == false && !Equals(storage, Field.Store.NO) && sentArrayField == false)
 					{
 						sentArrayField = true;
-						yield return new Field(name + "_IsArray", "true", Field.Store.YES, Field.Index.NOT_ANALYZED_NO_NORMS);
+						yield return new Field(name + "_IsArray", "true", Field.Store.YES, Field.Index.NOT_ANALYZED_NO_NORMS, Field.TermVector.NO);
 					}
 
 					if (CanCreateFieldsForNestedArray(itemToIndex, fieldIndexingOptions))
@@ -172,14 +174,14 @@ namespace Raven.Database.Indexing
 				if (!(value is DateTime) && !(value is DateTimeOffset) && !(value is TimeSpan))
 				{
 					yield return CreateFieldWithCaching(name, value.ToString(), storage,
-														indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+														indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 					yield break;
 				}
 			}
 			if (value is string)
 			{
 				var index = indexDefinition.GetIndex(name, Field.Index.ANALYZED);
-				yield return CreateFieldWithCaching(name, value.ToString(), storage, index);
+				yield return CreateFieldWithCaching(name, value.ToString(), storage, index, termVector);
 				yield break;
 			}
 
@@ -188,7 +190,7 @@ namespace Raven.Database.Indexing
 				var val = (TimeSpan)value;
 				var spanAsString = val.ToString(Default.TimeSpanLexicalFormat);
 				yield return CreateFieldWithCaching(name, spanAsString, storage,
-				   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+				   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 			}
 			else if (value is DateTime)
 			{
@@ -197,7 +199,7 @@ namespace Raven.Database.Indexing
 				if(val.Kind == DateTimeKind.Utc)
 					dateAsString += "Z";
 				yield return CreateFieldWithCaching(name, dateAsString, storage,
-						   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+						   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 			}
 			else if (value is DateTimeOffset)
 			{
@@ -213,12 +215,12 @@ namespace Raven.Database.Indexing
 					dtoStr = val.UtcDateTime.ToString(Default.DateTimeFormatsToWrite) + "Z";
 				}
 				yield return CreateFieldWithCaching(name, dtoStr, storage,
-						   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+						   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 			}
 			else if (value is bool)
 			{
 				yield return new Field(name, ((bool)value) ? "true" : "false", storage,
-							  indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+							  indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 
 			}
 			else if (value is decimal)
@@ -232,40 +234,40 @@ namespace Raven.Database.Indexing
 						s = s.Substring(0, s.Length - 1);
 				}
 				yield return CreateFieldWithCaching(name, s, storage,
-									   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+									   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 			}
 			else if (value is IConvertible) // we need this to store numbers in invariant format, so JSON could read them
 			{
 				var convert = ((IConvertible)value);
 				yield return CreateFieldWithCaching(name, convert.ToString(CultureInfo.InvariantCulture), storage,
-									   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+									   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 			}
 			else if (value is IDynamicJsonObject)
 			{
 				var inner = ((IDynamicJsonObject)value).Inner;
-				yield return CreateFieldWithCaching(name + "_ConvertToJson", "true", Field.Store.YES, Field.Index.NOT_ANALYZED_NO_NORMS);
+				yield return CreateFieldWithCaching(name + "_ConvertToJson", "true", Field.Store.YES, Field.Index.NOT_ANALYZED_NO_NORMS, Field.TermVector.NO);
 				yield return CreateFieldWithCaching(name, inner.ToString(Formatting.None), storage,
-									   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+									   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 			}
 			else
 			{
-				yield return CreateFieldWithCaching(name + "_ConvertToJson", "true", Field.Store.YES, Field.Index.NOT_ANALYZED_NO_NORMS);
+				yield return CreateFieldWithCaching(name + "_ConvertToJson", "true", Field.Store.YES, Field.Index.NOT_ANALYZED_NO_NORMS, Field.TermVector.NO);
 				yield return CreateFieldWithCaching(name, RavenJToken.FromObject(value).ToString(Formatting.None), storage,
-									   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS));
+									   indexDefinition.GetIndex(name, Field.Index.NOT_ANALYZED_NO_NORMS), termVector);
 			}
 
 
-			foreach (var numericField in CreateNumericFieldWithCaching(name, value, storage))
+			foreach (var numericField in CreateNumericFieldWithCaching(name, value, storage, termVector))
 				yield return numericField;
 		}
 
 		private IEnumerable<AbstractField> CreateNumericFieldWithCaching(string name, object value,
-			Field.Store defaultStorage)
+			Field.Store defaultStorage, Field.TermVector termVector)
 		{
 
 			var fieldName = name + "_Range";
 			var storage = indexDefinition.GetStorage(name, defaultStorage);
-			var cacheKey = new FieldCacheKey(name, null, storage, Field.TermVector.NO, multipleItemsSameFieldCount.ToArray());
+			var cacheKey = new FieldCacheKey(name, null, storage, termVector, multipleItemsSameFieldCount.ToArray());
 			NumericField numericField;
 			if (numericFieldsCache.TryGetValue(cacheKey, out numericField) == false)
 			{
@@ -323,12 +325,12 @@ namespace Raven.Database.Indexing
 			return true;
 		}
 
-		private Field CreateBinaryFieldWithCaching(string name, byte[] value, Field.Store store, Field.Index index)
+		private Field CreateBinaryFieldWithCaching(string name, byte[] value, Field.Store store, Field.Index index, Field.TermVector termVector)
 		{
 			if (value.Length > 1024)
 				throw new ArgumentException("Binary values must be smaller than 1Kb");
 
-			var cacheKey = new FieldCacheKey(name, null, store, Field.TermVector.NO, multipleItemsSameFieldCount.ToArray());
+			var cacheKey = new FieldCacheKey(name, null, store, termVector, multipleItemsSameFieldCount.ToArray());
 			Field field;
 			var stringWriter = new StringWriter();
 			JsonExtensions.CreateDefaultJsonSerializer().Serialize(stringWriter, value);
@@ -339,7 +341,7 @@ namespace Raven.Database.Indexing
 
 			if (fieldsCache.TryGetValue(cacheKey, out field) == false)
 			{
-				fieldsCache[cacheKey] = field = new Field(name, val, store, index);
+				fieldsCache[cacheKey] = field = new Field(name, val, store, index, termVector);
 			}
 			field.SetValue(val);
 			field.Boost = 1;
@@ -396,12 +398,8 @@ namespace Raven.Database.Indexing
 			}
 		}
 
-		private Field CreateFieldWithCaching(string name, string value, Field.Store store, Field.Index index)
+		private Field CreateFieldWithCaching(string name, string value, Field.Store store, Field.Index index, Field.TermVector termVector)
 		{
-		    var termVector = store == Field.Store.YES && (index == Field.Index.ANALYZED || index == Field.Index.ANALYZED_NO_NORMS)
-		        ? Field.TermVector.WITH_POSITIONS_OFFSETS // For FastVectorHighlighter
-		        : Field.TermVector.NO; 
-
 			var cacheKey = new FieldCacheKey(name, index, store, termVector, multipleItemsSameFieldCount.ToArray());
 			Field field;
 

--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -693,8 +693,9 @@ namespace Raven.Database.Indexing
 					else if (field.StringValue != null)
 					{
 						clonedField = new Field(field.Name, field.StringValue,
-						                        field.IsStored ? Field.Store.YES : Field.Store.NO,
-						                        field.IsIndexed ? Field.Index.ANALYZED_NO_NORMS : Field.Index.NOT_ANALYZED_NO_NORMS);
+												field.IsStored ? Field.Store.YES : Field.Store.NO,
+												field.IsIndexed ? Field.Index.ANALYZED_NO_NORMS : Field.Index.NOT_ANALYZED_NO_NORMS,
+												field.IsTermVectorStored ? Field.TermVector.YES : Field.TermVector.NO);
 					}
 					else
 					{

--- a/Raven.Database/Linq/AbstractViewGenerator.cs
+++ b/Raven.Database/Linq/AbstractViewGenerator.cs
@@ -70,6 +70,8 @@ namespace Raven.Database.Linq
 
 		public IDictionary<string, FieldIndexing> Indexes { get; set; }
 
+		public IDictionary<string, FieldTermVector> TermVectors { get; set; } 
+
 		public HashSet<string> ForEntityNames { get; set; }
 
 		public string[] Fields
@@ -96,6 +98,7 @@ namespace Raven.Database.Linq
 			Stores = new Dictionary<string, FieldStorage>();
 			Indexes = new Dictionary<string, FieldIndexing>();
 			SpatialStrategies = new ConcurrentDictionary<string, SpatialStrategy>();
+			TermVectors = new Dictionary<string, FieldTermVector>();
 		}
 
 		public void Init(IndexDefinition definition)

--- a/Raven.Database/Plugins/Builtins/CreateSilverlightIndexes.cs
+++ b/Raven.Database/Plugins/Builtins/CreateSilverlightIndexes.cs
@@ -25,6 +25,11 @@ select new { Tag, LastModified = (DateTime)doc[""@metadata""][""Last-Modified""]
 					{
 						{"Tag", FieldStorage.No},
 						{"LastModified", FieldStorage.No}
+					},
+					TermVectors =
+					{
+						{"Tag", FieldTermVector.No},
+						{"LastModified", FieldTermVector.No}						
 					}
 				});
 			}

--- a/Raven.Database/Queries/DynamicQueryOptimizer.cs
+++ b/Raven.Database/Queries/DynamicQueryOptimizer.cs
@@ -153,20 +153,22 @@ namespace Raven.Database.Queries
 
 					    if (indexQuery.HighlightedFields != null && indexQuery.HighlightedFields.Length > 0)
 					    {
-					        var nonHighlightableFields = indexQuery
-					            .HighlightedFields
-					            .Where(x =>
-					                   !indexDefinition.Stores.ContainsKey(x.Field) ||
-					                   indexDefinition.Stores[x.Field] != FieldStorage.Yes ||
-					                   !indexDefinition.Indexes.ContainsKey(x.Field) ||
-					                   indexDefinition.Indexes[x.Field] != FieldIndexing.Analyzed)
-					            .Select(x => x.Field)
-					            .ToArray();
+						    var nonHighlightableFields = indexQuery
+							    .HighlightedFields
+								.Where(x =>
+										!indexDefinition.Stores.ContainsKey(x.Field) ||
+										indexDefinition.Stores[x.Field] != FieldStorage.Yes ||
+										!indexDefinition.Indexes.ContainsKey(x.Field) ||
+										indexDefinition.Indexes[x.Field] != FieldIndexing.Analyzed ||
+										!indexDefinition.TermVectors.ContainsKey(x.Field) ||
+										indexDefinition.TermVectors[x.Field] != FieldTermVector.WithPositionsAndOffsets)
+								.Select(x => x.Field)
+								.ToArray();
 
 					        if (nonHighlightableFields.Any())
 					        {
 					            explain(indexName,
-					                () => "The following fields could not be highlighted because are not stored and not analysed: " +
+					                () => "The following fields could not be highlighted because they are not stored, analyzed and using term vectors with positions and offsets: " +
 					                      string.Join(", ", nonHighlightableFields));
 					            return false;
 					        }

--- a/Raven.Database/Storage/IndexDefinitionStorage.cs
+++ b/Raven.Database/Storage/IndexDefinitionStorage.cs
@@ -90,6 +90,7 @@ namespace Raven.Database.Storage
 					Reduce = generator.ReduceDefinition == null ? null : "Compiled reduce function: " + generator.GetType().AssemblyQualifiedName,
 					Indexes = generator.Indexes,
 					Stores = generator.Stores,
+					TermVectors = generator.TermVectors,
 					IsCompiled = true
 				};
 				indexCache.AddOrUpdate(name, copy, (s, viewGenerator) => copy);

--- a/Raven.Studio/Features/Indexes/EditIndexView.xaml
+++ b/Raven.Studio/Features/Indexes/EditIndexView.xaml
@@ -111,7 +111,7 @@
 										 MinimumPrefixLength="0"
 										 IsTextCompletionEnabled="True"
 										 VerticalAlignment="Center"
-										 Margin="5,5,5,0">
+										 Margin="0,5,5,0">
 						<i:Interaction.Behaviors>
 							<Behaviors:BindSuggestionsProvider SuggestionProvider="{Binding DataContext, RelativeSource={RelativeSource AncestorType=ItemsControl}}"/>
 						</i:Interaction.Behaviors>
@@ -122,12 +122,24 @@
 						</i:Interaction.Triggers>
 					</sdk:AutoCompleteBox>
 
+                    <TextBlock Text="TermVector"
+                               Grid.Row="6"
+                               VerticalAlignment="Center"
+                               Margin="0,0,4,0" />
+                    <ComboBox ItemsSource="{Binding TermVector, Converter={StaticResource enumerationFromValue}, Mode=OneTime}"
+                              SelectedItem="{Binding TermVector, Converter={StaticResource enumeratedValue}, Mode=TwoWay}"
+                              Grid.Row="6"
+                              Grid.Column="1"
+                              MinWidth="90"
+                              VerticalAlignment="Center" />
+                    
                     <TextBlock Text="Suggestion"
                                Grid.Row="6"
                                Grid.Column="2"
+                               Margin="8,0,4,0"
                                VerticalAlignment="Center" />
                     <StackPanel Orientation="Horizontal"
-                                HorizontalAlignment="Right"
+                                HorizontalAlignment="Left"
                         Grid.Row="6"
                                 Grid.Column="3">
                         <ComboBox ItemsSource="{Binding SuggestionDistance, Converter={StaticResource enumerationFromValue}, Mode=OneTime}"

--- a/Raven.Studio/Models/IndexDefinitionModel.cs
+++ b/Raven.Studio/Models/IndexDefinitionModel.cs
@@ -76,6 +76,7 @@ namespace Raven.Studio.Models
 
 			CreateOrEditField(index.Indexes, (f, i) => f.Indexing = i);
 			CreateOrEditField(index.Stores, (f, i) => f.Storage = i);
+			CreateOrEditField(index.TermVectors, (f, i) => f.TermVector = i);
 			CreateOrEditField(index.SortOptions, (f, i) => f.Sort = i);
 			CreateOrEditField(index.Analyzers, (f, i) => f.Analyzer = i);
 			CreateOrEditField(index.Suggestions, (f, i) =>
@@ -173,12 +174,14 @@ namespace Raven.Studio.Models
 			index.SortOptions.Clear();
 			index.Analyzers.Clear();
 			index.Suggestions.Clear();
+			index.TermVectors.Clear();
 			foreach (var item in Fields.Where(item => item.Name != null))
 			{
 				index.Indexes[item.Name] = item.Indexing;
 				index.Stores[item.Name] = item.Storage;
 				index.SortOptions[item.Name] = item.Sort;
 				index.Analyzers[item.Name] = item.Analyzer;
+				index.TermVectors[item.Name] = item.TermVector;
 				index.Suggestions[item.Name] = new SuggestionOptions { Accuracy = item.SuggestionAccuracy, Distance = item.SuggestionDistance };
 			}
 			index.RemoveDefaultValues();
@@ -642,6 +645,21 @@ namespace Raven.Studio.Models
 				}
 			}
 
+			private FieldTermVector termVector;
+			public FieldTermVector TermVector
+			{
+				get { return termVector; }
+				set
+				{
+					if (termVector != value)
+					{
+						termVector = value;
+						OnPropertyChanged(() => TermVector);
+					}
+				}
+			}
+
+
 			private SortOptions sort;
 			public SortOptions Sort
 			{
@@ -678,6 +696,7 @@ namespace Raven.Studio.Models
 					{
 						Storage = FieldStorage.No,
 						Indexing = FieldIndexing.Default,
+						TermVector =  FieldTermVector.No,
 						Sort = SortOptions.None,
 						Analyzer = string.Empty,
 						SuggestionAccuracy = 0,

--- a/Raven.Tests/Bugs/MoreLikeThisTrack.cs
+++ b/Raven.Tests/Bugs/MoreLikeThisTrack.cs
@@ -42,6 +42,8 @@ namespace Raven.Tests.Bugs
 				Store(x => x.Genre, FieldStorage.Yes);
 				Store(x => x.Artist, FieldStorage.Yes);
 				Store("FreeText", FieldStorage.Yes);
+
+				TermVector("FreeText", FieldTermVector.Yes);
 			}
 		}
 

--- a/Raven.Tests/Bundles/MoreLikeThis/MoreLikeThisShouldSupportMapReduceIndexes.cs
+++ b/Raven.Tests/Bundles/MoreLikeThis/MoreLikeThisShouldSupportMapReduceIndexes.cs
@@ -146,6 +146,7 @@ namespace Raven.Tests.Bundles.MoreLikeThis
 
 				Index(x => x.Text, FieldIndexing.Analyzed);
 				Index(x => x.BookId, FieldIndexing.NotAnalyzed);
+				TermVector(x=>x.Text, FieldTermVector.Yes);
 			}
 		}
 	}

--- a/Raven.Tests/Querying/UsingDynamicQueryWithLocalServer.cs
+++ b/Raven.Tests/Querying/UsingDynamicQueryWithLocalServer.cs
@@ -307,6 +307,11 @@ namespace Raven.Tests.Querying
 						{
 							{"Title", FieldIndexing.Analyzed},
 							{"Category", FieldIndexing.Analyzed}
+						},
+						TermVectors =
+						{
+							{"Title", FieldTermVector.WithPositionsAndOffsets},
+							{"Category", FieldTermVector.WithPositionsAndOffsets}							
 						}
 					});
 
@@ -388,6 +393,11 @@ namespace Raven.Tests.Querying
 						{
 							{"Title", FieldIndexing.Analyzed},
 							{"Category", FieldIndexing.Analyzed}
+						},
+						TermVectors =
+						{
+							{"Title", FieldTermVector.WithPositionsAndOffsets},
+							{"Category", FieldTermVector.WithPositionsAndOffsets}							
 						}
 					});
 
@@ -460,6 +470,11 @@ namespace Raven.Tests.Querying
 						{
 							{"Title", FieldIndexing.Analyzed},
 							{"Category", FieldIndexing.Analyzed}
+						},
+						TermVectors =
+						{
+							{"Title", FieldTermVector.WithPositionsAndOffsets},
+							{"Category", FieldTermVector.WithPositionsAndOffsets}							
 						}
 					});
 

--- a/Raven.Tests/Querying/UsingDynamicQueryWithRemoteServer.cs
+++ b/Raven.Tests/Querying/UsingDynamicQueryWithRemoteServer.cs
@@ -398,7 +398,12 @@ namespace Raven.Tests.Querying
 					{
 						{"Title", FieldIndexing.Analyzed},
 						{"Category", FieldIndexing.Analyzed}
-					}
+					},
+					TermVectors =
+						{
+							{"Title", FieldTermVector.WithPositionsAndOffsets},
+							{"Category", FieldTermVector.WithPositionsAndOffsets}							
+						}
 				});
 
 			var blogOne = new Blog
@@ -473,7 +478,12 @@ namespace Raven.Tests.Querying
 					{
 						{"Title", FieldIndexing.Analyzed},
 						{"Category", FieldIndexing.Analyzed}
-					}
+					},
+					TermVectors =
+						{
+							{"Title", FieldTermVector.WithPositionsAndOffsets},
+							{"Category", FieldTermVector.WithPositionsAndOffsets}							
+						}
 				});
 
 			var blogOne = new Blog
@@ -540,7 +550,12 @@ namespace Raven.Tests.Querying
 					{
 						{"Title", FieldIndexing.Analyzed},
 						{"Category", FieldIndexing.Analyzed}
-					}
+					},
+					TermVectors =
+						{
+							{"Title", FieldTermVector.WithPositionsAndOffsets},
+							{"Category", FieldTermVector.WithPositionsAndOffsets}							
+						}
 				});
 
 			var blogOne = new Blog


### PR DESCRIPTION
Index fields used with MoreLikeThis should use TermVector.Yes, but can
also work with Storage.Yes.
Index fields used with Highlighting must be set to
TermVector.WithPositionsAndOffsets
