### PR TITLE
RavenDB-2946 FipsEncryptor and DefaultEncryptor are not thread safe

### DIFF
--- a/Raven.Abstractions/Util/Encryptors/DefaultEncryptor.cs
+++ b/Raven.Abstractions/Util/Encryptors/DefaultEncryptor.cs
@@ -13,13 +13,23 @@ namespace Raven.Abstractions.Util.Encryptors
 	{
 		public DefaultEncryptor()
 		{
-			Hash = new DefaultHashEncryptor();
+			Hash = new DefaultHashEncryptor(allowNonThreadSafeMethods: false);
 		}
 
 		public override IHashEncryptor Hash { get; protected set; }
 
 		public class DefaultHashEncryptor : HashEncryptorBase, IHashEncryptor
 		{
+			public DefaultHashEncryptor()
+				: this(true)
+			{
+			}
+
+			public DefaultHashEncryptor(bool allowNonThreadSafeMethods)
+				: base(allowNonThreadSafeMethods)
+			{
+			}
+
 			public int StorageHashSize
 			{
 				get
@@ -28,40 +38,44 @@ namespace Raven.Abstractions.Util.Encryptors
 				}
 			}
 
-		    private MD5 md5;
+			private MD5 md5;
 
-		    public void TransformBlock(byte[] bytes, int offset, int length)
-		    {
-                if (md5 == null)
-                    md5 = MD5.Create();
+			public void TransformBlock(byte[] bytes, int offset, int length)
+			{
+				ThrowNotSupportedExceptionForNonThreadSafeMethod();
 
-		        md5.TransformBlock(bytes, offset, length, null, 0);
-		    }
+				if (md5 == null)
+					md5 = MD5.Create();
 
-		    public byte[] TransformFinalBlock()
-		    {
-                if (md5 == null)
-                    md5 = MD5.Create();
+				md5.TransformBlock(bytes, offset, length, null, 0);
+			}
 
-		        md5.TransformFinalBlock(new byte[0], 0, 0);
-			    return md5.Hash;
-		    }
+			public byte[] TransformFinalBlock()
+			{
+				ThrowNotSupportedExceptionForNonThreadSafeMethod();
 
-		    public void Dispose()
-		    {
-                if (md5 != null)
-                    md5.Dispose();
-		    }
+				if (md5 == null)
+					md5 = MD5.Create();
 
-		    public byte[] ComputeForStorage(byte[] bytes)
+				md5.TransformFinalBlock(new byte[0], 0, 0);
+				return md5.Hash;
+			}
+
+			public void Dispose()
+			{
+				if (md5 != null)
+					md5.Dispose();
+			}
+
+			public byte[] ComputeForStorage(byte[] bytes)
 			{
 				return ComputeHash(SHA256.Create(), bytes);
 			}
 
-            public byte[] ComputeForStorage(byte[] bytes, int offset, int length)
-            {
-                return ComputeHash(SHA256.Create(), bytes, offset, length);
-            }
+			public byte[] ComputeForStorage(byte[] bytes, int offset, int length)
+			{
+				return ComputeHash(SHA256.Create(), bytes, offset, length);
+			}
 
 			public byte[] ComputeForOAuth(byte[] bytes)
 			{
@@ -73,28 +87,28 @@ namespace Raven.Abstractions.Util.Encryptors
 				return ComputeHash(MD5.Create(), bytes);
 			}
 
-		    public byte[] Compute16(Stream stream)
-		    {
-		        using (var hasher = MD5.Create())
-		        {
-                    return hasher.ComputeHash(stream);
-		        }
-		    }
+			public byte[] Compute16(Stream stream)
+			{
+				using (var hasher = MD5.Create())
+				{
+					return hasher.ComputeHash(stream);
+				}
+			}
 
-		    public byte[] Compute16(byte[] bytes, int offset, int length)
-            {
-                return ComputeHash(MD5.Create(), bytes, offset, length);
-            }
+			public byte[] Compute16(byte[] bytes, int offset, int length)
+			{
+				return ComputeHash(MD5.Create(), bytes, offset, length);
+			}
 
 			public byte[] Compute20(byte[] bytes)
 			{
 				return ComputeHash(SHA1.Create(), bytes);
 			}
 
-            public byte[] Compute20(byte[] bytes, int offset, int length)
-            {
-                return ComputeHash(SHA1.Create(), bytes, offset, length);
-            }
+			public byte[] Compute20(byte[] bytes, int offset, int length)
+			{
+				return ComputeHash(SHA1.Create(), bytes, offset, length);
+			}
 		}
 	}
 }

