### PR TITLE
RavenDB-3417 

### DIFF
--- a/Raven.Client.Lightweight/Connection/RavenUrlExtensions.cs
+++ b/Raven.Client.Lightweight/Connection/RavenUrlExtensions.cs
@@ -31,7 +31,7 @@ namespace Raven.Client.Connection
 
 		public static string IndexingPerformanceStatistics(this string url)
 		{
-			return url + "/indexes/indexing-perf-stats";
+			return url + "/debug/indexing-perf-stats";
 		}
 
 		public static string Transformer(this string url, string transformer)

--- a/Raven.Database/DocumentDatabase.cs
+++ b/Raven.Database/DocumentDatabase.cs
@@ -489,6 +489,21 @@ namespace Raven.Database
 				.ToList();
 		}
 
+		public IndexingPerformanceStatistics[] IndexingPerformanceStatistics
+		{
+			get
+			{
+				return (from pair in IndexDefinitionStorage.IndexDefinitions
+					   let performance = IndexStorage.GetIndexingPerformance(pair.Key)
+					   select new IndexingPerformanceStatistics
+					   {
+						   IndexId = pair.Key,
+						   IndexName = pair.Value.Name,
+						   Performance = performance
+					   }).ToArray();
+			}
+		}
+
 		public DatabaseStatistics Statistics
 		{
 			get

--- a/Raven.Database/Server/Controllers/DebugController.cs
+++ b/Raven.Database/Server/Controllers/DebugController.cs
@@ -10,11 +10,11 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using System.Web;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Routing;
 using ICSharpCode.NRefactory.CSharp;
+
 using Raven.Abstractions;
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Logging;
@@ -194,9 +194,9 @@ namespace Raven.Database.Server.Controllers
 		/// <param name="format"></param>
 		/// <returns></returns>
 		[HttpGet]
-		[RavenRoute("debug/indexing-perf-stats")]
-		[RavenRoute("databases/{databaseName}/debug/indexing-perf-stats")]
-		public HttpResponseMessage IndexingPerfStats(string format = "json")
+		[RavenRoute("debug/indexing-perf-stats-with-timings")]
+		[RavenRoute("databases/{databaseName}/debug/indexing-perf-stats-with-timings")]
+		public HttpResponseMessage IndexingPerfStatsWthTimings(string format = "json")
 		{
 			var now = SystemTime.UtcNow;
 			var nowTruncToSeconds = new DateTime(now.Ticks / TimeSpan.TicksPerSecond * TimeSpan.TicksPerSecond, now.Kind);
@@ -381,7 +381,7 @@ namespace Raven.Database.Server.Controllers
 			{
 				Content = new PushStreamContent((stream, content, transportContext) => Database.TransactionalStorage.Batch(accessor =>
 				{
-					using(stream)
+					using (stream)
 					using (var docContent = accessor.Documents.RawDocumentByKey(docId))
 					{
 						docContent.CopyTo(stream);
@@ -394,22 +394,22 @@ namespace Raven.Database.Server.Controllers
 						ContentType = new MediaTypeHeaderValue("application/octet-stream"),
 						ContentDisposition = new ContentDispositionHeaderValue("attachment")
 						{
-							FileName = docId +".raw-doc"
+							FileName = docId + ".raw-doc"
 						}
 					}
 				}
 			};
 		}
 
-	    [HttpGet]
-	    [RavenRoute("debug/slow-dump-ref-csv")]
+		[HttpGet]
+		[RavenRoute("debug/slow-dump-ref-csv")]
 		[RavenRoute("databases/{databaseName}/debug/slow-dump-ref-csv")]
-        public HttpResponseMessage DumpRefsToCsv(int sampleCount = 10)
-	    {
-		    return new HttpResponseMessage
-		    {
-			    Content = new PushStreamContent((stream, content, context) =>
-			    {
+		public HttpResponseMessage DumpRefsToCsv(int sampleCount = 10)
+		{
+			return new HttpResponseMessage
+			{
+				Content = new PushStreamContent((stream, content, context) =>
+				{
 					using (var writer = new StreamWriter(stream))
 					{
 						writer.WriteLine("ref count,document key,sample references");
@@ -418,28 +418,28 @@ namespace Raven.Database.Server.Controllers
 							accessor.Indexing.DumpAllReferancesToCSV(writer, sampleCount);
 						});
 						writer.Flush();
-                        stream.Flush();
+						stream.Flush();
 					}
-			    })
-			    {
-				    Headers =
-				    {
-					    ContentDisposition = new ContentDispositionHeaderValue("attachment")
-					    {
-						    FileName = "doc-refs.csv",
-					    },
-					    ContentType = new MediaTypeHeaderValue("application/octet-stream")
-				    }
-			    }
-		    };
-	    }
+				})
+				{
+					Headers =
+					{
+						ContentDisposition = new ContentDispositionHeaderValue("attachment")
+						{
+							FileName = "doc-refs.csv",
+						},
+						ContentType = new MediaTypeHeaderValue("application/octet-stream")
+					}
+				}
+			};
+		}
 
 		[HttpGet]
 		[RavenRoute("debug/docrefs")]
 		[RavenRoute("databases/{databaseName}/debug/docrefs")]
 		public HttpResponseMessage DocRefs(string id)
 		{
-		    var op = GetQueryStringValue("op");
+			var op = GetQueryStringValue("op");
 			op = op == "from" ? "from" : "to";
 
 			var totalCountReferencing = -1;
@@ -460,7 +460,7 @@ namespace Raven.Database.Server.Controllers
 				Results = results
 			});
 		}
