### PR TITLE
Speeds up MapReduce for large indexes with many keys to reduce

### DIFF
--- a/Raven.Database/Storage/IMappedResultsStorageAction.cs
+++ b/Raven.Database/Storage/IMappedResultsStorageAction.cs
@@ -25,7 +25,7 @@ namespace Raven.Database.Storage
 		IEnumerable<MappedResultInfo> GetReducedResultsForDebug(string indexName, string key, int level, int start, int take);
 
 		void ScheduleReductions(string view, int level, IEnumerable<ReduceKeyAndBucket> reduceKeysAndBuckets);
-		IEnumerable<MappedResultInfo> GetItemsToReduce(string index, string[] reduceKeys, int level, bool loadData, int take, List<object> itemsToDelete, HashSet<Tuple<string,int>> itemsAlreadySeen);
+		IEnumerable<MappedResultInfo> GetItemsToReduce(string index, string[] reduceKeys, int level, bool loadData, int take, List<object> itemsToDelete, HashSet<Tuple<string, int>> itemsAlreadySeen, List<string> reduceKeysDone);
 		ScheduledReductionInfo DeleteScheduledReduction(List<object> itemsToDelete);
 		void PutReducedResult(string name, string reduceKey, int level, int sourceBucket, int bucket, RavenJObject data);
 		void RemoveReduceResults(string indexName, int level, string reduceKey, int sourceBucket);

--- a/Raven.Database/Storage/Managed/MappedResultsStorageAction.cs
+++ b/Raven.Database/Storage/Managed/MappedResultsStorageAction.cs
@@ -149,11 +149,7 @@ namespace Raven.Storage.Managed
 			return hasResult ? result : null;
 		}
 
-		public IEnumerable<MappedResultInfo> GetItemsToReduce(string index, string[] reduceKeys, int level, bool loadData,
-				int take,
-				List<object> itemsToDelete,
-				HashSet<Tuple<string, int>> itemsAlreadySeen
-			)
+		public IEnumerable<MappedResultInfo> GetItemsToReduce(string index, string[] reduceKeys, int level, bool loadData, int take, List<object> itemsToDelete, HashSet<Tuple<string, int>> itemsAlreadySeen, List<string> reduceKeysDone)
 		{
 			var seenLocally = new HashSet<Tuple<string, int>>();
 			foreach (var reduceKey in reduceKeys)

--- a/Raven.Tests/Issues/RavenDB_766.cs
+++ b/Raven.Tests/Issues/RavenDB_766.cs
@@ -106,10 +106,10 @@ namespace Raven.Tests.Issues
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce.GetItemsToReduce("a", new[] { "a" }, 1, true, 10, new List<object>(), new HashSet<Tuple<string, int>>());
+					var results = accessor.MapReduce.GetItemsToReduce("a", new[] { "a" }, 1, true, 10, new List<object>(), new HashSet<Tuple<string, int>>(), new List<string>());
 					Assert.Equal(0, results.Count());
 
-					results = accessor.MapReduce.GetItemsToReduce("b", new[] { "b" }, 1, true, 10, new List<object>(), new HashSet<Tuple<string, int>>());
+					results = accessor.MapReduce.GetItemsToReduce("b", new[] { "b" }, 1, true, 10, new List<object>(), new HashSet<Tuple<string, int>>(), new List<string>());
 					Assert.Equal(2, results.Count());
 				});
 			}

--- a/Raven.Tests/Issues/RavenDB_863.cs
+++ b/Raven.Tests/Issues/RavenDB_863.cs
@@ -42,7 +42,7 @@ namespace Raven.Tests.Issues
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce.GetItemsToReduce("test", new[] { "a", "b" }, 0, true, 2, new List<object>(), new HashSet<Tuple<string, int>>()).ToList();
+					var results = accessor.MapReduce.GetItemsToReduce("test", new[] { "a", "b" }, 0, true, 2, new List<object>(), new HashSet<Tuple<string, int>>(), new List<string>()).ToList();
 					Assert.Equal(2, results.Count);
 					Assert.Equal(results[0].Bucket, results[1].Bucket);
 				});
@@ -75,7 +75,7 @@ namespace Raven.Tests.Issues
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce.GetItemsToReduce("test", new[] { "a", "b" }, 0, true, 3, new List<object>(), new HashSet<Tuple<string, int>>()).ToList();
+					var results = accessor.MapReduce.GetItemsToReduce("test", new[] { "a", "b" }, 0, true, 3, new List<object>(), new HashSet<Tuple<string, int>>(), new List<string>()).ToList();
 					Assert.Equal(4, results.Count);
 				});
 			}


### PR DESCRIPTION
does not request reducekeys - that have already been processed for a specific level

speeds up reduce process for large indexes
