### PR TITLE
Try fix nullreferenceexception in DeleteScheduled Reductions

### DIFF
--- a/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
@@ -166,7 +166,7 @@ namespace Raven.Storage.Esent.StorageActions
 			var result = new ScheduledReductionInfo();
 			
 			var currentEtagBinary = Guid.Empty.ToByteArray();
-			foreach (OptimizedDeleter reader in itemsToDelete)
+			foreach (OptimizedDeleter reader in itemsToDelete.Where(x => x != null))
 			{
 				foreach (var sortedBookmark in reader.GetSortedBookmarks())
 				{


### PR DESCRIPTION
Hi

On my production server I have lots of errors with the same signature - 6 times during the last day - some hours between - And i've seen them before..
I've even been able to debug the problem and randomly itemsToDelete contain two items - where at index[0] there is a null object... reading the code - I cant see why... but this fix should help

2013-11-20 15:05:52.3951;Raven.Database.Indexing.AbstractIndexingExecuter;Error;;Failed to execute indexing;"System.AggregateException: One or more errors occurred. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Raven.Storage.Esent.StorageActions.DocumentStorageActions.DeleteScheduledReduction(List`1 itemsToDelete) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\StorageActions\MappedResults.cs:line 169
   at Raven.Database.Indexing.ReducingExecuter.<>c__DisplayClassb.<HandleReduceForIndex>b__5(IStorageActionsAccessor actions) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\ReducingExecuter.cs:line 69
   at Raven.Storage.Esent.TransactionalStorage.ExecuteBatch(Action`1 action, EsentTransactionContext transactionContext) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\TransactionalStorage.cs:line 665
   at Raven.Storage.Esent.TransactionalStorage.Batch(Action`1 action) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\TransactionalStorage.cs:line 617
   at Raven.Database.Indexing.ReducingExecuter.HandleReduceForIndex(IndexToWorkOn indexToWorkOn) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\ReducingExecuter.cs:line 67
   at System.Threading.Tasks.Task.Execute()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at Raven.Database.Indexing.DefaultBackgroundTaskExecuter.ExecuteAllInterleaved[T](WorkContext context, IList`1 result, Action`1 action) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\DefaultBackgroundTaskExecuter.cs:line 182
   at Raven.Database.Indexing.AbstractIndexingExecuter.ExecuteIndexing(Boolean isIdle, Boolean& onlyFoundIdleWork) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\AbstractIndexingExecuter.cs:line 250
   at Raven.Database.Indexing.AbstractIndexingExecuter.Execute() in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\AbstractIndexingExecuter.cs:line 49
---> (Inner Exception #0) System.NullReferenceException: Object reference not set to an instance of an object.
   at Raven.Storage.Esent.StorageActions.DocumentStorageActions.DeleteScheduledReduction(List`1 itemsToDelete) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\StorageActions\MappedResults.cs:line 169
   at Raven.Database.Indexing.ReducingExecuter.<>c__DisplayClassb.<HandleReduceForIndex>b__5(IStorageActionsAccessor actions) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\ReducingExecuter.cs:line 69
   at Raven.Storage.Esent.TransactionalStorage.ExecuteBatch(Action`1 action, EsentTransactionContext transactionContext) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\TransactionalStorage.cs:line 665
   at Raven.Storage.Esent.TransactionalStorage.Batch(Action`1 action) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Storage\Esent\TransactionalStorage.cs:line 617
   at Raven.Database.Indexing.ReducingExecuter.HandleReduceForIndex(IndexToWorkOn indexToWorkOn) in c:\Builds\RavenDB-Unstable-v2.5\Raven.Database\Indexing\ReducingExecuter.cs:line 67
   at System.Threading.Tasks.Task.Execute()<---
"
