### PR TITLE
added notification when index backup fails

### DIFF
--- a/Raven.Database/Indexing/IndexStorage.cs
+++ b/Raven.Database/Indexing/IndexStorage.cs
@@ -1427,10 +1427,10 @@ namespace Raven.Database.Indexing
 			return GetIndexInstance(index).GetIndexingPerformance();
 		}
 
-		public void Backup(string directory, string incrementalTag = null)
+		public void Backup(string directory, string incrementalTag = null, Action<string, string, BackupStatus.BackupMessageSeverity> notifyCallback = null)
 		{
 			Parallel.ForEach(indexes.Values, index =>
-				index.Backup(directory, path, incrementalTag));
+                index.Backup(directory, path, incrementalTag, notifyCallback));
 		}
 
 		public void MergeAllIndexes()

--- a/Raven.Database/Storage/BaseBackupOperation.cs
+++ b/Raven.Database/Storage/BaseBackupOperation.cs
@@ -111,7 +111,7 @@ namespace Raven.Database.Storage
                                         Path.Combine(backupSourceDirectory, "Temp" + Guid.NewGuid().ToString("N")), incrementalBackup)
 				};
 
-                database.IndexStorage.Backup(backupDestinationDirectory);
+                database.IndexStorage.Backup(backupDestinationDirectory,null, UpdateBackupStatus);
 
                 var progressNotifier = new ProgressNotifier();
                 foreach (var directoryBackup in directoryBackups)


### PR DESCRIPTION
* notice that there is still an issue on Voron incremental backup.
If the first backup had a bad index on Voron and the second one succeeds restoring the database will throw an exception.
* you might actually need to try and access the restored database to cause the exception.
I can't reproduce this on my master because the backup will fail entirely before the latest changes.   
i'll open an issue on this and include my branch path to reproduce