### PR TITLE
GetLegacyIndexDefinition should change back PrettifyGeneratedLinqExpressions to the original value

### DIFF
--- a/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
@@ -327,14 +327,15 @@ namespace Raven.Client.Indexes
         private IndexDefinition GetLegacyIndexDefinition(DocumentConvention documentConvention)
         {
             IndexDefinition legacyIndexDefinition;
-            documentConvention.PrettifyGeneratedLinqExpressions = false;
+			var oldPrettifyGeneratedLinqExpressions = documentConvention.PrettifyGeneratedLinqExpressions;
+			documentConvention.PrettifyGeneratedLinqExpressions = false;
             try
             {
                 legacyIndexDefinition = CreateIndexDefinition();
             }
             finally
             {
-                documentConvention.PrettifyGeneratedLinqExpressions = true;
+				documentConvention.PrettifyGeneratedLinqExpressions = oldPrettifyGeneratedLinqExpressions;
             }
             return legacyIndexDefinition;
         }

--- a/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/ReplicationTask.cs
@@ -885,7 +885,7 @@ namespace Raven.Bundles.Replication.Tasks
 
 				using (HttpRavenRequestFactory.Expect100Continue(destination.ConnectionStringOptions.Url))
 				{
-					var request = httpRavenRequestFactory.Create(url, "POST", destination.ConnectionStringOptions, destinationForceBuffering.GetOrAdd(destination.ConnectionStringOptions.Url, docDb.Configuration.Replication.ForceReplicationRequestBuffering));
+					var request = httpRavenRequestFactory.Create(url, "POST", destination.ConnectionStringOptions, GetRequestBuffering(destination));
 					request.Write(jsonDocuments);
 					request.ExecuteRequest(docDb.WorkContext.CancellationToken);
 


### PR DESCRIPTION
I think it should be done this way, please verify