### PR TITLE
moved CompiledIndexCacheDirectory to TEMP

### DIFF
--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -258,7 +258,7 @@ namespace Raven.Database.Config
 
 		    EmbeddedFilesDirectory = ravenSettings.EmbeddedFilesDirectory.Value.ToFullPath();
 
-			CompiledIndexCacheDirectory = ravenSettings.CompiledIndexCacheDirectory.Value.ToFullPath();
+			CompiledIndexCacheDirectory = ravenSettings.CompiledIndexCacheDirectory.Value.ToFullTempPath();
 
 			var taskSchedulerType = ravenSettings.TaskScheduler.Value;
 			if (taskSchedulerType != null)
@@ -836,7 +836,7 @@ namespace Raven.Database.Config
 		public bool CreateAnalyzersDirectoryIfNotExisting { get; set; }
 
 		/// <summary>
-		/// Where to cache the compiled indexes
+		/// Where to cache the compiled indexes. Absolute path or relative to TEMP directory.
 		/// Default: ~\Raven\CompiledIndexCache
 		/// </summary>
 		public string CompiledIndexCacheDirectory { get; set; }

--- a/Raven.Database/Extensions/IOExtensions.cs
+++ b/Raven.Database/Extensions/IOExtensions.cs
@@ -19,21 +19,21 @@ namespace Raven.Database.Extensions
 	{
 		const int retries = 10;
 
-        public static void DeleteFile(string file)
-        {
-            try
-            {
-                File.Delete(file);
-            }
-            catch (IOException)
-            {
+		public static void DeleteFile(string file)
+		{
+			try
+			{
+				File.Delete(file);
+			}
+			catch (IOException)
+			{
 
-            }
-            catch (UnauthorizedAccessException)
-            {
-                
-            }
-        }
+			}
+			catch (UnauthorizedAccessException)
+			{
+
+			}
+		}
 
 		public static void DeleteDirectory(string directory)
 		{
@@ -106,7 +106,7 @@ namespace Raven.Database.Extensions
 					{
 						throw new IOException(WhoIsLocking.ThisFile(path));
 					}
-					catch(IOException)
+					catch (IOException)
 					{
 						var processesUsingFiles = WhoIsLocking.GetProcessesUsingFile(path);
 						var stringBuilder = new StringBuilder();
@@ -137,9 +137,20 @@ namespace Raven.Database.Extensions
 					basePath = Path.GetDirectoryName(basePath.EndsWith("\\") ? basePath.Substring(0, basePath.Length - 2) : basePath);
 
 				path = Path.Combine(basePath ?? AppDomain.CurrentDomain.BaseDirectory, path.Substring(2));
-		}
+			}
 
 			return Path.IsPathRooted(path) ? path : Path.Combine(basePath ?? AppDomain.CurrentDomain.BaseDirectory, path);
+		}
+
+		public static string ToFullTempPath(this string path)
+		{
+			if (string.IsNullOrWhiteSpace(path))
+				return string.Empty;
+			path = Environment.ExpandEnvironmentVariables(path);
+			if (path.StartsWith(@"~\") || path.StartsWith(@"~/"))
+				path = Path.Combine(Path.GetTempPath(), path.Substring(2));
+
+			return Path.IsPathRooted(path) ? path : Path.Combine(Path.GetTempPath(), path);
 		}
 
 		public static void CopyDirectory(string from, string to)
@@ -154,13 +165,13 @@ namespace Raven.Database.Extensions
 			}
 		}
 
-	    static void CopyDirectory(DirectoryInfo source, DirectoryInfo target)
-	    {
-	        CopyDirectory(source, target, new string[0]);
-	    }
+		static void CopyDirectory(DirectoryInfo source, DirectoryInfo target)
+		{
+			CopyDirectory(source, target, new string[0]);
+		}
 
