### PR TITLE
RavenDB-3088 added the ability to limit number of replicated items from destination server

### DIFF
--- a/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
+++ b/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
@@ -423,7 +423,8 @@ namespace Raven.Database.Bundles.Replication.Controllers
 					{
 						Source = src,
 						ServerInstanceId = localServerInstanceId,
-						LastModified = SystemTime.UtcNow
+						LastModified = SystemTime.UtcNow,
+						MaxNumberOfItemsToReceiveInSingleBatch = Database.Configuration.Replication.MaxNumberOfItemsToReceiveInSingleBatch
 					};
 				}
 				else
@@ -441,6 +442,7 @@ namespace Raven.Database.Bundles.Replication.Controllers
 						sourceReplicationInformation.LastDocumentEtag = Etag.InvalidEtag;
 					}
 
+					sourceReplicationInformation.MaxNumberOfItemsToReceiveInSingleBatch = Database.Configuration.Replication.MaxNumberOfItemsToReceiveInSingleBatch;
 					sourceReplicationInformation.ServerInstanceId = localServerInstanceId;
 				}
 

--- a/Raven.Database/Bundles/Replication/Data/SourceReplicationInformation.cs
+++ b/Raven.Database/Bundles/Replication/Data/SourceReplicationInformation.cs
@@ -21,6 +21,8 @@ namespace Raven.Bundles.Replication.Data
 
 		public DateTime? LastModified { get; set; }
 
+		public int? MaxNumberOfItemsToReceiveInSingleBatch { get; set; }
+
 		public override string ToString()
 		{
 			return string.Format("LastDocumentEtag: {0}, LastAttachmentEtag: {1}", LastDocumentEtag, LastAttachmentEtag);

--- a/Raven.Database/Bundles/Replication/Data/SourceReplicationInformation.cs
+++ b/Raven.Database/Bundles/Replication/Data/SourceReplicationInformation.cs
@@ -21,7 +21,7 @@ namespace Raven.Bundles.Replication.Data
 
 		public DateTime? LastModified { get; set; }
 
-		public int? MaxNumberOfItemsToReceiveInSingleBatch { get; set; }
+		public int? LastBatchSize { get; set; }
 
 		public override string ToString()
 		{
@@ -33,5 +33,10 @@ namespace Raven.Bundles.Replication.Data
 			LastDocumentEtag = Etag.Empty;
 			LastAttachmentEtag = Etag.Empty;
 		}
+	}
+
+	public class SourceReplicationInformationWithBatchInformation : SourceReplicationInformation
+	{
+		public int? MaxNumberOfItemsToReceiveInSingleBatch { get; set; }
 	}
 }

