### PR TITLE
issue fixed: RavenDB-2190

### DIFF
--- a/Raven.Studio.Html5/App/viewmodels/deleteIndexesConfirm.ts
+++ b/Raven.Studio.Html5/App/viewmodels/deleteIndexesConfirm.ts
@@ -22,8 +22,15 @@ class deleteIndexesConfirm extends dialogViewModelBase {
     deleteIndexes() {
         var deleteTasks = this.indexNames
             .map(name => new deleteIndexCommand(name, this.db).execute());
+        var myDeleteTask = this.deleteTask;
 
-        $.when(deleteTasks).done(() => this.deleteTask.resolve());
+        $.when.apply($, deleteTasks)
+            .done(() => {
+                myDeleteTask.resolve();
+            })
+            .fail(()=> {
+                myDeleteTask.reject();
+            });
         dialog.close(this);
     }
 

--- a/Raven.Studio.Html5/App/viewmodels/indexes.ts
+++ b/Raven.Studio.Html5/App/viewmodels/indexes.ts
@@ -142,7 +142,14 @@ class indexes extends viewModelBase {
         if (indexes.length > 0) {
             var deleteIndexesVm = new deleteIndexesConfirm(indexes.map(i => i.name), this.activeDatabase());
             app.showDialog(deleteIndexesVm);
-            deleteIndexesVm.deleteTask.done(() => this.removeIndexesFromAllGroups(indexes));
+            deleteIndexesVm.deleteTask
+                .done((aa) => {
+                    this.removeIndexesFromAllGroups(indexes);
+                })
+                .fail(() => {
+                    this.removeIndexesFromAllGroups(indexes);
+                    this.fetchIndexes();
+            });
         }
     }
 


### PR DESCRIPTION
when the index is deleted, it is removed before the server reports whether the delete operation has succeeded, and if index deletion fails, the index is still removed from the list. Also, there is no visual indication to what is going on (deletion is in progress, etc.)

solution: jquery $.when was called in the wrong way. when receiving array of promises/deferreds, $.when.apply syntax should be used.
also, forced reload of all indexes if all/part of delete operations were failed
