### PR TITLE
Fix to support importing or exporting multiple document types via Smuggl...

### DIFF
--- a/Raven.Smuggler/Program.cs
+++ b/Raven.Smuggler/Program.cs
@@ -15,7 +15,8 @@ using Raven.Abstractions.Smuggler;
 
 namespace Raven.Smuggler
 {
-	using System.Net.Sockets;
+    using System.Linq;
+    using System.Net.Sockets;
 
 	public class Program
 	{
@@ -48,11 +49,11 @@ namespace Raven.Smuggler
 			            			},
 			            		{
 			            			"metadata-filter:{=}", "Filter documents by a metadata property." + Environment.NewLine +
-			            			                       "Usage example: Raven-Entity-Name=Posts", (key, val) => options.Filters.Add(new FilterSetting
+			            			                       "Usage example: Raven-Entity-Name=Posts, or Raven-Entity-Name=Posts,Persons for multiple document types", (key, val) => options.Filters.Add(new FilterSetting
 			            			                       {
 				            			                       Path = "@metadata." + key,
 															   ShouldMatch = true,
-															   Values = new List<string>{val}
+															   Values = val.Split(',').ToList()
 			            			                       })
 			            			},
 								{
@@ -61,7 +62,7 @@ namespace Raven.Smuggler
 			            			                       {
 				            			                       Path = "@metadata." + key,
 															   ShouldMatch = false,
-															   Values = new List<string>{val}
+															   Values = val.Split(',').ToList()
 			            			                       })
 			            			},
 			            		{
@@ -70,7 +71,7 @@ namespace Raven.Smuggler
 			            			              {
 													  Path = key,
 													  ShouldMatch = true,
-													  Values = new List<string>{val}
+													  Values = val.Split(',').ToList()
 			            			              })
 			            			},
 								{
@@ -79,7 +80,7 @@ namespace Raven.Smuggler
 			            			              {
 													  Path = key,
 													  ShouldMatch = false,
-													  Values = new List<string>{val}
+													  Values = val.Split(',').ToList()
 			            			              })
 			            			},
 			            		{


### PR DESCRIPTION
...er

Only one document type could be specified via smuggler.
Now supports syntax like: --metadata-filter=Raven-Entity-Name=Posts,Persons,Organizations
