### PR TITLE
Fix for RavenDB-2509 (failing smuggler tests with limit)

### DIFF
--- a/Raven.Abstractions/Smuggler/SmugglerApiBase.cs
+++ b/Raven.Abstractions/Smuggler/SmugglerApiBase.cs
@@ -314,7 +314,7 @@ namespace Raven.Abstractions.Smuggler
                     var maxRecords = options.Limit - totalCount;
                     if (maxRecords > 0 && reachedMaxEtag == false)
 			        {
-                        using (var documents = await GetDocuments(src, lastEtag, options.BatchSize))
+                        using (var documents = await GetDocuments(src, lastEtag, Math.Min(options.BatchSize,maxRecords)))
 			            {
 			                var watch = Stopwatch.StartNew();
 


### PR DESCRIPTION
if  remaining records (up to the limit) are smaller than batch size, use batch with appropriate size
