### PR TITLE
Add support for more string equals types that the user might do

### DIFF
--- a/Raven.Tests/Linq/WhereStringEquals.cs
+++ b/Raven.Tests/Linq/WhereStringEquals.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Linq;
+using Raven.Client.Embedded;
+using Xunit;
+
+namespace Raven.Tests.Linq
+{
+	public class WhereStringEquals : RavenTest
+	{
+		private readonly EmbeddableDocumentStore store;
+
+		public WhereStringEquals()
+		{
+			store = NewDocumentStore();
+			using (var session = store.OpenSession())
+			{
+				session.Store(new MyEntity {StringData = "Some data"});
+				session.Store(new MyEntity {StringData = "Some DATA"});
+				session.Store(new MyEntity {StringData = "Some other data"});
+				session.SaveChanges();
+			}
+		}
+
+		[Fact]
+		public void QueryString_CaseSensitive_ShouldWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => string.Equals(o.StringData, "Some data", StringComparison.InvariantCulture));
+
+				Assert.Equal(1, count);
+			}
+		}
+
+		[Fact]
+		public void QueryString_IgnoreCase_ShouldWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => string.Equals(o.StringData, "Some data", StringComparison.InvariantCultureIgnoreCase));
+
+				Assert.Equal(2, count);
+			}
+		}
+
+		[Fact]
+		public void QueryString_WithoutSpecifyingTheComparisonType_ShouldJustWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => string.Equals(o.StringData, "Some data"));
+
+				Assert.Equal(2, count);
+			}
+		}
+
+		[Fact]
+		public void QueryString_WithoutSpecifyingTheComparisonType_ShouldJustWork_InvertParametersOrder()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => string.Equals("Some data", o.StringData));
+
+				Assert.Equal(2, count);
+			}
+		}
+
+		[Fact]
+		public void RegularStringEqual_ShouldWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => "Some data" == o.StringData);
+
+				Assert.Equal(2, count);
+			}
+		}
+
+		[Fact]
+		public void ConstantStringEquals_ShouldWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => "Some data".Equals(o.StringData));
+
+				Assert.Equal(2, count);
+			}
+		}
+
+		[Fact]
+		public void StringEqualsConstant_ShouldWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => o.StringData.Equals("Some data"));
+
+				Assert.Equal(2, count);
+			}
+		}
+
+		[Fact]
+		public void StringEqualsConstant_IgnoreCase_ShouldWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => "Some data".Equals(o.StringData, StringComparison.OrdinalIgnoreCase));
+
+				Assert.Equal(2, count);
+			}
+		}
+
+		[Fact]
+		public void StringEqualsConstant_CaseSensitive_ShouldWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => "Some data".Equals(o.StringData, StringComparison.Ordinal));
+
+				Assert.Equal(1, count);
+			}
+		}
+
+		[Fact]
+		public void RegularStringEqual_CaseSensitive_ShouldWork()
+		{
+			using (var session = store.OpenSession())
+			{
+				var count = session.Query<MyEntity>()
+					.Customize(customization => customization.WaitForNonStaleResultsAsOfNow())
+					.Count(o => o.StringData.Equals("Some data", StringComparison.Ordinal));
+
+				Assert.Equal(1, count);
+			}
+		}
+
+		public class MyEntity
+		{
+			public string StringData { get; set; }
+		}
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -688,6 +688,7 @@
     <Compile Include="Issues\RavenDB_579.cs" />
     <Compile Include="Linq\OfTypeSupport.cs" />
     <Compile Include="Linq\SelectManyShouldWork.cs" />
+    <Compile Include="Linq\WhereStringEquals.cs" />
     <Compile Include="MailingList\Accounts.cs" />
     <Compile Include="MailingList\Afif.cs" />
     <Compile Include="MailingList\AlexanderZeitler.cs" />


### PR DESCRIPTION
In this pull request all the tests are passing except the case sensitive ones:

StringEqualsConstant_CaseSensitive_ShouldWork
RegularStringEqual_CaseSensitive_ShouldWork
QueryString_CaseSensitive_ShouldWork

So, this is still work in progress until those test will be fixed.
