### PR TITLE
Raven db 2497, 2427

### DIFF
--- a/Raven.Database/Bundles/SqlReplication/RelationalDatabaseWriter.cs
+++ b/Raven.Database/Bundles/SqlReplication/RelationalDatabaseWriter.cs
@@ -170,7 +170,7 @@ namespace Raven.Database.Bundles.SqlReplication
 					database.WorkContext.CancellationToken.ThrowIfCancellationRequested();
 
 					var sb = new StringBuilder("INSERT INTO ")
-						.Append(commandBuilder.QuoteIdentifier(tableName))
+                        .Append(string.Join(".", tableName.Split('.').Select(x => commandBuilder.QuoteIdentifier(x)).ToArray()))
 						.Append(" (")
 						.Append(commandBuilder.QuoteIdentifier(pkName))
 						.Append(", ");
@@ -238,10 +238,10 @@ namespace Raven.Database.Bundles.SqlReplication
 				{
 					cmd.Parameters.Clear();
 					var sb = new StringBuilder("DELETE FROM ")
-						.Append(commandBuilder.QuoteIdentifier(tableName))
-						.Append(" WHERE ")
-						.Append(commandBuilder.QuoteIdentifier(pkName))
-						.Append(" IN (");
+                        .Append(string.Join(".",tableName.Split('.').Select(x => commandBuilder.QuoteIdentifier(x)).ToArray()))
+				        .Append(" WHERE ")
+					    .Append(commandBuilder.QuoteIdentifier(pkName))
+					    .Append(" IN (");
 
 					for (int j = i; j < Math.Min(i + maxParams, identifiers.Count); j++)
 					{

--- a/Raven.Database/Bundles/SqlReplication/RelationalDatabaseWriter.cs
+++ b/Raven.Database/Bundles/SqlReplication/RelationalDatabaseWriter.cs
@@ -170,7 +170,7 @@ namespace Raven.Database.Bundles.SqlReplication
 					database.WorkContext.CancellationToken.ThrowIfCancellationRequested();
 
 					var sb = new StringBuilder("INSERT INTO ")
-                        .Append(string.Join(".", tableName.Split('.').Select(x => commandBuilder.QuoteIdentifier(x)).ToArray()))
+                        .Append(GetTableNameString(tableName))
 						.Append(" (")
 						.Append(commandBuilder.QuoteIdentifier(pkName))
 						.Append(", ");
@@ -227,6 +227,8 @@ namespace Raven.Database.Bundles.SqlReplication
 			}
 		}
 
+
+
 	    public void DeleteItems(string tableName, string pkName, bool doNotParameterize, List<string> identifiers)
 		{
 			const int maxParams = 1000;
@@ -238,7 +240,7 @@ namespace Raven.Database.Bundles.SqlReplication
 				{
 					cmd.Parameters.Clear();
 					var sb = new StringBuilder("DELETE FROM ")
-                        .Append(string.Join(".",tableName.Split('.').Select(x => commandBuilder.QuoteIdentifier(x)).ToArray()))
+                        .Append(GetTableNameString(tableName))
 				        .Append(" WHERE ")
 					    .Append(commandBuilder.QuoteIdentifier(pkName))
 					    .Append(" IN (");
@@ -285,7 +287,19 @@ namespace Raven.Database.Bundles.SqlReplication
 			}
 		}
 
-		public static string SanitizeSqlValue(string sqlValue)
+        private string GetTableNameString(string tableName)
+        {
+            if (cfg.PerformTableQuatation)
+            {
+                return string.Join(".", tableName.Split('.').Select(x => commandBuilder.QuoteIdentifier(x)).ToArray());
+            }
+            else
+            {
+                return tableName;
+            }
+        }
+
+        public static string SanitizeSqlValue(string sqlValue)
 		{
 			return sqlValue.Replace("'", "''");
 		}

