### PR TITLE
issue fixed :RavenDB-2097  Deleting transformer makes them only disappear

### DIFF
--- a/Raven.Database/Storage/IndexDefinitionStorage.cs
+++ b/Raven.Database/Storage/IndexDefinitionStorage.cs
@@ -190,16 +190,10 @@ namespace Raven.Database.Storage
         {
             if (configuration.RunInMemory)
                 return;
-            string indexName;
-            int i = 0;
-            while (true)
-            {
-                indexName = Path.Combine(path, i + ".transform");
-                if (File.Exists(indexName) == false)
-                    break;
-                i++;
-            }
-            File.WriteAllText(indexName,
+
+            string transformerFileName = Path.Combine(path, transformerDefinition.TransfomerId + ".transform");
+
+            File.WriteAllText(transformerFileName,
                               JsonConvert.SerializeObject(transformerDefinition, Formatting.Indented, Default.Converters));
         }
 


### PR DESCRIPTION
changing the transformer definition naming logic to [TransformerID].transform (instead of [first free id].transform), changing what was commited in commit number f51e6acfd60d450267156d69317bf565f6e94718.
