### PR TITLE
fixed string.format parameters in log message

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/AbstractFilesQuery.cs
+++ b/Raven.Client.Lightweight/FileSystem/AbstractFilesQuery.cs
@@ -730,7 +730,7 @@ namespace Raven.Client.FileSystem
         {
             Session.IncrementRequestCount();
 
-            log.Debug("Executing query on file system '{1}' in '{2}'", this.Session.FileSystemName, this.Session.StoreIdentifier);
+            log.Debug("Executing query on file system '{0}' in '{1}'", this.Session.FileSystemName, this.Session.StoreIdentifier);
 
             var result = await Commands.SearchAsync(this.ToString(), this.orderByFields, start, pageSize);
 


### PR DESCRIPTION
The string.format parameters had beend counted one-based. Nothing failed but the log message could not be created.

Tested it successfully in a running client application but apperently there is no unittest.