### PR TITLE
Do not update synchronizer value if no documents were put. Setting Etag....

### DIFF
--- a/Raven.Database/Impl/Synchronization/DatabaseEtagSynchronizer.cs
+++ b/Raven.Database/Impl/Synchronization/DatabaseEtagSynchronizer.cs
@@ -40,7 +40,7 @@ namespace Raven.Database.Impl.Synchronization
 
 		public void UpdateSynchronizationState(JsonDocument[] docs)
 		{
-			if (docs == null)
+			if (docs == null || docs.Length == 0)
 				return;
 
 			var lowestEtag = GetLowestEtag(docs);


### PR DESCRIPTION
...Empty value to the synchronizer resulted in moving back the whole indexing process and starting from scratch (because Etag.Empty is lower than all etags of docs)
