### PR TITLE
Added new setting Raven/DisablePerformanceCounters

### DIFF
--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -98,6 +98,8 @@ namespace Raven.Database.Config
 
 			PreventAutomaticSuggestionCreation = ravenSettings.PreventAutomaticSuggestionCreation.Value;
 
+			DisablePerformanceCounters = ravenSettings.DisablePerformanceCounters.Value;
+
 			MaxNumberOfItemsToIndexInSingleBatch = ravenSettings.MaxNumberOfItemsToIndexInSingleBatch.Value;
 
 			var initialNumberOfItemsToIndexInSingleBatch = Settings["Raven/InitialNumberOfItemsToIndexInSingleBatch"];
@@ -790,6 +792,11 @@ namespace Raven.Database.Config
 		/// If True the server will not create suggestions automatically based on the suggestion query. Default: false.
 		/// </summary>
 		public bool PreventAutomaticSuggestionCreation { get; set; }
+
+		/// <summary>
+		/// If True then no PerformanceCounters will be used. Default: false
+		/// </summary>
+		public bool DisablePerformanceCounters { get; set; }
 
 		[Browsable(false)]
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -41,6 +41,8 @@ namespace Raven.Database.Config
 				new IntegerSetting(settings["Raven/MaxIndexWritesBeforeRecreate"], 256 * 1024);
 			PreventAutomaticSuggestionCreation =
 				new BooleanSetting(settings["Raven/PreventAutomaticSuggestionCreation"], false);
+			DisablePerformanceCounters =
+				new BooleanSetting(settings["Raven/DisablePerformanceCounters"], false);
 
 			MaxNumberOfItemsToIndexInSingleBatch =
 				new IntegerSettingWithMin(settings["Raven/MaxNumberOfItemsToIndexInSingleBatch"],
@@ -244,5 +246,7 @@ namespace Raven.Database.Config
 		public IntegerSetting MaxIndexWritesBeforeRecreate { get; private set; }
 
 		public BooleanSetting PreventAutomaticSuggestionCreation { get; set; }
-	}
+    
+        public BooleanSetting DisablePerformanceCounters { get; set; }
+    }
 }

--- a/Raven.Database/Indexing/WorkContext.cs
+++ b/Raven.Database/Indexing/WorkContext.cs
@@ -244,7 +244,7 @@ namespace Raven.Database.Indexing
 
 		public void Init(string name)
 		{
-			if (Configuration.RunInMemory == false)
+			if (Configuration.DisablePerformanceCounters == false && Configuration.RunInMemory == false)
 			{
                 PerformanceCounters.Setup(name ?? Constants.SystemDatabase);
 			}


### PR DESCRIPTION
With this setting enabled, the performance counters will not be set up and only the NoOpPerformanceCounters are used.

This does not avoid the performance counter used in TransactionalStorage.GetDatabaseTransactionVersionSizeInBytes()
