### PR TITLE
RavenDB-1344 Deny changing active bundles by default

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -45,6 +45,7 @@ namespace Raven.Abstractions.Data
 		public const string NotForReplication = "Raven-Not-For-Replication";
 		public const string RavenDeleteMarker = "Raven-Delete-Marker";
 		public const string ActiveBundles = "Raven/ActiveBundles";
+		public const string AllowBundlesChange = "Raven-Temp-Allow-Bundles-Change";
 		public const string RavenAlerts = "Raven/Alerts";
 
 		//Paths

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -250,12 +250,9 @@ namespace Raven.Database.Config
 		{
 			get
 			{
-				var activeBundles = Settings["Raven/ActiveBundles"] ?? "";
+				var activeBundles = Settings[Constants.ActiveBundles] ?? "";
 
-				return activeBundles.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries)
-				                    .Select(x => x.Trim())
-				                    .ToList();
-
+				return activeBundles.GetSemicolonSeparatedValues();
 			}
 		} 
 

--- a/Raven.Database/Extensions/StringExtensions.cs
+++ b/Raven.Database/Extensions/StringExtensions.cs
@@ -1,0 +1,21 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="StringExtensions.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Raven.Database.Extensions
+{
+	public static class StringExtensions
+	{
+		public static List<string> GetSemicolonSeparatedValues(this string self)
+		{
+			return self.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+			.Select(x => x.Trim())
+			.ToList();
+		}
+	}
+}

--- a/Raven.Database/Plugins/Builtins/ActiveBundlesProtection.cs
+++ b/Raven.Database/Plugins/Builtins/ActiveBundlesProtection.cs
@@ -1,0 +1,57 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ActiveBundlesProtection.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Extensions;
+using Raven.Database.Extensions;
+using Raven.Json.Linq;
+
+namespace Raven.Database.Plugins.Builtins
+{
+	public class ActiveBundlesProtection : AbstractPutTrigger
+	{
+		private const string RavenDatabasesPrefix = "Raven/Databases/";
+
+		public override VetoResult AllowPut(string key, RavenJObject document, RavenJObject metadata, TransactionInformation transactionInformation)
+		{
+			if (key.StartsWith(RavenDatabasesPrefix, StringComparison.InvariantCultureIgnoreCase) == false)
+				return VetoResult.Allowed;
+
+			if(Database.Name != null && Database.Name != Constants.SystemDatabase)
+				return VetoResult.Allowed;
+
+			var tempPermission = metadata[Constants.AllowBundlesChange];
+
+			if (tempPermission != null)
+				metadata.Remove(Constants.AllowBundlesChange); // this is a temp marker so do not persist this medatada
+
+			var bundlesChangesAllowed = tempPermission != null && tempPermission.Value<string>().Equals("true", StringComparison.InvariantCultureIgnoreCase);
+
+			if(bundlesChangesAllowed)
+				return VetoResult.Allowed;
+
+			var existingDbDoc = Database.Get(key, transactionInformation);
+
+			if(existingDbDoc == null)
+				return VetoResult.Allowed;
+
+			var currentDbDocument = existingDbDoc.DataAsJson.JsonDeserialization<DatabaseDocument>();
+			var currentBundles = (currentDbDocument.Settings[Constants.ActiveBundles] ?? "").GetSemicolonSeparatedValues();
+
+			var newDbDocument = document.JsonDeserialization<DatabaseDocument>();
+			var newBundles = (newDbDocument.Settings[Constants.ActiveBundles] ?? "").GetSemicolonSeparatedValues();
+
+			if (currentBundles.Count != newBundles.Count || currentBundles.TrueForAll(x => newBundles.Contains(x) == false))
+			{
+				return VetoResult.Deny(
+					"You should not change 'Raven/ActiveBundles' setting for a database. This setting should be set only once when a database is created. " +
+					"If you really need to override it you have to specify {'" + Constants.ActiveBundles + "':'true'} in metadata of a database document every time when you send it.");
+			}
+
+			return VetoResult.Allowed;
+		}
+	}
+}

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Bundles\SqlReplication\RelationalDatabaseWriter.cs" />
     <Compile Include="Bundles\SqlReplication\SqlReplicationScriptedJsonPatcher.cs" />
     <Compile Include="Bundles\SqlReplication\SqlReplicationStatistics.cs" />
+    <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Impl\DTC\EsentInFlightTransactionalState.cs" />
     <Compile Include="Impl\DTC\EsentTransactionContext.cs" />
     <Compile Include="Impl\DTC\MuninInFlightTransactionalState.cs" />
@@ -212,6 +213,7 @@
     <Compile Include="Plugins\AbstractIndexReaderWarmer.cs" />
     <Compile Include="Linq\Ast\ThrowOnInvalidMethodCallsInReduce.cs" />
     <Compile Include="Linq\Ast\TransformFromClauses.cs" />
+    <Compile Include="Plugins\Builtins\ActiveBundlesProtection.cs" />
     <Compile Include="Prefetching\ConcurrentJsonDocumentSortedList.cs" />
     <Compile Include="Prefetching\Prefetcher.cs" />
     <Compile Include="Prefetching\PrefetchingUser.cs" />

--- a/Raven.Database/Server/Responders/Admin/AdminDatabases.cs
+++ b/Raven.Database/Server/Responders/Admin/AdminDatabases.cs
@@ -57,7 +57,7 @@ namespace Raven.Database.Server.Responders.Admin
 					var json = RavenJObject.FromObject(dbDoc);
 					json.Remove("Id");
 
-					Database.Put(docKey, null, json, new RavenJObject(), null);
+					Database.Put(docKey, null, json, context.Request.Headers.FilterHeaders(), null);
 					break;
 				case "DELETE":
 					var configuration = server.CreateTenantConfiguration(db);


### PR DESCRIPTION
It was done by using AbstractPutTrigger, however Temp-**\* metadata are already filtered out there. So I introduced a temp marker called 'Raven-Temp-Allow-Bundles-Change' to explicitly indicate that we want to change active bundles.
