### PR TITLE
Raven db 1217 different credentials and api keys

### DIFF
--- a/Raven.Abstractions/Data/ConnectionStringParser.cs
+++ b/Raven.Abstractions/Data/ConnectionStringParser.cs
@@ -5,6 +5,8 @@ using System.Configuration;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
+using Raven.Abstractions.Replication;
+using Raven.Imports.Newtonsoft.Json;
 
 namespace Raven.Abstractions.Data
 {
@@ -145,19 +147,22 @@ namespace Raven.Abstractions.Data
 					if (string.IsNullOrEmpty(ConnectionStringOptions.Url))
 						ConnectionStringOptions.Url = value;
 					break;
-				case "failoverurl":
+				case "failover":
 					if (ConnectionStringOptions.FailoverServers == null)
 						ConnectionStringOptions.FailoverServers = new FailoverServers();
 
-					var databaseNameAndFailoverUrl = value.Split('|');
+					var databaseNameAndFailoverDestination = value.Split('|');
 
-					if (databaseNameAndFailoverUrl.Length == 1)
+					ReplicationDestination destination;
+					if (databaseNameAndFailoverDestination.Length == 1)
 					{
-						ConnectionStringOptions.FailoverServers.AddForDefaultDatabase(urls: databaseNameAndFailoverUrl[0]);
+						destination = JsonConvert.DeserializeObject<ReplicationDestination>(databaseNameAndFailoverDestination[0]);
+						ConnectionStringOptions.FailoverServers.AddForDefaultDatabase(destination);
 					}
 					else
 					{
-						ConnectionStringOptions.FailoverServers.AddForDatabase(databaseName: databaseNameAndFailoverUrl[0], urls: databaseNameAndFailoverUrl[1]);
+						destination = JsonConvert.DeserializeObject<ReplicationDestination>(databaseNameAndFailoverDestination[1]);
+						ConnectionStringOptions.FailoverServers.AddForDatabase(databaseName: databaseNameAndFailoverDestination[0], destinations: destination);
 					}
 					break;
 				case "database":

--- a/Raven.Abstractions/Data/FailoverServers.cs
+++ b/Raven.Abstractions/Data/FailoverServers.cs
@@ -5,26 +5,27 @@
 // -----------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using Raven.Abstractions.Replication;
 
 namespace Raven.Abstractions.Data
 {
 	public class FailoverServers
 	{
-		private readonly HashSet<string> forDefaultDatabase = new HashSet<string>();
-		private readonly IDictionary<string, HashSet<string>> forDatabases = new Dictionary<string, HashSet<string>>();
+		private readonly HashSet<ReplicationDestination> forDefaultDatabase = new HashSet<ReplicationDestination>();
+		private readonly IDictionary<string, HashSet<ReplicationDestination>> forDatabases = new Dictionary<string, HashSet<ReplicationDestination>>();
 
-		public string[] ForDefaultDatabase
+		public ReplicationDestination[] ForDefaultDatabase
 		{
 			get
 			{
-				var result = new string[forDefaultDatabase.Count];
+				var result = new ReplicationDestination[forDefaultDatabase.Count];
 				forDefaultDatabase.CopyTo(result);
 				return result;
 			}
 			set { AddForDefaultDatabase(value); }
 		}
 
-		public IDictionary<string, string[]> ForDatabases
+		public IDictionary<string, ReplicationDestination[]> ForDatabases
 		{
 			set
 			{
@@ -45,34 +46,34 @@ namespace Raven.Abstractions.Data
 			return forDatabases.Keys.Contains(databaseName) && forDatabases[databaseName] != null && forDatabases[databaseName].Count > 0;
 		}
 
-		public string[] GetForDatabase(string databaseName)
+		public ReplicationDestination[] GetForDatabase(string databaseName)
 		{
 			if (forDatabases.Keys.Contains(databaseName) == false || forDatabases[databaseName] == null)
 				return null;
 
-			var result = new string[forDatabases[databaseName].Count];
+			var result = new ReplicationDestination[forDatabases[databaseName].Count];
 			forDatabases[databaseName].CopyTo(result);
 			return result;
 		}
 
-		public void AddForDefaultDatabase(params string[] urls)
+		public void AddForDefaultDatabase(params ReplicationDestination[] destinations)
 		{
-			foreach (var url in urls)
+			foreach (var dest in destinations)
 			{
-				forDefaultDatabase.Add(url.EndsWith("/") ? url.Substring(0, url.Length - 1) : url);
+				forDefaultDatabase.Add(dest);
 			}
 		}
 
-		public void AddForDatabase(string databaseName, params string[] urls)
+		public void AddForDatabase(string databaseName, params ReplicationDestination[] destinations)
 		{
 			if (forDatabases.Keys.Contains(databaseName) == false)
 			{
-				forDatabases[databaseName] = new HashSet<string>();
+				forDatabases[databaseName] = new HashSet<ReplicationDestination>();
 			}
 
-			foreach (var url in urls)
+			foreach (var dest in destinations)
 			{
-				forDatabases[databaseName].Add(url.EndsWith("/") ? url.Substring(0, url.Length - 1) : url);
+				forDatabases[databaseName].Add(dest);
 			}
 		}
 	}

--- a/Raven.Client.Lightweight/Connection/ReplicationInformer.cs
+++ b/Raven.Client.Lightweight/Connection/ReplicationInformer.cs
@@ -408,6 +408,8 @@ namespace Raven.Client.Connection
 
 							document = new JsonDocument();
 							document.DataAsJson = RavenJObject.FromObject(failoverServers);
+
+							fromFailoverUrls = true;
 						}
 					}
 				}

