### PR TITLE
RavenDB-3434 Making MaybePulseTransaction thread safe. The synchronizati...

### DIFF
--- a/Raven.Database/Storage/Voron/StorageActions/GeneralStorageActions.cs
+++ b/Raven.Database/Storage/Voron/StorageActions/GeneralStorageActions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading;
 using Raven.Abstractions.Extensions;
 using Raven.Abstractions.Util.Streams;
 using Raven.Database.Storage.Voron.Impl;
@@ -15,6 +15,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
     {
 	    private const int PulseTreshold = 16 * 1024 * 1024; // 16 MB
 
+		private readonly object maybePulseLock = new object();
 	    private readonly TableStorage storage;
 		private readonly Reference<WriteBatch> writeBatch;
         private readonly Reference<SnapshotReader> snapshot;
@@ -115,14 +116,17 @@ namespace Raven.Database.Storage.Voron.StorageActions
 
 		public bool MaybePulseTransaction()
 		{
-			if (++maybePulseCount%1000 != 0)
+			if (Interlocked.Increment(ref maybePulseCount)%1000 != 0)
 				return false;
 
-			if (writeBatch.Value.Size() >= PulseTreshold)
+			lock (maybePulseLock)
 			{
-				PulseTransaction();
+				if (writeBatch.Value.Size() >= PulseTreshold)
+				{
+					PulseTransaction();
+				}
+				return true;
 			}
-			return true;
 		}
     }
 }


### PR DESCRIPTION
...on mostly relays on atomic Interlocked.Increment operation. Additionally the actual checks are made inside the lock statement to handle the case that PulseTransaction takes longer than 1000 calls from other theads.