### PR TITLE
Fixing serialization of Etag when using Changes API

### DIFF
--- a/Raven.Database/Server/Connections/EventsTransport.cs
+++ b/Raven.Database/Server/Connections/EventsTransport.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Abstractions.Data;
 using Raven.Abstractions.Logging;
 using Raven.Database.Server.Abstractions;
 using Raven.Imports.Newtonsoft.Json;
@@ -74,8 +75,10 @@ namespace Raven.Database.Server.Connections
 					return initTask.ContinueWith(_ => SendAsync(data)).Unwrap();
 
 
-				return context.Response.WriteAsync("data: " + JsonConvert.SerializeObject(data, Formatting.None) + "\r\n\r\n")
-					.ContinueWith(DisconnectOnError);
+				return context.Response.WriteAsync("data: " +
+				                                   JsonConvert.SerializeObject(data, Formatting.None, new EtagJsonConverter()) +
+				                                   "\r\n\r\n")
+				              .ContinueWith(DisconnectOnError);
 			}
 			catch (Exception e)
 			{

--- a/Raven.Tests/Notifications/ClientServer.cs
+++ b/Raven.Tests/Notifications/ClientServer.cs
@@ -53,6 +53,7 @@ namespace Raven.Tests.Notifications
 
 				Assert.Equal("items/1", documentChangeNotification.Id);
 				Assert.Equal(documentChangeNotification.Type, DocumentChangeTypes.Put);
+				Assert.NotNull(documentChangeNotification.Etag);
 			}
 				Thread.Sleep(1000);
 			}


### PR DESCRIPTION
Without this fix DocumentChangesNotification.ETag was NULL on the client side.
