### PR TITLE
Added support for spatial bounding box indexes

### DIFF
--- a/Raven.Abstractions/Indexing/SpatialOptions.cs
+++ b/Raven.Abstractions/Indexing/SpatialOptions.cs
@@ -95,6 +95,7 @@
 	{
 		GeohashPrefixTree,
 		QuadPrefixTree,
+		BoundingBox
 	}
 
 	public enum SpatialRelation

--- a/Raven.Abstractions/Indexing/SpatialOptionsFactory.cs
+++ b/Raven.Abstractions/Indexing/SpatialOptionsFactory.cs
@@ -51,6 +51,16 @@ namespace Raven.Abstractions.Indexing
 			return GeohashPrefixTreeIndex(0, circleRadiusUnits);
 		}
 
+		public SpatialOptions BoundingBoxIndex(SpatialUnits circleRadiusUnits = SpatialUnits.Kilometers)
+		{
+			return new SpatialOptions
+			{
+				Type = SpatialFieldType.Geography,
+				Strategy = SpatialSearchStrategy.BoundingBox,
+				Units = circleRadiusUnits
+			};
+		}
+
 		public SpatialOptions GeohashPrefixTreeIndex(int maxTreeLevel, SpatialUnits circleRadiusUnits = SpatialUnits.Kilometers)
 		{
 			if (maxTreeLevel == 0)
@@ -82,6 +92,15 @@ namespace Raven.Abstractions.Indexing
 
 	public class CartesianSpatialOptionsFactory
 	{
+		public SpatialOptions BoundingBoxIndex()
+		{
+			return new SpatialOptions
+			{
+				Type = SpatialFieldType.Cartesian,
+				Strategy = SpatialSearchStrategy.BoundingBox
+			};
+		}
+
 		public SpatialOptions QuadPrefixTreeIndex(int maxTreeLevel, SpatialBounds bounds)
 		{
 			if (maxTreeLevel == 0)

--- a/Raven.Client.Lightweight/Spatial/SpatialCriteriaFactory.cs
+++ b/Raven.Client.Lightweight/Spatial/SpatialCriteriaFactory.cs
@@ -8,20 +8,30 @@ namespace Raven.Client.Spatial
 		public SpatialCriteria RelatesToShape(object shape, SpatialRelation relation)
 		{
 			return new SpatialCriteria
-			       {
-				       Relation = relation,
+				   {
+					   Relation = relation,
 					   Shape = shape
-			       };
-		}
-
-		public SpatialCriteria Within(object shape)
-		{
-			return RelatesToShape(shape, SpatialRelation.Within);
+				   };
 		}
 
 		public SpatialCriteria Intersects(object shape)
 		{
 			return RelatesToShape(shape, SpatialRelation.Intersects);
+		}
+
+		public SpatialCriteria Contains(object shape)
+		{
+			return RelatesToShape(shape, SpatialRelation.Contains);
+		}
+
+		public SpatialCriteria Disjoint(object shape)
+		{
+			return RelatesToShape(shape, SpatialRelation.Disjoint);
+		}
+
+		public SpatialCriteria Within(object shape)
+		{
+			return RelatesToShape(shape, SpatialRelation.Within);
 		}
 
 		public SpatialCriteria WithinRadiusOf(double radius, double x, double y)

--- a/Raven.Database/Indexing/Spatial/BBoxStrategyThatSupportsAllShapes.cs
+++ b/Raven.Database/Indexing/Spatial/BBoxStrategyThatSupportsAllShapes.cs
@@ -1,0 +1,38 @@
+﻿using Lucene.Net.Documents;
+using Lucene.Net.Search;
+using Lucene.Net.Spatial.BBox;
+using Lucene.Net.Spatial.Queries;
+using Spatial4n.Core.Context;
+using Spatial4n.Core.Shapes;
+
+namespace Raven.Database.Indexing.Spatial
+{
+	public class BBoxStrategyThatSupportsAllShapes : BBoxStrategy
+	{
+		public BBoxStrategyThatSupportsAllShapes(SpatialContext ctx, string fieldNamePrefix) : base(ctx, fieldNamePrefix)
+		{
+		}
+
+		private Rectangle GetRectangle(Shape shape)
+		{
+			return shape as Rectangle ?? shape.GetBoundingBox();
+		}
+
+		public override AbstractField[] CreateIndexableFields(Shape shape)
+		{
+			return CreateIndexableFields(GetRectangle(shape));
+		}
+
+		public override ConstantScoreQuery MakeQuery(SpatialArgs args)
+		{
+			args.Shape = GetRectangle(args.Shape);
+			return base.MakeQuery(args);
+		}
+
+		public override Filter MakeFilter(SpatialArgs args)
+		{
+			args.Shape = GetRectangle(args.Shape);
+			return base.MakeFilter(args);
+		}
+	}
+}

--- a/Raven.Database/Indexing/SpatialField.cs
+++ b/Raven.Database/Indexing/SpatialField.cs
@@ -82,6 +82,8 @@ namespace Raven.Database.Indexing
 					return new RecursivePrefixTreeStrategyThatSupportsWithin(new GeohashPrefixTree(context, opt.MaxTreeLevel), fieldName);
 				case SpatialSearchStrategy.QuadPrefixTree:
 					return new RecursivePrefixTreeStrategyThatSupportsWithin(new QuadPrefixTree(context, opt.MaxTreeLevel), fieldName);
+				case SpatialSearchStrategy.BoundingBox:
+					return new BBoxStrategyThatSupportsAllShapes(context, fieldName);
 			}
 			return null;
 		}

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Indexing\PrefetchingBehavior.cs" />
     <Compile Include="Indexing\RavenIndexWriter.cs" />
     <Compile Include="Indexing\RavenPerFieldAnalyzerWrapper.cs" />
+    <Compile Include="Indexing\Spatial\BBoxStrategyThatSupportsAllShapes.cs" />
     <Compile Include="Indexing\Spatial\RecursivePrefixTreeStrategyThatSupportsWithin.cs" />
     <Compile Include="Indexing\Spatial\ShapeStringReadWriter.cs" />
     <Compile Include="Indexing\Spatial\ShapeStringConverter.cs" />

--- a/Raven.Studio/Features/Indexes/EditIndexView.xaml
+++ b/Raven.Studio/Features/Indexes/EditIndexView.xaml
@@ -253,9 +253,17 @@
                                Grid.Row="4"
                                VerticalAlignment="Center"
                                Margin="0,0,4,0" />
-                    <ComboBox ItemsSource="{Binding Strategy, Converter={StaticResource enumerationFromValue}, Mode=OneTime}"
+                    <ComboBox ItemsSource="{Binding GeographyStrategies, Mode=OneTime}"
                               SelectedItem="{Binding Strategy, Converter={StaticResource enumeratedValue}, Mode=TwoWay}"
-							  IsEnabled="{Binding Type, Converter={StaticResource TrueWhenGeography}}"
+                              Visibility="{Binding IsGeographical, Mode=OneWay, Converter={StaticResource BooleanToVisibility}}"
+                              Grid.Row="4"
+                              Grid.Column="1"
+                              Grid.ColumnSpan="3"
+                              VerticalAlignment="Center"
+                              Margin="0,0,4,0" />
+                    <ComboBox ItemsSource="{Binding CartesianStrategies, Mode=OneTime}"
+                              SelectedItem="{Binding Strategy, Converter={StaticResource enumeratedValue}, Mode=TwoWay}"
+                              Visibility="{Binding IsCartesian, Mode=OneWay, Converter={StaticResource BooleanToVisibility}}"
                               Grid.Row="4"
                               Grid.Column="1"
                               Grid.ColumnSpan="3"
@@ -263,12 +271,14 @@
                               Margin="0,0,4,0" />
 
                     <TextBlock Text="Max Tree Level"
+                               Visibility="{Binding IsPrefixTreeIndex, Mode=OneWay, Converter={StaticResource BooleanToVisibility}}"
                                Grid.Row="4"
                                Grid.Column="5"
                                Grid.ColumnSpan="2"
                                Margin="8,0,4,0"
                                VerticalAlignment="Center" />
                     <TextBox Text="{Binding MaxTreeLevel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+										 Visibility="{Binding IsPrefixTreeIndex, Mode=OneWay, Converter={StaticResource BooleanToVisibility}}"
 										 Grid.Row="4"
 										 Grid.Column="7"
 										 MinWidth="40"

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -758,6 +758,7 @@
     <Compile Include="ResultsTransformer\StonglyTypedResultsTransformer.cs" />
     <Compile Include="Querying\HighlightesTests.cs" />
     <Compile Include="Security\OAuth\ReplicateWithOAuth.cs" />
+    <Compile Include="Spatial\BoundingBoxIndexTests.cs" />
     <Compile Include="Spatial\CartesianTests.cs" />
     <Compile Include="Spatial\GeoJsonConverterTests.cs" />
     <Compile Include="Spatial\GeoJsonTests.cs" />

--- a/Raven.Tests/Spatial/BoundingBoxIndexTests.cs
+++ b/Raven.Tests/Spatial/BoundingBoxIndexTests.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Raven.Abstractions.Indexing;
+using Raven.Client.Indexes;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Spatial
+{
+	public class BoundingBoxIndexTests : RavenTestBase
+	{
+		[Fact]
+		public void BoundingBoxTest()
+		{
+			// X XXX X
+			// X XXX X
+			// X XXX X
+			// X	 X
+			// XXXXXXX
+
+			var polygon = "POLYGON ((0 0, 0 5, 1 5, 1 1, 5 1, 5 5, 6 5, 6 0, 0 0))";
+			var rectangle1 = "2 2 4 4";
+			var rectangle2 = "6 6 10 10";
+			var rectangle3 = "0 0 6 6";
+
+			using (var store = NewDocumentStore())
+			{
+				store.Initialize();
+				new BBoxIndex().Execute(store);
+				new QuadTreeIndex().Execute(store);
+
+				using (var session = store.OpenSession())
+				{
+					session.Store(new SpatialDoc{Shape = polygon});
+					session.SaveChanges();
+				}
+
+				WaitForIndexing(store);
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<SpatialDoc>()
+										.Count();
+
+					Assert.Equal(1, result);
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<SpatialDoc, BBoxIndex>()
+										.Spatial(x => x.Shape, x => x.Intersects(rectangle1))
+										.Count();
+
+					Assert.Equal(1, result);
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<SpatialDoc, BBoxIndex>()
+										.Spatial(x => x.Shape, x => x.Intersects(rectangle2))
+										.Count();
+
+					Assert.Equal(0, result);
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<SpatialDoc, BBoxIndex>()
+										.Spatial(x => x.Shape, x => x.Disjoint(rectangle2))
+										.Count();
+
+					Assert.Equal(1, result);
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<SpatialDoc, BBoxIndex>()
+										.Spatial(x => x.Shape, x => x.Within(rectangle3))
+										.Count();
+
+					Assert.Equal(1, result);
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<SpatialDoc, QuadTreeIndex>()
+										.Spatial(x => x.Shape, x => x.Intersects(rectangle2))
+										.Count();
+
+					Assert.Equal(0, result);
+				}
+
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<SpatialDoc, QuadTreeIndex>()
+										.Spatial(x => x.Shape, x => x.Intersects(rectangle1))
+										.Count();
+
+					Assert.Equal(0, result);
+				}
+			}
+		}
+
+		public class SpatialDoc
+		{
+			 public string Id { get; set; }
+			 public string Shape { get; set; }
+		}
+
+		public class BBoxIndex : AbstractIndexCreationTask<SpatialDoc> 
+		{
+			public BBoxIndex()
+			{
+				Map = docs => from doc in docs
+							  select new
+									 {
+										 doc.Shape
+									 };
+
+				Spatial(x => x.Shape, x => x.Cartesian.BoundingBoxIndex());
+			}
+		}
+
+		public class QuadTreeIndex : AbstractIndexCreationTask<SpatialDoc> 
+		{
+			public QuadTreeIndex()
+			{
+				Map = docs => from doc in docs
+							  select new
+									 {
+										 doc.Shape
+									 };
+
+				Spatial(x => x.Shape, x => x.Cartesian.QuadPrefixTreeIndex(6, new SpatialBounds(0, 0, 16, 16)));
+			}
+		}
+	}
+}


### PR DESCRIPTION
It may be desirable to use a bounding box index when plotting shapes on a map/viewport, as it can be significantly faster at both indexing and querying than a prefix tree index.
