### PR TITLE
Fixed a bug in search that removed a the space between terms when AllowP...

### DIFF
--- a/Raven.Client.Lightweight/Document/AbstractDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AbstractDocumentQuery.cs
@@ -1922,7 +1922,7 @@ If you really want to do in memory filtering on the data returned from the query
 			return indexQuery;
 		}
 
-		private static readonly Regex espacePostfixWildcard = new Regex(@"\\\*(\s|$)",
+		private static readonly Regex escapePostfixWildcard = new Regex(@"\\\*(\s|$)",
 			RegexOptions.Compiled
 			);
 		protected QueryOperator defaultOperator;
@@ -1945,7 +1945,7 @@ If you really want to do in memory filtering on the data returned from the query
 					break;
 				case EscapeQueryOptions.AllowPostfixWildcard:
 					searchTerms = RavenQuery.Escape(searchTerms, false, false);
-					searchTerms = espacePostfixWildcard.Replace(searchTerms, "*");
+                    searchTerms = escapePostfixWildcard.Replace(searchTerms, "*${1}");
 					break;
 				case EscapeQueryOptions.AllowAllWildcards:
 					searchTerms = RavenQuery.Escape(searchTerms, false, false);


### PR DESCRIPTION
...ostfixWildcard was set

Changed the escapePostFixWildcard replace statement so it would not
remove spaces between search terms. Also fixed a type in the name of the
regex.