-        static void CopyDirectory(DirectoryInfo source, DirectoryInfo target, string[] skip)
-        {
+		static void CopyDirectory(DirectoryInfo source, DirectoryInfo target, string[] skip)
+		{
 			if (!target.Exists)
 				Directory.CreateDirectory(target.FullName);
 
@@ -173,11 +184,11 @@ namespace Raven.Database.Extensions
 			// and recurse
 			foreach (DirectoryInfo diSourceDir in source.GetDirectories())
 			{
-                if (skip.Contains(diSourceDir.Name))
-                    continue;
+				if (skip.Contains(diSourceDir.Name))
+					continue;
 
-                DirectoryInfo nextTargetDir = target.CreateSubdirectory(diSourceDir.Name);
-                CopyDirectory(diSourceDir, nextTargetDir, skip);
+				DirectoryInfo nextTargetDir = target.CreateSubdirectory(diSourceDir.Name);
+				CopyDirectory(diSourceDir, nextTargetDir, skip);
 			}
 		}
 
@@ -185,17 +196,17 @@ namespace Raven.Database.Extensions
 		{
 			var sb = new StringBuilder();
 			foreach (byte t in input)
-			    sb.Append(t.ToString("x2"));
+				sb.Append(t.ToString("x2"));
 
-		    return sb.ToString();
-        }
+			return sb.ToString();
+		}
 
-        public static string GetMD5Hash(this Stream stream)
-        {
-            using (var md5 = Encryptor.Current.CreateHash())
-            {
-                return GetMD5Hex(md5.Compute16(stream));
-            }
-        }
+		public static string GetMD5Hash(this Stream stream)
+		{
+			using (var md5 = Encryptor.Current.CreateHash())
+			{
+				return GetMD5Hex(md5.Compute16(stream));
+			}
+		}
 	}
 }

--- a/Raven.Database/Linq/QueryParsingUtils.cs
+++ b/Raven.Database/Linq/QueryParsingUtils.cs
@@ -417,10 +417,9 @@ namespace Raven.Database.Linq
 		private static string GetIndexCacheDir(InMemoryRavenConfiguration configuration)
 		{
 			var indexCacheDir = configuration.CompiledIndexCacheDirectory;
-			if (String.IsNullOrWhiteSpace(indexCacheDir))
-			{
-				indexCacheDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Raven", "CompiledIndexCache");
-			}
+			if (string.IsNullOrWhiteSpace(indexCacheDir))
+				indexCacheDir = Path.Combine(Path.GetTempPath(), "Raven", "CompiledIndexCache");
+
 			if (configuration.RunInMemory == false)
 			{
 				// if we aren't running in memory, we might be running in a mode where we can't write to our base directory

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -138,7 +138,7 @@ namespace Raven.Tests.Core.Configuration
 			configurationComparer.Assert(expected => expected.MaxConcurrentMultiGetRequests.Value, actual => actual.MaxConcurrentMultiGetRequests);
 			configurationComparer.Assert(expected => FilePathTools.MakeSureEndsWithSlash(expected.DataDir.Value.ToFullPath(null)) + @"Indexes", actual => actual.IndexStoragePath);
 			configurationComparer.Assert(expected => expected.DefaultStorageTypeName.Value, actual => actual.DefaultStorageTypeName);
-			configurationComparer.Assert(expected => expected.CompiledIndexCacheDirectory.Value.ToFullPath(null), actual => actual.CompiledIndexCacheDirectory);
+			configurationComparer.Assert(expected => expected.CompiledIndexCacheDirectory.Value.ToFullTempPath(), actual => actual.CompiledIndexCacheDirectory);
 			configurationComparer.Assert(expected => expected.FlushIndexToDiskSizeInMb.Value, actual => actual.FlushIndexToDiskSizeInMb);
 			configurationComparer.Assert(expected => expected.TombstoneRetentionTime.Value, actual => actual.TombstoneRetentionTime);
 			configurationComparer.Assert(expected => expected.Replication.ReplicationRequestTimeoutInMilliseconds.Value, actual => actual.Replication.ReplicationRequestTimeoutInMilliseconds);


### PR DESCRIPTION
_All_ databases from _all_ servers will point to the same directory e.g.
C:\Users\USER_NAME\AppData\Local\Temp\Raven\CompiledIndexCache

Relative paths are still supported but TempDir is a base directory for them, absolute paths works also.