### PR TITLE
RavenDB-1035 PrefetchingBehavior - TryGetInMemoryJsonDocuments returns o...

### DIFF
--- a/Raven.Database/DocumentDatabase.cs
+++ b/Raven.Database/DocumentDatabase.cs
@@ -708,8 +708,6 @@ namespace Raven.Database
 						metadata.EnsureSnapshot("Metadata was written to the database, cannot modify the document after it was written (changes won't show up in the db). Did you forget to call CreateSnapshot() to get a clean copy?");
 						document.EnsureSnapshot("Document was written to the database, cannot modify the document after it was written (changes won't show up in the db). Did you forget to call CreateSnapshot() to get a clean copy?");
 
-						PutTriggers.Apply(trigger => trigger.AfterPut(key, document, metadata, newEtag, null));
-
 						actions.AfterStorageCommitBeforeWorkNotifications(new JsonDocument
 						{
 							Metadata = metadata,
@@ -719,6 +717,8 @@ namespace Raven.Database
 							LastModified = addDocumentResult.SavedAt,
 							SkipDeleteFromIndex = addDocumentResult.Updated == false
 						}, indexingExecuter.PrefetchingBehavior.AfterStorageCommitBeforeWorkNotifications);
+
+						PutTriggers.Apply(trigger => trigger.AfterPut(key, document, metadata, newEtag, null));
 
 						TransactionalStorage
 							.ExecuteImmediatelyOrRegisterForSynchronization(() =>


### PR DESCRIPTION
...nly 2 documents when Versions bundle is enabled in both release ravendb and 2.5 branch
