### PR TITLE
RavenDB-3314 Allow to set index priority through the API

### DIFF
--- a/Raven.Abstractions/Indexing/IndexDefinition.cs
+++ b/Raven.Abstractions/Indexing/IndexDefinition.cs
@@ -153,6 +153,13 @@ namespace Raven.Abstractions.Indexing
 		/// </summary>
 		public int? MaxIndexOutputsPerDocument { get; set; }
 
+        /// <summary>
+        ///  index can have a priority that controls how much power of the indexing process it is allowed to consume. index priority can be forced by the user.
+        ///  There are four available values that you can set: Normal, Idle, Disabled, Abandoned
+        /// <para>Default value: null means that the priority of the index is Normal.</para>
+        /// </summary>
+        public IndexingPriority? Priority { get; set; }
+
 		/// <summary>
 		/// Equals the specified other.
 		/// </summary>

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -170,9 +170,23 @@ namespace Raven.Client.Connection.Async
 
          public Task SetIndexLockAsync(string name, IndexLockMode unLockMode , CancellationToken token = default(CancellationToken))
          {
-             return ExecuteWithReplication("lockModeChange", async operationMetadata =>
+             return ExecuteWithReplication("POST", async operationMetadata =>
              {
                  var operationUrl = operationMetadata.Url + "/indexes/" + name + "?op=" + "lockModeChange" + "&mode=" + unLockMode;
+                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationUrl, "POST", operationMetadata.Credentials, convention)))
+                 {
+                     request.AddOperationHeaders(OperationsHeaders);
+                     request.AddReplicationStatusHeaders(url, operationMetadata.Url, replicationInformer, convention.FailoverBehavior, HandleReplicationStatusChanges);
+
+                     return await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
+                 }
+             }, token);
+         }
+         public Task SetIndexPriorityAsync(string name, IndexingPriority normalPriority, CancellationToken token = default(CancellationToken))
+         {
+             return ExecuteWithReplication("POST", async operationMetadata =>
+             {
+                 var operationUrl = operationMetadata.Url + "/indexes/set-priority/" + name + "?priority=" + normalPriority;
                  using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationUrl, "POST", operationMetadata.Credentials, convention)))
                  {
                      request.AddOperationHeaders(OperationsHeaders);

--- a/Raven.Client.Lightweight/Connection/IDatabaseCommands.cs
+++ b/Raven.Client.Lightweight/Connection/IDatabaseCommands.cs
@@ -515,6 +515,8 @@ namespace Raven.Client.Connection
 
 	    void SetIndexLock(string name, IndexLockMode unlock);
 
+        void SetIndexPriority(string name, IndexingPriority normalPriority);
+
 		/// <summary>
 		///     Rollbacks the specified tx id
 		/// </summary>

--- a/Raven.Client.Lightweight/Connection/ServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/ServerClient.cs
@@ -208,6 +208,10 @@ namespace Raven.Client.Connection
         {
             asyncServerClient.SetIndexLockAsync(name, unLockMode).WaitUnwrap();
         }
+        public void SetIndexPriority(string name, IndexingPriority normalPriority )
+        {
+            asyncServerClient.SetIndexPriorityAsync(name, normalPriority).WaitUnwrap();
+        }
 
 		public IndexDefinition GetIndex(string name)
 		{

--- a/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
@@ -444,7 +444,8 @@ namespace Raven.Client.Indexes
                 SpatialIndexes = SpatialIndexes,
                 SpatialIndexesStrings = SpatialIndexesStrings,
                 DisableInMemoryIndexing = DisableInMemoryIndexing,
-                MaxIndexOutputsPerDocument = MaxIndexOutputsPerDocument
+                MaxIndexOutputsPerDocument = MaxIndexOutputsPerDocument,
+                Priority = Priority
             }.ToIndexDefinition(Conventions);
 
             var fields = Map.Body.Type.GenericTypeArguments.First().GetProperties();
@@ -489,6 +490,13 @@ namespace Raven.Client.Indexes
         /// <para>Default value: null means that the global value from Raven configuration will be taken to detect if number of outputs was exceeded.</para>
         /// </summary>
         public int? MaxIndexOutputsPerDocument { get; set; }
+
+        /// <summary>
+        ///  index can have a priority that controls how much power of the indexing process it is allowed to consume. index priority can be forced by the user.
+        ///  There are four available values that you can set: Normal, Idle, Disabled, Abandoned
+        /// <para>Default value: null means that the priority of the index is Normal.</para>
+        /// </summary>
+        public IndexingPriority? Priority { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether this instance is map reduce index definition

--- a/Raven.Client.Lightweight/Indexes/IndexDefinitionBuilder.cs
+++ b/Raven.Client.Lightweight/Indexes/IndexDefinitionBuilder.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Indexing;
 using Raven.Abstractions.Util;
@@ -121,7 +122,12 @@ namespace Raven.Client.Indexes
 		/// </summary>
 		public int? MaxIndexOutputsPerDocument { get; set; }
 
-		/// <summary>
+        /// <summary>
+        /// Gets or sets the index priority 
+        /// </summary>
+	    public IndexingPriority? Priority { get; set; }
+
+	    /// <summary>
 		/// Initializes a new instance of the <see cref="IndexDefinitionBuilder{TDocument,TReduceResult}"/> class.
 		/// </summary>
 		public IndexDefinitionBuilder()
@@ -168,6 +174,7 @@ namespace Raven.Client.Indexes
 				DisableInMemoryIndexing = DisableInMemoryIndexing,
 				MaxIndexOutputsPerDocument = MaxIndexOutputsPerDocument,
                 LockMode = LockMode,
+                Priority = Priority 
 			};
 
 			if (convention.PrettifyGeneratedLinqExpressions)

--- a/Raven.Database/DocumentDatabase.cs
+++ b/Raven.Database/DocumentDatabase.cs
@@ -509,10 +509,14 @@ namespace Raven.Database
 							index.Performance = IndexStorage.GetIndexingPerformance(index.Id);
 							index.IsTestIndex = indexDefinition.IsTestIndex;
 							index.IsOnRam = IndexStorage.IndexOnRam(index.Id);
-							if (indexDefinition != null)
-								index.LockMode = indexDefinition.LockMode;
+						    if (indexDefinition != null)
+						    {
+						        index.LockMode = indexDefinition.LockMode;
+                                if (indexDefinition.Priority != null)
+						            index.Priority = indexDefinition.Priority.Value;
+						    }
 
-							index.ForEntityName = IndexDefinitionStorage.GetViewGenerator(index.Id).ForEntityNames.ToArray();
+						    index.ForEntityName = IndexDefinitionStorage.GetViewGenerator(index.Id).ForEntityNames.ToArray();
 							IndexSearcher searcher;
 							using (IndexStorage.GetCurrentIndexSearcher(index.Id, out searcher))
 								index.DocsCount = searcher.IndexReader.NumDocs();

--- a/Raven.Database/Indexing/GenerateIndexDefinitionCode.cs
+++ b/Raven.Database/Indexing/GenerateIndexDefinitionCode.cs
@@ -83,6 +83,11 @@ namespace Raven.Database.Indexing
                 objectCreateExpression.Initializer.Elements.Add(new NamedExpression("MaxIndexOutputsPerDocument", new PrimitiveExpression(_indexDefinition.MaxIndexOutputsPerDocument)));
             }
 
