### PR TITLE
Performing a batch operation on sql replications documents error fix

### DIFF
--- a/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
+++ b/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
@@ -99,7 +99,7 @@ namespace Raven.Database.Bundles.SqlReplication
 			Database.TransactionalStorage.Batch(accessor =>
 			{
 				bool hasChanges = false;
-				foreach (var config in replicationConfigs)
+				foreach (var config in GetConfiguredReplicationDestinations())
 				{
 					if (string.Equals(config.RavenEntityName, metadata.Value<string>(Constants.RavenEntityName), StringComparison.InvariantCultureIgnoreCase) == false)
 						continue;


### PR DESCRIPTION
this happens when the batch operation sql replications documents contains a delete operation.
