### PR TITLE
RavenDB-2767 Memory consumption with late indexes

### DIFF
--- a/Raven.Database/Indexing/IndexingExecuter.cs
+++ b/Raven.Database/Indexing/IndexingExecuter.cs
@@ -12,7 +12,6 @@ using Raven.Abstractions;
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Logging;
-using Raven.Client.Linq;
 using Raven.Database.Impl;
 using Raven.Database.Json;
 using Raven.Database.Plugins;
@@ -35,6 +34,7 @@ namespace Raven.Database.Indexing
 			autoTuner = new IndexBatchSizeAutoTuner(context);
 			this.prefetcher = prefetcher;
 			defaultPrefetchingBehavior = prefetcher.CreatePrefetchingBehavior(PrefetchingUser.Indexer, autoTuner);
+			defaultPrefetchingBehavior.ShouldHandleUnusedDocumentsAddedAfterCommit = true;
 			prefetchingBehaviors.TryAdd(defaultPrefetchingBehavior);
 		}
 
@@ -225,8 +225,9 @@ namespace Raven.Database.Indexing
 			if (recentEtag.Restarts != fromEtag.Restarts || Math.Abs(recentEtag.Changes - fromEtag.Changes) > context.CurrentNumberOfItemsToIndexInSingleBatch)
 			{
 				// If the distance between etag of a recent document in db and etag to index from is greater than NumberOfItemsToProcessInSingleBatch
-				// then prevent the prefetcher from loading newly added documents. For such prefetcher we will relay only on future batches to prefetch docs.
-				newPrefetcher.IgnoreJustCommitedDocuments = true;
+				// then prevent the prefetcher from loading newly added documents. For such prefetcher we will relay only on future batches to prefetch docs to avoid
+				// large memory consumption by in memory prefetching queue that would hold all the new documents, but it would be a long time before we can reach them.
+				newPrefetcher.DisableCollectingDocumentsAfterCommit = true;
 			}
 
 			prefetchingBehaviors.Add(newPrefetcher);

--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -15,6 +15,7 @@ using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Logging;
 using Raven.Database.Config;
+using Raven.Database.Extensions;
 using Raven.Database.Impl;
 using Raven.Database.Indexing;
 
@@ -24,6 +25,12 @@ namespace Raven.Database.Prefetching
 
 	public class PrefetchingBehavior : IDisposable
 	{
+		private class DocAddedAfterCommit
+		{
+			public Etag Etag;
+			public DateTime AddedAt;
+		}
+
 		private static readonly ILog log = LogManager.GetCurrentClassLogger();
 		private readonly BaseBatchSizeAutoTuner autoTuner;
 		private readonly WorkContext context;
@@ -38,6 +45,7 @@ namespace Raven.Database.Prefetching
 
 		private readonly ConcurrentJsonDocumentSortedList prefetchingQueue = new ConcurrentJsonDocumentSortedList();
 
+		private DocAddedAfterCommit lowestInMemoryDocumentAddedAfterCommit;
 		private int currentIndexingAge;
 
 		public PrefetchingBehavior(PrefetchingUser prefetchingUser, WorkContext context, BaseBatchSizeAutoTuner autoTuner)
@@ -49,7 +57,8 @@ namespace Raven.Database.Prefetching
 
 		public PrefetchingUser PrefetchingUser { get; private set; }
 
-		public bool IgnoreJustCommitedDocuments { get; set; }
+		public bool DisableCollectingDocumentsAfterCommit { get; set; }
+		public bool ShouldHandleUnusedDocumentsAddedAfterCommit { get; set; }
 
 		public int InMemoryIndexingQueueSize
 		{
@@ -74,6 +83,8 @@ namespace Raven.Database.Prefetching
 
 		public List<JsonDocument> GetDocumentsBatchFrom(Etag etag)
 		{
+			HandleCollectingDocumentsAfterCommit(etag);
+
 			var results = GetDocsFromBatchWithPossibleDuplicates(etag);
 			// a single doc may appear multiple times, if it was updated while we were fetching things, 
 			// so we have several versions of the same doc loaded, this will make sure that we will only  
@@ -87,6 +98,42 @@ namespace Raven.Database.Prefetching
 				}
 			}
 			return results;
+		}
+
+		private void HandleCollectingDocumentsAfterCommit(Etag reqestedEtag)
+		{
+			if(ShouldHandleUnusedDocumentsAddedAfterCommit == false)
+				return;
+
+			if (DisableCollectingDocumentsAfterCommit)
+			{
+				if (lowestInMemoryDocumentAddedAfterCommit != null && reqestedEtag.CompareTo(lowestInMemoryDocumentAddedAfterCommit.Etag) > 0)
+				{
+					lowestInMemoryDocumentAddedAfterCommit = null;
+					DisableCollectingDocumentsAfterCommit = false;
+				}
+			}
+			else
+			{
+				if (lowestInMemoryDocumentAddedAfterCommit != null && SystemTime.UtcNow - lowestInMemoryDocumentAddedAfterCommit.AddedAt > TimeSpan.FromMinutes(10))
+				{
+					DisableCollectingDocumentsAfterCommit = true;
+				}
+			}
+		}
+
+		private void HandleCleanupOfUnusedDocumentsInQueue()
+		{
+			if (ShouldHandleUnusedDocumentsAddedAfterCommit == false)
+				return;
+
+			if(DisableCollectingDocumentsAfterCommit == false)
+				return;
+
+			if(lowestInMemoryDocumentAddedAfterCommit == null)
+				return;
+
+			prefetchingQueue.RemoveAfter(lowestInMemoryDocumentAddedAfterCommit.Etag);
 		}
 
 		private bool CanBeConsideredAsDuplicate(JsonDocument document)
