### PR TITLE
Relocation of applying Index Query triggers

### DIFF
--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -906,7 +906,7 @@ namespace Raven.Database.Indexing
 					RavenJObject[] termsDocs;
 					using (parent.GetSearcherAndTermsDocs(out indexSearcher, out termsDocs))
 					{
-						var luceneQuery = ApplyIndexTriggers(GetLuceneQuery());
+                        var luceneQuery = GetLuceneQuery();
 
 						TopDocs search = ExecuteQuery(indexSearcher, luceneQuery, indexQuery.Start, indexQuery.PageSize, indexQuery);
 						totalResults.Value = search.TotalHits;
@@ -934,7 +934,7 @@ namespace Raven.Database.Indexing
 					IndexSearcher indexSearcher;
 					using (parent.GetSearcher(out indexSearcher))
 					{
-						var luceneQuery = ApplyIndexTriggers(GetLuceneQuery());
+						var luceneQuery = GetLuceneQuery();
 
 
 						int start = indexQuery.Start;
@@ -1085,7 +1085,7 @@ namespace Raven.Database.Indexing
 						int intersectMatches = 0, skippedResultsInCurrentLoop = 0;
 						int previousBaseQueryMatches = 0, currentBaseQueryMatches = 0;
 
-						var firstSubLuceneQuery = ApplyIndexTriggers(GetLuceneQuery(subQueries[0], indexQuery));
+                        var firstSubLuceneQuery = GetLuceneQuery(subQueries[0], indexQuery);
 
 						//Do the first sub-query in the normal way, so that sorting, filtering etc is accounted for
 						var search = ExecuteQuery(indexSearcher, firstSubLuceneQuery, 0, pageSizeBestGuess, indexQuery);
@@ -1107,7 +1107,7 @@ namespace Raven.Database.Indexing
 
 							for (int i = 1; i < subQueries.Length; i++)
 							{
-								var luceneSubQuery = ApplyIndexTriggers(GetLuceneQuery(subQueries[i], indexQuery));
+								var luceneSubQuery = GetLuceneQuery(subQueries[i], indexQuery);
 								indexSearcher.Search(luceneSubQuery, null, intersectionCollector);
 							}
 
@@ -1232,7 +1232,7 @@ namespace Raven.Database.Indexing
 						DisposeAnalyzerAndFriends(toDispose, searchAnalyzer);
 					}
 				}
-				return luceneQuery;
+				return ApplyIndexTriggers(luceneQuery);
 			}
 
 			private static void DisposeAnalyzerAndFriends(List<Action> toDispose, RavenPerFieldAnalyzerWrapper analyzer)


### PR DESCRIPTION
The application of the index triggers is now done in the when returning the Lucene query instead of in the Query methods. This way both the Query and FacetQuery codepaths trigger the custom trigger.
