### PR TITLE
Fix an IndexOutOfRange exception. 

### DIFF
--- a/Raven.Database/Imports/Lucene.Net/FastVectorHightlighter/BaseFragmentsBuilder.cs
+++ b/Raven.Database/Imports/Lucene.Net/FastVectorHightlighter/BaseFragmentsBuilder.cs
@@ -271,7 +271,7 @@ namespace Lucene.Net.Search.Vectorhighlight
 					localStart = startOffset;
 		    }
 
-			if (endOffset != buffer.Length && buffer[endOffset + 1] != ' ')
+			if (endOffset != buffer.Length && buffer[endOffset] != ' ')
 			{
 				while (buffer[localEnd] != ' ' && localEnd != localStart && localEnd > minEnd)
 				{


### PR DESCRIPTION
This occurs when the string it bugger then the max allowed length (which is 128) of the string that contains the highlighted word/s.
