### PR TITLE
fix for RavenDB-3304 -> clean branch

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -46,6 +46,7 @@ namespace Raven.Abstractions.Data
 		public const string Metadata = "@metadata";
 		public const string NotForReplication = "Raven-Not-For-Replication";
 		public const string RavenDeleteMarker = "Raven-Delete-Marker";
+		public const string RavenIndexDeleteMarker = "Raven-Index-Delete-Marker";
 		public const string ActiveBundles = "Raven/ActiveBundles";
 		public const string AllowBundlesChange = "Raven-Temp-Allow-Bundles-Change";
 		public const string RavenAlerts = "Raven/Alerts";
@@ -127,6 +128,7 @@ namespace Raven.Abstractions.Data
 		public const string RavenReplicationConfig = "Raven/Replication/Config";
 
 		public const string RavenReplicationDocsTombstones = "Raven/Replication/Docs/Tombstones";
+		public const string RavenReplicationIndexesTombstones = "Raven/Replication/Indexes/Tombstones";
 
         [Obsolete("Use RavenFS instead.")]
 		public const string RavenReplicationAttachmentsTombstones = "Raven/Replication/Attachments/Tombstones";

--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -636,13 +636,14 @@ namespace Raven.Database.Actions
             PutIndex(index, indexDefinition);
         }
 
-        public void DeleteIndex(string name)
+        public bool DeleteIndex(string name)
         {
             var instance = IndexDefinitionStorage.GetIndexDefinition(name);
             if (instance == null) 
-				return;
+				return false;
 
 			DeleteIndex(instance);
+	        return true;
         }
 
 		internal void DeleteIndex(IndexDefinition instance, bool removeByNameMapping = true, bool clearErrors = true)

--- a/Raven.Database/Actions/NotificationActions.cs
+++ b/Raven.Database/Actions/NotificationActions.cs
@@ -22,6 +22,7 @@ namespace Raven.Database.Actions
         }
 
         public event Action<DocumentDatabase, DocumentChangeNotification, RavenJObject> OnDocumentChange;
+		public event Action<DocumentDatabase, IndexChangeNotification> OnIndexChange;
 
         public void RaiseNotifications(DocumentChangeNotification obj, RavenJObject metadata)
         {
@@ -31,10 +32,14 @@ namespace Raven.Database.Actions
                 onDocumentChange(Database, obj, metadata);
         }
 
+
         public void RaiseNotifications(IndexChangeNotification obj)
         {
             Database.TransportState.Send(obj);
-        }
+			var onIndexChange = OnIndexChange;
+			if (onIndexChange != null)
+				onIndexChange(Database, obj);
+		}
 
         public void RaiseNotifications(TransformerChangeNotification obj)
         {

--- a/Raven.Database/Bundles/Replication/Triggers/VirtualDeleteTrigger.cs
+++ b/Raven.Database/Bundles/Replication/Triggers/VirtualDeleteTrigger.cs
@@ -28,6 +28,11 @@ namespace Raven.Bundles.Replication.Triggers
 	{
 		readonly ThreadLocal<RavenJArray> deletedHistory = new ThreadLocal<RavenJArray>();
 
+		public override void Initialize()
+		{
+			Database.Notifications.OnIndexChange += OnIndexChange;
+		}
+
 		public override void OnDelete(string key, TransactionInformation transactionInformation)
 		{
 			using (Database.DisableAllTriggersForCurrentThread())
@@ -105,6 +110,22 @@ namespace Raven.Bundles.Replication.Triggers
 			var conflict = document.Metadata.Value<RavenJValue>(Constants.RavenReplicationConflict);
 
 			return conflict != null && conflict.Value<bool>() && document.DataAsJson.Value<RavenJArray>("Conflicts") != null;
+		}
+
+		private void OnIndexChange(Database.DocumentDatabase database, IndexChangeNotification eventArgs)
+		{
+			if (eventArgs.Type == IndexChangeTypes.IndexRemoved)
+			{
+				var metadata = new RavenJObject
+				{
+					{ Constants.RavenIndexDeleteMarker, true },
+					{ Constants.RavenReplicationSource, Database.TransactionalStorage.Id.ToString() },
+					{ Constants.RavenReplicationVersion, ReplicationHiLo.NextId(Database) }
+				};
+
+				Database.TransactionalStorage.Batch(accessor =>
+					accessor.Lists.Set(Constants.RavenReplicationIndexesTombstones, eventArgs.Name, metadata, UuidType.Indexing));
+			}
 		}
 	}
 }

