### PR TITLE
Fix for http://issues.hibernatingrhinos.com/issue/RavenDB-1167

### DIFF
--- a/Raven.Studio/Features/Stats/StatisticsStatusSectionModel.cs
+++ b/Raven.Studio/Features/Stats/StatisticsStatusSectionModel.cs
@@ -158,12 +158,20 @@ namespace Raven.Studio.Features.Stats
 								ToolTipData = "No Stale Indexes"
 							});
 						}
-						else
+						else if (list.Count > 1)
 						{
 							Statistics.Add(propertyInfo.Name, new StatInfo
 							{
-								Message = string.Format("There are {0} Stale indexes", list.Count),
+								Message = string.Format("There are {0} Stale Indexes", list.Count),
 								ToolTipData = string.Join(", ", list)
+							});
+						}
+						else // only one item
+						{
+							Statistics.Add(propertyInfo.Name, new StatInfo
+							{
+								Message = "There is 1 Stale Index",
+								ToolTipData = list[0].ToString() // only one item, no need to call string.Join()
 							});
 						}
 


### PR DESCRIPTION
Fix for http://issues.hibernatingrhinos.com/issue/RavenDB-1167.

Added logic for changing the text when there is only one item in the list.

Made capitalization of "Indexes" consistent across all cases.
