### PR TITLE
added executionTimeout to ravendb config defaults. Set to 20 minutes.

### DIFF
--- a/DefaultConfigs/Web.config
+++ b/DefaultConfigs/Web.config
@@ -10,7 +10,10 @@
 
 	<system.web>
 
+
 		<hostingEnvironment idleTimeout="Infinite" shutdownTimeout="300"/>
+
+    <httpRuntime executionTimeout="1200" />
 
 	</system.web>
 


### PR DESCRIPTION
Without the executionTimeout bumped up, import / backup tasks fail for larger databases. This sets the executionTimeout really high right out of the box so this isn't an issue anymore.
