### PR TITLE
Bug-Fix on ClientApi

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/AsyncFilesSession.cs
+++ b/Raven.Client.Lightweight/FileSystem/AsyncFilesSession.cs
@@ -85,6 +85,8 @@ namespace Raven.Client.FileSystem
             if (!filenames.Any())
                 return new FileHeader[0];
 
+            filenames = filenames.Select(FileHeader.Canonize);
+
             // only load documents that aren't already cached
             var idsOfNotExistingObjects = filenames.Where(x => IsLoaded(x) == false && IsDeleted(x) == false)
                                             .Distinct(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
Load of multiple files in one go will return all nulls.
