### PR TITLE
Setting how fields are fetched from the document in projections

### DIFF
--- a/Raven.Abstractions/Exceptions/ImplicitFetchFieldsFromDocumentNotAllowedException.cs
+++ b/Raven.Abstractions/Exceptions/ImplicitFetchFieldsFromDocumentNotAllowedException.cs
@@ -1,0 +1,49 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ImplicitFetchFieldsFromDocumentNotAllowedException.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Runtime.Serialization;
+
+namespace Raven.Abstractions.Exceptions
+{
+    [Serializable]
+    public class ImplicitFetchFieldsFromDocumentNotAllowedException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImplicitFetchFieldsFromDocumentNotAllowedException"/> class.
+        /// </summary>
+        public ImplicitFetchFieldsFromDocumentNotAllowedException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImplicitFetchFieldsFromDocumentNotAllowedException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public ImplicitFetchFieldsFromDocumentNotAllowedException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImplicitFetchFieldsFromDocumentNotAllowedException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner.</param>
+        public ImplicitFetchFieldsFromDocumentNotAllowedException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImplicitFetchFieldsFromDocumentNotAllowedException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected ImplicitFetchFieldsFromDocumentNotAllowedException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Exceptions\BadRequestException.cs" />
     <Compile Include="Exceptions\ClientNotSupportedException.cs" />
     <Compile Include="Exceptions\DocumentDoesNotExistsException.cs" />
+    <Compile Include="Exceptions\ImplicitFetchFieldsFromDocumentNotAllowedException.cs" />
     <Compile Include="Exceptions\InvalidSpatialShapeException.cs" />
     <Compile Include="Exceptions\SmugglerException.cs" />
     <Compile Include="Exceptions\SmugglerExportException.cs" />

--- a/Raven.Database/Actions/DocumentActions.cs
+++ b/Raven.Database/Actions/DocumentActions.cs
@@ -134,7 +134,7 @@ namespace Raven.Database.Actions
                     {
                         docCount = 0;
 						var docs = actions.Documents.GetDocumentsWithIdStartingWith(idPrefix, actualStart, pageSize, string.IsNullOrEmpty(skipAfter) ? null : skipAfter);
-                        var documentRetriever = new DocumentRetriever(actions, Database.ReadTriggers, Database.InFlightTransactionalState, transformerParameters);
+                        var documentRetriever = new DocumentRetriever(Database.Configuration, actions, Database.ReadTriggers, Database.InFlightTransactionalState, transformerParameters);
 
                         foreach (var doc in docs)
                         {
@@ -421,7 +421,7 @@ namespace Raven.Database.Actions
                     var documents = etag == null
                                         ? actions.Documents.GetDocumentsByReverseUpdateOrder(start, pageSize)
 										: actions.Documents.GetDocumentsAfter(etag, pageSize, token);
-                    var documentRetriever = new DocumentRetriever(actions, Database.ReadTriggers, Database.InFlightTransactionalState);
+                    var documentRetriever = new DocumentRetriever(Database.Configuration, actions, Database.ReadTriggers, Database.InFlightTransactionalState);
                     int docCount = 0;
                     foreach (var doc in documents)
                     {
@@ -471,7 +471,7 @@ namespace Raven.Database.Actions
 
             JsonDocument.EnsureIdInMetadata(document);
 
-            return new DocumentRetriever(null, Database.ReadTriggers, Database.InFlightTransactionalState)
+            return new DocumentRetriever(null, null, Database.ReadTriggers, Database.InFlightTransactionalState)
                 .ExecuteReadTriggers(document, transactionInformation, ReadOperation.Load);
         }
 
@@ -494,7 +494,7 @@ namespace Raven.Database.Actions
             }
 
             JsonDocument.EnsureIdInMetadata(document);
-            return new DocumentRetriever(null, Database.ReadTriggers, Database.InFlightTransactionalState)
+            return new DocumentRetriever(null, null, Database.ReadTriggers, Database.InFlightTransactionalState)
                 .ProcessReadVetoes(document, transactionInformation, ReadOperation.Load);
         }
 
@@ -520,7 +520,7 @@ namespace Raven.Database.Actions
             TransactionalStorage.Batch(
             actions =>
             {
-                docRetriever = new DocumentRetriever(actions, Database.ReadTriggers, Database.InFlightTransactionalState, transformerParameters);
+                docRetriever = new DocumentRetriever(Database.Configuration, actions, Database.ReadTriggers, Database.InFlightTransactionalState, transformerParameters);
                 using (new CurrentTransformationScope(Database, docRetriever))
                 {
                     var document = Get(key, transactionInformation);

--- a/Raven.Database/Actions/QueryActions.cs
+++ b/Raven.Database/Actions/QueryActions.cs
@@ -227,7 +227,7 @@ namespace Raven.Database.Actions
 				{
 					throw new IndexDisabledException(indexFailureInformation);
 				}
-				docRetriever = new DocumentRetriever(actions, database.ReadTriggers, database.InFlightTransactionalState, query.TransformerParameters, idsToLoad);
+				docRetriever = new DocumentRetriever(database.Configuration, actions, database.ReadTriggers, database.InFlightTransactionalState, query.TransformerParameters, idsToLoad);
 				var fieldsToFetch = new FieldsToFetch(query,
 					viewGenerator.ReduceDefinition == null
 						? Constants.DocumentIdFieldName

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -299,7 +299,7 @@ namespace Raven.Database.Config
 
 			TombstoneRetentionTime = ravenSettings.TombstoneRetentionTime.Value;
 
-		    ImplicitFieldsToFetchFromDocumentMode = ravenSettings.ImplicitFieldsToFetchFromDocumentMode.Value;
+		    ImplicitFetchFieldsFromDocumentMode = ravenSettings.ImplicitFetchFieldsFromDocumentMode.Value;
 
 			IgnoreSslCertificateErros = GetIgnoreSslCertificateErrorModeMode();
 
@@ -1004,7 +1004,7 @@ namespace Raven.Database.Config
         ///     DoNothing (fields are not fetched from the document)
         ///     Exception (an exception is thrown if we need to fetch fields from the document itself)
         /// </summary>
-        public string ImplicitFieldsToFetchFromDocumentMode { get; set; }
+        public string ImplicitFetchFieldsFromDocumentMode { get; set; }
 
 	    [Browsable(false)]
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -299,6 +299,8 @@ namespace Raven.Database.Config
 
 			TombstoneRetentionTime = ravenSettings.TombstoneRetentionTime.Value;
 
+		    ImplicitFieldsToFetchFromDocumentMode = ravenSettings.ImplicitFieldsToFetchFromDocumentMode.Value;
+
 			IgnoreSslCertificateErros = GetIgnoreSslCertificateErrorModeMode();
 
 			PostInit();
@@ -994,6 +996,15 @@ namespace Raven.Database.Config
 		/// How long can we keep the new index in memory before we have to flush it
 		/// </summary>
 		public TimeSpan NewIndexInMemoryMaxTime { get; set; }
+
+        /// <summary>
+        /// How FieldsToFetch are extracted from the document.
+        /// Default: Enabled. 
+        /// Other values are: 
+        ///     DoNothing (fields are not fetched from the document)
+        ///     Exception (an exception is thrown if we need to fetch fields from the document itself)
+        /// </summary>
+        public string ImplicitFieldsToFetchFromDocumentMode { get; set; }
 
 	    [Browsable(false)]
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -234,6 +234,8 @@ namespace Raven.Database.Config
 			FlushIndexToDiskSizeInMb = new IntegerSetting(settings["Raven/Indexing/FlushIndexToDiskSizeInMb"], 5);
 
 			TombstoneRetentionTime = new TimeSpanSetting(settings["Raven/TombstoneRetentionTime"], TimeSpan.FromDays(14), TimeSpanArgumentType.FromParse);
+
+            ImplicitFieldsToFetchFromDocumentMode = new StringSetting(settings["Raven/ImplicitFieldsToFetchFromDocumentMode"], "Enabled");
 		    
             if (settings["Raven/MaxServicePointIdleTime"] != null) 
                 ServicePointManager.MaxServicePointIdleTime = Convert.ToInt32(settings["Raven/MaxServicePointIdleTime"]);
@@ -394,6 +396,8 @@ namespace Raven.Database.Config
 		public IntegerSetting FlushIndexToDiskSizeInMb { get; set; }
 
 		public TimeSpanSetting TombstoneRetentionTime { get; private set; }
+
+        public StringSetting ImplicitFieldsToFetchFromDocumentMode { get; private set; }
 
 		public class VoronConfiguration
 		{

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -235,7 +235,7 @@ namespace Raven.Database.Config
 
 			TombstoneRetentionTime = new TimeSpanSetting(settings["Raven/TombstoneRetentionTime"], TimeSpan.FromDays(14), TimeSpanArgumentType.FromParse);
 
-            ImplicitFieldsToFetchFromDocumentMode = new StringSetting(settings["Raven/ImplicitFieldsToFetchFromDocumentMode"], "Enabled");
+            ImplicitFetchFieldsFromDocumentMode = new StringSetting(settings["Raven/ImplicitFetchFieldsFromDocumentMode"], "Enabled");
 		    
             if (settings["Raven/MaxServicePointIdleTime"] != null) 
                 ServicePointManager.MaxServicePointIdleTime = Convert.ToInt32(settings["Raven/MaxServicePointIdleTime"]);
@@ -397,7 +397,7 @@ namespace Raven.Database.Config
 
 		public TimeSpanSetting TombstoneRetentionTime { get; private set; }
 
-        public StringSetting ImplicitFieldsToFetchFromDocumentMode { get; private set; }
+        public StringSetting ImplicitFetchFieldsFromDocumentMode { get; private set; }
 
 		public class VoronConfiguration
 		{

--- a/Raven.Database/Impl/DocumentRetriever.cs
+++ b/Raven.Database/Impl/DocumentRetriever.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Raven.Abstractions.Logging;
+using Raven.Database.Config;
 using Raven.Database.Impl.DTC;
 using Raven.Imports.Newtonsoft.Json.Linq;
 using Raven.Abstractions.Data;
@@ -31,6 +32,7 @@ namespace Raven.Database.Impl
 		private readonly IDictionary<string, JsonDocument> cache = new Dictionary<string, JsonDocument>(StringComparer.OrdinalIgnoreCase);
 		private readonly HashSet<string> loadedIdsForRetrieval = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		private readonly HashSet<string> loadedIdsForFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+	    private readonly InMemoryRavenConfiguration configuration;
 		private readonly IStorageActionsAccessor actions;
 		private readonly OrderedPartCollection<AbstractReadTrigger> triggers;
 		private readonly InFlightTransactionalState inFlightTransactionalState;
@@ -40,11 +42,12 @@ namespace Raven.Database.Impl
 
 	    public Etag Etag = Etag.Empty;
 
-		public DocumentRetriever(IStorageActionsAccessor actions, OrderedPartCollection<AbstractReadTrigger> triggers, 
+	    public DocumentRetriever(InMemoryRavenConfiguration configuration, IStorageActionsAccessor actions, OrderedPartCollection<AbstractReadTrigger> triggers, 
 			InFlightTransactionalState inFlightTransactionalState,
             Dictionary<string, RavenJToken> transformerParameters = null,
             HashSet<string> itemsToInclude = null)
 		{
+		    this.configuration = configuration;
 			this.actions = actions;
 			this.triggers = triggers;
 			this.inFlightTransactionalState = inFlightTransactionalState;

--- a/Raven.Database/Indexing/IndexingExecuter.cs
+++ b/Raven.Database/Indexing/IndexingExecuter.cs
@@ -431,7 +431,7 @@ namespace Raven.Database.Indexing
 			var lastEtag = last.Etag;
 			var lastModified = last.LastModified.Value;
 
-			var documentRetriever = new DocumentRetriever(null, context.ReadTriggers, context.Database.InFlightTransactionalState);
+			var documentRetriever = new DocumentRetriever(null, null, context.ReadTriggers, context.Database.InFlightTransactionalState);
 
 			var filteredDocs =
 				BackgroundTaskExecuter.Instance.Apply(context, jsonDocs, doc =>

--- a/Raven.Database/Queries/MoreLikeThisQueryRunner.cs
+++ b/Raven.Database/Queries/MoreLikeThisQueryRunner.cs
@@ -138,7 +138,7 @@ namespace Raven.Database.Queries
 
 					database.TransactionalStorage.Batch(actions =>
 					{
-						documentRetriever = new DocumentRetriever(actions, database.ReadTriggers, database.InFlightTransactionalState, query.TransformerParameters, idsToLoad);
+						documentRetriever = new DocumentRetriever(database.Configuration, actions, database.ReadTriggers, database.InFlightTransactionalState, query.TransformerParameters, idsToLoad);
 
 						using (new CurrentTransformationScope(database, documentRetriever))
 						{

--- a/Raven.Database/Server/WebApi/Filters/RavenExceptionFilterAttribute.cs
+++ b/Raven.Database/Server/WebApi/Filters/RavenExceptionFilterAttribute.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Web.Http.Filters;
+using System.Web.Http.Results;
 using Jint.Runtime;
 
 using Raven.Abstractions.Connection;
@@ -23,6 +24,7 @@ namespace Raven.Database.Server.WebApi.Filters
 				{typeof (JavaScriptException), (ctx, e) => HandleJintException(ctx, e as JavaScriptException)},
 				{typeof (IndexDisabledException), (ctx, e) => HandleIndexDisabledException(ctx, e as IndexDisabledException)},
 				{typeof (IndexDoesNotExistsException), (ctx, e) => HandleIndexDoesNotExistsException(ctx, e as IndexDoesNotExistsException)},
+                {typeof (ImplicitFetchFieldsFromDocumentNotAllowedException), (ctx, e) => HandleImplicitFetchFieldsFromDocumentNotAllowedException(ctx, e as ImplicitFetchFieldsFromDocumentNotAllowedException)}
 			};
 
 		public override void OnException(HttpActionExecutedContext ctx)
@@ -152,5 +154,19 @@ namespace Raven.Database.Server.WebApi.Filters
 				Error = e.Information == null ? e.ToString() : e.Information.GetErrorMessage(),
 			});
 		}
+
+	    private static void HandleImplicitFetchFieldsFromDocumentNotAllowedException(HttpActionExecutedContext ctx, ImplicitFetchFieldsFromDocumentNotAllowedException e)
+	    {
+	        ctx.Response = new HttpResponseMessage
+	        {
+	            StatusCode = HttpStatusCode.InternalServerError
+	        };
+
+            SerializeError(ctx, new
+            {
+                Url = ctx.Request.RequestUri.PathAndQuery,
+                Error = e.Message
+            });
+	    }
 	}
 }

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -146,7 +146,7 @@ namespace Raven.Tests.Core.Configuration
 			configurationComparer.Assert(expected => expected.IndexAndTransformerReplicationLatencyInSec.Value, actual => actual.IndexAndTransformerReplicationLatencyInSec);
 			configurationComparer.Assert(expected => expected.MaxConcurrentRequestsForDatabaseDuringLoad.Value, actual => actual.MaxConcurrentRequestsForDatabaseDuringLoad);
 			configurationComparer.Assert(expected => expected.Replication.MaxNumberOfItemsToReceiveInSingleBatch.Value, actual => actual.Replication.MaxNumberOfItemsToReceiveInSingleBatch);
-            configurationComparer.Assert(expected => expected.ImplicitFieldsToFetchFromDocumentMode.Value, actual => actual.ImplicitFieldsToFetchFromDocumentMode);
+            configurationComparer.Assert(expected => expected.ImplicitFetchFieldsFromDocumentMode.Value, actual => actual.ImplicitFetchFieldsFromDocumentMode);
 			configurationComparer.Ignore(x => x.Storage.Esent.JournalsStoragePath);
 			configurationComparer.Ignore(x => x.Storage.Voron.JournalsStoragePath);
 

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -146,6 +146,7 @@ namespace Raven.Tests.Core.Configuration
 			configurationComparer.Assert(expected => expected.IndexAndTransformerReplicationLatencyInSec.Value, actual => actual.IndexAndTransformerReplicationLatencyInSec);
 			configurationComparer.Assert(expected => expected.MaxConcurrentRequestsForDatabaseDuringLoad.Value, actual => actual.MaxConcurrentRequestsForDatabaseDuringLoad);
 			configurationComparer.Assert(expected => expected.Replication.MaxNumberOfItemsToReceiveInSingleBatch.Value, actual => actual.Replication.MaxNumberOfItemsToReceiveInSingleBatch);
+            configurationComparer.Assert(expected => expected.ImplicitFieldsToFetchFromDocumentMode.Value, actual => actual.ImplicitFieldsToFetchFromDocumentMode);
 			configurationComparer.Ignore(x => x.Storage.Esent.JournalsStoragePath);
 			configurationComparer.Ignore(x => x.Storage.Voron.JournalsStoragePath);
 


### PR DESCRIPTION
I created the setting discussed in [this](Raven/ImplicitFetchFieldsFromDocumentMode) google groups thread.

The setting is named *Raven/ImplicitFetchFieldsFromDocumentMode* and configures how RavenDB will handle requested fields that should be fetched, if they are not stored in the index.

Possible values are:
- *Enabled* This is the default value. Fields are fetched from the document. (Exactly how RavenDB works until now)
- *DoNothing* No fields are fetched from the document.
- *Exception* An exception is thrown with a detailed error message.