### PR TITLE
RavenDB-3136 Query AggregateByInteger and Count fails

### DIFF
--- a/Raven.Client.Lightweight/Linq/DynamicAggregationQuery.cs
+++ b/Raven.Client.Lightweight/Linq/DynamicAggregationQuery.cs
@@ -166,7 +166,10 @@ namespace Raven.Client.Linq
 	            FacetResult value;
 	            if (facetResults.Results.TryGetValue(rename.Value, out value) &&
 	                facetResults.Results.ContainsKey(rename.Key) == false)
-	                facetResults.Results[rename.Key] = value;
+	            {
+                        facetResults.Results[rename.Key] = value;
+	                facetResults.Results.Remove(rename.Value);
+	            }
 	        }
 	        return facetResults;
 	    }

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -117,6 +117,7 @@
     <Compile Include="BulkInsertDatabaseUrl.cs" />
     <Compile Include="BulkInsertTests.cs" />
     <Compile Include="RaqvenDB_3222.cs" />
+    <Compile Include="RavenDB-3136.cs" />
     <Compile Include="RavenDB-3150.cs" />
     <Compile Include="RavenDB3075.cs" />
     <Compile Include="RavenDB_2627.cs" />

--- a/Raven.Tests.Issues/RavenDB-3136.cs
+++ b/Raven.Tests.Issues/RavenDB-3136.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Abstractions.Indexing;
+using Raven.Client;
+using Raven.Client.Indexes;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_3136 : RavenTestBase
+    {
+        [Fact]
+        public void AggregateByIntegerShouldReturnResultWithValuesAndCountEvenWithLambdaExpression()
+        {
+            using (var store = NewDocumentStore())
+            {
+                new SampleData_Index().Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new SampleData {IntegerAge = 2, StringAge = "2"});
+                    session.Store(new SampleData {IntegerAge = 2, StringAge = "2"});
+                    session.Store(new SampleData {IntegerAge = 3, StringAge = "3"});
+                    session.SaveChanges();
+                }
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    var resultInteger =
+                        session.Query<SampleData, SampleData_Index>()
+                            .AggregateBy(x => x.IntegerAge)
+                            .CountOn(x => x.IntegerAge)
+                            .ToList();
+
+                    Assert.Equal(resultInteger.Results.Count, 1);
+                    Assert.Equal(resultInteger.Results.First().Value.Values.Count(), 2);
+                    Assert.Equal(resultInteger.Results.First().Value.Values.First().Range, "2");
+                }
+            }
+        }
+
+        [Fact]
+        public void AggregateByIntegerShouldReturnResultWithValuesAndCount()
+        {
+            using (var store = NewDocumentStore())
+            {
+                new SampleData_Index().Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new SampleData {IntegerAge = 2, StringAge = "2"});
+                    session.Store(new SampleData {IntegerAge = 2, StringAge = "2"});
+                    session.Store(new SampleData {IntegerAge = 3, StringAge = "3"});
+                    session.SaveChanges();
+                }
+                WaitForIndexing(store);
+                using (var session = store.OpenSession())
+                {
+                    var resultInteger =
+                        session.Query<SampleData, SampleData_Index>()
+                            .AggregateBy("IntegerAge")
+                            .CountOn(x => x.IntegerAge)
+                            .ToList();
+
+                    Assert.Equal(resultInteger.Results.Count, 1);
+                    Assert.Equal(resultInteger.Results.First().Value.Values.Count(), 2);
+                    Assert.Equal(resultInteger.Results.First().Value.Values.First().Range, "2");
+                }
+            }
+        }
+
+        [Fact]
+        public void AggregateByStringShouldReturnResultWithValuesAndCount()
+        {
+            using (var store = NewDocumentStore())
+            {
+                new SampleData_Index().Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new SampleData {IntegerAge = 2, StringAge = "2"});
+                    session.Store(new SampleData {IntegerAge = 2, StringAge = "2"});
+                    session.Store(new SampleData {IntegerAge = 3, StringAge = "3"});
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var resultString =
+                        session.Query<SampleData, SampleData_Index>()
+                            .AggregateBy(x => x.StringAge)
+                            .CountOn(x => x.StringAge)
+                            .ToList();
+
+                    Assert.Equal(resultString.Results.Count, 1);
+                    Assert.Equal(resultString.Results.First().Value.Values.Count(), 2);
+                    Assert.Equal(resultString.Results.First().Value.Values.First().Range, "2");
+                }
+            }
+        }
+    }
+
+    public class SampleData
+    {
+        public string StringAge { get; set; }
+        public int IntegerAge { get; set; }
+    }
+
+    public class SampleData_Index : AbstractIndexCreationTask<SampleData>
+    {
+        public SampleData_Index()
+        {
+            Map = docs => from doc in docs select new {doc.StringAge, doc.IntegerAge};
+            Sort(x => x.IntegerAge, SortOptions.Int);
+            this.TermVector(x => x.IntegerAge, FieldTermVector.Yes);
+            this.TermVector(x => x.StringAge, FieldTermVector.Yes);
+        }
+    }
+}
+
+


### PR DESCRIPTION
after the renaming the key HandleRenames was adding to facetResults the same value under the key before the rename to (Key_Range)
now we keep the previous key before the change and remove the renamed key so we wont have multiple values.
In case of using aggregate with string the renaming isn't required and therefor it works fine.
