### PR TITLE
RavenDB-1417

### DIFF
--- a/Raven.Database/DocumentDatabase.cs
+++ b/Raven.Database/DocumentDatabase.cs
@@ -136,6 +136,12 @@ namespace Raven.Database
 			get { return indexingExecuter; }
 		}
 
+		private ReducingExecuter reducingExecuter;
+		public ReducingExecuter ReducingExecuter
+		{
+			get { return reducingExecuter; }
+		}
+
 		private readonly DatabaseEtagSynchronizer etagSynchronizer;
 		public DatabaseEtagSynchronizer EtagSynchronizer
 		{
@@ -673,8 +679,11 @@ namespace Raven.Database
 			indexingBackgroundTask = Task.Factory.StartNew(
 				indexingExecuter.Execute,
 				CancellationToken.None, TaskCreationOptions.LongRunning, backgroundTaskScheduler);
+
+			reducingExecuter = new ReducingExecuter(workContext);
+
 			reducingBackgroundTask = Task.Factory.StartNew(
-				new ReducingExecuter(workContext).Execute,
+				reducingExecuter.Execute,
 				CancellationToken.None, TaskCreationOptions.LongRunning, backgroundTaskScheduler);
 		}
 
@@ -689,8 +698,11 @@ namespace Raven.Database
 			indexingBackgroundTask = Task.Factory.StartNew(
 				indexingExecuter.Execute,
 				CancellationToken.None, TaskCreationOptions.LongRunning, backgroundTaskScheduler);
+
+			reducingExecuter = new ReducingExecuter(workContext);
+
 			reducingBackgroundTask = Task.Factory.StartNew(
-				new ReducingExecuter(workContext).Execute,
+				reducingExecuter.Execute,
 				CancellationToken.None, TaskCreationOptions.LongRunning, backgroundTaskScheduler);
 		}
 

--- a/Raven.Database/Indexing/AbstractIndexingExecuter.cs
+++ b/Raven.Database/Indexing/AbstractIndexingExecuter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -23,6 +24,7 @@ namespace Raven.Database.Indexing
         protected int workCounter;
         protected int lastFlushedWorkCounter;
         protected BaseBatchSizeAutoTuner autoTuner;
+		protected ConcurrentDictionary<int, Index> currentlyProcessedIndexes = new ConcurrentDictionary<int, Index>(); 
 
         protected AbstractIndexingExecuter(WorkContext context)
         {
@@ -254,6 +256,11 @@ namespace Raven.Database.Indexing
 
             return true;
         }
+
+		public Index[] GetCurrentlyProcessingIndexes()
+		{
+			return currentlyProcessedIndexes.Values.ToArray();
+		}
 
         protected abstract IndexToWorkOn GetIndexToWorkOn(IndexStats indexesStat);
 

--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -89,7 +89,7 @@ namespace Raven.Database.Indexing
 		private bool forceWriteToDisk;
 
 		public TimeSpan LastIndexingDuration { get; set; }
-		public long TimePerDoc { get; set; }
+		public double TimePerDoc { get; set; }
 		public Task CurrentMapIndexingTask { get; set; }
 
 		protected Index(Directory directory, int id, IndexDefinition indexDefinition, AbstractViewGenerator viewGenerator, WorkContext context)
@@ -1397,6 +1397,11 @@ namespace Raven.Database.Indexing
 			return currentlyIndexing.Values.Concat(indexingPerformanceStats).ToArray();
 		}
 
+		public IndexingPerformanceStats[] GetCurrentIndexingPerformance()
+		{
+			return currentlyIndexing.Values.ToArray();
+		}
+
 		public void Backup(string backupDirectory, string path, string incrementalTag)
 		{
 			if (directory is RAMDirectory)
@@ -1608,5 +1613,18 @@ namespace Raven.Database.Indexing
 					PublicName, numberOfAlreadyProducedOutputs, sourceDocumentId, maxNumberOfIndexOutputs));
         }
 
+
+		internal class IndexByIdEqualityComparer : IEqualityComparer<Index>
+		{
+			public bool Equals(Index x, Index y)
+			{
+				return x.IndexId == y.IndexId;
+			}
+
+			public int GetHashCode(Index obj)
+			{
+				return obj.IndexId.GetHashCode();
+			}
+		}
 	}
 }

