### PR TITLE
Added equality methods to SpatialOptions and SuggestionOptions

### DIFF
--- a/Raven.Abstractions/Indexing/SpatialOptions.cs
+++ b/Raven.Abstractions/Indexing/SpatialOptions.cs
@@ -2,6 +2,11 @@
 {
 	public class SpatialOptions
 	{
+		// about 2 meters, should be good enough (see: http://unterbahn.com/2009/11/metric-dimensions-of-geohash-partitions-at-the-equator/)
+		public const int DefaultGeohashLevel = 9;
+		// about 1 meter, should be good enough
+		public const int DefaultQuadTreeLevel = 25;
+
 		public SpatialOptions()
 		{
 			Type = SpatialFieldType.Geography;
@@ -17,10 +22,33 @@
 		public double MinY { get; set; }
 		public double MaxY { get; set; }
 
-		// about 2 meters, should be good enough (see: http://unterbahn.com/2009/11/metric-dimensions-of-geohash-partitions-at-the-equator/)
-		public const int DefaultGeohashLevel = 9;
-		// about 1 meter, should be good enough
-		public const int DefaultQuadTreeLevel = 25;
+		protected bool Equals(SpatialOptions other)
+		{
+			return Type == other.Type && Strategy == other.Strategy && MaxTreeLevel == other.MaxTreeLevel && MinX.Equals(other.MinX) && MaxX.Equals(other.MaxX) && MinY.Equals(other.MinY) && MaxY.Equals(other.MaxY);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((SpatialOptions)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				int hashCode = (int)Type;
+				hashCode = (hashCode * 397) ^ (int)Strategy;
+				hashCode = (hashCode * 397) ^ MaxTreeLevel;
+				hashCode = (hashCode * 397) ^ MinX.GetHashCode();
+				hashCode = (hashCode * 397) ^ MaxX.GetHashCode();
+				hashCode = (hashCode * 397) ^ MinY.GetHashCode();
+				hashCode = (hashCode * 397) ^ MaxY.GetHashCode();
+				return hashCode;
+			}
+		}
 	}
 
 	public enum SpatialFieldType

--- a/Raven.Abstractions/Indexing/SuggestionOptions.cs
+++ b/Raven.Abstractions/Indexing/SuggestionOptions.cs
@@ -15,5 +15,26 @@ namespace Raven.Abstractions.Indexing
 		/// </summary>
 		/// <value>The accuracy. The default value is 0.5f.</value>
 		public float Accuracy { get; set; }
+
+		protected bool Equals(SuggestionOptions other)
+		{
+			return Distance == other.Distance && Accuracy.Equals(other.Accuracy);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((SuggestionOptions)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return ((int)Distance * 397) ^ Accuracy.GetHashCode();
+			}
+		}
 	}
 }


### PR DESCRIPTION
This ensures that indexes that use Suggestions or Spatial do not keep getting rebuilt.
