### PR TITLE
Fixing an issue where SqlReplicaion would replicate the last Etag document

### DIFF
--- a/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
+++ b/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
@@ -261,10 +261,9 @@ namespace Raven.Database.Bundles.SqlReplication
 						try
 						{
 							var lastReplicatedEtag = GetLastEtagFor(localReplicationStatus, replicationConfig);
-
 							var deletedDocs = deletedDocsByConfig[replicationConfig];
 							var docsToReplicate = itemsToReplicate
-								.Where(x => lastReplicatedEtag.CompareTo(x.Etag) <= 0) // haven't replicate the etag yet
+								.Where(x => lastReplicatedEtag.CompareTo(x.Etag) < 0) // haven't replicate the etag yet
                                 .Where(document =>
                                 {
                                     var info = Database.GetRecentTouchesFor(document.Key);
@@ -280,7 +279,6 @@ namespace Raven.Database.Bundles.SqlReplication
                                     }
 	                                return true;
                                 });
-
 							if (deletedDocs.Count >= MaxNumberOfDeletionsToReplicate + 1)
 								docsToReplicate = docsToReplicate.Where(x => EtagUtil.IsGreaterThan(x.Etag, deletedDocs[deletedDocs.Count - 1].Etag) == false);
 


### PR DESCRIPTION
When you reset a Sql replication the last document in all the other replication would get replicated again