### PR TITLE
Adding fail test for multiple term query with date time inside

### DIFF
--- a/Raven.Database/Indexing/QueryBuilder.cs
+++ b/Raven.Database/Indexing/QueryBuilder.cs
@@ -28,7 +28,7 @@ namespace Raven.Database.Indexing
 		static readonly Regex untokenizedQuery = new Regex( FieldRegexVal + @"[\s\(]*(\[\[.+?\]\])|(?<=,)\s*(\[\[.+?\]\])(?=\s*[,\)])", RegexOptions.Compiled);
 		static readonly Regex searchQuery = new Regex(FieldRegexVal + @"\s*(\<\<.+?\>\>)(^[\d.]+)?", RegexOptions.Compiled | RegexOptions.Singleline);
         static readonly Regex dateQuery = new Regex(FieldRegexVal + DateTimeVal, RegexOptions.Compiled);
-        static readonly Regex inDatesQuery = new Regex(MethodRegexVal + @"\s*(\(.*" + DateTimeVal + @".*\))", RegexOptions.Compiled | RegexOptions.Singleline);
+        static readonly Regex inDatesQuery = new Regex(MethodRegexVal + @"\s*(\([^)]*" + DateTimeVal + @"[^)]*\))", RegexOptions.Compiled | RegexOptions.Singleline);
 		static readonly Regex rightOpenRangeQuery = new Regex(FieldRegexVal + @"\[(\S+)\sTO\s(\S+)\}", RegexOptions.Compiled);
 		static readonly Regex leftOpenRangeQuery = new Regex(FieldRegexVal + @"\{(\S+)\sTO\s(\S+)\]", RegexOptions.Compiled);
 		static readonly Regex commentsRegex = new Regex(@"( //[^""]+?)$", RegexOptions.Compiled | RegexOptions.Multiline);

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -417,6 +417,7 @@
     <Compile Include="SlowIndex.cs" />
     <Compile Include="RavenDB_3113.cs" />
     <Compile Include="RavenDB_3106.cs" />
+    <Compile Include="RavenDB-3225.cs" />
     <Compile Include="WaitForStaleOnAbandonedIndexShouldWork.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Raven.Tests.Issues/RavenDB-3225.cs
+++ b/Raven.Tests.Issues/RavenDB-3225.cs
@@ -1,0 +1,61 @@
+﻿using Raven.Tests.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client;
+using Raven.Client.Linq;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class TestingQuery : RavenTest
+    {
+        public class TestDataObject
+        {
+            public string A { get; set; }
+            public string B { get; set; }
+            public string C { get; set; }
+            public DateTimeOffset Created { get; set; }
+            public TimeSpan Span { get; set; }
+        }
+        [Fact]
+        public void DateTimeMultipleTermsQueryShouldWork()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new TestDataObject() { A = "X", B = "B1", C = "C1", Created = new DateTimeOffset(2000, 1, 10, 9, 30, 44, new TimeSpan()) });
+                    session.Store(new TestDataObject() { A = "X", B = "B2", C = "C2", Created = new DateTimeOffset(2001, 1, 10, 9, 30, 44, new TimeSpan()) });
+                    session.Store(new TestDataObject() { A = "X", B = "B3", C = "C3", Created = new DateTimeOffset(2002, 2, 10, 9, 30, 44, new TimeSpan()) });
+                    session.Store(new TestDataObject() { A = "Y", B = "B4", C = "C4", Created = new DateTimeOffset(2003, 3, 10, 9, 30, 44, new TimeSpan()) });
+                    session.Store(new TestDataObject() { A = "Y", B = "B5", C = "C5", Created = new DateTimeOffset(2004, 4, 10, 9, 30, 44, new TimeSpan()) });
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+
+                    var Ids = new List<string>() { "X" };
+
+
+                    RavenQueryStatistics stats;
+                    var query = session.Query<TestDataObject>().Statistics(out stats);
+
+                    query = query.Where(t => t.A.In(Ids)); //PUTTING THIS FIRST RETURNS 0 RESULTS
+                    query = query.Where(t => t.Created >= new DateTimeOffset(2001, 1, 1, 8, 1, 12, new TimeSpan()));
+                    
+                    var sueryStr = query.ToString();
+                    //WaitForUserToContinueTheTest(store);
+                    WaitForIndexing(store);
+                    var results = query.ToList();
+
+                    Assert.NotNull(results);
+                    Assert.Equal(2, results.Count);
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
(actual problem occurs when the in method is in the start and the rest of the query is at the left of it)