--- a/Raven.Database/Server/Controllers/IndexController.cs
+++ b/Raven.Database/Server/Controllers/IndexController.cs
@@ -223,7 +223,14 @@ namespace Raven.Database.Server.Controllers
 		public HttpResponseMessage IndexDelete(string id)
 		{
 			var index = id;
-			Database.Indexes.DeleteIndex(index);
+
+			var isReplication = GetQueryStringValue("is-replication");
+			if (Database.Indexes.DeleteIndex(index) &&
+				!String.IsNullOrWhiteSpace(isReplication) && isReplication.Equals("true", StringComparison.InvariantCultureIgnoreCase))
+			{
+				Log.Info("received index deletion from replication (replicating index tombstone)");
+			}
+
 			return GetEmptyMessage(HttpStatusCode.NoContent);
 		}
 

--- a/Raven.Tests.Core/Replication/IndexReplication.cs
+++ b/Raven.Tests.Core/Replication/IndexReplication.cs
@@ -516,6 +516,64 @@ namespace Raven.Tests.Core.Replication
 			}
 		}
 
+		[Fact]
+		public async Task Should_replicate_index_deletion()
+		{
+			using (var sourceServer = GetNewServer(8077))
+			using (var source = NewRemoteDocumentStore(ravenDbServer: sourceServer))
+			using (var destinationServer1 = GetNewServer(8078))
+			using (var destination1 = NewRemoteDocumentStore(ravenDbServer: destinationServer1))
+			using (var destinationServer2 = GetNewServer())
+			using (var destination2 = NewRemoteDocumentStore(ravenDbServer: destinationServer2))
+			using (var destinationServer3 = GetNewServer(8081))
+			using (var destination3 = NewRemoteDocumentStore(ravenDbServer: destinationServer3))
+			{
+				CreateDatabaseWithReplication(source, "testDB");
+				CreateDatabaseWithReplication(destination1, "testDB");
+				CreateDatabaseWithReplication(destination2, "testDB");
+				CreateDatabaseWithReplication(destination3, "testDB");
+
+				//turn-off automatic index replication - precaution
+				source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+				// ReSharper disable once AccessToDisposedClosure
+				SetupReplication(source, "testDB", store => false, destination1, destination2, destination3);
+
+				//make sure not to replicate the index automatically
+				var userIndex = new UserIndex();
+				source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+
+				var sourceDB = await sourceServer.Server.GetDatabaseInternal("testDB");
+				var replicationTask = sourceDB.StartupTasks.OfType<ReplicationTask>().First();
+				replicationTask.ReplicateIndexesAndTransformersTask(null);
+
+				var expectedIndexNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { userIndex.IndexName };
+				var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+				Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication1));
+
+				var indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+				Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication3));
+
+				var indexStatsAfterReplication2 = destination2.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+				Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication2));
+
+				source.DatabaseCommands.ForDatabase("testDB").DeleteIndex(userIndex.IndexName);
+
+				//the index is now replicated on all servers.
+				//now delete the index and verify that deletion is replicated
+				replicationTask.ReplicateIndexesAndTransformersTask(null);
+
+
+				indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+				Assert.Empty(indexStatsAfterReplication1);
+
+				indexStatsAfterReplication2 = destination2.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+				Assert.Empty(indexStatsAfterReplication2);
+
+				indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+				Assert.Empty(indexStatsAfterReplication3);
+			}
+		}
+
 		private static void CreateDatabaseWithReplication(DocumentStore store, string databaseName)
 		{
 			store.DatabaseCommands.GlobalAdmin.CreateDatabase(new DatabaseDocument


### PR DESCRIPTION
* on index deletion, index tombstone is written
* in replication task, if index tombstones are discovered, index DELETE requests are issued
* if replicated to all destinations, tombstone is purged