### PR TITLE
RavenDB-2806 During Voron storage recovery on startup we have to filter ...

### DIFF
--- a/Raven.Voron/Voron.Tests/Bugs/DataCorruptionInOverflow.cs
+++ b/Raven.Voron/Voron.Tests/Bugs/DataCorruptionInOverflow.cs
@@ -110,5 +110,108 @@ namespace Voron.Tests.Bugs
 				Assert.Equal(overflowValue, readBytes);
 			}
 		}
+
+		[Fact]
+		public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_RavenDB_2806()
+		{
+			RequireFileBasedPager();
+
+			const int testedOverflowSize = 20000;
+
+			var overflowValue = new byte[testedOverflowSize];
+			new Random(1).NextBytes(overflowValue);
+
+
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				var tree = Env.CreateTree(tx, "test");
+
+				var itemBytes = new byte[16000];
+
+				new Random(2).NextBytes(itemBytes);
+				tree.Add("items/1", itemBytes);
+
+				new Random(3).NextBytes(itemBytes);
+				tree.Add("items/2", itemBytes);
+
+				tree.Delete("items/1");
+				tree.Delete("items/2");
+
+				tree.Add("items/3", overflowValue);
+
+				tx.Commit();
+			}
+
+			RestartDatabase();
+
+			using (var tx = Env.NewTransaction(TransactionFlags.Read))
+			{
+				var tree = tx.ReadTree("test");
+
+				var readResult = tree.Read("items/3");
+
+				var readBytes = new byte[testedOverflowSize];
+
+				readResult.Reader.Read(readBytes, 0, testedOverflowSize);
+
+				Assert.Equal(overflowValue, readBytes);
+			}
+		}
+
+		[Fact]
+		public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_2_RavenDB_2806()
+		{
+			RequireFileBasedPager();
+
+			const int testedOverflowSize = 16000;
+
+			var overflowValue = new byte[testedOverflowSize];
+			new Random(1).NextBytes(overflowValue);
+
+
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				var tree = Env.CreateTree(tx, "test");
+
+				var itemBytes = new byte[2000];
+
+				new Random(2).NextBytes(itemBytes);
+				tree.Add("items/1", itemBytes);
+
+
+				itemBytes = new byte[30000];
+				new Random(3).NextBytes(itemBytes);
+				tree.Add("items/2", itemBytes);
+
+				tx.Commit();
+			}
+
+
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				var tree = Env.CreateTree(tx, "test");
+				tree.Delete("items/1");
+				tree.Delete("items/2");
+
+				tree.Add("items/3", overflowValue);
+
+				tx.Commit();
+			}
+
+			RestartDatabase();
+
+			using (var tx = Env.NewTransaction(TransactionFlags.Read))
+			{
+				var tree = tx.ReadTree("test");
+
+				var readResult = tree.Read("items/3");
+
+				var readBytes = new byte[testedOverflowSize];
+
+				readResult.Reader.Read(readBytes, 0, testedOverflowSize);
+
+				Assert.Equal(overflowValue, readBytes);
+			}
+		}
 	}
 }

--- a/Raven.Voron/Voron.Tests/StorageTest.cs
+++ b/Raven.Voron/Voron.Tests/StorageTest.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading;
 using Voron.Debugging;
 using Voron.Impl;
-using Voron.Impl.Paging;
 using Voron.Trees;
 
 namespace Voron.Tests
