### PR TITLE
add a check to see if the current category has the current option catego...

### DIFF
--- a/Raven.Server/FromMono/Options.cs
+++ b/Raven.Server/FromMono/Options.cs
@@ -844,7 +844,7 @@ namespace NDesk.Options
 			{
 				currentCategory = p.Category;
 			}
-			else if (p.Category.HasFlag(currentCategory) || p.Category == OptionCategory.None)
+			else if (p.Category.HasFlag(currentCategory) || currentCategory.HasFlag(p.Category) || p.Category == OptionCategory.None)
 			{
 				currentCategory |= p.Category;
 			}


### PR DESCRIPTION
...ry flag. This prevents the order in which arguments are supplied from causing InvalidOperationException when arguments can have multiple category flags.