### PR TITLE
Added ILicenseProvider plugin

### DIFF
--- a/Raven.Database/Commercial/ValidateLicense.cs
+++ b/Raven.Database/Commercial/ValidateLicense.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using System.Text;
@@ -14,6 +15,7 @@ using Raven.Abstractions.Data;
 using Raven.Abstractions.Logging;
 using Raven.Database.Config;
 using Raven.Database.Impl.Clustering;
+using Raven.Database.Plugins;
 using Rhino.Licensing;
 using Rhino.Licensing.Discovery;
 using Raven.Database.Extensions;
@@ -216,8 +218,15 @@ namespace Raven.Database.Commercial
 			}
 		}
 
-		private static string GetLicenseText(InMemoryRavenConfiguration config)
+		[Import(AllowDefault = true)]
+		private ILicenseProvider LicenseProvider { get; set; }
+
+		private string GetLicenseText(InMemoryRavenConfiguration config)
 		{
+			config.Container.SatisfyImportsOnce(this);
+			if (LicenseProvider != null && !string.IsNullOrEmpty(LicenseProvider.License))
+				return LicenseProvider.License;
+
 			var value = config.Settings["Raven/License"];
 			if (string.IsNullOrEmpty(value) == false)
 				return value;

--- a/Raven.Database/Plugins/ILicenseProvider.cs
+++ b/Raven.Database/Plugins/ILicenseProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.Composition;
+
+namespace Raven.Database.Plugins
+{
+	/// <summary>
+	/// Provides a RavenDB license programatically.
+	/// </summary>
+	[InheritedExport]
+	public interface ILicenseProvider
+	{
+		string License { get; }
+	}
+}

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Linq\Mono.Reflection\MethodBodyReader.cs" />
     <Compile Include="Linq\PrivateExtensions\DynamicEnumerable.cs" />
     <Compile Include="Linq\StringLiteralExpression.cs" />
+    <Compile Include="Plugins\ILicenseProvider.cs" />
     <Compile Include="Plugins\PluginsStatus.cs" />
     <Compile Include="Queries\MoreLikeThisQueryRunner.cs" />
     <Compile Include="Queries\MoreLikeThisQueryExtensions.cs" />

--- a/Raven.Tests/LicenseProviderPluginTest.cs
+++ b/Raven.Tests/LicenseProviderPluginTest.cs
@@ -1,0 +1,51 @@
+﻿using System.ComponentModel.Composition.Hosting;
+using System.Reflection;
+using Raven.Abstractions.Data;
+using Raven.Database.Config;
+using Raven.Database.Plugins;
+using Xunit;
+
+namespace Raven.Tests
+{
+	public class LicenseProviderPluginTest : RavenTest
+	{
+		public class TestLicenseProvider : ILicenseProvider
+		{
+			// We will test an invalid license.  We are just making sure it can be picked up - not its validity.
+			public string License
+			{
+				get { return "<license></license>"; }
+			}
+		}
+
+		protected override void ModifyConfiguration(InMemoryRavenConfiguration configuration)
+		{
+			configuration.Catalog.Catalogs.Add(new TypeCatalog(typeof(TestLicenseProvider)));
+		}
+
+		[Fact]
+		public void License_Can_Be_Provided_Via_Plugin()
+		{
+			using (var documentStore = NewDocumentStore())
+			{
+				// We have to get the license status via reflection since it is not exposed otherwise.
+
+				var database = documentStore.DocumentDatabase;
+
+				var field = database.GetType().GetField("validateLicense", BindingFlags.Instance | BindingFlags.NonPublic);
+				Assert.NotNull(field);
+				if (field == null) return;
+				var validateLicense = field.GetValue(database);
+
+				var prop = validateLicense.GetType().GetProperty("CurrentLicense", BindingFlags.Static | BindingFlags.Public);
+				Assert.NotNull(prop);
+				if (prop == null) return;
+				var status = (LicensingStatus) prop.GetValue(validateLicense, null);
+
+				// There should be an error status, since we provided an invalid license.
+				// If the license wasn't picked up, it would use the AGPL license with no error.
+				Assert.True(status.Error);
+			}
+		}
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -538,6 +538,7 @@
     <Compile Include="Issues\RavenDB_868.cs" />
     <Compile Include="Issues\SlowIndex.cs" />
     <Compile Include="Json\SupportForJsonPropertyAttribute.cs" />
+    <Compile Include="LicenseProviderPluginTest.cs" />
     <Compile Include="Linq\FlagsEnum.cs" />
     <Compile Include="DatabaseMemoryTargetTests.cs" />
     <Compile Include="Document\EmbeddedDocStoreWithHttpServer.cs" />


### PR DESCRIPTION
Currently there are only two ways to provide a RavenDB license:
- By dropping a license.xml file into the raven directory.
- With the `Raven/License` setting.

In embedded mode, the `Raven/License` setting can easily be applied when starting the embedded raven instance.

But in server mode, the only place to set `Raven/License` is in the `Raven.Server.exe.config` file, in the `appSettings`.

As an ISV with the "ISV Server" license, when I deploy my application I have to include the RavenDB server and my license.  But I don't want the license to be easily found by someone browsing the directory or looking in my config file.  They might take that license and use it on another RavenDB server for their own purposes.

This pull request adds a third option - to provide the license via a plugin.  I can now write a bundle for my application and include the license as an embedded resource.  I could even encrypt that resource string if I wanted to.  I can put other things in the bundle that are specific to my application, such as checking that certain documents or index exist, etc.  This will keep others from using my license outside of my application.
