### PR TITLE
Fix for problems with using RavenFS in embedded mode

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/FilesStore.cs
+++ b/Raven.Client.Lightweight/FileSystem/FilesStore.cs
@@ -294,7 +294,8 @@ namespace Raven.Client.FileSystem
             currentSessionId = sessionId;
             try
             {
-                var session = new AsyncFilesSession(this, this.AsyncFilesCommands, this.Listeners, sessionId);
+	            var client = SetupCommandsAsync(this.AsyncFilesCommands, sessionOptions);
+                var session = new AsyncFilesSession(this, client, this.Listeners, sessionId);
                 AfterSessionCreated(session);
                 return session;
             }
@@ -311,8 +312,8 @@ namespace Raven.Client.FileSystem
                 throw new ArgumentException("Filesystem cannot be null, empty or whitespace.", "FileSystem");
 
             filesCommands = filesCommands.ForFileSystem(options.FileSystem);
-            if (options.Credentials != null)
-                filesCommands = filesCommands.With(options.Credentials);
+	        if (options.ApiKey != null || options.Credentials != null)
+		        filesCommands = filesCommands.With(new OperationCredentials(options.ApiKey, options.Credentials));
             
             return filesCommands;
         }


### PR DESCRIPTION
This change makes the AsyncFilesSession use the AsyncFilesServerClient owned by its parent FilesStore instead of creating a new one that doesn't inherit the HttpJsonRequestFactory using the OwinClientHandler to send requests.

This fixes the problems I was having with getting a FIleNotFoundException when trying to store a new file because the FilesSession was trying to make requests to http://localhost/ and getting a 404 error from my local IIS.