--- a/Raven.Abstractions/Util/Encryptors/FipsEncryptor.cs
+++ b/Raven.Abstractions/Util/Encryptors/FipsEncryptor.cs
@@ -13,89 +13,103 @@ namespace Raven.Abstractions.Util.Encryptors
 	{
 		public FipsEncryptor()
 		{
-			Hash = new FipsHashEncryptor();
+			Hash = new FipsHashEncryptor(allowNonThreadSafeMethods: false);
 		}
 
 		public override IHashEncryptor Hash { get; protected set; }
 
 		public class FipsHashEncryptor : HashEncryptorBase, IHashEncryptor
 		{
-		    public void Dispose()
-		    {
-		        //no-op
-		    }
+			public FipsHashEncryptor()
+				: this(true)
+			{
+			}
 
-            ABCDStruct abcdStruct = MD5Core.GetInitialStruct();
-            private byte[] remainingBuffer = new byte[bufferSize];
-		    private int remainingCount = 0;
-		    private int totalLength = 0;
+			public FipsHashEncryptor(bool allowNonThreadSafeMethods)
+				: base(allowNonThreadSafeMethods)
+			{
+			}
 
-		    private const int bufferSize = 64;
+			public void Dispose()
+			{
+				//no-op
+			}
 
-		    public byte[] Compute16(Stream stream)
-		    {
-                byte[] buffer = new byte[4096];
-                int bytesRead;
-                do
-                {
-                    bytesRead = stream.Read(buffer, 0, 4096);
-                    if (bytesRead > 0)
-                    {
-                        TransformBlock(buffer, 0, bytesRead);
-                    }
-                } while (bytesRead > 0);
+			ABCDStruct abcdStruct = MD5Core.GetInitialStruct();
+			private readonly byte[] remainingBuffer = new byte[BufferSize];
+			private int remainingCount;
+			private int totalLength;
 
-		        return TransformFinalBlock();
-		    }
+			private const int BufferSize = 64;
 
-		    public byte[] TransformFinalBlock()
-		    {
-		        totalLength += remainingCount;
-		        return MD5Core.GetHashFinalBlock(remainingBuffer, 0, remainingCount, abcdStruct, (Int64) totalLength*8);
-		    }
+			public byte[] Compute16(Stream stream)
+			{
+				ThrowNotSupportedExceptionForNonThreadSafeMethod();
 
-		    public void TransformBlock(byte[] bytes, int offset, int length)
-		    {
-		        int start = offset;
-                if (remainingCount > 0)
-                {
-                    if (remainingCount + length < bufferSize)
-                    {
-                        // just append to remaining buffer
-                        Buffer.BlockCopy(bytes, offset, remainingBuffer, remainingCount, length);
-                        remainingCount += length;
-                        return;
-                    }
-                    else
-                    {
-                        // fill up buffer
-                        Buffer.BlockCopy(bytes, offset, remainingBuffer, remainingCount,  bufferSize - remainingCount);
-                        start += bufferSize - remainingCount;
-                        // now we have 64 bytes in buffer
-                        MD5Core.GetHashBlock(remainingBuffer, ref abcdStruct, 0);
-                        totalLength += bufferSize;
-                        remainingCount = 0;
-                    }
-                }
+				var buffer = new byte[4096];
+				int bytesRead;
+				do
+				{
+					bytesRead = stream.Read(buffer, 0, 4096);
+					if (bytesRead > 0)
+					{
+						TransformBlock(buffer, 0, bytesRead);
+					}
+				} while (bytesRead > 0);
 
-                // while has 64 bytes blocks
-                while (start <= length - bufferSize)
-                {
-                    MD5Core.GetHashBlock(bytes, ref abcdStruct, start);
-                    totalLength += bufferSize;
-                    start += bufferSize;
-                }
+				return TransformFinalBlock();
+			}
 
-                // save rest (if any)
-                if (start != length)
-                {
-                    remainingCount = length - start;
-                    Buffer.BlockCopy(bytes, start, remainingBuffer, 0, remainingCount);
-                }
+			public byte[] TransformFinalBlock()
+			{
+				ThrowNotSupportedExceptionForNonThreadSafeMethod();
 
-		    }
+				totalLength += remainingCount;
+				return MD5Core.GetHashFinalBlock(remainingBuffer, 0, remainingCount, abcdStruct, (Int64)totalLength * 8);
+			}
 
-		    public int StorageHashSize
+			public void TransformBlock(byte[] bytes, int offset, int length)
+			{
+				ThrowNotSupportedExceptionForNonThreadSafeMethod();
+
+				int start = offset;
+				if (remainingCount > 0)
+				{
+					if (remainingCount + length < BufferSize)
+					{
+						// just append to remaining buffer
+						Buffer.BlockCopy(bytes, offset, remainingBuffer, remainingCount, length);
+						remainingCount += length;
+						return;
+					}
+
+					// fill up buffer
+					Buffer.BlockCopy(bytes, offset, remainingBuffer, remainingCount, BufferSize - remainingCount);
+					start += BufferSize - remainingCount;
+					// now we have 64 bytes in buffer
+					MD5Core.GetHashBlock(remainingBuffer, ref abcdStruct, 0);
+					totalLength += BufferSize;
+					remainingCount = 0;
+				}
+
+				// while has 64 bytes blocks
+				while (start <= length - BufferSize)
+				{
+					MD5Core.GetHashBlock(bytes, ref abcdStruct, start);
+					totalLength += BufferSize;
+					start += BufferSize;
+				}
+
+				// save rest (if any)
+				if (start != length)
+				{
+					remainingCount = length - start;
+					Buffer.BlockCopy(bytes, start, remainingBuffer, 0, remainingCount);
+				}
+
+			}
+
+			public int StorageHashSize
 			{
 				get
 				{
@@ -106,17 +120,17 @@ namespace Raven.Abstractions.Util.Encryptors
 			//SHA1
 			public byte[] ComputeForStorage(byte[] bytes)
 			{
-				if(StorageHashSize == 20)
+				if (StorageHashSize == 20)
 					return Compute20(bytes);
 				return Compute16(bytes);
 			}
 
-            public byte[] ComputeForStorage(byte[] bytes, int offset, int length)
-            {
-                if (StorageHashSize == 20)
-                    return Compute20(bytes, offset, length);
-                return Compute16(bytes, offset, length);
-            }
+			public byte[] ComputeForStorage(byte[] bytes, int offset, int length)
+			{
+				if (StorageHashSize == 20)
+					return Compute20(bytes, offset, length);
+				return Compute16(bytes, offset, length);
+			}
 
 			public byte[] ComputeForOAuth(byte[] bytes)
 			{
@@ -128,20 +142,20 @@ namespace Raven.Abstractions.Util.Encryptors
 				return MD5Core.GetHash(bytes);
 			}
 
-            public byte[] Compute16(byte[] bytes, int offset, int length)
-            {
-                return MD5Core.GetHash(bytes, offset, length);
-            }
+			public byte[] Compute16(byte[] bytes, int offset, int length)
+			{
+				return MD5Core.GetHash(bytes, offset, length);
+			}
 
 			public byte[] Compute20(byte[] bytes)
 			{
 				return ComputeHash(SHA1.Create(), bytes, 20);
 			}
 
-            public byte[] Compute20(byte[] bytes, int offset, int length)
-            {
-                return ComputeHash(SHA1.Create(), bytes, offset, length, 20);
-            }
+			public byte[] Compute20(byte[] bytes, int offset, int length)
+			{
+				return ComputeHash(SHA1.Create(), bytes, offset, length, 20);
+			}
 		}
 
 		public class FipsSymmetricalEncryptor : ISymmetricalEncryptor

--- a/Raven.Abstractions/Util/Encryptors/HashEncryptorBase.cs
+++ b/Raven.Abstractions/Util/Encryptors/HashEncryptorBase.cs
@@ -5,6 +5,13 @@
 
 	public abstract class HashEncryptorBase
 	{
+		protected bool AllowNonThreadSafeMethods { get; private set; }
+
+		protected HashEncryptorBase(bool allowNonThreadSafeMethods)
+		{
+			AllowNonThreadSafeMethods = allowNonThreadSafeMethods;
+		}
+
 		public byte[] ComputeHash(HashAlgorithm algorithm, byte[] bytes, int? size = null)
 		{
 			using (algorithm)
@@ -28,5 +35,11 @@
                 return hash;
             }
         }
+
+		protected void ThrowNotSupportedExceptionForNonThreadSafeMethod()
+		{
+			if (AllowNonThreadSafeMethods == false)
+				throw new NotSupportedException("Non-thread-safe methods are not allowed.");
+		}
 	}
 }


### PR DESCRIPTION
fortunately, the non-thread safe methods were used along with CreateHash which is scoping properly. I just added a code to prevent a usage of them directly from Hash property.
