### PR TITLE
Websockets Test

### DIFF
--- a/Raven.Tests.Core/ChangesApi/Subscribing.cs
+++ b/Raven.Tests.Core/ChangesApi/Subscribing.cs
@@ -1,13 +1,10 @@
-﻿using System.Net.WebSockets;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using Raven.Abstractions.Data;
 using Raven.Json.Linq;
 using Raven.Tests.Core.Replication;
 using Raven.Tests.Core.Utils.Entities;
 using Raven.Tests.Core.Utils.Indexes;
 using System;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Raven.Tests.Core.ChangesApi
@@ -184,27 +181,6 @@ namespace Raven.Tests.Core.ChangesApi
                 source.Replication.WaitAsync(eTag, replicas: 1).Wait();
 
                 WaitUntilOutput("conflict");
-            }
-        }
-
-        [Fact]
-        public async Task Can_connect_via_websockets_and_receive_heartbeat()
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var clientWebSocket = new ClientWebSocket())
-                {
-                    string url = store.Url.Replace("http:", "ws:");
-                    url = url + "/changes/websocket?id=" + Guid.NewGuid();
-                    await clientWebSocket.ConnectAsync(new Uri(url), CancellationToken.None);
-
-                    var buffer = new byte[1024];
-                    WebSocketReceiveResult result =
-                        await clientWebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-                    var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
-
-                    Assert.Contains("Heartbeat", message);
-                }
             }
         }
     }

--- a/Raven.Tests.Core/ChangesApi/WebsocketsTests.cs
+++ b/Raven.Tests.Core/ChangesApi/WebsocketsTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Tests.Core.Replication;
+using Xunit;
+
+namespace Raven.Tests.Core.ChangesApi
+{
+    public class WebsocketsTests : RavenReplicationCoreTest
+    {
+        [Fact]
+        public async Task Can_connect_via_websockets_and_receive_heartbeat()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var clientWebSocket = new ClientWebSocket())
+                {
+                    string url = store.Url.Replace("http:", "ws:");
+                    url = url + "/changes/websocket?id=" + Guid.NewGuid();
+                    await clientWebSocket.ConnectAsync(new Uri(url), CancellationToken.None);
+
+                    var buffer = new byte[1024];
+                    WebSocketReceiveResult result =
+                        await clientWebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                    var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
+
+                    Assert.Contains("Heartbeat", message);
+                }
+            }
+        }
+    }
+}

--- a/Raven.Tests.Core/Raven.Tests.Core.csproj
+++ b/Raven.Tests.Core/Raven.Tests.Core.csproj
@@ -102,6 +102,7 @@
   <ItemGroup>
     <Compile Include="ChangesApi\ImplementingChangesClient.cs" />
     <Compile Include="ChangesApi\Subscribing.cs" />
+    <Compile Include="ChangesApi\WebsocketsTests.cs" />
     <Compile Include="Commands\Batches.cs" />
     <Compile Include="Commands\Querying.cs" />
     <Compile Include="Commands\Transformers.cs" />


### PR DESCRIPTION
Added a test to ensure the websockets endpoint worked.

Considered adding WebsocketsMiddleware nuget package, but to be honest, this works and there is no point changing it.

You might consider having the websockets endpoint same endpoint as the http events ("changes/events") instead of a separate one ("changes/websockets"). The endpoints will be differentiated by the scheme.
