### PR TITLE
RavenDB-1618 Reapplying the change from a responder (2.5) to an apropria...

### DIFF
--- a/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
+++ b/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
@@ -271,7 +271,8 @@ namespace Raven.Database.Bundles.Replication.Controllers
 				{
 					sourceReplicationInformation = new SourceReplicationInformation()
 					{
-						Source = src
+						Source = src,
+						ServerInstanceId = serverInstanceId
 					};
 				}
 				else


### PR DESCRIPTION
...te controller (3.0):
- RavenDB-1555 Even if the appropriate source replication document does not exist we have to add to the response the server id in order to be able to properly apply a replication strategy's filtering option where we prevent replication back to source
