### PR TITLE
removed unnecessary dependency

### DIFF
--- a/Raven.Abstractions/Exceptions/InvalidSpatialShapeException.cs
+++ b/Raven.Abstractions/Exceptions/InvalidSpatialShapeException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.Serialization;
-using Spatial4n.Core.Exceptions;
 
 namespace Raven.Abstractions.Exceptions
 {
@@ -26,7 +25,7 @@ namespace Raven.Abstractions.Exceptions
 
 		private readonly string invalidDocumentId;
 
-		public InvalidSpatialShapException(InvalidShapeException invalidShapeException, string invalidDocumentId)
+		public InvalidSpatialShapException(Exception invalidShapeException, string invalidDocumentId)
 			: base(invalidShapeException.Message, invalidShapeException)
 		{
 			this.invalidDocumentId = invalidDocumentId;

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -83,10 +83,6 @@
     <Reference Include="Mono.Cecil.Rocks">
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="Spatial4n.Core.NTS, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9f9456e1ca16d45e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\SharedLibs\Spatial4n.Core.NTS.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
No need to take a dependency on Spatial4n.Core.NTS in Raven.Abstractions.