### PR TITLE
RavenDB-3373 Ensure that an index which has all documents filtered out, ...

### DIFF
--- a/Raven.Database/Indexing/Index.cs
+++ b/Raven.Database/Indexing/Index.cs
@@ -243,11 +243,9 @@ namespace Raven.Database.Indexing
 
 				try
 				{
-					if (indexWriter == null)
-						CreateIndexWriter();
-
+					EnsureIndexWriter();
 					ForceWriteToDisk();
-					WriteInMemoryIndexToDiskIfNecessary(Etag.Empty);
+					WriteInMemoryIndexToDiskIfNecessary(GetLastEtagFromStats());
 				}
 				catch (Exception e)
 				{
@@ -293,6 +291,12 @@ namespace Raven.Database.Indexing
 			}
 		}
 
+		public void EnsureIndexWriter()
+		{
+			if (indexWriter == null)
+				CreateIndexWriter();
+		}
+
 		public void Flush(Etag highestETag)
 		{
 			lock (writeLock)
@@ -325,10 +329,9 @@ namespace Raven.Database.Indexing
 				{
 					logIndexing.Info("Starting merge of {0}", indexId);
 					var sp = Stopwatch.StartNew();
-					if (indexWriter == null)
-					{
-						CreateIndexWriter();
-					}
+					
+					EnsureIndexWriter();
+
 					indexWriter.Optimize();
 					logIndexing.Info("Done merging {0} - took {1}", indexId, sp.Elapsed);
 
@@ -490,10 +493,7 @@ namespace Raven.Database.Indexing
 						throw;
 					}
 
-					if (indexWriter == null)
-					{
-						CreateIndexWriter();
-					}
+					EnsureIndexWriter();
 
 					var locker = directory.MakeLock("writing-to-index.lock");
 					try

--- a/Raven.Database/Indexing/LuceneCodecDirectory.cs
+++ b/Raven.Database/Indexing/LuceneCodecDirectory.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Lucene.Net.Store;
 using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Logging;
+using Raven.Database.Extensions;
 using Raven.Database.Plugins;
 
 namespace Raven.Database.Indexing
@@ -96,7 +97,7 @@ namespace Raven.Database.Indexing
 			{
 				try
 				{
-					file.Delete();
+					IOExtensions.DeleteFile(file.FullName);
 				}
 				catch (Exception e)
 				{

--- a/Raven.Database/Indexing/RavenIndexWriter.cs
+++ b/Raven.Database/Indexing/RavenIndexWriter.cs
@@ -125,10 +125,15 @@ namespace Raven.Database.Indexing
 				                 { "Marker", CommitMarker.ToString(CultureInfo.InvariantCulture) }
 			                 };
 
+			var commitDataStored = false;
+
 			if (changesSinceCommit == 0 && SystemTime.UtcNow - lastCommitDataStoreTime > TimeSpan.FromMinutes(10))
+			{
 				ForceCommitDataStore();
-			else
-				lastCommitDataStoreTime = SystemTime.UtcNow;
+				commitDataStored = true;
+			}
+			else if (changesSinceCommit > 0)
+				commitDataStored = true;
 
 
 			if (lastEtag != null)
@@ -137,6 +142,10 @@ namespace Raven.Database.Indexing
 			try
 			{
 				indexWriter.Commit(commitData);
+
+				if (commitDataStored)
+					lastCommitDataStoreTime = SystemTime.UtcNow;
+
 				changesSinceCommit = 0;
 			}
 			catch (SystemException e)

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -377,6 +377,7 @@
     <Compile Include="RavenDB_3335.cs" />
     <Compile Include="Ravendb_334.cs" />
     <Compile Include="RavenDB_3344.cs" />
+    <Compile Include="RavenDB_3373.cs" />
     <Compile Include="RavenDB_3375.cs" />
     <Compile Include="RavenDB_349.cs" />
     <Compile Include="RavenDB_367.cs" />

--- a/Raven.Tests.Issues/RavenDB_3373.cs
+++ b/Raven.Tests.Issues/RavenDB_3373.cs
@@ -1,0 +1,102 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_3373.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Linq;
+using Raven.Abstractions;
+using Raven.Client.Indexes;
+using Raven.Tests.Common;
+using Raven.Tests.Common.Dto;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+	public class RavenDB_3373 : RavenTest
+	{
+		public class Users_ByName : AbstractIndexCreationTask<User>
+		{
+			public Users_ByName()
+			{
+				Map = users => from u in users select new { u.Name};
+			}
+		}
+		[Fact]
+		public void CanSearchAfterForcedCommitDataFlushes()
+		{
+			var dataDir = NewDataPath();
+			using (var store = NewDocumentStore(runInMemory: false, dataDir: dataDir))
+			{
+				new Users_ByName().Execute(store);
+
+				using (var session = store.OpenSession())
+				{
+					session.Store(new User
+					{
+						Name = "One",
+					});
+
+					session.Store(new User
+					{
+						Name = "Two",
+					});
+
+					session.Store(new User
+					{
+						Name = "Three",
+					});
+
+					session.SaveChanges();
+
+					Assert.Equal(3, session.Query<User, Users_ByName>().Customize(x => x.WaitForNonStaleResults()).ToList().Count);
+
+					store.DocumentDatabase.IndexStorage.FlushMapIndexes();
+
+					SystemTime.UtcDateTime = () => DateTime.Now.AddHours(1);
+					session.Store(new Address());
+					session.SaveChanges();
+					WaitForIndexing(store);
+
+					store.DocumentDatabase.IndexStorage.FlushMapIndexes();
+
+					SystemTime.UtcDateTime = () => DateTime.Now.AddHours(2);
+					session.Store(new Address());
+					session.SaveChanges();
+					WaitForIndexing(store);
+
+					store.DocumentDatabase.IndexStorage.FlushMapIndexes();
+
+					SystemTime.UtcDateTime = () => DateTime.Now.AddHours(3);
+					session.Store(new Address());
+					session.SaveChanges();
+					WaitForIndexing(store);
+
+					store.DocumentDatabase.IndexStorage.FlushMapIndexes();
+
+				}
+			}
+
+			using (var store = NewDocumentStore(runInMemory: false, dataDir: dataDir))
+			{
+				using (var session = store.OpenSession())
+				{
+					var result = session.Query<User, Users_ByName>().Customize(x => x.WaitForNonStaleResults()).ToList();
+
+					Assert.Equal(3, result.Count);
+
+					session.Store(new User
+					{
+						Name = "Four",
+					});
+
+					session.SaveChanges();
+
+					result = session.Query<User, Users_ByName>().Customize(x => x.WaitForNonStaleResults()).ToList();
+
+					Assert.Equal(4, result.Count);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
...flushes the last indexed etag according to the stats. Passing the last indexed etag value from index stats when in-memory index is written to a disk.
