### PR TITLE
better find PerformanceCounterInstance

### DIFF
--- a/Raven.Database/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorage.cs
@@ -207,7 +207,7 @@ namespace Raven.Storage.Esent
                     return getDatabaseTransactionVersionSizeInBytesErrorValue = -1;
                 var category = new PerformanceCounterCategory(categoryName);
                 var instances = category.GetInstanceNames();
-                var ravenInstance = instances.FirstOrDefault(x => x.StartsWith(uniquePrefix));
+                var ravenInstance = instances.FirstOrDefault(x => x.Contains(uniquePrefix));
                 const string counterName = "Version Buckets Allocated";
                 if (ravenInstance == null || !category.CounterExists(counterName))
                 {


### PR DESCRIPTION
It does not always 'startswith' - running as application or debugging on my win81 pc the Instancename is:
'Raven.Server.vshost/1-UxBsU-C:\Users\SteinArild\Source\Repos\RavenDb\build\Database'
trying to match uniquePrefix = '1-UxBsU'

Found this because I have a 22 index database  where "MaybePulseTransactions()" never hit because of this - and I ended up with EsentOutOfMemory exceptions....
