### PR TITLE
RavenDB-2898 EmbeddableDocumentStore fails in WebApi project

### DIFF
--- a/Raven.Database/Server/AppBuilderExtensions.cs
+++ b/Raven.Database/Server/AppBuilderExtensions.cs
@@ -143,7 +143,7 @@ namespace Owin
 			public ICollection<Assembly> GetAssemblies()
 			{
 				return AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(a => a.ExportedTypes.Any(t => t.IsAssignableFrom(typeof(RavenBaseApiController))))
+                    .Where(a => !a.IsDynamic && a.ExportedTypes.Any(t => t.IsAssignableFrom(typeof(RavenBaseApiController))))
                     .ToList();
 			}
 		}


### PR DESCRIPTION
Limit built-in WebApi to only include assemblies with RavenBaseApiController overrides.
