### PR TITLE
Fixing test RavenDB1369.CanRestoreIncrementalToMultipleLocationsToDiffer...

### DIFF
--- a/Raven.Database/Storage/Voron/Backup/RestoreOperation.cs
+++ b/Raven.Database/Storage/Voron/Backup/RestoreOperation.cs
@@ -38,11 +38,7 @@ namespace Raven.Database.Storage.Voron.Backup
                             .OrderBy(dir=>dir)
                             .Select(dir=> Path.Combine(dir,BackupMethods.Filename))
                             .ToList();
-                        BackupMethods.Incremental.Restore(options, new IncrementalBackup.IncrementalRestorePaths
-                        {
-                            DatabaseLocation = _restoreRequest.DatabaseLocation,
-                            JournalLocation = _restoreRequest.JournalsLocation
-                        }, backupPaths);
+                        BackupMethods.Incremental.Restore(options, backupPaths);
                     }
 				}
 

--- a/Raven.Tests/Issues/RavenDB1369.cs
+++ b/Raven.Tests/Issues/RavenDB1369.cs
@@ -220,7 +220,8 @@ namespace Raven.Tests.Issues
 
                     store.DatabaseCommands.GlobalAdmin.StartBackup(backupDir, new DatabaseDocument(), true, "DB1");
                     WaitForBackup(store.DatabaseCommands.ForDatabase("DB1"), true);
-
+					
+					Thread.Sleep(1000); // incremental tag has seconds precision
                 }
 
                 store.DatabaseCommands.GlobalAdmin.StartRestore(new RestoreRequest


### PR DESCRIPTION
...entDatabase. Proper usage of temporary directories. No need to copy voron headers into incremental backup files. Making test aware of seconds precision in incremental backup dirs.
