### PR TITLE
RavenDB-2876 Studio : how to open studio when API Key is required?

### DIFF
--- a/Raven.Database/Server/Controllers/DatabasesController.cs
+++ b/Raven.Database/Server/Controllers/DatabasesController.cs
@@ -69,14 +69,19 @@ namespace Raven.Database.Server.Controllers
 			List<string> approvedDatabases = null;
 			if (DatabasesLandlord.SystemConfiguration.AnonymousUserAccessMode == AnonymousUserAccessMode.None)
 			{
-				var user = User;
+                var authorizer = (MixedModeRequestAuthorizer)this.ControllerContext.Configuration.Properties[typeof(MixedModeRequestAuthorizer)];
+
+                HttpResponseMessage authMsg;
+                if (authorizer.TryAuthorize(this, out authMsg) == false)
+                    return authMsg;
+
+			    var user = authorizer.GetUser(this);
+
 				if (user == null)
 					return null;
 
 				if (user.IsAdministrator(DatabasesLandlord.SystemConfiguration.AnonymousUserAccessMode) == false)
 				{
-					var authorizer = (MixedModeRequestAuthorizer)this.ControllerContext.Configuration.Properties[typeof(MixedModeRequestAuthorizer)];
-
 					approvedDatabases = authorizer.GetApprovedResources(user, this, databasesNames);
 				}
 			}


### PR DESCRIPTION
Ayende, could you have a look at this change? 

User property was always null and controller method returning null (causing 500 error). Databases endpoint isn't valided so user isn't available. I've changed it to manually authorize and it seems to work. 
