### PR TITLE
RavenDB-2815 3.0b3492 : does not take Voron as the storage type if ESENT...

### DIFF
--- a/Raven.Studio.Html5/App/viewmodels/databases.ts
+++ b/Raven.Studio.Html5/App/viewmodels/databases.ts
@@ -112,7 +112,7 @@ class databases extends viewModelBase {
                         "Raven/ActiveBundles": bundles.join(";")
                     };
                     if (storageEngine) {
-                        settings["Raven/StorageEngine"] = storageEngine;
+                        settings["Raven/StorageTypeName"] = storageEngine;
                     }
                     settings["Raven/DataDir"] = (!this.isEmptyStringOrWhitespace(databasePath)) ? databasePath : "~/Databases/" + databaseName;
                     if (!this.isEmptyStringOrWhitespace(databaseLogs)) {


### PR DESCRIPTION
... is the default.
