### PR TITLE
RavenDB-2936 Do not return details for UpdateByIndex and DeleteByIndex o...

### DIFF
--- a/Raven.Abstractions/Data/BulkOperationOptions.cs
+++ b/Raven.Abstractions/Data/BulkOperationOptions.cs
@@ -4,22 +4,26 @@ using System.Threading;
 
 namespace Raven.Abstractions.Data
 {
-    /// <summary>
-    /// Holds diffrents setting options for base operations.
-    /// </summary>
-    public class BulkOperationOptions
-    {
-        /// <summary>
-        /// indicates whether operations are allowed on stale indexes.
-        /// </summary>
-         public bool AllowStale { get; set; }
+	/// <summary>
+	/// Holds different setting options for base operations.
+	/// </summary>
+	public class BulkOperationOptions
+	{
+		/// <summary>
+		/// Indicates whether operations are allowed on stale indexes.
+		/// </summary>
+		public bool AllowStale { get; set; }
 
-         public TimeSpan? StaleTimeout { get; set; }
+		public TimeSpan? StaleTimeout { get; set; }
 
-        /// <summary>
-        /// limits the amount of base operation per second allowed.
-        /// </summary>
-         public int? MaxOpsPerSec { get; set; }
+		/// <summary>
+		/// Limits the amount of base operation per second allowed.
+		/// </summary>
+		public int? MaxOpsPerSec { get; set; }
 
-    }
+		/// <summary>
+		/// Determines whether operation details about each document should be returned by server.
+		/// </summary>
+		public bool RetrieveDetails { get; set; }
+	}
 }

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -348,7 +348,8 @@ namespace Raven.Client.Connection.Async
 			return ExecuteWithReplication("DELETE", async operationMetadata =>
 			{
 				var notNullOptions = options ?? new BulkOperationOptions();
-				string path = queryToDelete.GetIndexQueryUrl(operationMetadata.Url, indexName, "bulk_docs") + "&allowStale=" + notNullOptions.AllowStale;
+				string path = queryToDelete.GetIndexQueryUrl(operationMetadata.Url, indexName, "bulk_docs") + "&allowStale=" + notNullOptions.AllowStale
+					 + "&details=" + notNullOptions.RetrieveDetails;
 				if (notNullOptions.MaxOpsPerSec != null)
 					path += "&maxOpsPerSec=" + notNullOptions.MaxOpsPerSec;
 				if (notNullOptions.StaleTimeout != null)
@@ -993,7 +994,7 @@ namespace Raven.Client.Connection.Async
 			{
 				var notNullOptions = options ?? new BulkOperationOptions();
 				string path = queryToUpdate.GetIndexQueryUrl(operationMetadata.Url, indexName, "bulk_docs") + "&allowStale=" + notNullOptions.AllowStale
-					+ "&maxOpsPerSec=" + notNullOptions.MaxOpsPerSec;
+					+ "&maxOpsPerSec=" + notNullOptions.MaxOpsPerSec + "&details=" + notNullOptions.RetrieveDetails;
 				if (notNullOptions.StaleTimeout != null)
 					path += "&staleTimeout=" + notNullOptions.StaleTimeout;
 				using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, path, method, operationMetadata.Credentials, convention)))

--- a/Raven.Database/Impl/DatabaseBulkOperations.cs
+++ b/Raven.Database/Impl/DatabaseBulkOperations.cs
@@ -129,7 +129,9 @@ namespace Raven.Database.Impl
 								batchCount++;
 							    operations++;
 								var result = batchOperation(enumerator.Current, transactionInformation);
-								array.Add(RavenJObject.FromObject(result));
+
+								if(options.RetrieveDetails)
+									array.Add(RavenJObject.FromObject(result));
 
 							    if (operations >= maxOpsPerSec && duration.ElapsedMilliseconds < 1000)
 							    {

--- a/Raven.Database/Server/Controllers/DocumentsBatchController.cs
+++ b/Raven.Database/Server/Controllers/DocumentsBatchController.cs
@@ -119,12 +119,14 @@ namespace Raven.Database.Server.Controllers
             if (string.IsNullOrEmpty(index))
                 return GetEmptyMessage(HttpStatusCode.BadRequest);
 
-            var option = new BulkOperationOptions
-            {
-                AllowStale = GetAllowStale(),
-                MaxOpsPerSec = GetMaxOpsPerSec(),
-                StaleTimeout = GetStaleTimeout()
-            };
+	        var option = new BulkOperationOptions
+	        {
+		        AllowStale = GetAllowStale(),
+		        MaxOpsPerSec = GetMaxOpsPerSec(),
+		        StaleTimeout = GetStaleTimeout(),
+		        RetrieveDetails = GetRetrieveDetails()
+	        };
+
             var indexQuery = GetIndexQuery(maxPageSize: int.MaxValue);
 
             var status = new BulkOperationStatus();

--- a/Raven.Database/Server/Controllers/RavenDbApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenDbApiController.cs
@@ -494,6 +494,13 @@ namespace Raven.Database.Server.Controllers
             return result;
         }
 