--- a/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
@@ -407,7 +407,7 @@ namespace Raven.Bundles.Replication.Tasks
 				using (docDb.DisableAllTriggersForCurrentThread())
 				using (var stats = new ReplicationStatisticsRecorder(destination, destinationStats))
 				{
-					SourceReplicationInformation destinationsReplicationInformationForSource;
+					SourceReplicationInformationWithBatchInformation destinationsReplicationInformationForSource;
 					using (var scope = stats.StartRecording("Destination"))
 					{
 						try
@@ -564,7 +564,7 @@ namespace Raven.Bundles.Replication.Tasks
 			return true;
 		}
 
-		private bool? ReplicateDocuments(ReplicationStrategy destination, SourceReplicationInformation destinationsReplicationInformationForSource, ReplicationStatisticsRecorder.ReplicationStatisticsRecorderScope recorder, out int replicatedDocuments)
+		private bool? ReplicateDocuments(ReplicationStrategy destination, SourceReplicationInformationWithBatchInformation destinationsReplicationInformationForSource, ReplicationStatisticsRecorder.ReplicationStatisticsRecorderScope recorder, out int replicatedDocuments)
 		{
 			replicatedDocuments = 0;
 			JsonDocumentsToReplicate documentsToReplicate = null;
@@ -978,7 +978,7 @@ namespace Raven.Bundles.Replication.Tasks
 			public List<JsonDocument> LoadedDocs { get; set; }
 		}
 
-		private JsonDocumentsToReplicate GetJsonDocuments(SourceReplicationInformation destinationsReplicationInformationForSource, ReplicationStrategy destination, PrefetchingBehavior prefetchingBehavior, ReplicationStatisticsRecorder.ReplicationStatisticsRecorderScope scope)
+		private JsonDocumentsToReplicate GetJsonDocuments(SourceReplicationInformationWithBatchInformation destinationsReplicationInformationForSource, ReplicationStrategy destination, PrefetchingBehavior prefetchingBehavior, ReplicationStatisticsRecorder.ReplicationStatisticsRecorderScope scope)
 		{
 			var timeout = TimeSpan.FromSeconds(docDb.Configuration.Replication.FetchingFromDiskTimeoutInSeconds);
 			var duration = Stopwatch.StartNew();
@@ -1285,7 +1285,7 @@ namespace Raven.Bundles.Replication.Tasks
 				.ToList();
 		}
 
-		internal SourceReplicationInformation GetLastReplicatedEtagFrom(ReplicationStrategy destination)
+		internal SourceReplicationInformationWithBatchInformation GetLastReplicatedEtagFrom(ReplicationStrategy destination)
 		{
 			try
 			{
@@ -1294,7 +1294,7 @@ namespace Raven.Bundles.Replication.Tasks
 				var url = destination.ConnectionStringOptions.Url + "/replication/lastEtag?from=" + UrlEncodedServerUrl() +
 						  "&currentEtag=" + currentEtag + "&dbid=" + docDb.TransactionalStorage.Id;
 				var request = httpRavenRequestFactory.Create(url, "GET", destination.ConnectionStringOptions);
-				var lastReplicatedEtagFrom = request.ExecuteRequest<SourceReplicationInformation>();
+				var lastReplicatedEtagFrom = request.ExecuteRequest<SourceReplicationInformationWithBatchInformation>();
 				return lastReplicatedEtagFrom;
 			}
 			catch (WebException e)

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -283,6 +283,7 @@ namespace Raven.Database.Config
 
 			Replication.FetchingFromDiskTimeoutInSeconds = ravenSettings.Replication.FetchingFromDiskTimeoutInSeconds.Value;
 			Replication.ReplicationRequestTimeoutInMilliseconds = ravenSettings.Replication.ReplicationRequestTimeoutInMilliseconds.Value;
+			Replication.MaxNumberOfItemsToReceiveInSingleBatch = ravenSettings.Replication.MaxNumberOfItemsToReceiveInSingleBatch.Value;
 
             FileSystem.MaximumSynchronizationInterval = ravenSettings.FileSystem.MaximumSynchronizationInterval.Value;
 			FileSystem.DataDirectory = ravenSettings.FileSystem.DataDir.Value;
@@ -1248,6 +1249,11 @@ namespace Raven.Database.Config
 			/// Number of milliseconds before replication requests will timeout. Default: 60 * 1000.
 			/// </summary>
 			public int ReplicationRequestTimeoutInMilliseconds { get; set; }
+
+			/// <summary>
+			/// Maximum number of items replication will receive in single batch. Min: 512. Default: null (let source server decide).
+			/// </summary>
+			public int? MaxNumberOfItemsToReceiveInSingleBatch { get; set; }
 		}
 
         public class FileSystemConfiguration

--- a/Raven.Database/Config/Settings/NullableIntegerSettingWithMin.cs
+++ b/Raven.Database/Config/Settings/NullableIntegerSettingWithMin.cs
@@ -1,0 +1,41 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="NullableIntegerSettingWithMin.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+
+namespace Raven.Database.Config.Settings
+{
+	internal class NullableIntegerSettingWithMin : Setting<int?>
+	{
+		private readonly int minValue;
+
+		public NullableIntegerSettingWithMin(string value, int? defaultValue, int minValue)
+			: base(value, defaultValue)
+		{
+			this.minValue = minValue;
+		}
+
+		public NullableIntegerSettingWithMin(string value, Func<int?> getDefaultValue, int minValue)
+			: base(value, getDefaultValue)
+		{
+			this.minValue = minValue;
+		}
+
+		public override int? Value
+		{
+			get
+			{
+				var val = string.IsNullOrEmpty(value) == false
+						   ? int.Parse(value)
+						   : (getDefaultValue != null ? getDefaultValue() : defaultValue);
+
+				if (val.HasValue) 
+					return Math.Max(minValue, val.Value);
+
+				return val;
+			}
+		}
+	}
+}

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -211,6 +211,7 @@ namespace Raven.Database.Config
 
 			Replication.FetchingFromDiskTimeoutInSeconds = new IntegerSetting(settings["Raven/Replication/FetchingFromDiskTimeout"], 30);
 			Replication.ReplicationRequestTimeoutInMilliseconds = new IntegerSetting(settings["Raven/Replication/ReplicationRequestTimeout"], 60 * 1000);
+			Replication.MaxNumberOfItemsToReceiveInSingleBatch = new NullableIntegerSettingWithMin(settings["Raven/Replication/MaxNumberOfItemsToReceiveInSingleBatch"], (int?)null, 512);
 
             FileSystem.MaximumSynchronizationInterval = new TimeSpanSetting(settings[Constants.FileSystem.MaximumSynchronizationInterval], TimeSpan.FromSeconds(60), TimeSpanArgumentType.FromParse);
             FileSystem.IndexStoragePath = new StringSetting(settings[Constants.FileSystem.IndexStorageDirectory], string.Empty);
@@ -419,6 +420,8 @@ namespace Raven.Database.Config
 			public IntegerSetting FetchingFromDiskTimeoutInSeconds { get; set; }
 
 			public IntegerSetting ReplicationRequestTimeoutInMilliseconds { get; set; }
+
+			public NullableIntegerSettingWithMin MaxNumberOfItemsToReceiveInSingleBatch { get; set; }
 		}
 
 		public class FileSystemConfiguration

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Actions\QueryActions.cs" />
     <Compile Include="Actions\SubscriptionActions.cs" />
     <Compile Include="Actions\TaskActions.cs" />
