### PR TITLE
Heavy Writes Optimizations

### DIFF
--- a/Raven.Database/FileSystem/Storage/Voron/Schema/Updates/SchemaUpdateBase.cs
+++ b/Raven.Database/FileSystem/Storage/Voron/Schema/Updates/SchemaUpdateBase.cs
@@ -25,7 +25,7 @@ namespace Raven.Database.FileSystem.Storage.Voron.Schema.Updates
             var schemaVersionSlice = new Slice("schema_version");
 			using (var tx = tableStorage.Environment.NewTransaction(TransactionFlags.ReadWrite))
 			{
-                tx.ReadTree(Tables.Details.TableName).Add(schemaVersionSlice, ToSchemaVersion);
+                tx.ReadTree(Tables.Details.TableName).Add(schemaVersionSlice, new Slice(ToSchemaVersion));
 				tx.Commit();
 			}
 

--- a/Raven.Database/Storage/Voron/Schema/Updates/SchemaUpdateBase.cs
+++ b/Raven.Database/Storage/Voron/Schema/Updates/SchemaUpdateBase.cs
@@ -25,7 +25,7 @@ namespace Raven.Database.Storage.Voron.Schema.Updates
 		{
 			using (var tx = tableStorage.Environment.NewTransaction(TransactionFlags.ReadWrite))
 			{
-                tx.ReadTree(Tables.Details.TableName).Add("schema_version", ToSchemaVersion);
+                tx.ReadTree(Tables.Details.TableName).Add(new Slice("schema_version"), new Slice(ToSchemaVersion));
 				tx.Commit();
 			}
 


### PR DESCRIPTION
I was able to push from 8.44M in 10 seconds to around 10.48M in 10 seconds with these 2 optimizations. 

Check the oldest transaction commit, that is the one that will require a deeper review; the other one is actually reverting an optimization because using the custom comparers for long keys (last optimization batch) has changed the balance of operations costs.  