### PR TITLE
RavenDB-3205 Fixing failing test - after a recent change (18afd1def0f2fd...

### DIFF
--- a/Raven.Tests.FileSystem/Auth/ClientOAuthAuthentication.cs
+++ b/Raven.Tests.FileSystem/Auth/ClientOAuthAuthentication.cs
@@ -116,8 +116,8 @@ namespace Raven.Tests.FileSystem.Auth
 
 	        var names = await adminClient.GetNamesAsync();
 
-            Assert.Equal(1, names.Length); // will not return 'testName' file system name because used apiKey doesn't have access to a such file system
-            Assert.Equal("AdminClientWorkWithOAuthEnabled", names[0]);
+            Assert.Equal(2, names.Length);
+            Assert.Contains("AdminClientWorkWithOAuthEnabled", names);
 
 			var stats = await adminClient.GetStatisticsAsync();            
 			Assert.Equal(0, stats.Length); // 0 because our fs aren't active


### PR DESCRIPTION
...b16c35b9f7f1bf82e1ed2f2b89) now it's possible to get just a name of a file system that you don't have access to while anonymus access 'All / Get / Admin' is set.
