### PR TITLE
issue 2352 fixed

### DIFF
--- a/Raven.Studio.Html5/App/viewmodels/createDatabase.ts
+++ b/Raven.Studio.Html5/App/viewmodels/createDatabase.ts
@@ -109,6 +109,9 @@ class createDatabase extends dialogViewModelBase {
         else if (rg3.test(name)) {
             message = "The name '" + name + "' is forbidden for use!";
         }
+        else if (name[name.length-1]==".") {
+            message = "The database name can't end with a dot !";
+        }
         return message;
     }
 


### PR DESCRIPTION
Cannot create databases named A->F followed by a dot.
It's wrong issue definition. The problem exists with all names ended by dot because of msft path function.
Solution : name ended by dot not permitted
