### PR TITLE
Expose FilesStore on EmbeddableDocumentStore

### DIFF
--- a/Raven.Database/Client/EmbeddableDocumentStore.cs
+++ b/Raven.Database/Client/EmbeddableDocumentStore.cs
@@ -12,6 +12,7 @@ using Raven.Client.Changes;
 using Raven.Client.Connection;
 using Raven.Client.Connection.Async;
 using Raven.Client.Document;
+using Raven.Client.FileSystem;
 using Raven.Client.Indexes;
 using Raven.Client.Listeners;
 using Raven.Database;
@@ -248,6 +249,18 @@ namespace Raven.Client.Embedded
         {
             get { return Inner.AsyncDatabaseCommands; }
         }
+
+        public IFilesStore FilesStore
+        {
+            get
+            {
+                var eds = Inner as EmbeddedDocumentStore;
+                if (eds != null)
+                    return eds.FilesStore;
+                return null;
+            }
+        }
+
         public IAsyncDocumentSession OpenAsyncSession()
         {
             return Inner.OpenAsyncSession();

--- a/Raven.Database/Client/EmbeddedDocumentStore.cs
+++ b/Raven.Database/Client/EmbeddedDocumentStore.cs
@@ -8,6 +8,7 @@ using Raven.Client.Connection;
 using Raven.Client.Connection.Async;
 using Raven.Client.Document;
 using Raven.Client.Extensions;
+using Raven.Client.FileSystem;
 using Raven.Client.Indexes;
 using Raven.Client.Listeners;
 using Raven.Database.Config;
@@ -57,6 +58,11 @@ namespace Raven.Database.Client
 					.ResultUnwrap();
 			}
 		}
+
+        public IFilesStore FilesStore
+        {
+            get { return server.FilesStore; }
+        }
 
         public string ConnectionStringName
         {


### PR DESCRIPTION
Follows the pattern of other things exposed on EmbeddableDocumentStore. If there is a better way, please let me know.
