### PR TITLE
issue fixed:RavenDB-2159 Implement ace editor full screen mode

### DIFF
--- a/Raven.Studio.Html5/App/common/aceEditorBindingHandler.ts
+++ b/Raven.Studio.Html5/App/common/aceEditorBindingHandler.ts
@@ -18,7 +18,9 @@ class aceEditorBindingHandler {
         lang: "ace/mode/csharp",
         readOnly: false
     }
-    
+
+    static dom = require("ace/lib/dom");    
+    static commands = require("ace/commands/default_commands").commands;
     
     static install() {
         if (!ko.bindingHandlers["aceEditor"]) {
@@ -38,6 +40,18 @@ class aceEditorBindingHandler {
                     value: "general"
                 }
             });
+
+            /// taken from https://github.com/ajaxorg/ace-demos/blob/master/scrolling-editor.html
+            aceEditorBindingHandler.commands.push({
+                name: "Toggle Fullscreen",
+                bindKey: "F11",
+                exec: function(editor) {
+                    aceEditorBindingHandler.dom.toggleCssClass(document.body, "fullScreen");
+                    aceEditorBindingHandler.dom.toggleCssClass(editor.container, "fullScreen-editor");
+                    editor.resize();
+                }
+            });
+            /// 
         }
     }
 

--- a/Raven.Studio.Html5/Content/app.css
+++ b/Raven.Studio.Html5/Content/app.css
@@ -1,4 +1,4 @@
-html,
+﻿html,
 body {
   height: 100%;
 }
@@ -60,6 +60,29 @@ body {
   -ms-text-overflow: ellipsis;
   -o-text-overflow: ellipsis;
   text-overflow: ellipsis;
+}
+/*
+.ace_editor {
+		border: 1px solid lightgray;
+		margin: auto;
+		height: 200px;
+		width: 80%;
+		position: relative !important
+	}*/
+.fullScreen .fullScreen-editor {
+  height: auto!important;
+  width: auto!important;
+  border: 0;
+  margin: 0;
+  position: fixed !important;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10000;
+}
+.fullScreen {
+  overflow: hidden;
 }
 .dropdown-menu .selected {
   color: #555;

--- a/Raven.Studio.Html5/Content/app.less
+++ b/Raven.Studio.Html5/Content/app.less
@@ -79,6 +79,34 @@ html, body {
     }
 }
 
+/// taken from https://github.com/ajaxorg/ace-demos/blob/master/scrolling-editor.html
+/*
+.ace_editor {
+		border: 1px solid lightgray;
+		margin: auto;
+		height: 200px;
+		width: 80%;
+		position: relative !important
+	}*/
+
+.fullScreen .fullScreen-editor{ 
+	height: auto!important;
+	width: auto!important;
+	border: 0;
+    margin: 0;
+    position: fixed !important;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+	z-index: 10000
+}
+
+.fullScreen {
+	overflow: hidden
+}
+///
+
 .dropdown-menu{
     .selected{
         color: #555;


### PR DESCRIPTION
now, when in editor, if pressing F-11, the editor is spread to whole window, if pressing again, we return to the "original" view
