### PR TITLE
Parameterise recent touch count

### DIFF
--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -179,6 +179,8 @@ namespace Raven.Database.Config
 				IndexStoragePath = indexStoragePathSettingValue;
 			}
 
+			MaxRecentTouchesToRemember = ravenSettings.MaxRecentTouchesToRemember.Value;
+
 			// HTTP settings
 			HostName = ravenSettings.HostName.Value;
 
@@ -807,6 +809,12 @@ namespace Raven.Database.Config
 		/// Default: 10,000
 		/// </summary>
 		public int MaxStepsForScript { get; set; }
+
+		/// <summary>
+		/// The maximum number of recent document touches to store (i.e. updates done in
+		/// order to initiate indexing rather than because something has actually changed).
+		/// </summary>
+		public int MaxRecentTouchesToRemember { get; set; }
 
 		/// <summary>
 		/// The number of additional steps to add to a given script based on the processed document's quota.

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -144,9 +144,10 @@ namespace Raven.Database.Config
 
 			MaxStepsForScript = new IntegerSetting(settings["Raven/MaxStepsForScript"], 10*1000);
 			AdditionalStepsForScriptBasedOnDocumentSize = new IntegerSetting(settings["Raven/AdditionalStepsForScriptBasedOnDocumentSize"], 5);
+
+			MaxRecentTouchesToRemember = new IntegerSetting(settings["Raven/MaxRecentTouchesToRemember"], 1024);
 		}
 
-	    
 		private string GetDefaultWebDir()
 		{
 			return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Raven/WebUI");
@@ -274,5 +275,7 @@ namespace Raven.Database.Config
     
         public BooleanSetting DisablePerformanceCounters { get; set; }
 		public TimeSpanSetting DatbaseOperationTimeout { get; private set; }
+
+		public IntegerSetting MaxRecentTouchesToRemember { get; set; }
 	}
 }


### PR DESCRIPTION
As discussed here https://groups.google.com/d/msg/ravendb/iUl8tO6A6Rw/D306KFy9sigJ, a fixed limit of 1024 touches to remember is somewhat lacking under certain situations. Here I have allowed it to be set from a config option, defaulting to 1024.
