### PR TITLE
SqlReplication now properly deletes inner objects even if replicate to doesn't appear in the script

### DIFF
--- a/Raven.Database/Bundles/SqlReplication/ItemToReplicate.cs
+++ b/Raven.Database/Bundles/SqlReplication/ItemToReplicate.cs
@@ -6,5 +6,6 @@ namespace Raven.Database.Bundles.SqlReplication
 	{
 		public string DocumentId { get; set; }
 		public RavenJObject Columns { get; set; }
+        public bool DeleteMarker { get; set; }
 	}
 }


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-3341