+    <Compile Include="Config\Settings\NullableIntegerSettingWithMin.cs" />
     <Compile Include="Indexing\Sorting\Custom\CustomSortField.cs" />
     <Compile Include="Indexing\Sorting\Custom\CustomSortFieldCompartor.cs" />
     <Compile Include="Indexing\Sorting\Custom\IndexEntriesToComparablesGenerator.cs" />

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -143,6 +143,7 @@ namespace Raven.Tests.Core.Configuration
 			configurationComparer.Assert(expected => expected.Indexing.MaxNumberOfItemsToProcessInTestIndexes.Value, actual => actual.Indexing.MaxNumberOfItemsToProcessInTestIndexes);
 			configurationComparer.Assert(expected => expected.IndexAndTransformerReplicationLatencyInSec.Value, actual => actual.IndexAndTransformerReplicationLatencyInSec);
 			configurationComparer.Assert(expected => expected.MaxConcurrentRequestsForDatabaseDuringLoad.Value, actual => actual.MaxConcurrentRequestsForDatabaseDuringLoad);
+			configurationComparer.Assert(expected => expected.Replication.MaxNumberOfItemsToReceiveInSingleBatch.Value, actual => actual.Replication.MaxNumberOfItemsToReceiveInSingleBatch);
 			configurationComparer.Ignore(x => x.Storage.Esent.JournalsStoragePath);
 			configurationComparer.Ignore(x => x.Storage.Voron.JournalsStoragePath);
 


### PR DESCRIPTION
(Raven/Replication/MaxNumberOfItemsToReceiveInSingleBatch)
