### PR TITLE
Changed  implementation of SetupRequestToProperDatabase

### DIFF
--- a/Raven.Database/Counters/Controllers/RavenCountersApiController.cs
+++ b/Raven.Database/Counters/Controllers/RavenCountersApiController.cs
@@ -192,7 +192,7 @@ namespace Raven.Database.Counters.Controllers
 	        get { throw new NotImplementedException(); }
 	    }
 
-	    public override bool SetupRequestToProperDatabase(RequestManager rm)
+	    public override async Task<bool> SetupRequestToProperDatabase(RequestManager rm)
 		{
 			var tenantId = CountersName;
 
@@ -217,7 +217,7 @@ namespace Raven.Database.Counters.Controllers
 			{
 				try
 				{
-					if (resourceStoreTask.Wait(TimeSpan.FromSeconds(30)) == false)
+                    if (await Task.WhenAny(resourceStoreTask, Task.Delay(TimeSpan.FromSeconds(30))) != resourceStoreTask)
 					{
 						var msg = "The counter " + tenantId +
 								  " is currently being loaded, but after 30 seconds, this request has been aborted. Please try again later, file system loading continues.";

--- a/Raven.Database/FileSystem/Controllers/RavenFsApiController.cs
+++ b/Raven.Database/FileSystem/Controllers/RavenFsApiController.cs
@@ -313,8 +313,7 @@ namespace Raven.Database.FileSystem.Controllers
 	    {
 	        get { return FileSystem.Configuration; }
 	    }
-
-	    public override bool SetupRequestToProperDatabase(RequestManager rm)
+        public override async Task<bool> SetupRequestToProperDatabase(RequestManager rm)
         {
             if (!RavenFileSystem.IsRemoteDifferentialCompressionInstalled)
                 throw new HttpException(503, "File Systems functionality is not supported. Remote Differential Compression is not installed.");
@@ -345,7 +344,7 @@ namespace Raven.Database.FileSystem.Controllers
             {
                 try
                 {
-                    if (resourceStoreTask.Wait(TimeSpan.FromSeconds(30)) == false)
+                    if (await Task.WhenAny(resourceStoreTask, Task.Delay(TimeSpan.FromSeconds(30))) != resourceStoreTask)
                     {
                         var msg = "The filesystem " + tenantId +
                                   " is currently being loaded, but after 30 seconds, this request has been aborted. Please try again later, file system loading continues.";

--- a/Raven.Database/Server/Controllers/RavenBaseApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenBaseApiController.cs
@@ -705,7 +705,7 @@ namespace Raven.Database.Server.Controllers
             AddHeader("Temp-Request-Time", sp.ElapsedMilliseconds.ToString("#,#;;0", CultureInfo.InvariantCulture), msg);
         }
 
-	    public abstract bool SetupRequestToProperDatabase(RequestManager requestManager);
+	    public abstract Task<bool> SetupRequestToProperDatabase(RequestManager requestManager);
 
         public abstract string TenantName { get; }
 

--- a/Raven.Database/Server/Controllers/RavenDbApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenDbApiController.cs
@@ -545,7 +545,7 @@ namespace Raven.Database.Server.Controllers
 		}
 
 
-        public override bool SetupRequestToProperDatabase(RequestManager rm)
+        public override async Task<bool> SetupRequestToProperDatabase(RequestManager rm)
         {
             var tenantId = this.DatabaseName;
             var landlord = this.DatabasesLandlord;
@@ -596,7 +596,7 @@ namespace Raven.Database.Server.Controllers
 
 						try
 						{
-							if (resourceStoreTask.Wait(TimeSpan.FromSeconds(TimeToWaitForDatabaseToLoad)) == false)
+                            if (await Task.WhenAny(resourceStoreTask, Task.Delay(TimeSpan.FromSeconds(TimeToWaitForDatabaseToLoad))) != resourceStoreTask)
 							{
 								var msg = string.Format("The database {0} is currently being loaded, but after {1} seconds, this request has been aborted. Please try again later, database loading continues.", tenantId, TimeToWaitForDatabaseToLoad);
 								Logger.Warn(msg);

--- a/Raven.Database/Server/WebApi/RequestManager.cs
+++ b/Raven.Database/Server/WebApi/RequestManager.cs
@@ -155,8 +155,8 @@ namespace Raven.Database.Server.WebApi
 			try
 			{
 				Interlocked.Increment(ref concurrentRequests);
-
-				if (controller.SetupRequestToProperDatabase(this))
+			    var requestSuccess = await controller.SetupRequestToProperDatabase(this);
+                if (requestSuccess)
 				{
 					if (controller.ResourceConfiguration.RejectClientsMode && controllerContext.Request.Headers.Contains(Constants.RavenClientVersion))
 					{


### PR DESCRIPTION
The changes were made so that the diffrent implementation of the method won't hold a thread while waiting for the DB to come up/ respond.
for more details see :http://issues.hibernatingrhinos.com/issue/RavenDB-3195