--- a/Raven.Client.Lightweight/Connection/ReplicationInformer.cs
+++ b/Raven.Client.Lightweight/Connection/ReplicationInformer.cs
@@ -63,9 +63,9 @@ namespace Raven.Client.Connection
 		}
 
 		/// <summary>
-		/// Urls of failover servers set manually in config file or when document store was initialized
+		/// Failover servers set manually in config file or when document store was initialized
 		/// </summary>
-		public string[] FailoverUrls { get; internal set; }
+		public ReplicationDestination[] FailoverServers { get; internal set; }
 
 		/// <summary>
 		/// Gets the replication destinations.
@@ -335,17 +335,14 @@ namespace Raven.Client.Connection
 
 						if (document == null)
 						{
-							if (FailoverUrls != null && FailoverUrls.Length > 0) // try to use configured failover servers
+							if (FailoverServers != null && FailoverServers.Length > 0) // try to use configured failover servers
 							{
 								var failoverServers = new ReplicationDocument { Destinations = new List<ReplicationDestination>() };
 
-								foreach (var failoverUrl in FailoverUrls)
+								foreach (var failover in FailoverServers)
 								{
-									failoverServers.Destinations.Add(new ReplicationDestination()
-									{
-										Url = failoverUrl
-									});
-					}
+									failoverServers.Destinations.Add(failover);
+								}
 
 								document = new JsonDocument();
 								document.DataAsJson = RavenJObject.FromObject(failoverServers);
@@ -394,16 +391,13 @@ namespace Raven.Client.Connection
 
 					if (document == null)
 					{
-						if (FailoverUrls != null && FailoverUrls.Length > 0) // try to use configured failover servers
+						if (FailoverServers != null && FailoverServers.Length > 0) // try to use configured failover servers
 						{
 							var failoverServers = new ReplicationDocument {Destinations = new List<ReplicationDestination>()};
 
-							foreach (var failoverUrl in FailoverUrls)
+							foreach (var failover in FailoverServers)
 							{
-								failoverServers.Destinations.Add(new ReplicationDestination()
-								{
-									Url = failoverUrl
-								});
+								failoverServers.Destinations.Add(failover);
 							}
 
 							document = new JsonDocument();

--- a/Raven.Client.Lightweight/Document/DocumentStore.cs
+++ b/Raven.Client.Lightweight/Document/DocumentStore.cs
@@ -734,13 +734,13 @@ namespace Raven.Client.Document
 
 			if (dbName == DefaultDatabase)
 			{
-				if (FailoverServers.IsSetForDefaultDatabase && result.FailoverUrls == null)
-					result.FailoverUrls = FailoverServers.ForDefaultDatabase;
+				if (FailoverServers.IsSetForDefaultDatabase && result.FailoverServers == null)
+					result.FailoverServers = FailoverServers.ForDefaultDatabase;
 		}
 			else
 			{
-				if (FailoverServers.IsSetForDatabase(dbName) && result.FailoverUrls == null)
-					result.FailoverUrls = FailoverServers.GetForDatabase(dbName);
+				if (FailoverServers.IsSetForDatabase(dbName) && result.FailoverServers == null)
+					result.FailoverServers = FailoverServers.GetForDatabase(dbName);
 			}
 
 			return result;

--- a/Raven.Tests/App.config
+++ b/Raven.Tests/App.config
@@ -7,7 +7,7 @@
     <add name="Local" connectionString="DataDir = ~\Data"/>
     <add name="Server" connectionString="Url = http://localhost:8079"/>
     <add name="Secure" connectionString="Url = http://localhost:8079;user=beam;password=up"/>
-    <add name="FailoverServers" connectionString="Url = http://localhost:8079;FailoverUrl = http://localhost:8078;FailoverUrl = http://localhost:8077/databases/test; FailoverUrl = Northwind|http://localhost:8076/"/>
+    <add name="FailoverServers" connectionString="Url = http://localhost:8079;Failover = {Url:'http://localhost:8078'};Failover = {Url:'http://localhost:8077/', Database:'test'}; Failover = Northwind|{Url:'http://localhost:8076/'};Failover={Url:'http://localhost:8075', Username:'user', Password:'secret'};Failover={Url:'http://localhost:8074', ApiKey:'d5723e19-92ad-4531-adad-8611e6e05c8a'}"/>
 
 		<add name="SqlExpress" providerName="System.Data.SqlClient" connectionString="Data Source=.\sqlexpress;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1"/>
 		<add name="LocalHost" providerName="System.Data.SqlClient" connectionString="Data Source=.;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1"/>

--- a/Raven.Tests/ConnectionStrings.cs
+++ b/Raven.Tests/ConnectionStrings.cs
@@ -105,18 +105,24 @@ namespace Raven.Tests
 		}
 
 		[Fact]
-		public void Can_get_failover_urls()
+		public void Can_get_failover_servers()
 		{
 			using (var store = new DocumentStore())
 			{
-				store.ParseConnectionString("Url=http://localhost:8079/;FailoverUrl=http://localhost:8078/;FailoverUrl=http://localhost:8077/databases/test;FailoverUrl=Northwind|http://localhost:8076/");
+				store.ParseConnectionString("Url=http://localhost:8079/;Failover={Url:'http://localhost:8078/'};Failover={Url:'http://localhost:8077', Database:'test'};Failover=Northwind|{Url:'http://localhost:8076/'};Failover={Url:'http://localhost:8075', Username:'user', Password:'secret'};Failover={Url:'http://localhost:8074', ApiKey:'d5723e19-92ad-4531-adad-8611e6e05c8a'}");
 
 				Assert.Equal("http://localhost:8079", store.Url);
-				Assert.Equal(2, store.FailoverServers.ForDefaultDatabase.Length);
-				Assert.Equal("http://localhost:8078", store.FailoverServers.ForDefaultDatabase[0]);
-				Assert.Equal("http://localhost:8077/databases/test", store.FailoverServers.ForDefaultDatabase[1]);
+				Assert.Equal(4, store.FailoverServers.ForDefaultDatabase.Length);
+				Assert.Equal("http://localhost:8078", store.FailoverServers.ForDefaultDatabase[0].Url);
+				Assert.Equal("http://localhost:8077", store.FailoverServers.ForDefaultDatabase[1].Url);
+				Assert.Equal("test", store.FailoverServers.ForDefaultDatabase[1].Database);
 				Assert.Equal(1, store.FailoverServers.GetForDatabase("Northwind").Length);
-				Assert.Equal("http://localhost:8076", store.FailoverServers.GetForDatabase("Northwind")[0]);
+				Assert.Equal("http://localhost:8076", store.FailoverServers.GetForDatabase("Northwind")[0].Url);
+				Assert.Equal("http://localhost:8075", store.FailoverServers.ForDefaultDatabase[2].Url);
+				Assert.Equal("user", store.FailoverServers.ForDefaultDatabase[2].Username);
+				Assert.Equal("secret", store.FailoverServers.ForDefaultDatabase[2].Password);
+				Assert.Equal("http://localhost:8074", store.FailoverServers.ForDefaultDatabase[3].Url);
+				Assert.Equal("d5723e19-92ad-4531-adad-8611e6e05c8a", store.FailoverServers.ForDefaultDatabase[3].ApiKey);
 			}
 		}
 	}


### PR DESCRIPTION
Note that the first commit fixes the invalid storing of failover servers in isolated storage (a bug introduced during a merge), so now it make happen that tests in RavenDB_1217 will try to load them from cache - make sure that you have the cache cleaned.
