### PR TITLE
RavenDB-2663 if there were no writes to index, we need to create index w...

### DIFF
--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -207,17 +207,17 @@ namespace Raven.Database.Indexing
 					}
 				}
 
-				if (indexWriter != null)
+				try
 				{
-					try
-					{
-						ForceWriteToDisk();
-						WriteInMemoryIndexToDiskIfNecessary(Etag.Empty);
-					}
-					catch (Exception e)
-					{
-						logIndexing.ErrorException("Error while writing in memory index to disk.", e);
-					}
+					if (indexWriter == null)
+						CreateIndexWriter();
+
+					ForceWriteToDisk();
+					WriteInMemoryIndexToDiskIfNecessary(Etag.Empty);
+				}
+				catch (Exception e)
+				{
+					logIndexing.ErrorException("Error while writing in memory index to disk.", e);
 				}
 
 				if (indexWriter != null) // just in case, WriteInMemoryIndexToDiskIfNecessary recreates writer


### PR DESCRIPTION
...riter and persist empty index on disk to prevent index reset during database loading
