### PR TITLE
Unique constraint empty value

### DIFF
--- a/Bundles/Raven.Bundles.UniqueConstraints/Util.cs
+++ b/Bundles/Raven.Bundles.UniqueConstraints/Util.cs
@@ -36,14 +36,14 @@ namespace Raven.Bundles.UniqueConstraints
 
         public static bool TryGetUniqueValues(RavenJToken prop, out string[] uniqueValues)
         {
-            if (prop == null || prop.Type == JTokenType.Null)
+            if (prop == null || prop.Type == JTokenType.Null || (prop.Type == JTokenType.String && string.IsNullOrEmpty(prop.Value<string>())))
             {
                 uniqueValues = null;
                 return false;
             }
 
             var array = prop as RavenJArray;
-            uniqueValues = array != null ? array.Select(p => p.Value<string>()).ToArray() : new[] { prop.Value<string>() };
+            uniqueValues = array != null ? array.Select(p => p.Value<string>()).Where(x => !string.IsNullOrEmpty(x)).ToArray() : new[] { prop.Value<string>() };
             return true;
         }
 	}

--- a/Raven.Tests.Bundles/Raven.Tests.Bundles.csproj
+++ b/Raven.Tests.Bundles/Raven.Tests.Bundles.csproj
@@ -176,6 +176,7 @@
     <Compile Include="SqlReplication\CanReplicate.cs" />
     <Compile Include="UniqueConstraints\Bugs\CaseInsensitive.cs" />
     <Compile Include="UniqueConstraints\Bugs\Concurrency.cs" />
+    <Compile Include="UniqueConstraints\Bugs\EmptyValues.cs" />
     <Compile Include="UniqueConstraints\Bugs\JimBolla.cs" />
     <Compile Include="UniqueConstraints\Bugs\Lars.cs" />
     <Compile Include="UniqueConstraints\Bugs\MultiTenancy.cs" />

--- a/Raven.Tests.Bundles/UniqueConstraints/Bugs/EmptyValues.cs
+++ b/Raven.Tests.Bundles/UniqueConstraints/Bugs/EmptyValues.cs
@@ -1,0 +1,37 @@
+﻿using Raven.Tests.Common;
+using Xunit;
+using System;
+using System.Collections.Generic;
+using Xunit.Sdk;
+
+namespace Raven.Tests.Bundles.UniqueConstraints.Bugs
+{
+    public class EmptyValues : UniqueConstraintsTest
+    {
+        [Fact]
+        public void When_Updating_Constraint_To_Empty_Value_Should_Delete_Constraint_Document()
+        {
+            var user = new User { Name = "Test", Email = "foo@bar.com", TaskIds = null };
+
+            using (var session = DocumentStore.OpenSession())
+            {
+                session.Store(user);
+                session.SaveChanges();
+            }
+
+            using (var session = DocumentStore.OpenSession())
+            {
+                var existingUser = session.Load<User>(user.Id);
+
+                existingUser.Email = ""; // Empty values are the troublesome
+                session.SaveChanges();
+            }
+
+            using (var session = DocumentStore.OpenSession())
+            {
+                var constraints = session.Advanced.LoadStartingWith<object>("UniqueConstraints/");
+                Assert.Equal(0, constraints.Length);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Improves handling of empty values on the UniqueConstraint bundle.

If someone updates on inserts and empty string value in a UniqueConstraint field should treat the same as a null field.