### PR TITLE
avoiding double escape in RavenQuery.Escape

### DIFF
--- a/Raven.Abstractions/Util/RavenQuery.cs
+++ b/Raven.Abstractions/Util/RavenQuery.cs
@@ -39,8 +39,6 @@ namespace Raven.Abstractions.Util
 			{
 				return "\"\"";
 			}
-
-			bool isPhrase = false;
 			int start = 0;
 			int length = term.Length;
 			StringBuilder buffer = null;
@@ -96,16 +94,10 @@ namespace Raven.Abstractions.Util
 					case ' ':
 					case '\t':
 						{
-							if (!isPhrase && makePhrase)
+							if (makePhrase)
 							{
-								if (buffer == null)
-								{
-									// allocate builder with headroom
-									buffer = new StringBuilder(length * 2);
-								}
-
-								buffer.Insert(0, "\"");
-								isPhrase = true;
+                                //If it is a phrase there is no need to double escape just escape the original term.
+							    return new StringBuilder(term).Insert(0,"\"").Append("\"").ToString();								
 							}
 							break;
 						}
@@ -134,12 +126,6 @@ namespace Raven.Abstractions.Util
 			{
 				// append any trailing substring
 				buffer.Append(term, start, length - start);
-			}
-
-			if (isPhrase)
-			{
-				// quoted phrase
-				buffer.Append('"');
 			}
 
 			return buffer.ToString();

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -375,6 +375,7 @@
     <Compile Include="RavenDB_3335.cs" />
     <Compile Include="Ravendb_334.cs" />
     <Compile Include="RavenDB_3344.cs" />
+    <Compile Include="RavenDB_3375.cs" />
     <Compile Include="RavenDB_349.cs" />
     <Compile Include="RavenDB_367.cs" />
     <Compile Include="RavenDB_381.cs" />

--- a/Raven.Tests.Issues/RavenDB_3375.cs
+++ b/Raven.Tests.Issues/RavenDB_3375.cs
@@ -1,0 +1,80 @@
+﻿
+using System;
+using System.Linq;
+using System.Threading;
+using Raven.Client;
+using Raven.Client.Embedded;
+using Raven.Client.Indexes;
+using Xunit;
+
+namespace Bug
+{
+    public class QueryEscapeTest
+    {
+        public class Post
+        {
+            public int Id { get; set; }
+            public string[] Tags { get; set; }
+        }
+
+        public class TagsIndex : AbstractIndexCreationTask<Post>
+        {
+            public TagsIndex()
+            {
+                Map = posts => from post in posts
+                               from tag in post.Tags
+                               select new { _ = CreateField("Tag", tag, false, false) };
+            }
+        }
+
+        [Fact]
+        public void CanQueryPhraseWithEscapedCharacters()
+        {
+            using (var store = new EmbeddableDocumentStore())
+            {
+                store.Configuration.RunInMemory = true;
+                store.Initialize();
+                store.DatabaseCommands.PutIndex("TagsIndex", new TagsIndex().CreateIndexDefinition());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Post
+                    {
+                        Id = 1,
+                        Tags = new[] { "NoSpace:1", "Space :2"}
+                    });
+                    session.SaveChanges();
+                }
+
+                WaitForIndexes(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query1 = session.Advanced.DocumentQuery<Post>("TagsIndex");
+                    query1 = query1.WhereEquals("Tag", "NoSpace:1", false);
+                    Console.WriteLine(query1.ToString()); // Tag:[["NoSpace\:1"]]
+                    var posts = query1.ToArray();
+                    Assert.Equal(1, posts.Length); // Passes
+
+                    var query2 = session.Advanced.DocumentQuery<Post>("TagsIndex")
+                                        .WhereEquals("Tag", "Space :2", false);
+                    Console.WriteLine(query2.ToString()); // Tag:[["Space \:2"]]
+                    var posts2 = query2.ToArray();
+                    Assert.Equal(1, posts2.Length); // Fails
+
+                }
+            }
+        }
+
+        static void WaitForIndexes(IDocumentStore store)
+        {
+            do
+            {
+                var stats = store.DatabaseCommands.GetStatistics();
+                if (stats.StaleIndexes.Length == 0) return;
+                Thread.Sleep(100);
+            } while (true);
+        }
+    }
+}
+

--- a/Raven.Tests/Bugs/QueryWithReservedCharacters.cs
+++ b/Raven.Tests/Bugs/QueryWithReservedCharacters.cs
@@ -45,7 +45,7 @@ namespace Raven.Tests.Bugs
 					var allSync = session
 						.Advanced
                         .DocumentQuery<Bar<Foo>>("ByClr")
-						.Where("ClrType:[[" + RavenQuery.Escape(typeName) + "]]")
+						.Where("ClrType:[[" + RavenQuery.Escape(typeName,false,false) + "]]")
 						.WaitForNonStaleResultsAsOfNow(TimeSpan.MaxValue)
 						.ToList();
 


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-3375
In the case of a Phrase i just add the quotes and drop the escaped buffer.
This change seems to be right, it did break one test and i have changed that test 
WhenQueryingByGenericClrTypes_ThenAutoQuotedLuceneQueryFails
