### PR TITLE
Changing logs format. Making sure that warnings are printed too. Giving ...

### DIFF
--- a/Raven.Tests.Common/RavenTest.cs
+++ b/Raven.Tests.Common/RavenTest.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-
+using System.Linq;
 using Raven.Abstractions;
 using Raven.Abstractions.Logging;
 using Raven.Client.Embedded;
@@ -67,15 +67,9 @@ namespace Raven.Tests.Common
 					WriteLine(writer);
 				    WriteLine(writer, "Logs for: " + databaseName);
 
-				    foreach (var info in target.GeneralLog)
+				    foreach (var info in target.GeneralLog.Concat(target.WarnLog).OrderBy(x => x.TimeStamp))
 				    {
-						WriteLine(writer, "========================================");
-						WriteLine(writer, "Time: " + info.TimeStamp);
-						WriteLine(writer, "Level: " + info.Level);
-						WriteLine(writer, "Logger: " + info.LoggerName);
-						WriteLine(writer, "Message: " + info.FormattedMessage);
-						WriteLine(writer, "Exception: " + info.Exception);
-						WriteLine(writer, "========================================");
+						WriteLine(writer, string.Format("{0},{1},{2},{3},{4}", info.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss.ffff"), info.Level, info.LoggerName, info.FormattedMessage, info.Exception));
 				    }
 
 				    WriteLine(writer);

--- a/Raven.Tests.Issues/RavenDB_1041.cs
+++ b/Raven.Tests.Issues/RavenDB_1041.cs
@@ -62,9 +62,9 @@ namespace Raven.Tests.Issues
 		{
 			ShowLogs = true;
 
-			var store1 = CreateStore(requestedStorageType: "esent");
-			var store2 = CreateStore(requestedStorageType: "esent");
-			var store3 = CreateStore(requestedStorageType: "esent");
+			var store1 = CreateStore(requestedStorageType: "esent", databaseName: "CanWaitForReplicationOfParticularEtag_Store1");
+			var store2 = CreateStore(requestedStorageType: "esent", databaseName: "CanWaitForReplicationOfParticularEtag_Store2");
+			var store3 = CreateStore(requestedStorageType: "esent", databaseName: "CanWaitForReplicationOfParticularEtag_Store3");
 
 			SetupReplication(store1.DatabaseCommands, store2, store3);
 


### PR DESCRIPTION
...unique database names to ensure the proper log output.
