### PR TITLE
Make SingleStepReduce respect max number of items to reduce in one batch

### DIFF
--- a/Raven.Database/Storage/IMappedResultsStorageAction.cs
+++ b/Raven.Database/Storage/IMappedResultsStorageAction.cs
@@ -39,7 +39,7 @@ namespace Raven.Database.Storage
 		void UpdatePerformedReduceType(string indexName, string reduceKey, ReduceType performedReduceType);
 		ReduceType GetLastPerformedReduceType(string indexName, string reduceKey);
 		IEnumerable<int> GetMappedBuckets(string indexName, string reduceKey);
-		IEnumerable<MappedResultInfo> GetMappedResults(string indexName, IEnumerable<string> keysToReduce, bool loadData);
+		IEnumerable<MappedResultInfo> GetMappedResults(string indexName, HashSet<string> keysLeftToReduce, bool loadData, int take, HashSet<string> keysReturned);
 		IEnumerable<ReduceTypePerKey> GetReduceKeysAndTypes(string view, int start, int take);
 	}
 


### PR DESCRIPTION
This is my suggestion for improving:
    RavenDB-2774 SingleStepReduce do not respect maxItemsToReduce and causes unpredictable memory and disk consuption
Please verify that the transactions around the batches are done correctly 
