### PR TITLE
RavenDB-3301 Any changes to JsonRequestFactory before calling Initialize() should be maintained after it.

### DIFF
--- a/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequestFactory.cs
+++ b/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequestFactory.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Specialized;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using Raven.Abstractions;
 using Raven.Abstractions.Connection;
@@ -41,7 +42,7 @@ namespace Raven.Client.Connection
 				handler(sender, generateRequestResult());
 		}
 
-		private readonly int maxNumberOfCachedRequests;
+		private int maxNumberOfCachedRequests;
 
 		internal readonly HttpClientCache httpClientCache;
 
@@ -83,7 +84,7 @@ namespace Raven.Client.Connection
 		}
 
 		internal CachedRequestOp ConfigureCaching(string url, Action<string, string> setHeader)
-		{
+		 {
 			var cachedRequest = cache.Get(url);
 			if (cachedRequest == null)
 				return new CachedRequestOp { SkipServerCheck = false };
@@ -109,11 +110,19 @@ namespace Raven.Client.Connection
 		/// Reset the number of cached requests and clear the entire cache
 		/// Mostly used for testing
 		/// </summary>
-		public void ResetCache()
+		public void ResetCache(int? newMaxNumberOfCachedRequests = null)
 		{
+
+		    if (newMaxNumberOfCachedRequests != null && newMaxNumberOfCachedRequests.Value == maxNumberOfCachedRequests)
+		        return;
+
 			if (cache != null)
 				cache.Dispose();
 
+		    if (newMaxNumberOfCachedRequests != null)
+		    {
+		        maxNumberOfCachedRequests = newMaxNumberOfCachedRequests.Value;
+            }
 			cache = new SimpleCache(maxNumberOfCachedRequests);
 			NumOfCachedRequests = 0;
 		}
@@ -198,6 +207,7 @@ namespace Raven.Client.Connection
 		/// <summary>
 		/// Advanced: Don't set this unless you know what you are doing!
 		/// 
+		/// 
 		/// Enable using basic authentication using http
 		/// By default, RavenDB only allows basic authentication over HTTPS, setting this property to true
 		/// will instruct RavenDB to make unsecured calls (usually only good for testing / internal networks).
@@ -259,7 +269,7 @@ namespace Raven.Client.Connection
 
 		internal void IncrementCachedRequests()
 		{
-			Interlocked.Increment(ref NumOfCachedRequests);
+			 Interlocked.Increment(ref NumOfCachedRequests);
 		}
 
 		internal void CacheResponse(string url, RavenJToken data, NameValueCollection headers)

--- a/Raven.Client.Lightweight/Document/DocumentStore.cs
+++ b/Raven.Client.Lightweight/Document/DocumentStore.cs
@@ -368,9 +368,9 @@ namespace Raven.Client.Document
 
 			AssertValidConfiguration();
 
-			jsonRequestFactory = InitializeJsonRequestFactory();
+		    jsonRequestFactory = new HttpJsonRequestFactory(MaxNumberOfCachedRequests, HttpMessageHandler, Conventions.AcceptGzipContent);
 
-			try
+		    try
 			{
 				InitializeSecurity();
 
@@ -410,12 +410,7 @@ namespace Raven.Client.Document
 			return this;
 		}
 
-		private HttpJsonRequestFactory InitializeJsonRequestFactory()
-		{
-			return new HttpJsonRequestFactory(MaxNumberOfCachedRequests, HttpMessageHandler, Conventions.AcceptGzipContent);
-		}
-
-		public override void InitializeProfiling()
+	    public override void InitializeProfiling()
 		{
 			if (jsonRequestFactory == null)
 				throw new InvalidOperationException("Cannot call InitializeProfiling() before Initialize() was called.");
@@ -815,17 +810,16 @@ namespace Raven.Client.Document
 		/// <summary>
 		/// Max number of cached requests (default: 2048)
 		/// </summary>
-		public int MaxNumberOfCachedRequests
+		public new int MaxNumberOfCachedRequests
 		{
 			get { return maxNumberOfCachedRequests; }
 			set
 			{
 				maxNumberOfCachedRequests = value;
-				if (jsonRequestFactory != null)
-					jsonRequestFactory.Dispose();
-				jsonRequestFactory = InitializeJsonRequestFactory();
+                jsonRequestFactory.ResetCache(maxNumberOfCachedRequests);
 			}
 		}
+
 		public HttpMessageHandler HttpMessageHandler { get; set; }
 
 		public override BulkInsertOperation BulkInsert(string database = null, BulkInsertOptions options = null)

--- a/Raven.Client.Lightweight/DocumentStoreBase.cs
+++ b/Raven.Client.Lightweight/DocumentStoreBase.cs
@@ -321,7 +321,13 @@ namespace Raven.Client
 			return profilingContext.TryGet(id);
 		}
 
-		/// <summary>
+	    public int MaxNumberOfCachedRequests
+	    {
+	        get { throw new NotImplementedException(); }
+	        set { throw new NotImplementedException(); }
+	    }
+
+	    /// <summary>
 		/// Setup the context for aggressive caching.
 		/// </summary>
 		public IDisposable AggressivelyCache()

--- a/Raven.Client.Lightweight/IDocumentStore.cs
+++ b/Raven.Client.Lightweight/IDocumentStore.cs
@@ -5,16 +5,14 @@
 //-----------------------------------------------------------------------
 using System;
 using System.Collections.Specialized;
-using System.Threading;
 using System.Threading.Tasks;
-
 using Raven.Abstractions.Data;
 using Raven.Client.Changes;
 using Raven.Client.Connection;
+using Raven.Client.Connection.Async;
 using Raven.Client.Connection.Profiling;
 using Raven.Client.Document;
 using Raven.Client.Indexes;
-using Raven.Client.Connection.Async;
 
 namespace Raven.Client
 {
@@ -199,5 +197,7 @@ namespace Raven.Client
 		void InitializeProfiling();
 
 		ProfilingInformation GetProfilingInformationFor(Guid id);
+
+        int MaxNumberOfCachedRequests { get; set; }
 	}
 }

--- a/Raven.Database/Client/EmbeddableDocumentStore.cs
+++ b/Raven.Database/Client/EmbeddableDocumentStore.cs
@@ -415,5 +415,11 @@ namespace Raven.Client.Embedded
 	    {
 		    return _inner.GetProfilingInformationFor(id);
 	    }
+
+        public int MaxNumberOfCachedRequests
+        {
+            get { return _inner.MaxNumberOfCachedRequests; }
+            set { _inner.MaxNumberOfCachedRequests = value; }
+        }
     }
 }

