### PR TITLE
fixing an issue where Sql replication would replicate last Etag document

### DIFF
--- a/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
+++ b/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
@@ -288,7 +288,7 @@ namespace Raven.Database.Bundles.SqlReplication
 
 								var deletedDocs = deletedDocsByConfig[replicationConfig];
 								var docsToReplicate = itemsToReplicate
-									.Where(x => lastReplicatedEtag.CompareTo(x.Etag) <= 0) // haven't replicate the etag yet
+									.Where(x => lastReplicatedEtag.CompareTo(x.Etag) < 0) // haven't replicate the etag yet
 									.Where(document =>
 									{
 										var info = Database.Documents.GetRecentTouchesFor(document.Key);


### PR DESCRIPTION
When you run sql replication task the last etag document is always been replicated although it was already replicated.