### PR TITLE
Expiration bundle makes extra queries when there's a match

### DIFF
--- a/Raven.Database/Bundles/Expiration/ExpiredDocumentsCleaner.cs
+++ b/Raven.Database/Bundles/Expiration/ExpiredDocumentsCleaner.cs
@@ -96,9 +96,12 @@ namespace Raven.Bundles.Expiration
 					if(queryResult.Results.Count == 0)
 						break;
 
-					start += pageSize;
-
 					list.AddRange(queryResult.Results.Select(result => result.Value<string>("__document_id")).Where(x=>string.IsNullOrEmpty(x) == false));
+
+                    if (queryResult.Results.Count < pageSize)
+                        break;
+
+                    start += pageSize;
 				}
 
 				if (list.Count == 0)


### PR DESCRIPTION
No need to query again if we got less results than the requested page size - this just makes an extra query that is 99.99999 percent guaranteed to return 0 results.

Also, might be worth transitioning this over to working off a stream instead of paged queries
