### PR TITLE
fix keysToReduce must be the same for all levels

### DIFF
--- a/Raven.Database/Indexing/ReducingExecuter.cs
+++ b/Raven.Database/Indexing/ReducingExecuter.cs
@@ -102,7 +102,7 @@ namespace Raven.Database.Indexing
 
 				var reduceParams = new GetItemsToReduceParams(
 					index.IndexName, 
-					keysToReduce, 
+					keysToReduce.ToArray(), 
 					level,
 					true,
 					itemsToDelete);


### PR DESCRIPTION
Refactoring seems to have removed this logic
