### PR TITLE
Fix "Failed to execute indexing" exception

### DIFF
--- a/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
@@ -160,8 +160,8 @@ namespace Raven.Storage.Esent.StorageActions
 		public ScheduledReductionInfo DeleteScheduledReduction(List<object> itemsToDelete)
 		{
 			var hasResult = false;
-            var result = new ScheduledReductionInfo();
-            if (itemsToDelete != null)
+			var result = new ScheduledReductionInfo();
+		    if (itemsToDelete != null)
 		    {
 		        var currentEtagBinary = Guid.Empty.ToByteArray();
 		        foreach (OptimizedDeleter reader in itemsToDelete)


### PR DESCRIPTION
Fix for the following exception was reported in the Studio during indexing (v2622):

Message: Failed to execute indexing
Exception: System.AggregateException: One or more errors occurred. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Raven.Storage.Esent.StorageActions.DocumentStorageActions.DeleteScheduledReduction(List`1 itemsToDelete) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\StorageActions\MappedResults.cs:line 165
   at Raven.Database.Indexing.ReducingExecuter.<>c__DisplayClassb.<HandleReduceForIndex>b__5(IStorageActionsAccessor actions) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\ReducingExecuter.cs:line 69
   at Raven.Storage.Esent.TransactionalStorage.ExecuteBatch(Action`1 action, EsentTransactionContext transactionContext) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\TransactionalStorage.cs:line 657
   at Raven.Storage.Esent.TransactionalStorage.Batch(Action`1 action) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\TransactionalStorage.cs:line 609
   at Raven.Database.Indexing.ReducingExecuter.HandleReduceForIndex(IndexToWorkOn indexToWorkOn) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\ReducingExecuter.cs:line 67
   at System.Threading.Tasks.Task.Execute()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at Raven.Database.Indexing.DefaultBackgroundTaskExecuter.ExecuteAllInterleaved[T](WorkContext context, IList`1 result, Action`1 action) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\DefaultBackgroundTaskExecuter.cs:line 182
   at Raven.Database.Indexing.AbstractIndexingExecuter.ExecuteIndexing(Boolean isIdle, Boolean& onlyFoundIdleWork) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\AbstractIndexingExecuter.cs:line 247
   at Raven.Database.Indexing.AbstractIndexingExecuter.Execute() in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\AbstractIndexingExecuter.cs:line 48
---> (Inner Exception #0) System.NullReferenceException: Object reference not set to an instance of an object.
   at Raven.Storage.Esent.StorageActions.DocumentStorageActions.DeleteScheduledReduction(List`1 itemsToDelete) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\StorageActions\MappedResults.cs:line 165
   at Raven.Database.Indexing.ReducingExecuter.<>c__DisplayClassb.<HandleReduceForIndex>b__5(IStorageActionsAccessor actions) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\ReducingExecuter.cs:line 69
   at Raven.Storage.Esent.TransactionalStorage.ExecuteBatch(Action`1 action, EsentTransactionContext transactionContext) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\TransactionalStorage.cs:line 657
   at Raven.Storage.Esent.TransactionalStorage.Batch(Action`1 action) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\TransactionalStorage.cs:line 609
   at Raven.Database.Indexing.ReducingExecuter.HandleReduceForIndex(IndexToWorkOn indexToWorkOn) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\ReducingExecuter.cs:line 67
   at System.Threading.Tasks.Task.Execute()<---
