### PR TITLE
RavenDB-901

### DIFF
--- a/RavenDB/Server/Raven.Database/Queries/TermsQueryRunner.cs
+++ b/RavenDB/Server/Raven.Database/Queries/TermsQueryRunner.cs
@@ -4,9 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 
@@ -25,7 +23,12 @@ namespace Raven.Database.Queries
 		{
 			if(field == null) throw new ArgumentNullException("field");
 			if(index == null) throw new ArgumentNullException("index");
-			
+
+			if (field.EndsWith("_Range"))
+			{
+				field = field.Substring(0, field.Length - "_Range".Length);
+			}
+
 			var result = new HashSet<string>();
 			IndexSearcher currentIndexSearcher;
 			using(database.IndexStorage.GetCurrentIndexSearcher(index, out currentIndexSearcher))


### PR DESCRIPTION
Converting the binary values written as a string into the numerical ones found quite hard because the term does not have the information about the type, it was really hard to differentiate between long and double for example. We could use the index SortOptions info but it's not always available. Instead of that I decided that instead of conversion we can just provide the values stored as string. After all we always return them as strings, so should not make the difference.