--- a/Raven.Database/Bundles/SqlReplication/RelationalDatabaseWriterSimulator.cs
+++ b/Raven.Database/Bundles/SqlReplication/RelationalDatabaseWriterSimulator.cs
@@ -72,7 +72,7 @@ namespace Raven.Database.Bundles.SqlReplication
             {
 
                 var sb = new StringBuilder("INSERT INTO ")
-                        .Append(commandBuilder.QuoteIdentifier(tableName))
+                        .Append(GetTableNameString(tableName))
                         .Append(" (")
                         .Append(commandBuilder.QuoteIdentifier(pkName))
                         .Append(", ");
@@ -119,7 +119,7 @@ namespace Raven.Database.Bundles.SqlReplication
             {
 
                 var sb = new StringBuilder("DELETE FROM ")
-                    .Append(commandBuilder.QuoteIdentifier(tableName))
+                    .Append(GetTableNameString(tableName))
                     .Append(" WHERE ")
                     .Append(commandBuilder.QuoteIdentifier(pkName))
                     .Append(" IN (");
@@ -150,6 +150,18 @@ namespace Raven.Database.Bundles.SqlReplication
             }
 
 
+        }
+
+        private string GetTableNameString(string tableName)
+        {
+            if (cfg.PerformTableQuatation)
+            {
+                return string.Join(".", tableName.Split('.').Select(x => commandBuilder.QuoteIdentifier(x)).ToArray());
+            }
+            else
+            {
+                return tableName;
+            }
         }
     }
 }

--- a/Raven.Database/Bundles/SqlReplication/SqlReplicationConfig.cs
+++ b/Raven.Database/Bundles/SqlReplication/SqlReplicationConfig.cs
@@ -16,6 +16,7 @@ namespace Raven.Database.Bundles.SqlReplication
 		public bool Disabled { get; set; }
 
 		public bool ParameterizeDeletesDisabled { get; set; }
+        public bool ForceSqlServerQueryRecompile { get; set; }
 
 		public string RavenEntityName { get; set; }
 		public string Script { get; set; }

--- a/Raven.Database/Bundles/SqlReplication/SqlReplicationConfig.cs
+++ b/Raven.Database/Bundles/SqlReplication/SqlReplicationConfig.cs
@@ -17,6 +17,7 @@ namespace Raven.Database.Bundles.SqlReplication
 
 		public bool ParameterizeDeletesDisabled { get; set; }
         public bool ForceSqlServerQueryRecompile { get; set; }
+        public bool PerformTableQuatation { get; set; }
 
 		public string RavenEntityName { get; set; }
 		public string Script { get; set; }

