### PR TITLE
RavenDB-2955 Delete auto indexes surpassed by another one (which include...

### DIFF
--- a/Raven.Abstractions/Extensions/Internal/DictionaryExtensions.cs
+++ b/Raven.Abstractions/Extensions/Internal/DictionaryExtensions.cs
@@ -21,5 +21,20 @@ namespace Raven.Abstractions.Extensions
 			self.TryGetValue(key, out value);
 			return value;
 		}
+
+		public static bool ContentEquals<TKey, TValue>(IDictionary<TKey, TValue> x, IDictionary<TKey, TValue> y)
+		{
+			if (x.Count != y.Count)
+				return false;
+			foreach (var v in x)
+			{
+				TValue value;
+				if (y.TryGetValue(v.Key, out value) == false)
+					return false;
+				if (Equals(value, v.Value) == false)
+					return false;
+			}
+			return true;
+		} 
 	}
 }

--- a/Raven.Abstractions/Indexing/IndexDefinition.cs
+++ b/Raven.Abstractions/Indexing/IndexDefinition.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Abstractions.Data;
+using Raven.Abstractions.Extensions;
 using Raven.Imports.Newtonsoft.Json;
 
 namespace Raven.Abstractions.Indexing
@@ -169,29 +170,16 @@ namespace Raven.Abstractions.Indexing
 					Equals(other.IndexId, IndexId) &&
 					Equals(other.Reduce, Reduce) &&
                     Equals(other.MaxIndexOutputsPerDocument, MaxIndexOutputsPerDocument) &&
-					DictionaryEquals(other.Stores, Stores) &&
-					DictionaryEquals(other.Indexes, Indexes) &&
-					DictionaryEquals(other.Analyzers, Analyzers) &&
-					DictionaryEquals(other.SortOptions, SortOptions) &&
-					DictionaryEquals(other.Suggestions, Suggestions) &&
-					DictionaryEquals(other.TermVectors, TermVectors) &&
-					DictionaryEquals(other.SpatialIndexes, SpatialIndexes);
+					DictionaryExtensions.ContentEquals(other.Stores, Stores) &&
+					DictionaryExtensions.ContentEquals(other.Indexes, Indexes) &&
+					DictionaryExtensions.ContentEquals(other.Analyzers, Analyzers) &&
+					DictionaryExtensions.ContentEquals(other.SortOptions, SortOptions) &&
+					DictionaryExtensions.ContentEquals(other.Suggestions, Suggestions) &&
+					DictionaryExtensions.ContentEquals(other.TermVectors, TermVectors) &&
+					DictionaryExtensions.ContentEquals(other.SpatialIndexes, SpatialIndexes);
 		}
 
-		private static bool DictionaryEquals<TKey, TValue>(IDictionary<TKey, TValue> x, IDictionary<TKey, TValue> y)
-		{
-			if (x.Count != y.Count)
-				return false;
-			foreach (var v in x)
-			{
-				TValue value;
-				if (y.TryGetValue(v.Key, out value) == false)
-					return false;
-				if (Equals(value, v.Value) == false)
-					return false;
-			}
-			return true;
-		}
+		
 
 		private static int DictionaryHashCode<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> x)
 		{

--- a/Raven.Abstractions/Indexing/MergeSuggestions.cs
+++ b/Raven.Abstractions/Indexing/MergeSuggestions.cs
@@ -10,5 +10,9 @@ namespace Raven.Abstractions.Indexing
 	    public string Collection = String.Empty; // the collection that is being merged
 
         public IndexDefinition MergedIndex = new IndexDefinition();  //propose for new index with all it's properties
+
+		public List<string> CanDelete = new List<string>();  // index names
+
+	    public string SurpassingIndex = string.Empty;
     }
 }

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -325,6 +325,7 @@
     <Compile Include="RavenDB_2909.cs" />
     <Compile Include="RavenDB_2936.cs" />
     <Compile Include="RavenDB_295.cs" />
+    <Compile Include="RavenDB_2955.cs" />
     <Compile Include="RavenDB_299.cs" />
     <Compile Include="RavenDB_301.cs" />
     <Compile Include="RavenDB_302.cs" />

