### PR TITLE
Add an endpoint to expose those details

### DIFF
--- a/Raven.Database/Impl/DTC/EsentTransactionContext.cs
+++ b/Raven.Database/Impl/DTC/EsentTransactionContext.cs
@@ -32,19 +32,19 @@ namespace Raven.Database.Impl.DTC
 		public Session Session { get; private set; }
 		public DateTime CreatedAt { get; private set; }
 		public Transaction Transaction { get; private set; }
-	    private bool alreadyInContext;
+	    public bool AlreadyInContext { get; private set; }
 
 		public IDisposable EnterSessionContext()
 		{
-		    if (alreadyInContext)
+		    if (AlreadyInContext)
 		        return new DisposableAction(() => { });
 
 			Api.JetSetSessionContext(Session, sessionContext);
-		    alreadyInContext = true;
+		    AlreadyInContext = true;
 			return new DisposableAction(() =>
 			{
 			    Api.JetResetSessionContext(Session);
-			    alreadyInContext = false;
+			    AlreadyInContext = false;
 			});
 		}
 

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Prefetching\Prefetcher.cs" />
     <Compile Include="Prefetching\PrefetchingUser.cs" />
     <Compile Include="Server\Responders\Admin\AdminDetailedSizeBreakdown.cs" />
+    <Compile Include="Server\Responders\TransactionsList.cs" />
     <Compile Include="Server\Responders\Debugging\DebugDocumentsCount.cs" />
     <Compile Include="Server\Responders\Debugging\DebugIndexFields.cs" />
     <Compile Include="Server\Responders\Debugging\DebugLists.cs" />
@@ -230,6 +231,7 @@
     <Compile Include="Server\Responders\Debugging\DebugPrefetchStatus.cs" />
     <Compile Include="Server\Responders\SingleAuthToken.cs" />
     <Compile Include="Server\Responders\TransactionPrepare.cs" />
+    <Compile Include="Server\Responders\TransactionsRollbackAll.cs" />
     <Compile Include="Server\Security\Authentication.cs" />
     <Compile Include="Server\Security\AuthenticationForCommercialUseOnly.cs" />
     <Compile Include="Extensions\ConcurrentQueueExtensions.cs" />
@@ -833,6 +835,7 @@
     <Compile Include="Storage\Managed\StorageActionsAccessor.cs" />
     <Compile Include="Storage\Managed\TasksStorageActions.cs" />
     <Compile Include="Storage\Managed\TransactionalStorage.cs" />
+    <Compile Include="Storage\TransactionContextData.cs" />
     <Compile Include="Tasks\RemoveFromIndexTask.cs" />
     <Compile Include="Tasks\Task.cs" />
     <Compile Include="Indexing\IndexStorage.cs" />

--- a/Raven.Database/Server/Responders/TransactionsList.cs
+++ b/Raven.Database/Server/Responders/TransactionsList.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Raven.Database.Extensions;
+using Raven.Database.Server.Abstractions;
+
+namespace Raven.Database.Server.Responders
+{
+	public class TransactionsList : AbstractRequestResponder
+	{
+		public override string UrlPattern
+		{
+			get { return "^/transaction/list"; }
+		}
+
+		public override string[] SupportedVerbs
+		{
+			get { return new[] { "GET" }; }
+		}
+
+		public override void Respond(IHttpContext context)
+		{
+            context.WriteJson(new { TransactionData = Database.TransactionalStorage.GetTransactionContextsData() });
+		}
+	}
+}

--- a/Raven.Database/Server/Responders/TransactionsRollbackAll.cs
+++ b/Raven.Database/Server/Responders/TransactionsRollbackAll.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using Raven.Database.Extensions;
+using Raven.Database.Server.Abstractions;
+
+namespace Raven.Database.Server.Responders
+{
+    public class TransactionsRollbackAll : AbstractRequestResponder
+    {
+        public override string UrlPattern
+        {
+            get { return "^/transaction/rollbackAll"; }
+        }
+
+        public override string[] SupportedVerbs
+        {
+            get { return new[] { "GET" }; }
+        }
+
+        public override void Respond(IHttpContext context)
+        {
+            var txId = context.Request.QueryString["tx"];
+            var transactions = Database.TransactionalStorage.GetTransactionContextsData();
+            foreach (var transactionContextData in transactions)
+            {
+                Database.Rollback(transactionContextData.Id);
+            }
+            context.WriteJson(new { RolledBackTransactionsAmount = transactions.Count });
+        }
+    }
+}

--- a/Raven.Database/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorage.cs
@@ -758,5 +758,10 @@ namespace Raven.Storage.Esent
             Console.Write(message);
             Console.WriteLine();
         }
+
+        public List<TransactionContextData> GetTransactionContextsData()
+	    {
+            return inFlightTransactionalState.GetTransactionContextsData();
+	    }
     }
 }

--- a/Raven.Database/Storage/ITransactionalStorage.cs
+++ b/Raven.Database/Storage/ITransactionalStorage.cs
@@ -44,5 +44,6 @@ namespace Raven.Database.Storage
 		void DumpAllStorageTables();
 		InFlightTransactionalState GetInFlightTransactionalState(DocumentDatabase self, Func<string, Etag, RavenJObject, RavenJObject, TransactionInformation, PutResult> put, Func<string, Etag, TransactionInformation, bool> delete);
         IList<string> ComputeDetailedStorageInformation();
+        List<TransactionContextData> GetTransactionContextsData();
 	}
 }

--- a/Raven.Database/Storage/Managed/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Managed/TransactionalStorage.cs
@@ -312,5 +312,11 @@ namespace Raven.Storage.Managed
 		{
 			persistenceSource.EnsureCapacity(value);
 		}
-	}
+
+
+        public List<TransactionContextData> GetTransactionContextsData()
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/Raven.Database/Storage/TransactionContextData.cs
+++ b/Raven.Database/Storage/TransactionContextData.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Raven.Database.Storage
+{
+    public class TransactionContextData
+    {
+        public string Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public int NumberOfActionsAfterCommit { get; set; }
+        public bool IsAlreadyInContext { get; set; }
+        public List<string> DocumentIdsToTouch { get; set; }
+    }
+}


### PR DESCRIPTION
Allow to cancel transactions
Add a log statement in the clenaup so we'll know it is running.
Change the frequency of the run to be every 30 seconds, instead of every 5.
