### PR TITLE
RavenDB-3152 Smuggler client side filtering should not impact how we get the next etag

### DIFF
--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -116,6 +116,7 @@
     <Compile Include="1379\RavenDB_1379_Client_Lazy.cs" />
     <Compile Include="1379\RavenDB_1379_Client_Remote.cs" />
     <Compile Include="ActualValueInJsonReaderException.cs" />
+    <Compile Include="RavenDB-3152.cs" />
     <Compile Include="RavenDB-3179.cs" />
     <Compile Include="RavenDB-3302.cs" />
     <Compile Include="RavenDB-3314.cs" />
@@ -491,6 +492,10 @@
     <ProjectReference Include="..\Raven.Tests.Common\Raven.Tests.Common.csproj">
       <Project>{381234cc-8aa7-41ff-8cad-22330e15f993}</Project>
       <Name>Raven.Tests.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Raven.Tests.Core\Raven.Tests.Core.csproj">
+      <Project>{93287FBA-732A-4603-9BBE-9CFDC82FC8BE}</Project>
+      <Name>Raven.Tests.Core</Name>
     </ProjectReference>
     <ProjectReference Include="..\Raven.Tests.Helpers\Raven.Tests.Helpers.csproj">
       <Project>{1B88473F-743B-4F6B-8E5E-97BB816E6C68}</Project>

--- a/Raven.Tests.Issues/RavenDB-3152.cs
+++ b/Raven.Tests.Issues/RavenDB-3152.cs
@@ -1,0 +1,184 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.Policy;
+using System.Threading.Tasks;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Indexing;
+using Raven.Abstractions.Smuggler;
+using Raven.Client;
+using Raven.Client.Document;
+using Raven.Client.Extensions;
+using Raven.Client.Indexes;
+using Raven.Database.Extensions;
+using Raven.Json.Linq;
+using Raven.Server;
+using Raven.Smuggler;
+using Raven.Tests.Core.Commands;
+using Raven.Tests.Helpers;
+using Raven.Tests.MailingList;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+	public class RavenDB_3152 : RavenTestBase
+	{
+		[Fact]
+		public async Task Smuggler_filtering_next_etag()
+		{
+			using (var server = GetNewServer())
+			{
+				using (var store = new DocumentStore {Url = server.SystemDatabase.Configuration.ServerUrl}.Initialize())
+				{
+					store
+						.DatabaseCommands
+						.GlobalAdmin
+						.CreateDatabase(new DatabaseDocument
+						{
+							Id = "Dba1",
+							Settings =
+							{
+								{"Raven/DataDir", "Dba1"}
+							}
+						});
+					store.DatabaseCommands.EnsureDatabaseExists("Dba1");
+
+					store
+						.DatabaseCommands
+						.GlobalAdmin
+						.CreateDatabase(new DatabaseDocument
+						{
+							Id = "Dba2",
+							Settings =
+							{
+								{"Raven/DataDir", "Dba2"}
+							}
+						});
+					store.DatabaseCommands.EnsureDatabaseExists("Dba2");
+				}
+				using (var store1 = new DocumentStore
+				{
+					Url = server.SystemDatabase.Configuration.ServerUrl,
+					DefaultDatabase = "Dba1"
+				}.Initialize())
+				{
+					StoreWorkerseDba1(store1);
+					using (var session = store1.OpenSession())
+					{
+						var workers = session.Query<Worker>().ToList();
+						Assert.Equal(3, workers.Count);
+
+						var index1 = store1.DatabaseCommands.GetIndex("WorkerByName");
+						var index2 = store1.DatabaseCommands.GetIndex("WorkerByAge");
+						var index3 = store1.DatabaseCommands.GetIndex("WorkerAccountNumber");
+						Assert.Equal("WorkerByName", index1.Name);
+						Assert.Equal("WorkerByAge", index2.Name);
+						Assert.Equal("WorkerAccountNumber", index3.Name);
+					}
+				}
+
+				SmugglerDatabaseApi smugglerApi = new SmugglerDatabaseApi(new SmugglerDatabaseOptions
+				{
+					OperateOnTypes = ItemType.Documents | ItemType.Indexes,
+					Incremental = false
+				});
+				smugglerApi.Options.Filters.Add(new FilterSetting
+				{
+					Path = "Name",
+					ShouldMatch = true,
+					Values = { "worker/22", "worker/333" }
+				});
+
+				await smugglerApi.Between(
+					new SmugglerBetweenOptions<RavenConnectionStringOptions>
+					{
+						From = new RavenConnectionStringOptions
+						{
+							Url = server.SystemDatabase.Configuration.ServerUrl,
+							DefaultDatabase = "Dba1"
+						},
+						To = new RavenConnectionStringOptions
+						{
+							Url = server.SystemDatabase.Configuration.ServerUrl,
+							DefaultDatabase = "Dba2"
+						}
+
+					});
+
+				using (var store2 = new DocumentStore
+				{
+					Url = server.SystemDatabase.Configuration.ServerUrl,
+					DefaultDatabase = "Dba2"
+
+				}.Initialize())
+				{
+					using (var session = store2.OpenSession())
+					{
+						var workers = session.Query<Worker>().ToList();
+						Assert.Equal(0, workers.Count);
+						var index1 = store2.DatabaseCommands.GetIndex("WorkerByName");
+						var index2 = store2.DatabaseCommands.GetIndex("WorkerByAge");
+						var index3 = store2.DatabaseCommands.GetIndex("WorkerAccountNumber");
+						Assert.Equal("WorkerByName", index1.Name);
+						Assert.Equal("WorkerByAge", index2.Name);
+						Assert.Equal("WorkerAccountNumber", index3.Name);
+					}
+				}
+			}
+		}
+
+		public void StoreWorkerseDba1(IDocumentStore docStore)
+		{
+			using (var session = docStore.OpenSession())
+			{
+				session.Store(new Worker { Name = "worker/1", Age = 20, AccountNumber = 1536 });
+				session.Store(new Worker { Name = "worker/2", Age = 40, AccountNumber = 2006 });
+				session.Store(new Worker { Name = "worker/3", Age = 30, AccountNumber = 1106 });
+				session.SaveChanges();
+			}
+			new WorkerByName().Execute(docStore);
+			new WorkerByAge().Execute(docStore);
+			new WorkerAccountNumber().Execute(docStore);
+
+			WaitForIndexing(docStore);
+		}
+	}
+
+	public class Worker
+	{
+		public string Name { get; set; }
+		public int Age { get; set; }
+		public int AccountNumber { get; set; }
+	}
+
+	public class WorkerByName : AbstractIndexCreationTask<Worker>
+	{
+		public WorkerByName()
+		{
+			Map = workers => from worker in workers
+							 select new { worker.Name };
+			Index(x => x.Name, FieldIndexing.Analyzed);
+
+		}
+	}
+
+	public class WorkerByAge : AbstractIndexCreationTask<Worker>
+	{
+		public WorkerByAge()
+		{
+			Map = workers => from worker in workers
+				select new {worker.Age};
+			Sort(x => x.Age, SortOptions.Int);
+
+		}
+	}
+
+	public class WorkerAccountNumber : AbstractIndexCreationTask<Worker>
+	{
+		public WorkerAccountNumber()
+		{
+			Map = workers => from worker in workers
+							 select new { worker.AccountNumber };
+
+		}
+	}
+}


### PR DESCRIPTION
fixed filtering when moving data between two databases.
 last etag is being updated for each document
fixed for streaming and also for the case when streaming isn't supported

Signed-off-by: Hila Mefano <hila@ayende.com>