--- a/Raven.Tests.Issues/RavenDB_2955.cs
+++ b/Raven.Tests.Issues/RavenDB_2955.cs
@@ -1,0 +1,152 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_2955.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Linq;
+using Raven.Abstractions.Indexing;
+using Raven.Tests.Common;
+using Raven.Tests.Common.Dto;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+	public class RavenDB_2955 : RavenTest
+	{
+		[Fact]
+		public void ShouldDeleteAutoIndexSurpassedByAnotherAutoIndex()
+		{
+			using (var store = NewDocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					session.Query<Person>().Where(x => x.Name == "a").ToList();
+
+					session.Query<Person>().Where(x => x.Name == "a" && x.AddressId == "addresses/1").ToList();
+				}
+
+				var autoIndexes = store.DatabaseCommands.GetStatistics().Indexes.Where(x => x.Name.StartsWith("Auto/")).ToList();
+
+				Assert.Equal(2, autoIndexes.Count);
+
+				store.DocumentDatabase.IndexStorage.RunIdleOperations();
+
+				autoIndexes = store.DatabaseCommands.GetStatistics().Indexes.Where(x => x.Name.StartsWith("Auto/")).ToList();
+
+				Assert.Equal(1, autoIndexes.Count);
+			}
+		}
+
+		[Fact]
+		public void ShouldDeleteAutoIndexesSurpassedByStaticIndex()
+		{
+			using (var store = NewDocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					session.Query<Person>().Where(x => x.Name == "a").ToList();
+					session.Query<Person>().Where(x => x.Name == "a" && x.AddressId == "addresses/1").ToList();
+				}
+
+				store.DatabaseCommands.PutIndex("People/ByName", new IndexDefinition()
+				{
+					Map = "from doc in docs.People select new { doc.Name, doc.AddressId }"
+				});
+
+				var autoIndexes = store.DatabaseCommands.GetStatistics().Indexes.Where(x => x.Name.StartsWith("Auto/")).ToList();
+
+				Assert.Equal(2, autoIndexes.Count);
+
+				store.DocumentDatabase.IndexStorage.RunIdleOperations();
+
+				autoIndexes = store.DatabaseCommands.GetStatistics().Indexes.Where(x => x.Name.StartsWith("Auto/")).ToList();
+
+				Assert.Equal(0, autoIndexes.Count);
+
+			}
+		}
+
+		[Fact]
+		public void ShouldNotDeleteAutoIndexesIfSurpassedIndexIsStale()
+		{
+			using (var store = NewDocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					session.Query<Person>().Where(x => x.Name == "a").ToList();
+				}
+
+				store.DatabaseCommands.PutIndex("People/ByName", new IndexDefinition()
+				{
+					Map = "from doc in docs.People select new { doc.Name, doc.AddressId }"
+				});
+
+				var autoIndexes = store.DatabaseCommands.GetStatistics().Indexes.Where(x => x.Name.StartsWith("Auto/")).ToList();
+
+				Assert.Equal(1, autoIndexes.Count);
+
+				store.DatabaseCommands.Admin.StopIndexing();
+
+				using (var session = store.OpenSession())
+				{
+					session.Store(new Person());
+
+					session.SaveChanges();
+				}
+
+				store.DocumentDatabase.IndexStorage.RunIdleOperations();
+
+				autoIndexes = store.DatabaseCommands.GetStatistics().Indexes.Where(x => x.Name.StartsWith("Auto/")).ToList();
+
+				Assert.Equal(1, autoIndexes.Count);
+			}
+		}
+
+		[Fact]
+		public void ShouldNotDeleteStaticIndexeWhichIsSurpassedByAnotherStaticOne()
+		{
+			using (var store = NewDocumentStore())
+			{
+				store.DatabaseCommands.PutIndex("People/ByName", new IndexDefinition
+				{
+					Map = "from doc in docs.People select new { doc.Name }"
+				});
+
+				store.DatabaseCommands.PutIndex("People/ByName2", new IndexDefinition
+				{
+					Map = "from doc in docs.People select new { doc.Name, doc.AddressId }"
+				});
+
+				var indexCount = store.DatabaseCommands.GetStatistics().Indexes.Length;
+
+				store.DocumentDatabase.IndexStorage.RunIdleOperations();
+
+				Assert.Equal(indexCount, store.DatabaseCommands.GetStatistics().Indexes.Length);
+			}
+		}
+
+		[Fact]
+		public void ShouldNotDeleteAnyAutoIndex()
+		{
+			using (var store = NewDocumentStore())
+			{
+				using (var session = store.OpenSession())
+				{
+					session.Query<Person>().Where(x => x.Name == "a").ToList();
+
+					session.Query<User>().Where(x => x.Name == "a").ToList();
+				}
+
+				var autoIndexes = store.DatabaseCommands.GetStatistics().Indexes.Where(x => x.Name.StartsWith("Auto/")).ToList();
+
+				Assert.Equal(2, autoIndexes.Count);
+
+				store.DocumentDatabase.IndexStorage.RunIdleOperations();
+
+				autoIndexes = store.DatabaseCommands.GetStatistics().Indexes.Where(x => x.Name.StartsWith("Auto/")).ToList();
+
+				Assert.Equal(2, autoIndexes.Count);
+			}
+		}
+	}
+}


### PR DESCRIPTION
...s it). This change also accomplishes server side work for RavenDB-2912.
