### PR TITLE
Add well known headers to headersToIgnoreClient so they're not saved as metadata.

### DIFF
--- a/Raven.Abstractions/Extensions/MetadataExtensions.cs
+++ b/Raven.Abstractions/Extensions/MetadataExtensions.cs
@@ -107,6 +107,12 @@ namespace Raven.Abstractions.Extensions
 			"Upgrade",
 			"Via",
 			"Warning",
+
+			// IIS Application Request Routing Module
+			"X-ARR-LOG-ID",
+			"X-ARR-SSL",
+			"X-Forwarded-For",
+			"X-Original-URL"
 		};
 
 		/// <summary>


### PR DESCRIPTION
Added four headers used by the IIS Application Request Routing Module and also the Has-Api-Key header used by Raven for api key authentication.
