### PR TITLE
add failing tests for indexes respecting datamember name attribute

### DIFF
--- a/Raven.Tests/Bugs/Indexing/DataContracts.cs
+++ b/Raven.Tests/Bugs/Indexing/DataContracts.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using Xunit;
+
+namespace Raven.Tests.Bugs.Indexing
+{
+	public class DataContracts : RavenTest
+	{
+		[Fact]
+		public void RespectsNameOnDataMemberAttribute()
+		{
+			using (var store = NewDocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					session.Store(new DataContractClass { Name = "tname" });
+					session.SaveChanges();
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<DataContractClass>()
+						.Where(tc => tc.Name.Equals("tname"))
+						.FirstOrDefault();
+
+					Assert.NotNull(result);
+					Assert.Equal("tname", result.Name);
+				}
+			}
+		}
+
+		[Fact]
+		public void RespectsNameOnDataMemberAttributeWithNestedCollection()
+		{
+			using (var store = NewDocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					session.Store(new WrapperClass
+					{
+						Children = new List<DataContractClass>
+						{
+							new DataContractClass{ Name = "tname"}
+						}
+					});
+
+					session.SaveChanges();
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<WrapperClass>()
+						.Where(wc => wc.Children.Any(c => c.Name.Equals("tname")))
+						.FirstOrDefault();
+
+					Assert.NotNull(result);
+					Assert.Equal("tname", result.Children.FirstOrDefault().Name);
+				}
+			}
+		}
+
+		[DataContract]
+		public class WrapperClass
+		{
+			[DataMember]
+			public string Id { get; set; }
+
+			[DataMember(Name="offspring")]
+			public ICollection<DataContractClass> Children { get; set; }
+		}
+
+		[DataContract]
+		public class DataContractClass
+		{
+			[DataMember]
+			public string Id { get; set; }
+
+			[DataMember(Name="n")]
+			public string Name { get; set; }
+		}
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Bugs\Indexing\CanHaveAnIndexNameThatStartsWithDynamic.cs" />
     <Compile Include="Bugs\Indexing\CanHaveEscapedSecialCharactersInDefinition.cs" />
     <Compile Include="Bugs\Indexing\CannotCreateIndexWithoutReduce.cs" />
+    <Compile Include="Bugs\Indexing\DataContracts.cs" />
     <Compile Include="Bugs\Indexing\WillRemoveTypesThatNotExistsOnTheServer.cs" />
     <Compile Include="Bugs\Indexing\IndexBuilderShouldCastNull.cs" />
     <Compile Include="Bugs\Indexing\WithStringReverse.cs" />


### PR DESCRIPTION
I am unable to use a dynamic index to access properties of a collection that have a custom name value in the DataMember Attribute.

While I currently do not have time to dive into raven internals, I have provided a couple of failing tests that should cover the scenario.
