### PR TITLE
Dropping support for slow indexes - they caused complicated indexing pro...

### DIFF
--- a/Raven.Database/Indexing/AbstractIndexingExecuter.cs
+++ b/Raven.Database/Indexing/AbstractIndexingExecuter.cs
@@ -229,9 +229,7 @@ namespace Raven.Database.Indexing
                         continue;
                     var indexToWorkOn = GetIndexToWorkOn(indexesStat);
                     var index = context.IndexStorage.GetIndexInstance(indexesStat.Name);
-                    if (index == null || // not there
-                        index.CurrentMapIndexingTask != null)
-                        // busy doing indexing work already, not relevant for this batch
+                    if (index == null) // not there
                         continue;
 
                     indexToWorkOn.Index = index;

--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -20,7 +20,6 @@ using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Lucene.Net.Search.Vectorhighlight;
 using Lucene.Net.Store;
-using Mono.CSharp;
 using Raven.Abstractions;
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
@@ -40,7 +39,6 @@ using Raven.Json.Linq;
 using Directory = Lucene.Net.Store.Directory;
 using Document = Lucene.Net.Documents.Document;
 using Field = Lucene.Net.Documents.Field;
-using Task = System.Threading.Tasks.Task;
 using Version = Lucene.Net.Util.Version;
 
 namespace Raven.Database.Indexing
@@ -82,10 +80,6 @@ namespace Raven.Database.Indexing
 		private readonly ConcurrentQueue<IndexingPerformanceStats> indexingPerformanceStats = new ConcurrentQueue<IndexingPerformanceStats>();
 		private readonly static StopAnalyzer stopAnalyzer = new StopAnalyzer(Version.LUCENE_30);
 		private bool forceWriteToDisk;
-
-		public TimeSpan LastIndexingDuration { get; set; }
-		public long TimePerDoc { get; set; }
-		public Task CurrentMapIndexingTask { get; set; }
 
 		protected Index(Directory directory, string name, IndexDefinition indexDefinition, AbstractViewGenerator viewGenerator, WorkContext context)
 		{
@@ -184,18 +178,6 @@ namespace Raven.Database.Indexing
 				}
 
 				disposed = true;
