### PR TITLE
Review this commit... There is nothing sooo strange here but the improvement is too good to be true.

### DIFF
--- a/Raven.Database/Actions/DocumentActions.cs
+++ b/Raven.Database/Actions/DocumentActions.cs
@@ -254,13 +254,13 @@ namespace Raven.Database.Actions
 		        {
 			        cts.Token.ThrowIfCancellationRequested();
 
+                    var docsToInsert = docs.ToArray();
+                    var batch = 0;
+                    var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    var collectionsAndEtags = new Dictionary<string, Etag>(StringComparer.OrdinalIgnoreCase);
+
 			        using (Database.DocumentLock.Lock())
 			        {
-				        var docsToInsert = docs.ToArray();
-						var batch = 0;
-						var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-						var collectionsAndEtags = new Dictionary<string, Etag>(StringComparer.OrdinalIgnoreCase);
-
 				        TransactionalStorage.Batch(accessor =>
 				        {
 					        var inserts = 0;


### PR DESCRIPTION
We make sure of not deserializing the batch inside the database write lock. It has the interesting side effect of improving bulk insert performance by 25%

Before the commit:
Bulk inserted received 50.000 documents in 00:00:30.9422179, task #: 1

After the commit:
Bulk inserted received 50.000 documents in 00:00:24.0021129, task #: 1