+		protected bool GetRetrieveDetails()
+		{
+			bool details;
+			bool.TryParse(GetQueryStringValue("details"), out details);
+			return details;
+		}
+
 		protected void HandleReplication(HttpResponseMessage msg)
 		{
 			var clientPrimaryServerUrl = GetHeader(Constants.RavenClientPrimaryServerUrl);

--- a/Raven.DtcTests/RavenDB_1562.cs
+++ b/Raven.DtcTests/RavenDB_1562.cs
@@ -105,7 +105,10 @@ namespace Raven.Tests.Issues
 
                 var deleteExistingDocsIndexQuery = new IndexQuery { Query = deleteExistingDocsQuery.ToString() };
 
-                var deleteByIndex = databaseCommands.DeleteByIndex(new DocsIndex().IndexName, deleteExistingDocsIndexQuery, null);
+                var deleteByIndex = databaseCommands.DeleteByIndex(new DocsIndex().IndexName, deleteExistingDocsIndexQuery, new BulkOperationOptions()
+                {
+	                RetrieveDetails = true
+                });
                 var array = deleteByIndex.WaitForCompletion() as RavenJArray;
 
                 Assert.Equal(1, array.Length);

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -322,6 +322,7 @@
     <Compile Include="RavenDB_2862.cs" />
     <Compile Include="RavenDB_2877.cs" />
     <Compile Include="RavenDB_2908.cs" />
+    <Compile Include="RavenDB_2936.cs" />
     <Compile Include="RavenDB_295.cs" />
     <Compile Include="RavenDB_299.cs" />
     <Compile Include="RavenDB_301.cs" />

--- a/Raven.Tests.Issues/RavenDB_2936.cs
+++ b/Raven.Tests.Issues/RavenDB_2936.cs
@@ -1,0 +1,143 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_2936.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Indexing;
+using Raven.Json.Linq;
+using Raven.Tests.Common;
+using Raven.Tests.Common.Dto;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+	public class RavenDB_2936 : RavenTest
+	{
+		[Fact]
+		public void ShouldNotRetrieveOperationDetails()
+		{
+			using (var store = NewDocumentStore())
+			{
+				store.DatabaseCommands.PutIndex("Users/ByName", new IndexDefinition()
+				{
+					Map = "from user in docs.Users select new { user.Name }"
+				});
+
+				using (var session = store.OpenSession())
+				{
+					session.Store(new User()
+					{
+						Name = "Arek"
+					});
+
+					session.Store(new User()
+					{
+						Name = "Oren"
+					});
+
+					session.Store(new User()
+					{
+						Name = "Ayende"
+					});
+
+					session.SaveChanges();
+				}
+
+				WaitForIndexing(store);
+
+				var result = store.DatabaseCommands.UpdateByIndex("Users/ByName",
+					new IndexQuery(),
+					new ScriptedPatchRequest
+					{
+						Script = @"this.LastName = 'Smith'"
+					})
+					.WaitForCompletion();
+
+				Assert.Empty((RavenJArray)result);
+
+				result = store.DatabaseCommands.UpdateByIndex("Users/ByName", 
+					new IndexQuery(),
+					new[]
+					{
+						new PatchRequest
+						{
+							Type = PatchCommandType.Set,
+							Name = "NewProp",
+							Value = "Value"
+						}
+					}).WaitForCompletion();
+
+				Assert.Empty((RavenJArray)result);
+
+				result = store.DatabaseCommands.DeleteByIndex("Users/ByName", new IndexQuery())
+					.WaitForCompletion();
+
+				Assert.Empty((RavenJArray)result);
+			}
+		}
+
+		[Fact]
+		public void ShouldRetrieveOperationDetailsWhenTheyWereRequested()
+		{
+			using (var store = NewDocumentStore())
+			{
+				store.DatabaseCommands.PutIndex("Users/ByName", new IndexDefinition()
+				{
+					Map = "from user in docs.Users select new { user.Name }"
+				});
+
+				using (var session = store.OpenSession())
+				{
+					session.Store(new User()
+					{
+						Name = "Arek"
+					});
+
+					session.Store(new User()
+					{
+						Name = "Oren"
+					});
+
+					session.Store(new User()
+					{
+						Name = "Ayende"
+					});
+
+					session.SaveChanges();
+				}
+
+				WaitForIndexing(store);
+
+				var result = store.DatabaseCommands.UpdateByIndex("Users/ByName",
+					new IndexQuery(),
+					new ScriptedPatchRequest
+					{
+						Script = @"this.LastName = 'Smith'"
+					}, new BulkOperationOptions { RetrieveDetails = true })
+					.WaitForCompletion();
+
+				Assert.NotNull(result);
+
+				result = store.DatabaseCommands.UpdateByIndex("Users/ByName",
+					new IndexQuery(),
+					new[]
+					{
+						new PatchRequest
+						{
+							Type = PatchCommandType.Set,
+							Name = "NewProp",
+							Value = "Value"
+						}
+					}, new BulkOperationOptions { RetrieveDetails = true }).WaitForCompletion();
+
+				Assert.NotNull(result);
+
+				result = store.DatabaseCommands.DeleteByIndex("Users/ByName", new IndexQuery(), new BulkOperationOptions { RetrieveDetails = true })
+					.WaitForCompletion();
+
+				Assert.NotNull(result);
+			}
+		}
+	}
+}

--- a/Raven.Tests.MailingList/Wayne.cs
+++ b/Raven.Tests.MailingList/Wayne.cs
@@ -40,7 +40,7 @@ namespace Raven.Tests.MailingList
 					this.Friends += 1;
 					output(this.Friends);
 					"
-				});
+				}, new BulkOperationOptions(){ RetrieveDetails = true});
 
 				var state = (RavenJArray)op.WaitForCompletion();
 				Assert.Contains("1", state[0].Value<RavenJArray>("Debug")[0].ToString(Formatting.None));
@@ -70,7 +70,7 @@ namespace Raven.Tests.MailingList
 					this.Friends += 1;
 					output(this.Friends);
 					"
-				});
+				}, new BulkOperationOptions(){ RetrieveDetails = true});
 
 				var state = (RavenJArray)op.WaitForCompletion();
 				Assert.Contains("1", state[0].Value<RavenJArray>("Debug")[0].ToString(Formatting.None));


### PR DESCRIPTION
...peration by default - they can be very large while the most common scenario is just to check the status. If you are interested in details you need to specify BulkOperationOptions { RetrieveDetails = true }
