### PR TITLE
Implemented .BulkCopy() as a smarter StdLib.memcpy() ...

### DIFF
--- a/Raven.Voron/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/Raven.Voron/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -868,7 +868,7 @@ namespace Voron.Impl.Journal
 				var txPage = txPages[index];
 				var scratchPage = tx.Environment.ScratchBufferPool.AcquirePagePointer(txPage.ScratchFileNumber, txPage.PositionInScratchBuffer);
 				var count = txPage.NumberOfPages * AbstractPager.PageSize;
-                StdLib.memcpy(write, scratchPage, count);
+                MemoryUtils.BulkCopy(write, scratchPage, count);
 				write += count;
 			}
 

--- a/Raven.Voron/Voron/Platform/Win32/Win32MemoryMapPager.cs
+++ b/Raven.Voron/Voron/Platform/Win32/Win32MemoryMapPager.cs
@@ -277,7 +277,7 @@ namespace Voron.Platform.Win32
 			ThrowObjectDisposedIfNeeded();
 
 			int toCopy = pagesToWrite * PageSize;
-            StdLib.memcpy(PagerState.MapBase + pagePosition * PageSize, start.Base, toCopy);
+            MemoryUtils.BulkCopy(PagerState.MapBase + pagePosition * PageSize, start.Base, toCopy);
 
 			return toCopy;
 		}

--- a/Raven.Voron/Voron/Util/MemoryUtils.cs
+++ b/Raven.Voron/Voron/Util/MemoryUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using Voron.Impl;
 
 namespace Voron.Util
 {
@@ -157,6 +158,25 @@ namespace Voron.Util
             }
         }
 
+        /// <summary>
+        /// Bulk copy is optimized to handle copy operations where n is statistically big. While it will use a faster copy operation for 
+        /// small amounts of memory, when you have smaller than 2048-4096 bytes calls (depending on the target CPU) it will always be
+        /// faster to call .Copy() directly.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void BulkCopy(byte* dest, byte* src, int n)
+        {
+            if (n >= 2048)
+                StdLib.memcpy(dest, src, n);
+            else
+                Copy(dest, src, n);
+        }
+
+        /// <summary>
+        /// Copy is optimized to handle copy operations where n is statistically small. 
+        /// This method is optimized at the IL level to be extremely efficient for copies smaller than
+        /// 4096 bytes or heterogeneous workloads with occasional big copies.         
+        /// </summary>
         public static unsafe void Copy(byte* dest, byte* src, int n)
         {
             while (true) // Unrolling while with no pointers


### PR DESCRIPTION
checking which copy operation will be the appropriate given the data size.
Copy will still be fully optimized for use with statistically small workloads.