### PR TITLE
fixed problem with disposing TransactionalStorage not allowing database ...

### DIFF
--- a/Raven.Abstractions/Util/AtomicDictionary.cs
+++ b/Raven.Abstractions/Util/AtomicDictionary.cs
@@ -64,6 +64,28 @@ namespace Raven.Abstractions.Util
 			}
 		}
 
+        public void Update(string key, Func<string, TVal> valueGenerator)
+        {
+            using (globalLocker.EnterReadLock())
+            {
+                key = key ?? NullValue;
+                object value;
+                if (locks.TryGetValue(key, out value) == false)
+                {
+                    this.GetOrAdd(key, valueGenerator);
+                    return;
+                }
+                lock (value)
+                {                    
+                    TVal val;
+                    if (items.TryGetValue(key, out val)){
+                        items.TryUpdate(key,valueGenerator(null),val);
+                    }
+                    
+                }
+            }
+        }
+
 		public void Remove(string key)
 		{
 			using(globalLocker.EnterReadLock())

--- a/Raven.Database/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorage.cs
@@ -150,6 +150,12 @@ namespace Raven.Storage.Esent
 								"Could not properly terminate Esent instance because of disk exception. Ignoring this error to allow to shutdown RavenDB instance.",
 								e);
 						}
+                        catch (Exception ex)
+                        {
+                            log.ErrorException(
+                                "Unexpected error occured while terminating Esent Storage. Ignoring this error to allow to shutdown RavenDB instance.",
+                                ex);
+                        }
                         
                         GC.SuppressFinalize(this);
                     });


### PR DESCRIPTION
...to dispose completely, if unexpected error accures in esent.

change the way we treat shutting down databases in HttpServer.cs. instead of removing database from the ResourcesStoresCache, we first "plant" a special exception throwing task at the begining of the dispose process and remove the databace from the cache only when dispose process is done
