### PR TITLE
Fix for duplicate access control headers

### DIFF
--- a/Raven.Database/Server/Controllers/RavenBaseApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenBaseApiController.cs
@@ -265,7 +265,14 @@ namespace Raven.Database.Server.Controllers
 		{
 			if (msg.Content == null)
 				msg.Content = new JsonContent();
-			msg.Content.Headers.Add(key, value);
+
+            // Ensure we haven't already appended these values.
+            IEnumerable<string> existingValues;
+            var hasExistingHeaderAppended = msg.Content.Headers.TryGetValues(key, out existingValues) && existingValues.Any(v => v == value);
+            if (!hasExistingHeaderAppended)
+            {
+                msg.Content.Headers.Add(key, value);
+            }
 		}
 
 		private string GetDateString(RavenJToken token, string format)


### PR DESCRIPTION
Fixes RavenDB-1597, where duplicate access control headers get added, thus breaking CORS.
