### PR TITLE
Small change - to avoid an extra loop for already processed reducekey

### DIFF
--- a/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
@@ -219,6 +219,8 @@ namespace Raven.Storage.Esent.StorageActions
 				}
 				do
 				{
+                    if (getItemsToReduceParams.Take <= 0)
+                        break;
 					var indexFromDb = Api.RetrieveColumnAsString(session, ScheduledReductions, tableColumnsCache.ScheduledReductionColumns["view"], Encoding.Unicode, RetrieveColumnGrbit.RetrieveFromIndex);
 					var levelFromDb =
 						Api.RetrieveColumnAsInt32(session, ScheduledReductions, tableColumnsCache.ScheduledReductionColumns["level"], RetrieveColumnGrbit.RetrieveFromIndex).
@@ -250,9 +252,6 @@ namespace Raven.Storage.Esent.StorageActions
 							}
 						}
 					}
-
-					if (getItemsToReduceParams.Take <= 0)
-						break;
 				} while (Api.TryMoveNext(session, ScheduledReductions));
 
 				getItemsToReduceParams.ReduceKeys.Remove(reduceKey);


### PR DESCRIPTION
If numbers of items to take has been reached and at the same time 

"} while (Api.TryMoveNext(session, ScheduledReductions));" is done 

then "getItemsToReduceParams.ReduceKeys.Remove(reduceKey);" will not be hit 

and the next time the GetItemsToReduce is called it will start with the same reduceKey ...
