### PR TITLE
RavenDB-1732 Prevent Raven/DocumentsByEntityName index from indexing in-...

### DIFF
--- a/Raven.Client.Lightweight/Indexes/RavenDocumentsByEntityName.cs
+++ b/Raven.Client.Lightweight/Indexes/RavenDocumentsByEntityName.cs
@@ -44,7 +44,9 @@ select new { Tag, LastModified = (DateTime)doc[""@metadata""][""Last-Modified""]
 					{
 						{"Tag", FieldTermVector.No},
 						{"LastModified", FieldTermVector.No}
-					}
+					},
+
+				DisableInMemoryIndexing = true
 			};
 		}
 	}


### PR DESCRIPTION
...memory

This is according to Itamar's suggestion (http://issues.hibernatingrhinos.com/issue/RavenDB-1732). If you don't agree just close this PR without merging it.
