### PR TITLE
Don't throw exception for valid response codes, specifically this throws...

### DIFF
--- a/Raven.Client.Lightweight/Document/Batches/LazyFacetsOperation.cs
+++ b/Raven.Client.Lightweight/Document/Batches/LazyFacetsOperation.cs
@@ -60,11 +60,10 @@ namespace Raven.Client.Document.Batches
 
 		public void HandleResponse(GetResponse response)
 		{
-			if (response.Status != 200 && response.Status != 304)
-			{
-				throw new InvalidOperationException("Got an unexpected response code for the request: " + response.Status + "\r\n" +
-													response.Result);
-			}
+            if (response.RequestHasErrors())
+            {
+                throw new InvalidOperationException("Got an unexpected response code for the request: " + response.Status + "\r\n" + response.Result);
+            }
 
 			var result = (RavenJObject)response.Result;
 			Result = result.JsonDeserialization<FacetResults>();


### PR DESCRIPTION
... when we get a perfectly valid response back when aggressively caching lazy facet queries