### PR TITLE
Make RavenDB2 work on WindowsXP

### DIFF
--- a/Raven.Database/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorage.cs
@@ -586,10 +586,15 @@ namespace Raven.Storage.Esent
 
 		public static void DisableIndexChecking(JET_INSTANCE jetInstance)
 		{
-			const int JET_paramEnableIndexCleanup = 54;
-
 			Api.JetSetSystemParameter(jetInstance, JET_SESID.Nil, JET_param.EnableIndexChecking, 0, null);
-			Api.JetSetSystemParameter(jetInstance, JET_SESID.Nil, (JET_param)JET_paramEnableIndexCleanup, 0, null);	
+			if (Environment.OSVersion.Version >= new Version(5, 2))
+			{
+				// JET_paramEnableIndexCleanup is not supported on WindowsXP
+
+				const int JET_paramEnableIndexCleanup = 54;
+
+				Api.JetSetSystemParameter(jetInstance, JET_SESID.Nil, (JET_param) JET_paramEnableIndexCleanup, 0, null);
+			}
 		}
 	}
 }

--- a/Raven.Database/Storage/Esent/TransactionalStorageConfigurator.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorageConfigurator.cs
@@ -64,8 +64,12 @@ namespace Raven.Storage.Esent
 				AlternateDatabaseRecoveryDirectory = path
 			};
 
-			const int JET_paramEnableIndexCleanup = 54;
-			Api.JetSetSystemParameter(jetInstance, JET_SESID.Nil, (JET_param)JET_paramEnableIndexCleanup, 1, null);				
+			if (Environment.OSVersion.Version >= new Version(5, 2))
+			{
+				// JET_paramEnableIndexCleanup is not supported on WindowsXP
+				const int JET_paramEnableIndexCleanup = 54;
+				Api.JetSetSystemParameter(jetInstance, JET_SESID.Nil, (JET_param) JET_paramEnableIndexCleanup, 1, null);
+			}
 
 			return instanceParameters;
 		}


### PR DESCRIPTION
JET_paramEnableIndexCleanup is only supported on Windows Server 2003 and up