--- a/Raven.Studio.Html5/App/models/dto.ts
+++ b/Raven.Studio.Html5/App/models/dto.ts
@@ -460,6 +460,7 @@ interface sqlReplicationDto extends documentDto {
     ConnectionStringSettingName: string;
     SqlReplicationTables: sqlReplicationTableDto[];
     ForceSqlServerQueryRecompile?: boolean;
+    PerformTableQuatation?:boolean;
 }
 
 interface facetDto {

--- a/Raven.Studio.Html5/App/models/dto.ts
+++ b/Raven.Studio.Html5/App/models/dto.ts
@@ -459,6 +459,7 @@ interface sqlReplicationDto extends documentDto {
     ConnectionStringName: string;
     ConnectionStringSettingName: string;
     SqlReplicationTables: sqlReplicationTableDto[];
+    ForceSqlServerQueryRecompile?: boolean;
 }
 
 interface facetDto {

--- a/Raven.Studio.Html5/App/models/sqlReplication.ts
+++ b/Raven.Studio.Html5/App/models/sqlReplication.ts
@@ -8,7 +8,7 @@ class sqlReplication extends document {
     private CONNECTION_STRING = "Connection String";
     private CONNECTION_STRING_NAME = "Connection String Name";
     private CONNECTION_STRING_SETTING_NAME = "Connection String Setting Name";
-
+    
     availableConnectionStringTypes = [
         { label: "Connection String", value: this.CONNECTION_STRING },
         { label: "Connection String Name", value: this.CONNECTION_STRING_NAME },
@@ -24,6 +24,7 @@ class sqlReplication extends document {
     connectionStringValue = ko.observable<string>(null).extend({ required: true });
     ravenEntityName = ko.observable<string>("").extend({ required: true });
     parameterizeDeletesDisabled = ko.observable<boolean>(false).extend({ required: true });
+    forceSqlServerQueryRecompile = ko.observable<boolean>(false);
     sqlReplicationTables = ko.observableArray<sqlReplicationTable>().extend({ required: true });
     script = ko.observable<string>("").extend({ required: true });
     connectionString = ko.observable<string>(null);
@@ -46,6 +47,7 @@ class sqlReplication extends document {
         this.parameterizeDeletesDisabled(dto.ParameterizeDeletesDisabled);
         this.sqlReplicationTables(dto.SqlReplicationTables.map(tab => new sqlReplicationTable(tab)));
         this.script(dto.Script);
+        this.forceSqlServerQueryRecompile(!!dto.ForceSqlServerQueryRecompile? dto.ForceSqlServerQueryRecompile:false);
 
         this.setupConnectionString(dto);
 
@@ -126,7 +128,8 @@ class sqlReplication extends document {
             ConnectionString: null,
             ConnectionStringName: null,
             ConnectionStringSettingName: null,
-            SqlReplicationTables: sqlReplicationTables
+            SqlReplicationTables: sqlReplicationTables,
+            ForceSqlServerQueryRecompile:false
         });
     }
 
@@ -144,6 +147,7 @@ class sqlReplication extends document {
             ConnectionString: this.prepareConnectionString(this.CONNECTION_STRING),
             ConnectionStringName: this.prepareConnectionString(this.CONNECTION_STRING_NAME),
             ConnectionStringSettingName: this.prepareConnectionString(this.CONNECTION_STRING_SETTING_NAME),
+            ForceSqlServerQueryRecompile: this.forceSqlServerQueryRecompile(),
             SqlReplicationTables: this.sqlReplicationTables().map(tab => tab.toDto())
         };
     }
@@ -182,6 +186,14 @@ class sqlReplication extends document {
 
     saveNewRavenEntityName(newRavenEntityName) {
         this.ravenEntityName(newRavenEntityName);
+    }
+
+
+    isSqlServerKindOfDB(): boolean {
+        if (this.factoryName() == 'System.Data.SqlClient' || this.factoryName() == 'System.Data.SqlServerCe.4.0' || this.factoryName() == 'System.Data.SqlServerCe.3.5') {
+            return true;
+        }
+        return false;
     }
 }
 

--- a/Raven.Studio.Html5/App/models/sqlReplication.ts
+++ b/Raven.Studio.Html5/App/models/sqlReplication.ts
@@ -25,6 +25,7 @@ class sqlReplication extends document {
     ravenEntityName = ko.observable<string>("").extend({ required: true });
     parameterizeDeletesDisabled = ko.observable<boolean>(false).extend({ required: true });
     forceSqlServerQueryRecompile = ko.observable<boolean>(false);
+    performTableQuatation = ko.observable<boolean>(true);
     sqlReplicationTables = ko.observableArray<sqlReplicationTable>().extend({ required: true });
     script = ko.observable<string>("").extend({ required: true });
     connectionString = ko.observable<string>(null);
@@ -48,7 +49,7 @@ class sqlReplication extends document {
         this.sqlReplicationTables(dto.SqlReplicationTables.map(tab => new sqlReplicationTable(tab)));
         this.script(dto.Script);
         this.forceSqlServerQueryRecompile(!!dto.ForceSqlServerQueryRecompile? dto.ForceSqlServerQueryRecompile:false);
-
+        this.performTableQuatation(!!dto.PerformTableQuatation ? dto.PerformTableQuatation : true);
         this.setupConnectionString(dto);
 
         this.metadata = new documentMetadata(dto['@metadata']);
@@ -129,7 +130,8 @@ class sqlReplication extends document {
             ConnectionStringName: null,
             ConnectionStringSettingName: null,
             SqlReplicationTables: sqlReplicationTables,
-            ForceSqlServerQueryRecompile:false
+            ForceSqlServerQueryRecompile: false,
+            PerformTableQuatation:true
         });
     }
 
@@ -148,6 +150,7 @@ class sqlReplication extends document {
             ConnectionStringName: this.prepareConnectionString(this.CONNECTION_STRING_NAME),
             ConnectionStringSettingName: this.prepareConnectionString(this.CONNECTION_STRING_SETTING_NAME),
             ForceSqlServerQueryRecompile: this.forceSqlServerQueryRecompile(),
+            PerformTableQuatation: this.performTableQuatation(),
             SqlReplicationTables: this.sqlReplicationTables().map(tab => tab.toDto())
         };
     }

--- a/Raven.Studio.Html5/App/views/editSqlReplication.html
+++ b/Raven.Studio.Html5/App/views/editSqlReplication.html
@@ -110,6 +110,22 @@
 
                     </div>
                 </div>
+                <div class="form-group" data-bind="visible:$root.isBasicView() === false &&  isSqlServerKindOfDB() === true ">
+                    <label class="col-sm-4 control-label">Force Query Recompiling</label>
+                    <!--<div class="col-sm-8">
+                            <select tabindex="7" required class="form-control"
+                                    data-bind="options: ['Connection String','Connection String Name','Connection String Setting Name'], optionsCaption: '', value: connectionStringType"></select>
+
+                        </div>-->
+                    <div class="btn-group col-sm-8" data-toggle="buttons">
+                        <label class="btn btn-primary" data-bind="click: function(){forceSqlServerQueryRecompile(true)}, css: { active: forceSqlServerQueryRecompile() === true }">
+                            <input type="radio" name="options"> Enabled
+                        </label>
+                        <label class="btn btn-primary" tabindex="1" data-bind="click: function(){forceSqlServerQueryRecompile(false)}, css: { active: forceSqlServerQueryRecompile() === false }">
+                            <input type="radio" name="options"> Disabled
+                        </label>
+                    </div>
+                </div>
             </div>
             <div class="col-sm-6">
                 <div class="form-group">

--- a/Raven.Studio.Html5/App/views/editSqlReplication.html
+++ b/Raven.Studio.Html5/App/views/editSqlReplication.html
@@ -90,19 +90,6 @@
                 </div>
                 <div class="col-sm-12 advanced"><a  data-bind="attr:{title:('Switch to ' + ($root.isBasicView() === true?'Advanced':'Basic') + ' mode')}, click: function(){$root.isBasicView.toggle();}, css:{active: !$root.isBasicView() === true}">Advanced >></a></div>
                 <div class="form-group" data-bind="visible:$root.isBasicView() == false">
-                    <label class="col-sm-4 control-label">Parameterize Deletes</label>
-                    <div class="col-sm-8">
-                        <div tabindex="4" class="btn-group" data-toggle="buttons">
-                            <label class="btn btn-primary" data-bind="click: enableParameterizeDeletes, css: { active: !parameterizeDeletesDisabled() }">
-                                <input type="radio" name="options"> Enabled
-                            </label>
-                            <label class="btn btn-primary" data-bind="click: disableParameterizeDeletes, css: { active: parameterizeDeletesDisabled }">
-                                <input type="radio" name="options"> Disabled
-                            </label>
-                        </div>
-                    </div>
-                </div>
-                <div class="form-group" data-bind="visible:$root.isBasicView() == false">
                     <label class="col-sm-4 control-label">Connection String Source</label>
                     <div class="col-sm-8">
                         <select tabindex="7" required class="form-control"
@@ -110,20 +97,22 @@
 
                     </div>
                 </div>
+                <div class="form-group" data-bind="visible:$root.isBasicView() == false">
+                    <label class="col-sm-4 control-label">Disable Parameterized Deletes</label>
+                    <div class="checkbox col-sm-8">
+                        <input type="checkbox" data-bind=" checked:parameterizeDeletesDisabled" />
+                    </div>
+                </div>
                 <div class="form-group" data-bind="visible:$root.isBasicView() === false &&  isSqlServerKindOfDB() === true ">
                     <label class="col-sm-4 control-label">Force Query Recompiling</label>
-                    <!--<div class="col-sm-8">
-                            <select tabindex="7" required class="form-control"
-                                    data-bind="options: ['Connection String','Connection String Name','Connection String Setting Name'], optionsCaption: '', value: connectionStringType"></select>
-
-                        </div>-->
-                    <div class="btn-group col-sm-8" data-toggle="buttons">
-                        <label class="btn btn-primary" data-bind="click: function(){forceSqlServerQueryRecompile(true)}, css: { active: forceSqlServerQueryRecompile() === true }">
-                            <input type="radio" name="options"> Enabled
-                        </label>
-                        <label class="btn btn-primary" tabindex="1" data-bind="click: function(){forceSqlServerQueryRecompile(false)}, css: { active: forceSqlServerQueryRecompile() === false }">
-                            <input type="radio" name="options"> Disabled
-                        </label>
+                    <div class="checkbox col-sm-8">
+                        <input type="checkbox" data-bind=" checked:forceSqlServerQueryRecompile" />
+                    </div>
+                </div>
+                <div class="form-group" data-bind="visible:$root.isBasicView() === false">
+                    <label class="col-sm-4 control-label">Perform Table Quatation</label>
+                    <div class="checkbox col-sm-8">
+                        <input type="checkbox" data-bind=" checked:performTableQuatation" />
                     </div>
                 </div>
             </div>

--- a/Raven.Studio.Html5/Content/app.css
+++ b/Raven.Studio.Html5/Content/app.css
@@ -116,11 +116,16 @@ body {
 #editSQLReplication .advanced {
   padding-left: 0;
 }
+#editSQLReplication .checkbox {
+  align-content: flex-start;
+}
+#editSQLReplication .checkbox input[type=checkbox] {
+  font-size: large;
+  margin-left: 0;
+}
 .sqlReplication-Stats {
   width: 60vw;
   max-height: 60vh !important;
-  overflow-x: hidden !important;
-  overflow-y: hidden !important;
 }
 @media (max-width: 767px) {
   .sqlReplication-Stats {
@@ -140,6 +145,8 @@ body {
   max-height: 60vh!important;
   overflow-x: hidden!important;
   overflow-y: hidden!important;
+  overflow-x: hidden !important;
+  overflow-y: hidden !important;
 }
 @media (max-width: 767px) {
   .replicationSimulation {
@@ -883,9 +890,7 @@ body {
   text-overflow: ellipsis;
 }
 #shellHeader {
-  /*#goToDocInput {
-        width: 10em;
-    }*/
+  /*# sourceMappingURL=app.css.map */
   /* When the screen width < 1150, shrink down the padding between the nav bar items. */
   /* Tiny screens (phones, etc) will collapse the navbar into a drop down. */
 }

--- a/Raven.Studio.Html5/Content/app.less
+++ b/Raven.Studio.Html5/Content/app.less
@@ -152,6 +152,14 @@ html, body {
     {
         padding-left:0;
     }
+    .checkbox{
+        input[type=checkbox]{
+            font-size:large;
+            margin-left:0;
+        }
+        align-content:flex-start;
+        
+    }
 }
 
 .sqlReplication-Stats {


### PR DESCRIPTION
sql replication features and issues:
treated problem with schema.table quatation
added feature: now allow to fore recompiling for sqlServer type of dbs
added feature: now allow to controlling table quatation
added feature: now allow using custom js function that return objects conatining type and length data
added feature: now allow using predefined functions of the type above for varchar and nvarchar
