### PR TITLE
RavenDB-2612 Use MaxIndexOutputsPerDocument to limit the number of items...

### DIFF
--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -144,7 +144,9 @@ namespace Raven.Database.Indexing
 			}
 		}
 
-	    public string PublicName { get { return this.indexDefinition.Name; } }
+	    public string PublicName { get { return indexDefinition.Name; } }
+
+		public int? MaxIndexOutputsPerDocument { get { return indexDefinition.MaxIndexOutputsPerDocument; } }
 
 		public volatile bool IsMapIndexingInProgress;
 


### PR DESCRIPTION
... to index in single batch