-				var task = CurrentMapIndexingTask;
-				if (task != null)
-				{
-					try
-					{
-						task.Wait();
-					}
-					catch (Exception e)
-					{
-						logIndexing.Warn("Error while closing the index (could not wait for current indexing task)", e);
-					}
-				}
 
 				foreach (var indexExtension in indexExtensions)
 				{

--- a/Raven.Database/Indexing/IndexingExecuter.cs
+++ b/Raven.Database/Indexing/IndexingExecuter.cs
@@ -173,152 +173,10 @@ namespace Raven.Database.Indexing
 			context.PerformanceCounters.IndexedPerSecond.IncrementBy(jsonDocs.Count);
 			var result = FilterIndexes(indexesToWorkOn, jsonDocs, lastEtag).ToList();
 
-			ExecuteAllInterleaved(result, index => HandleIndexingFor(index, lastEtag, lastModified));
+			BackgroundTaskExecuter.Instance.ExecuteAllInterleaved(context, result,
+																  index => HandleIndexingFor(index, lastEtag, lastModified));
 
 			return lastEtag;
-		}
-
-		SemaphoreSlim indexingSemaphore;
-		private ManualResetEventSlim indexingCompletedEvent;
-		readonly ConcurrentSet<System.Threading.Tasks.Task> pendingTasks = new ConcurrentSet<System.Threading.Tasks.Task>();
-
-		private void ExecuteAllInterleaved(IList<IndexingBatchForIndex> result, Action<IndexingBatchForIndex> action)
-		{
-			if (result.Count == 0)
-				return;
-			/*
-			This is EXPLICILTY not here, we always want to allow this to run additional indexes
-			if we still have free spots to run them from threading perspective.
-			 
-			if (result.Count == 1)
-			{
-				action(result[0]);
-				return;
-			}
-			*/
-
-			var maxNumberOfParallelIndexTasks = context.Configuration.MaxNumberOfParallelIndexTasks;
-
-			SortResultsMixedAccordingToTimePerDoc(result);
-
-			int isSlowIndex = 0;
-			var totalIndexingTime = Stopwatch.StartNew();
-			var tasks = new System.Threading.Tasks.Task[result.Count];
-			for (int i = 0; i < result.Count; i++)
-			{
-				var index = result[i];
-				var indexToWorkOn = index;
-
-				var sp = Stopwatch.StartNew();
-				var task = new System.Threading.Tasks.Task(() => action(indexToWorkOn));
-				indexToWorkOn.Index.CurrentMapIndexingTask = tasks[i] = task.ContinueWith(done =>
-				{
-					try
-					{
-						sp.Stop();
-
-						if (done.IsFaulted) // this observe the exception
-						{
-							Log.WarnException("Failed to execute indexing task", done.Exception);
-						}
-
-						indexToWorkOn.Index.LastIndexingDuration = sp.Elapsed;
-						indexToWorkOn.Index.TimePerDoc = sp.ElapsedMilliseconds / Math.Max(1, indexToWorkOn.Batch.Docs.Count);
-						indexToWorkOn.Index.CurrentMapIndexingTask = null;
-
-						return done;
-					}
-					catch (ObjectDisposedException)
-					{
-						// nothing to do here, this may happen if the database is disposed
-						// while we have a long running task that didn't complete in time
-						return new CompletedTask();
-					}
-					finally
-					{
-						if (indexingSemaphore != null)
-							indexingSemaphore.Release();
-						if (indexingCompletedEvent != null)
-							indexingCompletedEvent.Set();
-						if (Thread.VolatileRead(ref isSlowIndex) != 0)
-						{
-							// we now need to notify the engine that the slow index(es) is done, and we need to resume its indexing
-							try
-							{
-								context.ShouldNotifyAboutWork(() => "Slow Index Completed Indexing Batch");
-								context.NotifyAboutWork();
-							}
-							catch (ObjectDisposedException)
-							{
-								// nothing to do here, this may happen if the database is disposed
-								// while we have a long running task
-							}
-						}
-					}
-				}).Unwrap();
-
-				indexingSemaphore.Wait();
-
-				task.Start(context.Database.BackgroundTaskScheduler);
-			}
-
-			// we only get here AFTER we finished scheduling all the indexes
-			// we wait until we have at least parallel / 2 spots opened (for the _next_ indexing batch) or 8, if we are 
-			// running on Enterprise / high end systems
-			int minIndexingSpots = Math.Min((maxNumberOfParallelIndexTasks / 2), 8);
-			while (indexingSemaphore.CurrentCount < minIndexingSpots)
-			{
-				indexingCompletedEvent.Wait();
-				indexingCompletedEvent.Reset();
-			}
-
-			// now we have the chance to start a new indexing batch with the old items, but we still
-			// want to wait for a bit to _avoid_ creating multiple batches if we can possibly avoid it.
-			// We will wait for 3/4 the time we waited so far, and a min of 15 seconds
-			var timeToWait = Math.Max((int)(totalIndexingTime.ElapsedMilliseconds / 4) * 3, 15000);
-			var totalWaitTime = Stopwatch.StartNew();
-			while (indexingSemaphore.CurrentCount < maxNumberOfParallelIndexTasks)
-			{
-				int timeout = timeToWait - (int)totalWaitTime.ElapsedMilliseconds;
-				if (timeout <= 0)
-					break;
-				indexingCompletedEvent.Reset();
-				indexingCompletedEvent.Wait(timeout);
-			}
-
-			var creatingNewBatch = indexingSemaphore.CurrentCount < maxNumberOfParallelIndexTasks;
-			if (creatingNewBatch == false)
-				return;
-
-			Interlocked.Increment(ref isSlowIndex);
-
-			if (Log.IsDebugEnabled == false)
-				return;
-
-			var slowIndexes = result.Where(x =>
-			{
-				var currentMapIndexingTask = x.Index.CurrentMapIndexingTask;
-				return currentMapIndexingTask != null && !currentMapIndexingTask.IsCompleted;
-			})
-				.Select(x => x.IndexName)
-				.ToArray();
-
-			Log.Debug("Indexing is now split because there are {0:#,#} slow indexes [{1}], memory usage may increase, and those indexing may experience longer stale times (but other indexes will be faster)",
-					 slowIndexes.Length,
-					 string.Join(", ", slowIndexes));
-		}
-
-		private static void SortResultsMixedAccordingToTimePerDoc(IList<IndexingBatchForIndex> result)
-		{
-			var orderedBy = result.OrderBy(x => x.Index.TimePerDoc).ToArray();
-			int startPos = 0, endPos = orderedBy.Length;
-			int resultPos = 0;
-			while (startPos < endPos)
-			{
-				result[resultPos++] = orderedBy[startPos++];
-				if (resultPos + 1 < result.Count)
-					result[resultPos++] = orderedBy[--endPos];
-			}
 		}
 
 		private void HandleIndexingFor(IndexingBatchForIndex batchForIndex, Etag lastEtag, DateTime lastModified)
@@ -352,8 +210,6 @@ namespace Raven.Database.Indexing
 		public class IndexingBatchForIndex
 		{
 			public string IndexName { get; set; }
-
-			public Index Index { get; set; }
 
 			public Etag LastIndexedEtag { get; set; }
 
@@ -444,7 +300,6 @@ namespace Raven.Database.Indexing
 				{
 					Batch = batch,
 					IndexName = indexToWorkOn.IndexName,
-					Index = indexToWorkOn.Index,
 					LastIndexedEtag = indexToWorkOn.LastIndexedEtag
 				};
 
@@ -504,29 +359,10 @@ namespace Raven.Database.Indexing
 		protected override void Dispose()
 		{
 			var exceptionAggregator = new ExceptionAggregator(Log, "Could not dispose of IndexingExecuter");
-			foreach (var pendingTask in pendingTasks)
-			{
-				exceptionAggregator.Execute(pendingTask.Wait);
-			}
-			pendingTasks.Clear();
 
 			exceptionAggregator.Execute(prefetchingBehavior.Dispose);
 
-			if (indexingCompletedEvent != null)
-				exceptionAggregator.Execute(indexingCompletedEvent.Dispose);
-			if (indexingSemaphore != null)
-				exceptionAggregator.Execute(indexingSemaphore.Dispose);
 			exceptionAggregator.ThrowIfNeeded();
-
-			indexingCompletedEvent = null;
-			indexingSemaphore = null;
-		}
-
-		protected override void Init()
-		{
-			indexingSemaphore = new SemaphoreSlim(context.Configuration.MaxNumberOfParallelIndexTasks);
-			indexingCompletedEvent = new ManualResetEventSlim(false);
-			base.Init();
 		}
     }
 }


### PR DESCRIPTION
...blems in heavy concurrent load scenario because the slow indexes lost last etags from the etag synchronizer
