### PR TITLE
Fixing RavenDB-1499 (2nd attempt)

### DIFF
--- a/Bundles/Raven.Bundles.Tests/Raven.Bundles.Tests.csproj
+++ b/Bundles/Raven.Bundles.Tests/Raven.Bundles.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="UniqueConstraints\Bugs\Concurrency.cs" />
     <Compile Include="UniqueConstraints\Bugs\JimBolla.cs" />
     <Compile Include="UniqueConstraints\Bugs\Lars.cs" />
+    <Compile Include="UniqueConstraints\Bugs\RavenDB_1499.cs" />
     <Compile Include="UniqueConstraints\Bugs\Troy.cs" />
     <Compile Include="UniqueConstraints\Bugs\Troy2.cs" />
     <Compile Include="UniqueConstraints\Bugs\Troy3.cs" />

--- a/Bundles/Raven.Bundles.Tests/UniqueConstraints/Bugs/RavenDB_1499.cs
+++ b/Bundles/Raven.Bundles.Tests/UniqueConstraints/Bugs/RavenDB_1499.cs
@@ -1,0 +1,41 @@
+﻿using Raven.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Raven.Client.UniqueConstraints;
+
+namespace Raven.Bundles.Tests.UniqueConstraints.Bugs
+{
+    public class RavenDB_1499 : UniqueConstraintsTest
+    {
+        [Fact]
+        public void LoadByUniqueConstraint_should_throw_a_meaningful_exception_if_the_attribute_isnt_found()
+        {
+            using (var session = DocumentStore.OpenSession())
+            {
+                Assert.Throws<InvalidOperationException>(() => DoLoad<WikiPage>(session));
+            }
+        }
+
+        static void DoLoad<T>(IDocumentSession session) where T : IHaveSlug
+        {
+            var loaded = session.LoadByUniqueConstraint<T>(cat => cat.Slug, Guid.NewGuid());
+        }
+    }
+
+    public interface IHaveSlug
+    {
+        string Slug { get; set; }
+    }
+
+    public class WikiPage : IHaveSlug
+    {
+        [UniqueConstraint]
+        public string Slug { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
+++ b/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
@@ -22,12 +22,20 @@ namespace Raven.Client.UniqueConstraints
 			if (value == null) throw new ArgumentNullException("value", "The unique value cannot be null");
 			var typeName = session.Advanced.DocumentStore.Conventions.GetTypeTagName(typeof(T));
 			var body = GetMemberExpression(keySelector);
-		    var propertyName = body.Member.Name;
-            var att = (UniqueConstraintAttribute)Attribute.GetCustomAttribute(body.Member, typeof(UniqueConstraintAttribute));
+			var propertyName = body.Member.Name;
+			var att = (UniqueConstraintAttribute)Attribute.GetCustomAttribute(body.Member, typeof(UniqueConstraintAttribute));
+			bool isDef = Attribute.IsDefined(body.Member, typeof(UniqueConstraintAttribute));
 
+			if (isDef == false)
+			{
+				var msg = string.Format(
+					"You are calling LoadByUniqueConstraints on {0}.{1}, but you haven't marked this property with [UniqueConstraint]",
+					body.Member.DeclaringType.Name, propertyName);
+				throw new InvalidOperationException(msg);
+			}
 
 			var uniqueId = "UniqueConstraints/" + typeName.ToLowerInvariant() + "/" + propertyName.ToLowerInvariant() + "/" +
-                           Raven.Bundles.UniqueConstraints.Util.EscapeUniqueValue(value, att.CaseInsensitive);
+						   Raven.Bundles.UniqueConstraints.Util.EscapeUniqueValue(value, att.CaseInsensitive);
 			var constraintDoc = session.Include("RelatedId").Load<RavenJObject>(uniqueId);
 			if (constraintDoc == null)
 				return default(T);


### PR DESCRIPTION
Something went wrong with my local git repo, so I had to redo it. This is the same code changes as https://github.com/ayende/ravendb/pull/492, so you can ignore that one.

BTW, I get quite a few OWIN errors when running ClientServer tests is this branch:

```
System.MissingMemberException : The server factory could not be located for the given input: Microsoft.Owin.Host.HttpListener
Stack Trace:
   at Microsoft.Owin.Hosting.Engine.HostingEngine.ResolveServerFactory(StartContext context)
   at Microsoft.Owin.Hosting.Engine.HostingEngine.Start(StartContext context)
   at Microsoft.Owin.Hosting.WebApp.StartImplementation(IServiceProvider services, StartOptions options, Action`1 startup)
   at Microsoft.Owin.Hosting.WebApp.Start(String url, Action`1 startup)
   at Raven.Database.Server.OwinHttpServer..ctor(InMemoryRavenConfiguration config) in c:\Users\Matt\Documents\GitHub\ravendb\Raven.Database\Server\OwinHttpServer.cs:line 23
   at Raven.Server.RavenDbServer..ctor(InMemoryRavenConfiguration configuration) in c:\Users\Matt\Documents\GitHub\ravendb\Raven.Server\RavenDbServer.cs:line 34
   at Raven.Tests.Helpers.RavenTestBase.GetNewServer(Int32 port, String dataDirectory, Boolean runInMemory, String requestedStorage, Boolean enableAuthentication, String activeBundles) in c:\Users\Matt\Documents\GitHub\ravendb\Raven.Tests.Helpers\RavenTestBase.cs:line 196
   at Raven.Tests.Helpers.RavenTestBase.NewRemoteDocumentStore(Boolean fiddler, RavenDbServer ravenDbServer, String databaseName, Boolean runInMemory, String dataDirectory, String requestedStorage, Boolean enableAuthentication) in c:\Users\Matt\Documents\GitHub\ravendb\Raven.Tests.Helpers\RavenTestBase.cs:line 127
   at Raven.Bundles.Tests.UniqueConstraints.Bugs.TroyMapReduce.UsingRemote() in c:\Users\Matt\Documents\GitHub\ravendb\Bundles\Raven.Bundles.Tests\UniqueConstraints\Bugs\TroyMapReduce.cs:line 59
```
