### PR TITLE
RavenDB-2033 and RavenDB-2090 If WriteFileGather finishes synchronously ...

### DIFF
--- a/Raven.Voron/Voron/Impl/Journal/Win32JournalWriter.cs
+++ b/Raven.Voron/Voron/Impl/Journal/Win32JournalWriter.cs
@@ -72,7 +72,11 @@ namespace Voron.Impl.Journal
 			}
 			_segments[pages.Length].Buffer = null; // null terminating
 
-			WriteFileGather(_handle, _segments, (uint) pages.Length*4096, IntPtr.Zero, _nativeOverlapped);
+			var operationCompleted = WriteFileGather(_handle, _segments, (uint) pages.Length*4096, IntPtr.Zero, _nativeOverlapped);
+
+			if (operationCompleted) 
+				return;
+
 			switch (Marshal.GetLastWin32Error())
 			{
 				case ErrorSuccess:


### PR DESCRIPTION
...then we shouldn't check LastWin32Error on windows server systems
