### PR TITLE
fixed LastCollectionEtags initialization

### DIFF
--- a/Raven.Database/Actions/LastCollectionEtags.cs
+++ b/Raven.Database/Actions/LastCollectionEtags.cs
@@ -43,7 +43,9 @@ namespace Raven.Database.Actions
 				IndexStats stats = null;
 				context.Database.TransactionalStorage.Batch(accessor =>
 				{
-					stats = accessor.Indexing.GetIndexStats(indexId);
+					var isStale = accessor.Staleness.IsIndexStale(indexId, null, null);
+					if (isStale == false)
+						stats = accessor.Indexing.GetIndexStats(indexId);
 				});
 
 				if (stats == null)


### PR DESCRIPTION
 if indexes are stale, there is no way to indicate which etag from particular collection was last without breaking the IsStale mechanism in queries