@@ -399,7 +446,7 @@ namespace Raven.Database.Prefetching
 
 		public static JsonDocument GetHighestJsonDocumentByEtag(List<JsonDocument> past)
 		{
-			var highest = new Abstractions.Util.ComparableByteArray(Etag.Empty);
+			var highest = Etag.Empty;
 			JsonDocument highestDoc = null;
 			for (int i = past.Count - 1; i >= 0; i--)
 			{
@@ -408,7 +455,7 @@ namespace Raven.Database.Prefetching
 				{
 					continue;
 				}
-				highest = new Abstractions.Util.ComparableByteArray(etag);
+				highest = etag;
 				highestDoc = past[i];
 			}
 			return highestDoc;
@@ -445,7 +492,7 @@ namespace Raven.Database.Prefetching
 
 		public void AfterStorageCommitBeforeWorkNotifications(JsonDocument[] docs)
 		{
-			if (context.Configuration.DisableDocumentPreFetching || docs.Length == 0 || IgnoreJustCommitedDocuments)
+			if (context.Configuration.DisableDocumentPreFetching || docs.Length == 0 || DisableCollectingDocumentsAfterCommit)
 				return;
 
 			if (prefetchingQueue.Count >= // don't use too much, this is an optimization and we need to be careful about using too much mem
@@ -453,10 +500,29 @@ namespace Raven.Database.Prefetching
 				prefetchingQueue.Aggregate(0, (x,c) => x + SelectSerializedSizeOnDiskIfNotNull(c)) > context.Configuration.AvailableMemoryForRaisingBatchSizeLimit)
 				return;
 
+			Etag lowestEtag = null;
+
 			foreach (var jsonDocument in docs)
 			{
 				DocumentRetriever.EnsureIdInMetadata(jsonDocument);
 				prefetchingQueue.Add(jsonDocument);
+
+				if (ShouldHandleUnusedDocumentsAddedAfterCommit && (lowestEtag == null || jsonDocument.Etag.CompareTo(lowestEtag) < 0))
+				{
+					lowestEtag = jsonDocument.Etag;
+				}
+			}
+
+			if (ShouldHandleUnusedDocumentsAddedAfterCommit && lowestEtag != null)
+			{
+				if (lowestInMemoryDocumentAddedAfterCommit == null || lowestEtag.CompareTo(lowestInMemoryDocumentAddedAfterCommit.Etag) < 0)
+				{
+					lowestInMemoryDocumentAddedAfterCommit = new DocAddedAfterCommit
+					{
+						Etag = lowestEtag,
+						AddedAt = SystemTime.UtcNow
+					};
+				}
 			}
 		}
 
@@ -491,6 +557,8 @@ namespace Raven.Database.Prefetching
 			{
 				prefetchingQueue.TryDequeue(out result);
 			}
+
+			HandleCleanupOfUnusedDocumentsInQueue();
 		}
 
 		public bool FilterDocuments(JsonDocument document)

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -302,6 +302,7 @@
     <Compile Include="RavenDB_2762 .cs" />
     <Compile Include="RavenDB_2764.cs" />
     <Compile Include="RavenDB_2710.cs" />
+    <Compile Include="RavenDB_2767.cs" />
     <Compile Include="RavenDB_295.cs" />
     <Compile Include="RavenDB_299.cs" />
     <Compile Include="RavenDB_301.cs" />