+            if (_indexDefinition.Priority != null)
+            {
+                objectCreateExpression.Initializer.Elements.Add(new NamedExpression("Priority", new PrimitiveExpression(_indexDefinition.Priority)));
+            }
+
             if (_indexDefinition.Indexes.Count > 0)
             {
                 objectCreateExpression.Initializer.Elements.Add(new NamedExpression("Indexes", CreateExpressionFromStringToEnumDictionary(_indexDefinition.Indexes)));

--- a/Raven.Database/Server/Controllers/IndexController.cs
+++ b/Raven.Database/Server/Controllers/IndexController.cs
@@ -140,6 +140,9 @@ namespace Raven.Database.Server.Controllers
 			if (jsonIndex.ContainsKey("MaxIndexOutputsPerDocument") == false)
 				data.MaxIndexOutputsPerDocument = 16*1024;
 
+            if (jsonIndex.ContainsKey("Priority")== false)
+                data.Priority = IndexingPriority.Normal;
+
 			try
 			{
 				Database.Indexes.PutIndex(index, data);

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -116,6 +116,7 @@
     <Compile Include="1379\RavenDB_1379_Client_Lazy.cs" />
     <Compile Include="1379\RavenDB_1379_Client_Remote.cs" />
     <Compile Include="ActualValueInJsonReaderException.cs" />
+    <Compile Include="RavenDB-3314.cs" />
     <Compile Include="RavenDB_3230.cs" />
     <Compile Include="RavenDB_3271.cs" />
     <Compile Include="RavenDB_3276.cs" />

--- a/Raven.Tests.Issues/RavenDB-3314.cs
+++ b/Raven.Tests.Issues/RavenDB-3314.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Indexing;
+using Raven.Client.Document;
+using Raven.Client.Indexes;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_3314 : RavenTestBase
+    {
+        [Fact]
+        public void set_index_priority()
+        {
+            using (var store = NewRemoteDocumentStore(fiddler: true))
+            {
+
+                var index = new SampleIndex
+                {
+                    Conventions = new DocumentConvention()
+                };
+                index.Execute(store);
+
+                store.DatabaseCommands.SetIndexPriority("SampleIndex", IndexingPriority.Normal);
+
+                var stats = store.DatabaseCommands.GetStatistics().Indexes.First(x => x.Name == "SampleIndex");
+
+                Assert.Equal(IndexingPriority.Normal, stats.Priority);
+
+
+
+
+                store.DatabaseCommands.SetIndexPriority("SampleIndex", IndexingPriority.Idle);
+
+                stats = store.DatabaseCommands.GetStatistics().Indexes.First(x => x.Name == "SampleIndex");
+
+                Assert.Equal(IndexingPriority.Idle, stats.Priority);
+
+
+
+                store.DatabaseCommands.SetIndexPriority("SampleIndex", IndexingPriority.Disabled);
+
+                stats = store.DatabaseCommands.GetStatistics().Indexes.First(x => x.Name == "SampleIndex");
+
+                Assert.Equal(IndexingPriority.Disabled, stats.Priority);
+
+
+
+                store.DatabaseCommands.SetIndexPriority("SampleIndex", IndexingPriority.Abandoned);
+
+                stats = store.DatabaseCommands.GetStatistics().Indexes.First(x => x.Name == "SampleIndex");
+
+                Assert.Equal(IndexingPriority.Abandoned, stats.Priority); 
+
+
+            }
+        }
+        [Fact]
+        public void set_index_priority_through_index_definition()
+        {
+
+            using (var store = NewRemoteDocumentStore(fiddler: true))
+            {
+
+                var index1 = new SampleIndex1
+                {
+                    Conventions = new DocumentConvention()
+                };
+                index1.Execute(store);
+                var stats = store.DatabaseCommands.GetStatistics().Indexes.First(x => x.Name == "SampleIndex1");
+                Assert.Equal(IndexingPriority.Abandoned, stats.Priority);
+
+
+                var index2 = new SampleIndex2
+                {
+                    Conventions = new DocumentConvention()
+                };
+                index2.Execute(store);
+
+                stats = store.DatabaseCommands.GetStatistics().Indexes.First(x => x.Name == "SampleIndex2");
+
+                Assert.Equal(IndexingPriority.Idle, stats.Priority);
+
+
+
+                var index3 = new SampleIndex3
+                {
+                    Conventions = new DocumentConvention()
+                };
+                index3.Execute(store);
+
+                stats = store.DatabaseCommands.GetStatistics().Indexes.First(x => x.Name == "SampleIndex3");
+
+                Assert.Equal(IndexingPriority.Disabled, stats.Priority);
+
+
+
+                var index4 = new SampleIndex4
+                {
+                    Conventions = new DocumentConvention()
+                };
+                index4.Execute(store);
+
+                stats = store.DatabaseCommands.GetStatistics().Indexes.First(x => x.Name == "SampleIndex4");
+
+                Assert.Equal(IndexingPriority.Normal, stats.Priority);
+
+            }
+        }
+
+        public class SampleIndex : AbstractIndexCreationTask<Employee>
+        {
+            public SampleIndex()
+            {
+                Map = employees => from employee in employees
+                    select new
+                    {
+                        employee.Name,
+                        employee.Address
+                    };
+            }
+
+        }
+        public class SampleIndex1 : AbstractIndexCreationTask<Employee>
+        {
+            public SampleIndex1()
+            {
+                Map = employees => from employee in employees
+                                   select new
+                                   {
+                                       employee.Name,
+                                       employee.Address
+                                   };
+                Priority = IndexingPriority.Abandoned;
+            }
+
+        }
+
+        public class SampleIndex2 : AbstractIndexCreationTask<Employee>
+        {
+            public SampleIndex2()
+            {
+                Map = employees => from employee in employees
+                                   select new
+                                   {
+                                       employee.Name,
+                                       employee.Address
+                                   };
+                Priority = IndexingPriority.Idle;
+            }
+
+        }
+        public class SampleIndex3 : AbstractIndexCreationTask<Employee>
+        {
+            public SampleIndex3()
+            {
+                Map = employees => from employee in employees
+                                   select new
+                                   {
+                                       employee.Name,
+                                       employee.Address
+                                   };
+                Priority = IndexingPriority.Disabled;
+            }
+
+        }
+        public class SampleIndex4 : AbstractIndexCreationTask<Employee>
+        {
+            public SampleIndex4()
+            {
+                Map = employees => from employee in employees
+                                   select new
+                                   {
+                                       employee.Name,
+                                       employee.Address
+                                   };
+            }
+        }
+        public class Employee
+        {
+            public string Name { get; set; }
+            public string Address { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Client can set index priority through client API and also through index definition