### PR TITLE
RavenDB-2800: RavenFS File-Metadata-Etag display in studio

### DIFF
--- a/Raven.Studio.Html5/App/commands/filesystem/updateFileMetadataCommand.ts
+++ b/Raven.Studio.Html5/App/commands/filesystem/updateFileMetadataCommand.ts
@@ -18,8 +18,9 @@ class updateFileMetadataCommand extends commandBase {
 
         //We only want to stringify when the header's value is a json doc.
         for (var key in this.metadata) {
-            if (typeof (this.metadata[key]) != "string" && typeof (this.metadata[key]) != "number")
-                customHeaders[key] = JSON.stringify(this.metadata[key]);
+            var value = this.metadata[key];
+            if (typeof (value) != "string" && typeof (value) != "number")
+                customHeaders[key] = JSON.stringify(value);
             else {
                 customHeaders[key] = this.metadata[key]
             }

--- a/Raven.Studio.Html5/App/models/filesystem/fileMetadata.ts
+++ b/Raven.Studio.Html5/App/models/filesystem/fileMetadata.ts
@@ -1,6 +1,17 @@
 ﻿class fileMetadata {
 
-    standardProps = ["RavenFs-Size", "Last-Modified", "ETag", "Creation-Date"];
+    standardProps = ["ravenfs-size", "raven-last-modified", "etag", "raven-creation-date"];
+
+    // We don't want to keep certain reserved properties in the metadata text area.    
+    headerPropsToRemove = ["Origin", "Raven-Server-Build", "Raven-Client-Version", "Non-Authoritative-Information", "Raven-Timer-Request", "Content-Length",
+        "Raven-Authenticated-User", "Has-Api-Key", "Access-Control-Allow-Origin", "Access-Control-Max-Age", "Access-Control-Allow-Methods",
+        "Access-Control-Request-Headers", "Access-Control-Allow-Headers", "Reverse-Via", "Persistent-Auth", "Allow", "Content-Disposition",
+        "Content-Encoding", "Content-Language", "Content-Location", "Content-MD5", "Content-Range", "Content-Type", "Expires", "Keep-Alive",
+        "X-Powered-By", "X-AspNet-Version", "X-Requested-With", "X-SourceFiles", "Accept-Charset", "Accept-Encoding", "Accept", "Accept-Language",
+        "Authorization", "Cookie", "Expect", "From", "Host", "If-MatTemp-Index-Scorech", "If-Modified-Since", "If-None-Match", "If-Range",
+        "If-Unmodified-Since", "Max-Forwards", "Referer", "TE", "User-Agent", "Accept-Ranges", "Age", "Allow", "Location", "Retry-After",
+        "Server", "Set-Cookie2", "Set-Cookie", "Vary", "Www-Authenticate", "Cache-Control", "Connection", "Date", "Pragma", "Trailer", "Upgrade",
+        "Transfer-Encoding", "Via", "Warning", "X-ARR-LOG-ID", "X-ARR-SSL", "X-Forwarded-For", "X-Original-URL", "Temp-Request-Time", "DNT"]; 
 
     ravenFSSize: string;
     ravenSynchronizationHistory: any;
@@ -15,11 +26,23 @@
         if (dto) {
             this.ravenFSSize = dto['RavenFS-Size'];
             this.creationDate = dto['Raven-Creation-Date'];
-            this.lastModified = dto['Last-Modified'];            
+            this.lastModified = dto['Raven-Last-Modified'];            
             this.etag = dto['ETag'];
+            if (this.etag == null) // HACK: Handle different capitalization of Etag by Firefox.
+                this.etag = dto['Etag'];
 
+            if (this.etag.startsWith('"'))
+                this.etag = this.etag.slice(1, this.etag.length - 1);
+
+            // Effectively remove all the headers that are not useful as metadata.
+            var property: string;
             for (var property in dto) {
-                if (!this.standardProps.contains(property)) {
+                if (this.headerPropsToRemove.contains(property))
+                    delete dto[property];
+            }
+                       
+            for (property in dto) {                                                
+                if (!this.standardProps.contains(property.toLowerCase())) {
                     this.nonStandardProps = this.nonStandardProps || [];
                     var value = dto[property];
                     this[property] = value;
@@ -32,8 +55,8 @@
     toDto(): fileMetadataDto {
         var dto: any = {
             'Raven-Creation-Date':this.creationDate,
-            'Last-Modified': this.lastModified,
-            'ETag': this.etag,
+            'Raven-Last-Modified': this.lastModified,
+            'ETag': '"' + this.etag + '"',
             'RavenFS-Size': this.ravenFSSize,
         };
 

--- a/Raven.Studio.Html5/App/viewmodels/filesystem/filesystemEditFile.ts
+++ b/Raven.Studio.Html5/App/viewmodels/filesystem/filesystemEditFile.ts
@@ -171,19 +171,15 @@ class filesystemEditFile extends viewModelBase {
 
             // We don't want to show certain reserved properties in the metadata text area.
             // Remove them from the DTO, restore them on save.
-            var metaPropsToRemove = ["Origin", "Raven-Server-Build", "Raven-Client-Version", "Non-Authoritative-Information", "Raven-Timer-Request",
-                "Raven-Authenticated-User", "Raven-Last-Modified", "Raven-Creation-Date", "Has-Api-Key", "Access-Control-Allow-Origin", "Access-Control-Max-Age", "Access-Control-Allow-Methods",
-                "Access-Control-Request-Headers", "Access-Control-Allow-Headers", "Reverse-Via", "Persistent-Auth", "Allow", "Content-Disposition", "Content-Encoding",
-                "Content-Language", "Content-Location", "Content-MD5", "Content-Range", "Content-Type", "Expires", "Last-Modified", "Content-Length", "Keep-Alive", "X-Powered-By",
-                "X-AspNet-Version", "X-Requested-With", "X-SourceFiles", "Accept-Charset", "Accept-Encoding", "Accept", "Accept-Language", "Authorization", "Cookie", "Expect",
-                "From", "Host", "If-MatTemp-Index-Scorech", "If-Modified-Since", "If-None-Match", "If-Range", "If-Unmodified-Since", "Max-Forwards", "Referer", "TE", "User-Agent", "Accept-Ranges",
-                "Age", "Allow", "ETag", "Location", "Retry-After", "Server", "Set-Cookie2", "Set-Cookie", "Vary", "Www-Authenticate", "Cache-Control", "Connection", "Date", "Pragma",
-                "Trailer", "Transfer-Encoding", "Upgrade", "Via", "Warning", "X-ARR-LOG-ID", "X-ARR-SSL", "X-Forwarded-For", "X-Original-URL",
-                "RavenFS-Size", "Temp-Request-Time", "DNT", "Creation-Date", "Raven-Synchronization-History", "Raven-Synchronization-Version", "Raven-Synchronization-Source"];
+            var metaPropsToRemove = ["Raven-Last-Modified", "Raven-Creation-Date", "Last-Modified", "Creation-Date", "ETag", "RavenFS-Size" ];
 
             for (var property in metaDto) {
                 if (metaDto.hasOwnProperty(property) && metaPropsToRemove.contains(property)) {
-                    if (metaDto[property]) {
+                    var value = metaDto[property];
+                    if (typeof (value) != "string" && typeof (value) != "number") {
+                        this.metaPropsToRestoreOnSave.push({ name: property, value: JSON.stringify(value) });
+                    }
+                    else {
                         this.metaPropsToRestoreOnSave.push({ name: property, value: metaDto[property].toString() });
                     }
                     delete metaDto[property];


### PR DESCRIPTION
Fixed: We were leaking some headers into the process that should have been effectively removed when creating the metadata object.
Fixed: When the metadata not shown wasn't a primitive object if fail when reconstructing it to be sent. Ex: Raven-Synchronization-History
Fixed: In some places we were still using Last-Modified instead of Raven-Last-Modified
