### PR TITLE
Remove the dependency on Microsoft.CompilerServices.AsyncTargetingPack f...

### DIFF
--- a/NuGet/RavenDB.Client.nuspec
+++ b/NuGet/RavenDB.Client.nuspec
@@ -13,7 +13,11 @@
 		<requireLicenseAcceptance>true</requireLicenseAcceptance>
 		<tags>nosql ravendb raven document database client</tags>
 		<dependencies>
-			<dependency id="Microsoft.CompilerServices.AsyncTargetingPack" version=""/>
+			<group>
+				<dependency id="Microsoft.CompilerServices.AsyncTargetingPack" version=""/>
+			</group>
+			<group targetFramework="net45">
+			</group>
 		</dependencies>
 		<frameworkAssemblies>
 			<frameworkAssembly assemblyName="System.ComponentModel.Composition" targetFramework="net40" />

--- a/NuGet/RavenDB.Database.nuspec
+++ b/NuGet/RavenDB.Database.nuspec
@@ -13,12 +13,22 @@
 		<requireLicenseAcceptance>true</requireLicenseAcceptance>
 		<tags>nosql ravendb raven document database</tags>
 		<dependencies>
-			<dependency id="Microsoft.CompilerServices.AsyncTargetingPack" version=""/>
-			<dependency id="System.Spatial" version="5.2"/>
-			<dependency id="WindowsAzure.Storage" version="2.0"/>
-			<dependency id="Microsoft.Data.Edm" version="5.2" />
-		  	<dependency id="Microsoft.Data.OData" version="5.2" />
-		  	<dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8" />
+			<group>
+				<dependency id="Microsoft.CompilerServices.AsyncTargetingPack" version=""/>
+				<dependency id="System.Spatial" version="5.2"/>
+				<dependency id="WindowsAzure.Storage" version="2.0"/>
+				<dependency id="Microsoft.Data.Edm" version="5.2" />
+				<dependency id="Microsoft.Data.OData" version="5.2" />
+				<dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8" />
+			</group>
+			
+			<group targetFramework="net45">
+				<dependency id="System.Spatial" version="5.2"/>
+				<dependency id="WindowsAzure.Storage" version="2.0"/>
+				<dependency id="Microsoft.Data.Edm" version="5.2" />
+				<dependency id="Microsoft.Data.OData" version="5.2" />
+				<dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8" />
+			</group>
 		</dependencies>
 		<frameworkAssemblies>
 			<frameworkAssembly assemblyName="System.ComponentModel.Composition" targetFramework="net40" />

--- a/Utilities/Raven.ProjectRewriter/Program.cs
+++ b/Utilities/Raven.ProjectRewriter/Program.cs
@@ -167,7 +167,7 @@ namespace Raven.ProjectRewriter
 			{
 				if (element.Attribute("Include").Value == "Microsoft.CompilerServices.AsyncTargetingPack.Net4")
 				{
-					element.Element(xmlns + "HintPath").Value = element.Element(xmlns + "HintPath").Value.Replace(@"net40\Microsoft.CompilerServices.AsyncTargetingPack.Net4", @"net45\Microsoft.CompilerServices.AsyncTargetingPack.Net45");
+					element.Remove();
 				}
 				else if (element.Attribute("Include").Value == "System.Reactive.Core")
 				{


### PR DESCRIPTION
...or .NET 4.5 and .NET 4.5.1 projects.

This is possible by using a feature of NuGet 2.0 which allow us to specify dependencies per platform.
