### PR TITLE
Aggresive cache convention fix 2.5

### DIFF
--- a/Raven.Client.Lightweight/Document/DocumentConvention.cs
+++ b/Raven.Client.Lightweight/Document/DocumentConvention.cs
@@ -100,7 +100,7 @@ namespace Raven.Client.Document
 			CustomizeJsonSerializer = serializer => { };
 			FindIdValuePartForValueTypeConversion = (entity, id) => id.Split(new[] { IdentityPartsSeparator }, StringSplitOptions.RemoveEmptyEntries).Last();
 			ShouldAggressiveCacheTrackChanges = true;
-			ShouldSaveChangesForceAggresiveCacheCheck = true;
+			ShouldSaveChangesForceAggressiveCacheCheck = true;
 		}
 
 		private IEnumerable<object> DefaultApplyReduceFunction(
@@ -466,7 +466,7 @@ namespace Raven.Client.Document
 		/// This will make any outdated data revalidated, and will work nicely as long as you have just a 
 		/// single client. For multiple clients, <see cref="ShouldAggressiveCacheTrackChanges"/>.
 		/// </summary>
-		public bool ShouldSaveChangesForceAggresiveCacheCheck { get; set; }
+		public bool ShouldSaveChangesForceAggressiveCacheCheck { get; set; }
 
 
 #if !SILVERLIGHT

--- a/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
@@ -826,7 +826,7 @@ more responsive application.
 		protected void UpdateBatchResults(IList<BatchResult> batchResults, SaveChangesData saveChangesData)
 		{
 #if !SILVERLIGHT && !NETFX_CORE
-			if (documentStore.HasJsonRequestFactory && Conventions.ShouldSaveChangesForceAggresiveCacheCheck &&  batchResults.Count != 0)
+			if (documentStore.HasJsonRequestFactory && Conventions.ShouldSaveChangesForceAggressiveCacheCheck &&  batchResults.Count != 0)
 			{
 				documentStore.JsonRequestFactory.ExpireItemsFromCache(DatabaseName ?? Constants.SystemDatabase);
 			}

--- a/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
@@ -826,7 +826,7 @@ more responsive application.
 		protected void UpdateBatchResults(IList<BatchResult> batchResults, SaveChangesData saveChangesData)
 		{
 #if !SILVERLIGHT && !NETFX_CORE
-			if (documentStore.HasJsonRequestFactory && Conventions.ShouldAggressiveCacheTrackChanges &&  batchResults.Count != 0)
+			if (documentStore.HasJsonRequestFactory && Conventions.ShouldSaveChangesForceAggresiveCacheCheck &&  batchResults.Count != 0)
 			{
 				documentStore.JsonRequestFactory.ExpireItemsFromCache(DatabaseName ?? Constants.SystemDatabase);
 			}

--- a/Raven.Client.Lightweight/Util/SimpleCache.cs
+++ b/Raven.Client.Lightweight/Util/SimpleCache.cs
@@ -129,7 +129,7 @@ namespace Raven.Client.Util
 				DateTime lastWrite;
 				if (lastWritePerDb.TryGetValue(value.Database, out lastWrite))
 				{
-					if (value.Time < lastWrite)
+					if (value.Time <= lastWrite)
 						value.ForceServerCheck = true;
 				}
 			}

--- a/Raven.Tests/Issues/RavenDB_406.cs
+++ b/Raven.Tests/Issues/RavenDB_406.cs
@@ -17,12 +17,12 @@ namespace Raven.Tests.Issues
 	public class RavenDB_406 : RavenTest
 	{
 		[Fact]
-		public void LoadResultShoudBeUpToDateEvenIfAggresiveCacheIsEnabled()
+		public void LoadResultShoudBeUpToDateEvenIfAggressiveCacheIsEnabled()
 		{
 			using (GetNewServer())
 			using (var store = new DocumentStore { Url = "http://localhost:8079" }.Initialize())
 			{
-				store.Conventions.ShouldSaveChangesForceAggresiveCacheCheck = false;
+				store.Conventions.ShouldSaveChangesForceAggressiveCacheCheck = false;
 				using (var session = store.OpenSession())
 				{
 					session.Store(new User()
@@ -72,12 +72,12 @@ namespace Raven.Tests.Issues
 		}
 
 		[Fact]
-		public void QueryResultShoudBeUpToDateEvenIfAggresiveCacheIsEnabled()
+		public void QueryResultShoudBeUpToDateEvenIfAggressiveCacheIsEnabled()
 		{
 			using (GetNewServer())
 			using (var store = new DocumentStore { Url = "http://localhost:8079" }.Initialize())
 			{
-				store.Conventions.ShouldSaveChangesForceAggresiveCacheCheck = false;
+				store.Conventions.ShouldSaveChangesForceAggressiveCacheCheck = false;
 				new RavenDocumentsByEntityName().Execute(store);
 
 				using (var session = store.OpenSession())
@@ -134,7 +134,7 @@ namespace Raven.Tests.Issues
 			using (GetNewServer())
 			using (var store = new DocumentStore { Url = "http://localhost:8079"}.Initialize())
 			{
-				store.Conventions.ShouldSaveChangesForceAggresiveCacheCheck = false;
+				store.Conventions.ShouldSaveChangesForceAggressiveCacheCheck = false;
 
 				store.DatabaseCommands.EnsureDatabaseExists("Northwind_1");
 				store.DatabaseCommands.EnsureDatabaseExists("Northwind_2");
@@ -218,7 +218,7 @@ namespace Raven.Tests.Issues
 			using (var server = GetNewServer())
 			using (var store = new DocumentStore {Url = "http://localhost:8079"}.Initialize())
 			{
-				store.Conventions.ShouldSaveChangesForceAggresiveCacheCheck = false;
+				store.Conventions.ShouldSaveChangesForceAggressiveCacheCheck = false;
 				using (var session = store.OpenSession())
 				{
 					session.Store(new User()


### PR DESCRIPTION
Oren,

the commit 'Use the right convention' fixes the commit https://github.com/ayende/ravendb/commit/4b4df3f11a8de9034 where I thing a glitch was introduced because the added convention ShouldSaveChangesForceAggresiveCacheCheck had no usages.

If you confirm it's ok (just by merging it) then I will create a pull request for 3.0
