### PR TITLE
RavenDB-2856 escape HTTPS replication URLs just like HTTP URLs

### DIFF
--- a/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
@@ -370,7 +370,7 @@ namespace Raven.Bundles.Replication.Tasks
 
 		public static string EscapeDestinationName(string url)
 		{
-			return Uri.EscapeDataString(url.Replace("http://", "").Replace("/", "").Replace(":", ""));
+			return Uri.EscapeDataString(url.Replace("https://", "").Replace("http://", "").Replace("/", "").Replace(":", ""));
 		}
 
 		private void WarnIfNoReplicationTargetsWereFound()


### PR DESCRIPTION
Fixes http://issues.hibernatingrhinos.com/issue/RavenDB-2856