--- a/Raven.Database/Indexing/IndexingExecuter.cs
+++ b/Raven.Database/Indexing/IndexingExecuter.cs
@@ -223,7 +223,7 @@ namespace Raven.Database.Indexing
 						}
 
 						indexToWorkOn.Index.LastIndexingDuration = sp.Elapsed;
-						indexToWorkOn.Index.TimePerDoc = sp.ElapsedMilliseconds / Math.Max(1, indexToWorkOn.Batch.Docs.Count);
+						indexToWorkOn.Index.TimePerDoc = (double) sp.ElapsedMilliseconds / Math.Max(1, indexToWorkOn.Batch.Docs.Count);
 						indexToWorkOn.Index.CurrentMapIndexingTask = null;
 
 						return done;
@@ -323,6 +323,8 @@ namespace Raven.Database.Indexing
 
 		private void HandleIndexingFor(IndexingBatchForIndex batchForIndex, Etag lastEtag, DateTime lastModified)
 		{
+			currentlyProcessedIndexes.TryAdd(batchForIndex.IndexId, batchForIndex.Index);
+
 			try
 			{
 				transactionalStorage.Batch(actions => IndexDocuments(actions, batchForIndex.IndexId, batchForIndex.Batch));
@@ -345,6 +347,9 @@ namespace Raven.Database.Indexing
 					// whatever we succeeded in indexing or not, we have to update this
 					// because otherwise we keep trying to re-index failed documents
 										   actions.Indexing.UpdateLastIndexed(batchForIndex.Index.indexId, lastEtag, lastModified));
+
+				Index _;
+				currentlyProcessedIndexes.TryRemove(batchForIndex.IndexId, out _);
 			}
 		}
 

--- a/Raven.Database/Indexing/ReducingExecuter.cs
+++ b/Raven.Database/Indexing/ReducingExecuter.cs
@@ -43,6 +43,7 @@ namespace Raven.Database.Indexing
 			var singleStepReduceKeys = mappedResultsInfo.Where(x => x.OperationTypeToPerform == ReduceType.SingleStep).Select(x => x.ReduceKey).ToArray();
 			var multiStepsReduceKeys = mappedResultsInfo.Where(x => x.OperationTypeToPerform == ReduceType.MultiStep).Select(x => x.ReduceKey).ToArray();
 
+			currentlyProcessedIndexes.TryAdd(indexToWorkOn.IndexId, indexToWorkOn.Index);
 			try
 			{
 				if (singleStepReduceKeys.Length > 0)
@@ -74,6 +75,9 @@ namespace Raven.Database.Indexing
 						actions.Indexing.UpdateLastReduced(indexToWorkOn.Index.indexId, latest.Etag, latest.Timestamp);
 					});
 				}
+
+				Index _;
+				currentlyProcessedIndexes.TryRemove(indexToWorkOn.IndexId, out _);
 			}
 		}
 

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -284,7 +284,6 @@
     <Compile Include="Issues\RavenDB_1435.cs" />
     <Compile Include="Issues\RavenDB_1497.cs" />
     <Compile Include="Issues\RavenDB_1520.cs" />
-    <Compile Include="Issues\RavenDB_1534.cs" />
     <Compile Include="Issues\RavenDB_1539.cs" />
     <Compile Include="Issues\RavenDB_1561.cs" />
     <Compile Include="Issues\RavenDB_1560.cs" />


### PR DESCRIPTION
Endpoint output:

{
    NumberOfCurrentlyWorkingIndexes: 2,
    Indexes: [
    {
        IndexName: "Raven/DocumentsByEntityName",
        IsMapReduce: false,
        CurrentOperations: [
            {
            Operation: "Current",
            NumberOfProcessingItems: 16384
            }
        ],
        LastMapRate: "0.1670 ms/doc",
        Priority: "None",
        OverallIndexingRate: [
            {
            Operation: "Index",
            Rate: "0.2384 ms/doc"
            }
        ]
    },
    {
        IndexName: "SampleDataReduce/Index",
        IsMapReduce: true,
        CurrentOperations: [
        {
            Operation: "Current Map",
            NumberOfProcessingItems: 16383
        }
        ],
        LastMapRate: "0.1554 ms/doc",
        Priority: "None",
        OverallIndexingRate: [
            {
                Operation: "Map",
                Rate: "0.2170 ms/doc"
            },
            {
                Operation: "Reduce Level 2",
                Rate: "0.0185 ms/doc"
            }
        ]
    }
    ]
}