@@ -16,6 +15,7 @@ namespace Voron.Tests
 	{
 		private StorageEnvironment _storageEnvironment;
 		protected StorageEnvironmentOptions _options;
+		protected const string DataDir = "test.data";
 
 		public StorageEnvironment Env
 		{
@@ -40,7 +40,7 @@ namespace Voron.Tests
 
 		protected StorageTest()
 		{
-			DeleteDirectory("test.data");
+			DeleteDirectory(DataDir);
 		    _options = StorageEnvironmentOptions.CreateMemoryOnly();
 			Configure(_options);
 		}
@@ -58,8 +58,8 @@ namespace Voron.Tests
                 throw new InvalidOperationException("Too late");
             if (_options is StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)
 	            return;
-            DeleteDirectory("test.data");
-            _options = StorageEnvironmentOptions.ForPath("test.data");
+            DeleteDirectory(DataDir);
+            _options = StorageEnvironmentOptions.ForPath(DataDir);
             Configure(_options);
 	    }
 
@@ -118,7 +118,7 @@ namespace Voron.Tests
 		    if (_storageEnvironment != null)
 		        _storageEnvironment.Dispose();
 			_options.Dispose();
-			DeleteDirectory("test.data");
+			DeleteDirectory(DataDir);
 
 			_storageEnvironment = null;
 			_options = null;

--- a/Raven.Voron/Voron/Impl/Journal/JournalFile.cs
+++ b/Raven.Voron/Voron/Impl/Journal/JournalFile.cs
@@ -168,7 +168,6 @@ namespace Voron.Impl.Journal
 				ptt[freedPageNumber] = new PagePosition
 				{
 					ScratchPos = -1,
-					JournalPos = -1,
 					ScratchNumber = -1,
 					TransactionId = tx.Id,
 					JournalNumber = Number,
@@ -197,7 +196,6 @@ namespace Voron.Impl.Journal
 				{
 					ScratchPos = txPage.PositionInScratchBuffer,
 					ScratchNumber = txPage.ScratchFileNumber,
-					JournalPos = -1, // needed only during recovery and calculated there
 					TransactionId = tx.Id,
 					JournalNumber = Number
 				};
@@ -209,7 +207,6 @@ namespace Voron.Impl.Journal
 			    {
 				    ScratchPos = freedPage.PositionInScratchBuffer,
 					ScratchNumber = freedPage.ScratchFileNumber,
-				    JournalPos = -1, // needed only during recovery and calculated there
 				    TransactionId = tx.Id,
 				    JournalNumber = Number
 			    });

--- a/Raven.Voron/Voron/Impl/PagePosition.cs
+++ b/Raven.Voron/Voron/Impl/PagePosition.cs
@@ -9,7 +9,7 @@ namespace Voron.Impl
 	{
 		protected bool Equals(PagePosition other)
 		{
-			return ScratchPos == other.ScratchPos && JournalPos == other.JournalPos && TransactionId == other.TransactionId && JournalNumber == other.JournalNumber && IsFreedPageMarker == other.IsFreedPageMarker && ScratchNumber == other.ScratchNumber;
+			return ScratchPos == other.ScratchPos && TransactionId == other.TransactionId && JournalNumber == other.JournalNumber && IsFreedPageMarker == other.IsFreedPageMarker && ScratchNumber == other.ScratchNumber;
 		}
 
 		public override int GetHashCode()
@@ -17,7 +17,6 @@ namespace Voron.Impl
 			unchecked
 			{
 				int hashCode = ScratchPos.GetHashCode();
-				hashCode = (hashCode * 397) ^ JournalPos.GetHashCode();
 				hashCode = (hashCode * 397) ^ TransactionId.GetHashCode();
 				hashCode = (hashCode * 397) ^ JournalNumber.GetHashCode();
 				hashCode = (hashCode * 397) ^ IsFreedPageMarker.GetHashCode();
@@ -27,7 +26,6 @@ namespace Voron.Impl
 		}
 
 		public long ScratchPos;
-		public long JournalPos;
 		public long TransactionId;
 		public long JournalNumber;
 		public int ScratchNumber;
@@ -48,7 +46,7 @@ namespace Voron.Impl
 
 		public override string ToString()
 		{
-			return string.Format("ScratchPos: {0}, JournalPos: {1}, TransactionId: {2}, JournalNumber: {3}, ScratchNumber: {4}, IsFreedPageMarker: {5}", ScratchPos, JournalPos, TransactionId, JournalNumber, ScratchNumber, IsFreedPageMarker);
+			return string.Format("ScratchPos: {0}, TransactionId: {1}, JournalNumber: {2}, ScratchNumber: {3}, IsFreedPageMarker: {4}", ScratchPos, TransactionId, JournalNumber, ScratchNumber, IsFreedPageMarker);
 		}
 	}
 }


### PR DESCRIPTION
...out pages from journals that have been overwritten by overflow pages in later transactions. That caused the data corruption in overflow pages. Introducing RecoveryPagePosition class only for recovery purposes instead of using PagePosition that contained field needed only for recovery.
