### PR TITLE
Fixing incorrect assertion - there isn't any reason why a freed page cou...

### DIFF
--- a/Raven.Voron/Voron/Impl/Transaction.cs
+++ b/Raven.Voron/Voron/Impl/Transaction.cs
@@ -473,7 +473,7 @@ namespace Voron.Impl
 
 		internal void FreePage(long pageNumber)
 		{
-			Debug.Assert(pageNumber >= 2);
+			Debug.Assert(pageNumber >= 0);
 			_freeSpaceHandling.FreePage(this, pageNumber);
 
 			_freedPages.Add(pageNumber);


### PR DESCRIPTION
...ldn't have number 0 or 1, after a tree rebalancing they could be leafs. We leave this assertion just to be sure that we don't try to release a corrupted page (number < 0)
