### PR TITLE
IsAggregationTypeNumerical(string) blows up if no AggregationType is set...

### DIFF
--- a/Raven.Database/Queries/FacetedQueryRunner.cs
+++ b/Raven.Database/Queries/FacetedQueryRunner.cs
@@ -48,6 +48,10 @@ namespace Raven.Database.Queries
                         throw new InvalidOperationException("Facet " + facet.Name + " cannot have aggregation set to " +
                                                             facet.Aggregation + " without having a value in AggregationField");
 
+                    if (string.IsNullOrEmpty(facet.AggregationType))
+                        throw new InvalidOperationException("Facet " + facet.Name + " cannot have aggregation set to " +
+                                                            facet.Aggregation + " without having a value in AggregationType");
+
                     if (facet.AggregationField.EndsWith("_Range") == false)
                     {
                         if( QueryForFacets.IsAggregationTypeNumerical(facet.AggregationType))


### PR DESCRIPTION
... on facet, so require AggregationType if an aggregation is specified that is not AggregationType.None and AggregationType.Count

Upgrading to RavenDB 3 from 2.5, we have facets which specify a Min and Max aggregation but do not specify an AggregationType, this causes an exception on line 351 of FacetedQueryRunner because _aggregationType_ is null.

I assume you want to throw an exception if no AggregationType is specified as per the changeset, but I notice that no exception is thrown from line 353 of FacetedQueryRunner if the aggregation type cannot be found. Maybe this should also throw, however I don't fully understand the significance of returning false from IsAggregationTypeNumerical when the AggregationType is actually numerical.