--- a/Raven.Database/Client/EmbeddedDocumentStore.cs
+++ b/Raven.Database/Client/EmbeddedDocumentStore.cs
@@ -457,5 +457,13 @@ namespace Raven.Database.Client
 	    {
 		    return server.DocumentStore.GetProfilingInformationFor(id);
 	    }
+
+        public DocumentStore DocumentStore { get { return server.DocumentStore; } }
+
+        public int MaxNumberOfCachedRequests
+        {
+            get { return DocumentStore.MaxNumberOfCachedRequests; }
+            set { DocumentStore.MaxNumberOfCachedRequests = value; }
+        }
     }
 }

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -121,6 +121,7 @@
     <Compile Include="RavenDB-3150.cs" />
     <Compile Include="RavenDB-3277.cs" />
     <Compile Include="RavenDB-3300.cs" />
+    <Compile Include="RavenDB-3301.cs" />
     <Compile Include="RavenDB3075.cs" />
     <Compile Include="RavenDB_2627.cs" />
     <Compile Include="RavenDB_2867.cs" />

--- a/Raven.Tests.Issues/RavenDB-3301.cs
+++ b/Raven.Tests.Issues/RavenDB-3301.cs
@@ -1,0 +1,71 @@
+﻿using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_3301 : RavenTestBase
+    {
+        private class Item
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+        [Fact]
+
+        public void MaintainChangesToJsonRequestFactory()
+        {
+            using (var store = NewRemoteDocumentStore(true))
+            {
+                using (var session = store.OpenSession())
+                {
+
+                    for (int i = 0; i < 20; i++)
+                    {
+                        session.Store(new Item {Name = "item"});
+                    }
+                    session.SaveChanges();
+
+                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                    Assert.Equal(2, store.JsonRequestFactory.CurrentCacheSize);
+                }
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.MaxNumberOfRequestsPerSession = 3000;
+                    for (int i = 1; i < 20; i++)
+                    {
+                        session.Load<Item>(i);
+                    }
+                    Assert.Equal(19, session.Advanced.NumberOfRequests);
+                    Assert.Equal(21, store.JsonRequestFactory.CurrentCacheSize);
+                }
+
+                store.MaxNumberOfCachedRequests = 3;
+                
+                Assert.Equal(3, store.MaxNumberOfCachedRequests);
+                Assert.Equal(0, store.JsonRequestFactory.CurrentCacheSize);
+
+                using (var session = store.OpenSession())
+                {
+                    for (int i = 1; i < 20; i++)
+                    {
+                        session.Load<Item>(i);    
+                    }
+                    
+                    Assert.Equal(19, session.Advanced.NumberOfRequests);
+                    Assert.Equal(3, store.JsonRequestFactory.CurrentCacheSize);
+
+                    session.Load<Item>(1);
+                    session.Load<Item>(2);
+                    session.Load<Item>(3);
+                    session.Load<Item>(4);
+                    
+                    Assert.Equal(19, session.Advanced.NumberOfRequests);
+                    Assert.Equal(3, store.JsonRequestFactory.CurrentCacheSize);
+
+                }
+                store.MaxNumberOfCachedRequests = 3;
+                Assert.Equal(3, store.JsonRequestFactory.CurrentCacheSize);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Creating HttpJsonRequestFactory only once per store.
When changing the cache size, only the cache size is being changed