### PR TITLE
RavenDB-1758. TransactionMergingWriter should use same CancellationToken...

### DIFF
--- a/Raven.Database/Storage/Voron/Impl/TableStorage.cs
+++ b/Raven.Database/Storage/Voron/Impl/TableStorage.cs
@@ -106,7 +106,15 @@ namespace Raven.Database.Storage.Voron.Impl
 
 		public void Write(WriteBatch writeBatch)
 		{
-			env.Writer.Write(writeBatch);
+		    try
+		    {
+                env.Writer.Write(writeBatch);
+		    }
+		    catch (AggregateException ae)
+		    {
+		        if (ae.InnerException is OperationCanceledException == false) // this can happen during storage disposal
+		            throw;
+		    }
 		}
 
 		public long GetEntriesCount(TableBase table)

--- a/Raven.Voron/Voron/StorageEnvironment.cs
+++ b/Raven.Voron/Voron/StorageEnvironment.cs
@@ -66,7 +66,7 @@ namespace Voron
 			
 			if(Writer != null)
 				Writer.Dispose();
-			Writer = new TransactionMergingWriter(this, DebugJournal);
+            Writer = new TransactionMergingWriter(this, _cancellationTokenSource.Token, DebugJournal);
 	    }
 #endif
 
@@ -94,7 +94,7 @@ namespace Voron
                 State.FreeSpaceRoot.Name = Constants.FreeSpaceTreeName;
                 State.Root.Name = Constants.RootTreeName;
 
-                Writer = new TransactionMergingWriter(this);
+                Writer = new TransactionMergingWriter(this, _cancellationTokenSource.Token);
 
                 if (_options.ManualFlushing == false)
                     _flushingTask = FlushWritesToDataFileAsync();
@@ -221,7 +221,7 @@ namespace Voron
 			    if (Writer != null && value != null)
 			    {
 				    Writer.Dispose();
-				    Writer = new TransactionMergingWriter(this, _debugJournal);
+                    Writer = new TransactionMergingWriter(this, _cancellationTokenSource.Token, _debugJournal);
 			    }
 
 		    }


### PR DESCRIPTION
... as StorageEnvironment, ignoring OperationCancelledExceptions during write (can happen during env disposal)