--- a/Raven.Tests.Issues/RavenDB_2767.cs
+++ b/Raven.Tests.Issues/RavenDB_2767.cs
@@ -1,0 +1,160 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_2767.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Globalization;
+using System.Linq;
+using Raven.Abstractions;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Util;
+using Raven.Client.Embedded;
+using Raven.Database.Indexing;
+using Raven.Database.Prefetching;
+using Raven.Tests.Common;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+	public class RavenDB_2767 : RavenTest
+	{
+		private readonly EmbeddableDocumentStore store;
+		private readonly PrefetchingBehavior prefetchingBehavior;
+
+		public RavenDB_2767()
+		{
+			store = NewDocumentStore();
+			var workContext = store.SystemDatabase.WorkContext;
+			prefetchingBehavior = new PrefetchingBehavior(PrefetchingUser.Indexer, workContext, new IndexBatchSizeAutoTuner(workContext));
+			prefetchingBehavior.ShouldHandleUnusedDocumentsAddedAfterCommit = true;
+		}
+
+		[Fact]
+		public void ShouldDisableCollectingDocsAfterCommit()
+		{
+			Etag last = Etag.Empty;
+
+			SystemTime.UtcDateTime = () => DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(15));
+
+			prefetchingBehavior.AfterStorageCommitBeforeWorkNotifications(Enumerable.Range(0, 5).Select(x =>
+			{
+				last = EtagUtil.Increment(last, 1);
+
+				return new JsonDocument
+				{
+					Etag = last,
+					Key = x.ToString(CultureInfo.InvariantCulture)
+				};
+			}).ToArray());
+
+			last = EtagUtil.Increment(last, store.Configuration.MaxNumberOfItemsToProcessInSingleBatch);
+
+			prefetchingBehavior.AfterStorageCommitBeforeWorkNotifications(Enumerable.Range(0, 5).Select(x =>
+			{
+				last = EtagUtil.Increment(last, 1);
+
+				return new JsonDocument
+				{
+					Etag = last,
+					Key = x.ToString(CultureInfo.InvariantCulture)
+				};
+			}).ToArray());
+
+			SystemTime.UtcDateTime = null;
+
+			var documentsBatchFrom = prefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty);
+
+			prefetchingBehavior.CleanupDocuments(documentsBatchFrom.Last().Etag);
+
+			Assert.True(prefetchingBehavior.DisableCollectingDocumentsAfterCommit);
+
+			for (int i = 0; i < 5; i++)
+			{
+				last = EtagUtil.Increment(last, 1);
+				prefetchingBehavior.AfterStorageCommitBeforeWorkNotifications(new[]
+				{
+					new JsonDocument
+					{
+						Etag = last,
+						Key = i.ToString(CultureInfo.InvariantCulture)
+					},
+				});
+			}
+
+			Assert.Equal(0, prefetchingBehavior.InMemoryIndexingQueueSize);
+		}
+
+		[Fact]
+		public void ShouldCleanUpDocsThatResideInQueueTooLong()
+		{
+			Etag last = Etag.Empty;
+
+			SystemTime.UtcDateTime = () => DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(15));
+
+			for (int i = 0; i < 5; i++)
+			{
+				last = EtagUtil.Increment(last, 1);
+				prefetchingBehavior.AfterStorageCommitBeforeWorkNotifications(new[]
+				{
+					new JsonDocument
+					{
+						Etag = last,
+						Key = i.ToString(CultureInfo.InvariantCulture)
+					},
+				});
+			}
+
+			SystemTime.UtcDateTime = null;
+
+			prefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty);
+			prefetchingBehavior.CleanupDocuments(Etag.Empty);
+
+			Assert.Equal(0, prefetchingBehavior.InMemoryIndexingQueueSize);
+		}
+
+		[Fact]
+		public void ShouldEnableCollectingDocsAfterCommit()
+		{
+			Etag last = Etag.Empty;
+
+			SystemTime.UtcDateTime = () => DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(15));
+
+			last = EtagUtil.Increment(last, 1);
+			prefetchingBehavior.AfterStorageCommitBeforeWorkNotifications(new[]
+			{
+				new JsonDocument
+				{
+					Etag = last,
+					Key = "items/1"
+				}
+			});
+
+			SystemTime.UtcDateTime = null;
+
+			prefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty);
+			prefetchingBehavior.CleanupDocuments(Etag.Empty);
+
+			Assert.True(prefetchingBehavior.DisableCollectingDocumentsAfterCommit);
+
+			prefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty.IncrementBy(5)); // will trigger check for enabling collecting docs again
+
+			Assert.False(prefetchingBehavior.DisableCollectingDocumentsAfterCommit);
+
+			for (int i = 0; i < 5; i++)
+			{
+				last = EtagUtil.Increment(last, 1);
+				prefetchingBehavior.AfterStorageCommitBeforeWorkNotifications(new[]
+				{
+					new JsonDocument
+					{
+						Etag = last,
+						Key = i.ToString(CultureInfo.InvariantCulture)
+					},
+				});
+			}
+
+			Assert.Equal(5, prefetchingBehavior.InMemoryIndexingQueueSize);
+		}
+	}
+}


### PR DESCRIPTION
The default time used to determine if we should disable collecting newly added documents do the prefetching queue is 10 minutes - after this time I consider the queue as unused and cleanup it.
