### PR TITLE
Fixing Etag/Guid conversion

### DIFF
--- a/Raven.Abstractions/Data/Etag.cs
+++ b/Raven.Abstractions/Data/Etag.cs
@@ -235,31 +235,29 @@ namespace Raven.Abstractions.Data
 			return Parse(s);
 		}
 
-        public static implicit operator Etag(Guid g)
-        {
-            return Parse(g.ToByteArray());
-        }
+		public static implicit operator Etag(Guid g)
+		{
+			return GuidToEtag(g);
+		}
 
-        public static implicit operator Guid?(Etag e)
-        {
-            if (e == null)
-                return null;
-            return new Guid(e.ToByteArray());
-        }
+		public static implicit operator Guid?(Etag e)
+		{
+			if (e == null)
+				return null;
+			return EtagToGuid(e);
+		}
 
+		public static implicit operator Etag(Guid? g)
+		{
+			if (g == null)
+				return null;
+			return GuidToEtag(g.Value);
+		}
 
-
-        public static implicit operator Etag(Guid? g)
-        {
-            if (g == null)
-                return null;
-            return Parse(g.Value.ToByteArray());
-        }
-
-        public static implicit operator Guid(Etag e)
-        {
-            return new Guid(e.ToByteArray());
-        }
+		public static implicit operator Guid(Etag e)
+		{
+			return EtagToGuid(e);
+		}
 
 		public Etag HashWith(Etag other)
 		{
@@ -286,6 +284,30 @@ namespace Raven.Abstractions.Data
 			return first.CompareTo(second) > 0
 				? first
 				: second;
+		}
+
+		private static Guid EtagToGuid(Etag etag)
+		{
+			var bytes = etag.ToByteArray();
+			if (BitConverter.IsLittleEndian)
+			{
+				Array.Reverse(bytes, 0, 4);
+				Array.Reverse(bytes, 4, 2);
+				Array.Reverse(bytes, 6, 2);
+			}
+			return new Guid(bytes);
+		}
+
+		private static Etag GuidToEtag(Guid guid)
+		{
+			var bytes = guid.ToByteArray();
+			if (BitConverter.IsLittleEndian)
+			{
+				Array.Reverse(bytes, 0, 4);
+				Array.Reverse(bytes, 4, 2);
+				Array.Reverse(bytes, 6, 2);
+			}
+			return Etag.Parse(bytes);
 		}
 	}
 

--- a/Raven.Tests/Issues/RavenDB_1470.cs
+++ b/Raven.Tests/Issues/RavenDB_1470.cs
@@ -1,0 +1,64 @@
+﻿
+using System;
+using Raven.Abstractions.Data;
+using Xunit;
+
+namespace Raven.Tests.Bugs
+{
+	public class RavenDB_1470
+	{
+		[Fact]
+		public void Etag_to_Guid_conversion()
+		{
+			var etag = new Raven.Abstractions.Data.Etag("01234567-8901-2345-6789-012345678901");
+			var guid = (Guid) etag;
+			var nullabelGuid = (Guid?)etag;
+			Assert.Equal(etag.ToString(), guid.ToString());
+			Assert.Equal(etag.ToString(), nullabelGuid.ToString());
+		}
+
+		[Fact]
+		public void Guid_to_Etag_conversion()
+		{
+			var guid = new Guid("01234567-8901-2345-6789-012345678901");
+			var nullableGuid = (Guid?)guid;
+			Assert.Equal(guid.ToString(), ((Raven.Abstractions.Data.Etag)guid).ToString());
+			Assert.Equal(guid.ToString(), ((Raven.Abstractions.Data.Etag)nullableGuid).ToString());
+		}
+
+		[Fact]
+		public void Etag_guid_comparision()
+		{
+			var etag = new Raven.Abstractions.Data.Etag("01234567-8901-2345-6789-012345678901");
+			var guid = new Guid("01234567-8901-2345-6789-012345678901");
+			Assert.True(etag.Equals(guid));
+			Assert.True(guid.Equals(etag));
+		}
+
+		[Fact]
+		public void Etag_converted_to_Guid_then_to_string_and_back_yields_the_same_Etag()
+		{
+			var originalEtag = new Raven.Abstractions.Data.Etag(UuidType.Documents, 12, 12);
+
+			var etagAsGuid = (Guid)originalEtag;
+			var etagAfterConversionToString = etagAsGuid.ToString();
+
+			var etagAfterGuidAndStringConversion = Raven.Abstractions.Data.Etag.Parse(etagAfterConversionToString);
+
+			Assert.Equal(originalEtag, etagAfterGuidAndStringConversion);
+		}
+
+		[Fact]
+		public void Etag_converted_to_string_then_to_Guid_and_back_yields_the_same_Etag()
+		{
+			var originalEtag = new Raven.Abstractions.Data.Etag(UuidType.Documents, 12, 12);
+
+			var etagAsString = originalEtag.ToString();
+			var etagAsStringConvertedToGuid = Guid.Parse(etagAsString);
+
+			var etagAfterConversion = (Raven.Abstractions.Data.Etag)etagAsStringConvertedToGuid;
+
+			Assert.Equal(originalEtag, etagAfterConversion);
+		}
+	}
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Bugs\Facets\FacetErrors.cs" />
     <Compile Include="Bugs\Facets\FacetsCreationTest.cs" />
     <Compile Include="Bugs\Facets\DateTimeFacets.cs" />
+    <Compile Include="Issues\RavenDB_1470.cs" />
     <Compile Include="Bugs\WhenStoringADocumentWithAsyncSessionAndZipCompressionOn.cs" />
     <Compile Include="Issues\RavenDB_1435.cs" />
     <Compile Include="LicenseValidatorTest.cs" />


### PR DESCRIPTION
This closes #1470.

See my comment on #1470. 
the first 3 values of a Guid are Int32/Int16//Int16 and Guid expects these values to be in the systems endian byte order. Etag does always create/parse byte arrays with big endian order, so in little endian systems the Guid/Etag conversion is broken.

It might be better to make Etag's Parse() / ToByteArray() compatible to Guid, but I have no idea if this would cause any trouble, so I just fixed the Guid/Etag conversion.

Please note that this might still be a breaking change for everyone who used Etags and converted them to Guids.
