### PR TITLE
Lucene.Net.Util.Version does not necessarily exist in the analyzer type ...

### DIFF
--- a/Raven.Database/Extensions/IndexingExtensions.cs
+++ b/Raven.Database/Extensions/IndexingExtensions.cs
@@ -35,8 +35,7 @@ namespace Raven.Database.Extensions
 				if (ctors != null)
 					return (Analyzer)Activator.CreateInstance(assembly.FullName, analyzerType.FullName).Unwrap();
 
-				var type = analyzerType.Assembly.GetType(typeof(Lucene.Net.Util.Version).FullName);
-				ctors = analyzerType.GetConstructor(new[] { type });
+                ctors = analyzerType.GetConstructor(new[] { typeof(Lucene.Net.Util.Version) });
 				if (ctors != null) 
 					return (Analyzer)Activator
 						.CreateInstance(assembly.FullName, analyzerType.FullName, false, BindingFlags.CreateInstance | BindingFlags.Public | BindingFlags.Instance, null, new object[] { Lucene.Net.Util.Version.LUCENE_30 }, CultureInfo.InvariantCulture, null)


### PR DESCRIPTION
...assembly, meaning we are unable to get the correct constructor for analyzer. Bug was introduced in commit d8eaa57c