-        //DumpAllReferancesToCSV
+		//DumpAllReferancesToCSV
 		[HttpGet]
 		[RavenRoute("debug/d0crefs-t0ps")]
 		[RavenRoute("databases/{databaseName}/debug/d0crefs-t0ps")]
@@ -762,6 +762,14 @@ namespace Raven.Database.Server.Controllers
 					ThreadPoolStats = Database.ReducingThreadPool.GetThreadPoolStats()
 				}
 			});
+		}
+
+		[HttpGet]
+		[RavenRoute("debug/indexing-perf-stats")]
+		[RavenRoute("databases/{databaseName}/debug/indexing-perf-stats")]
+		public HttpResponseMessage IndexingPerfStats()
+		{
+			return GetMessageWithObject(Database.IndexingPerformanceStatistics);
 		}
 	}
 

--- a/Raven.Database/Server/Controllers/IndexController.cs
+++ b/Raven.Database/Server/Controllers/IndexController.cs
@@ -68,14 +68,9 @@ namespace Raven.Database.Server.Controllers
                 if (string.IsNullOrEmpty(GetQueryStringValue("explain")) == false) 
                     return GetExplanation(index);
 
-				if (string.Equals(id, "indexing-perf-stats", StringComparison.OrdinalIgnoreCase))
-					return GetIndexingPerformanceStatistics();
-
                 return GetIndexQueryResult(index, cts.Token);
             }
 		}
-
-		
 
 		[HttpPost]
 		[RavenRoute("indexes/last-queried")]
@@ -773,20 +768,6 @@ namespace Raven.Database.Server.Controllers
 
 			stats.LastQueryTimestamp = Database.IndexStorage.GetLastQueryTime(instance.indexId);
 			stats.SetLastDocumentEtag(lastEtag);
-			return GetMessageWithObject(stats);
-		}
-
-		private HttpResponseMessage GetIndexingPerformanceStatistics()
-		{
-			var stats = from pair in Database.IndexDefinitionStorage.IndexDefinitions 
-						let performance = Database.IndexStorage.GetIndexingPerformance(pair.Key) 
-						select new IndexingPerformanceStatistics
-						       {
-							       IndexId = pair.Key, 
-								   IndexName = pair.Value.Name, 
-								   Performance = performance
-						       };
-
 			return GetMessageWithObject(stats);
 		}
 	}

--- a/Raven.Database/Util/DebugInfoProvider.cs
+++ b/Raven.Database/Util/DebugInfoProvider.cs
@@ -3,18 +3,9 @@
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Management;
-using Raven.Abstractions;
+
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Extensions;
-using Raven.Abstractions.Indexing;
-using Raven.Abstractions.Json;
 using Raven.Abstractions.Logging;
 using Raven.Bundles.Replication.Tasks;
 using Raven.Database.Bundles.Replication.Utils;
