### PR TITLE
RavenDB-1700 Fixing the order of freeing scratch pages: we have to free ...

### DIFF
--- a/Raven.Tryouts/Program.cs
+++ b/Raven.Tryouts/Program.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Raven.Tests.Faceted;
-using Raven.Tests.Issues;
-using System.Threading;
-using Raven.Tests.Notifications;
-using Raven.Tests.Suggestions;
+using Raven.Tests.Bugs.DTC;
 
 namespace Raven.Tryouts
 {
@@ -19,9 +15,9 @@ namespace Raven.Tryouts
 			{
 				Console.WriteLine(i);
                 Environment.SetEnvironmentVariable("run", i.ToString("000"));
-				using (var x = new WithIIS())
+				using (var x = new Embedded())
 				{
-					x.CheckNotificationInIIS();
+					x.AllowNonAuthoritativeInformationAlwaysWorks();
 				}
 			}
 			


### PR DESCRIPTION
...pages of unused journals first before the other journals because otherwise a read transaction could read an outdated page from the older and not relevant journal