@@ -26,11 +17,18 @@ using Raven.Database.Tasks;
 using Raven.Imports.Newtonsoft.Json;
 using Raven.Json.Linq;
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Management;
+
 namespace Raven.Database.Util
 {
 	public static class DebugInfoProvider
 	{
-		const CompressionLevel compressionLevel = CompressionLevel.Optimal;
+		private const CompressionLevel CompressionLevel = System.IO.Compression.CompressionLevel.Optimal;
 
 		public static void CreateInfoPackageForDatabase(ZipArchive package, DocumentDatabase database, RequestManager requestManager, string zipEntryPrefix = null)
         {
@@ -45,7 +43,7 @@ namespace Raven.Database.Util
 
             if (database.StartupTasks.OfType<ReplicationTask>().Any())
             {
-                var replication = package.CreateEntry(zipEntryPrefix + "replication.json", compressionLevel);
+                var replication = package.CreateEntry(zipEntryPrefix + "replication.json", CompressionLevel);
 
                 using (var statsStream = replication.Open())
                 using (var streamWriter = new StreamWriter(statsStream))
@@ -58,7 +56,7 @@ namespace Raven.Database.Util
             var sqlReplicationTask = database.StartupTasks.OfType<SqlReplicationTask>().FirstOrDefault();
             if (sqlReplicationTask != null)
             {
-                var replication = package.CreateEntry(zipEntryPrefix + "sql_replication.json", compressionLevel);
+                var replication = package.CreateEntry(zipEntryPrefix + "sql_replication.json", CompressionLevel);
 
                 using (var statsStream = replication.Open())
                 using (var streamWriter = new StreamWriter(statsStream))
@@ -68,7 +66,7 @@ namespace Raven.Database.Util
                 }
             }
 
-            var stats = package.CreateEntry(zipEntryPrefix + "stats.json", compressionLevel);
+            var stats = package.CreateEntry(zipEntryPrefix + "stats.json", CompressionLevel);
 
             using (var statsStream = stats.Open())
             using (var streamWriter = new StreamWriter(statsStream))
@@ -77,7 +75,16 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var metrics = package.CreateEntry(zipEntryPrefix + "metrics.json", compressionLevel);
+			var indexingPerformanceStats = package.CreateEntry(zipEntryPrefix + "indexing_performance_stats.json", CompressionLevel);
+
+			using (var statsStream = indexingPerformanceStats.Open())
+			using (var streamWriter = new StreamWriter(statsStream))
+			{
+				jsonSerializer.Serialize(streamWriter, database.IndexingPerformanceStatistics);
+				streamWriter.Flush();
+			}
+
+            var metrics = package.CreateEntry(zipEntryPrefix + "metrics.json", CompressionLevel);
 
             using (var metricsStream = metrics.Open())
             using (var streamWriter = new StreamWriter(metricsStream))
@@ -86,7 +93,7 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var logs = package.CreateEntry(zipEntryPrefix + "logs.csv", compressionLevel);
+            var logs = package.CreateEntry(zipEntryPrefix + "logs.csv", CompressionLevel);
 
             using (var logsStream = logs.Open())
             using (var streamWriter = new StreamWriter(logsStream))
@@ -110,7 +117,7 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var config = package.CreateEntry(zipEntryPrefix + "config.json", compressionLevel);
+            var config = package.CreateEntry(zipEntryPrefix + "config.json", CompressionLevel);
 
             using (var configStream = config.Open())
             using (var streamWriter = new StreamWriter(configStream))
@@ -120,7 +127,7 @@ namespace Raven.Database.Util
                 jsonWriter.Flush();
             }
 
-            var indexes = package.CreateEntry(zipEntryPrefix + "indexes.json", compressionLevel);
+            var indexes = package.CreateEntry(zipEntryPrefix + "indexes.json", CompressionLevel);
 
             using (var indexesStream = indexes.Open())
             using (var streamWriter = new StreamWriter(indexesStream))
@@ -129,7 +136,7 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var currentlyIndexing = package.CreateEntry(zipEntryPrefix + "currently-indexing.json", compressionLevel);
+            var currentlyIndexing = package.CreateEntry(zipEntryPrefix + "currently-indexing.json", CompressionLevel);
 
             using (var currentlyIndexingStream = currentlyIndexing.Open())
             using (var streamWriter = new StreamWriter(currentlyIndexingStream))
@@ -138,7 +145,7 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var queries = package.CreateEntry(zipEntryPrefix + "queries.json", compressionLevel);
+            var queries = package.CreateEntry(zipEntryPrefix + "queries.json", CompressionLevel);
 
             using (var queriesStream = queries.Open())
             using (var streamWriter = new StreamWriter(queriesStream))
@@ -147,7 +154,7 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var version = package.CreateEntry(zipEntryPrefix + "version.json", compressionLevel);
+            var version = package.CreateEntry(zipEntryPrefix + "version.json", CompressionLevel);
 
             using (var versionStream = version.Open())
             using (var streamWriter = new StreamWriter(versionStream))
@@ -160,7 +167,7 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var prefetchStatus = package.CreateEntry(zipEntryPrefix + "prefetch-status.json", compressionLevel);
+            var prefetchStatus = package.CreateEntry(zipEntryPrefix + "prefetch-status.json", CompressionLevel);
 
             using (var prefetchStatusStream = prefetchStatus.Open())
             using (var streamWriter = new StreamWriter(prefetchStatusStream))
@@ -169,7 +176,7 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var requestTracking = package.CreateEntry(zipEntryPrefix + "request-tracking.json", compressionLevel);
+            var requestTracking = package.CreateEntry(zipEntryPrefix + "request-tracking.json", CompressionLevel);
 
             using (var requestTrackingStream = requestTracking.Open())
             using (var streamWriter = new StreamWriter(requestTrackingStream))
@@ -178,7 +185,7 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-            var tasks = package.CreateEntry(zipEntryPrefix + "tasks.json", compressionLevel);
+            var tasks = package.CreateEntry(zipEntryPrefix + "tasks.json", CompressionLevel);
 
             using (var tasksStream = tasks.Open())
             using (var streamWriter = new StreamWriter(tasksStream))
@@ -187,14 +194,14 @@ namespace Raven.Database.Util
                 streamWriter.Flush();
             }
 
-			var systemUtilization = package.CreateEntry(zipEntryPrefix + "system-utilization.json", compressionLevel);
+			var systemUtilization = package.CreateEntry(zipEntryPrefix + "system-utilization.json", CompressionLevel);
 
 			using (var systemUtilizationStream = systemUtilization.Open())
 			using (var streamWriter = new StreamWriter(systemUtilizationStream))
 			{
 				long totalPhysicalMemory = -1;
 				long availableMemory = -1;
-				object cpuTimes = null;
+				object cpuTimes;
 
 				try
 				{

--- a/Raven.Studio.Html5/App/commands/database/debug/getIndexingBatchStatsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/database/debug/getIndexingBatchStatsCommand.ts
@@ -55,7 +55,7 @@ class getIndexingBatchStatsCommand extends commandBase {
     }
 
     private getQueryUrlFragment(): string {
-        return "/debug/indexing-perf-stats";
+        return "/debug/indexing-perf-stats-with-timings";
     }
 }
 

--- a/Raven.Studio.Html5/App/commands/database/debug/getIndexingPerfStatsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/database/debug/getIndexingPerfStatsCommand.ts
@@ -8,7 +8,7 @@ class getIndexingPerfStatsCommand extends commandBase {
     }
 
     execute(): JQueryPromise<any> {
-        var url = "/debug/indexing-perf-stats";
+        var url = "/debug/indexing-perf-stats-with-timings";
         return this.query<any>(url, null, this.db);
     }
 }


### PR DESCRIPTION
- moved indexing-perf-stats to debug controller
- added indexing perf stats to debug package info
- renamed old indexing-perf-stats from debug controller to indexing-perf-stats-with-timings
