### PR TITLE
Voron page splitter bugs

### DIFF
--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -117,7 +117,6 @@
     <Compile Include="1379\RavenDB_1379_Client_Lazy.cs" />
     <Compile Include="1379\RavenDB_1379_Client_Remote.cs" />
     <Compile Include="ActualValueInJsonReaderException.cs" />
-    <Compile Include="HttpEncoding.cs" />
     <Compile Include="RavenDB-3152.cs" />
     <Compile Include="RavenDB-3179.cs" />
     <Compile Include="RavenDB-3302.cs" />

--- a/Raven.Voron/Voron.Tests/Bugs/SplittingPageWithPrefixes.cs
+++ b/Raven.Voron/Voron.Tests/Bugs/SplittingPageWithPrefixes.cs
@@ -1,0 +1,76 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SplittingPageWithPrefixes.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.IO;
+using Voron.Debugging;
+using Xunit;
+
+namespace Voron.Tests.Bugs
+{
+	public class SplittingPageWithPrefixes : StorageTest
+	{
+		[Fact]
+		public void ShouldHaveEnoughSpaceOnNewPageDuringTruncate()
+		{
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				Env.CreateTree(tx, "prefixed-tree", keysPrefixing: true);
+
+				tx.Commit();
+			}
+
+			var r = new Random(1);
+
+			for (int i = 0; i < 1000; i++)
+			{
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					var tree = tx.ReadTree("prefixed-tree");
+
+					if (i == 115)
+					{
+						DebugStuff.RenderAndShow(tx, tree.State.RootPageNumber, 1);
+					}
+
+					tree.Add(new string('a', r.Next(2000)) + i, new MemoryStream(new byte[128]));
+					tree.Add(new string('b', r.Next(1000)) + i, new MemoryStream(new byte[256]));
+					tree.Add(new string('c', r.Next(2000)) + i, new MemoryStream(new byte[128]));
+					tree.Add(new string('d', r.Next(500)) + i, new MemoryStream(new byte[512]));
+
+					tx.Commit();
+				}
+			}
+		}
+
+		[Fact]
+		public void ShouldHaveEnoughSpaceOnNewPageWhenSplittingPageInHalf()
+		{
+			using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+			{
+				Env.CreateTree(tx, "prefixed-tree", keysPrefixing: true);
+
+				tx.Commit();
+			}
+
+			var r = new Random(3);
+
+			for (int i = 0; i < 1000; i++)
+			{
+				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
+				{
+					var tree = tx.ReadTree("prefixed-tree");
+
+					tree.Add(new string('a', r.Next(2000)) + i, new MemoryStream(new byte[128]));
+					tree.Add(new string('b', r.Next(1000)) + i, new MemoryStream(new byte[256]));
+					tree.Add(new string('c', r.Next(2000)) + i, new MemoryStream(new byte[128]));
+					tree.Add(new string('d', r.Next(500)) + i, new MemoryStream(new byte[512]));
+
+					tx.Commit();
+				}
+			}
+		}
+	}
+}

--- a/Raven.Voron/Voron.Tests/Bugs/SplittingPageWithPrefixes.cs
+++ b/Raven.Voron/Voron.Tests/Bugs/SplittingPageWithPrefixes.cs
@@ -5,7 +5,6 @@
 // -----------------------------------------------------------------------
 using System;
 using System.IO;
-using Voron.Debugging;
 using Xunit;
 
 namespace Voron.Tests.Bugs
@@ -29,11 +28,6 @@ namespace Voron.Tests.Bugs
 				using (var tx = Env.NewTransaction(TransactionFlags.ReadWrite))
 				{
 					var tree = tx.ReadTree("prefixed-tree");
-
-					if (i == 115)
-					{
-						DebugStuff.RenderAndShow(tx, tree.State.RootPageNumber, 1);
-					}
 
 					tree.Add(new string('a', r.Next(2000)) + i, new MemoryStream(new byte[128]));
 					tree.Add(new string('b', r.Next(1000)) + i, new MemoryStream(new byte[256]));

--- a/Raven.Voron/Voron.Tests/Voron.Tests.csproj
+++ b/Raven.Voron/Voron.Tests/Voron.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Bugs\InvalidReleasesOfScratchPages.cs" />
     <Compile Include="Bugs\MultiReads.cs" />
     <Compile Include="Bugs\Iterating.cs" />
+    <Compile Include="Bugs\SplittingPageWithPrefixes.cs" />
     <Compile Include="Bugs\StartsWithSearch.cs" />
     <Compile Include="Bugs\FreeSpaceAndOverflowPages.cs" />
     <Compile Include="Bugs\DataCorruptionInOverflow.cs" />

--- a/Raven.Voron/Voron/Trees/PageSplitter.cs
+++ b/Raven.Voron/Voron/Trees/PageSplitter.cs
@@ -158,9 +158,16 @@ namespace Voron.Trees
             if (currentIndex < splitIndex)
                 newPosition = false;
 
-            if (_page.IsLeaf)
+	        PrefixNode[] prefixes = null;
+
+	        if (_tree.KeysPrefixing && _page.HasPrefixes)
+	        {
+		        prefixes = _page.GetPrefixes();
+	        }
+
+	        if (_page.IsLeaf || prefixes != null)
             {
-                splitIndex = AdjustSplitPosition(currentIndex, splitIndex, ref newPosition);
+                splitIndex = AdjustSplitPosition(currentIndex, splitIndex, prefixes, ref newPosition);
             }
 
 	        var currentKey = _page.GetNodeKey(splitIndex);
@@ -180,7 +187,18 @@ namespace Voron.Trees
             AddSeparatorToParentPage(rightPage.PageNumber, seperatorKey);
 
 	        MemorySlice instance = _page.CreateNewEmptyKey();
-            // move the actual entries from page to right page
+
+	        if (prefixes != null)
+	        {
+				for (int i = 0; i < prefixes.Length; i++)
+				{
+					var prefix = prefixes[i];
+
+					rightPage.WritePrefix(new Slice(prefix.ValuePtr, prefix.PrefixLength), i);
+				}
+	        }
+
+	        // move the actual entries from page to right page
             ushort nKeys = _page.NumberOfEntries;
             for (int i = splitIndex; i < nKeys; i++)
             {
@@ -193,6 +211,7 @@ namespace Voron.Trees
                 {
 	                _page.SetNodeKey(node, ref instance);
 	                var key = rightPage.PrepareKeyToInsert(instance, rightPage.NumberOfEntries);
+
 					rightPage.CopyNodeDataToEndOfPage(node, key);
                 }
             }
@@ -283,8 +302,7 @@ namespace Voron.Trees
             }
         }
 
-        private int AdjustSplitPosition(int currentIndex, int splitIndex,
-            ref bool newPosition)
+        private int AdjustSplitPosition(int currentIndex, int splitIndex, PrefixNode[] prefixes, ref bool newPosition)
         {
 	        MemorySlice keyToInsert;
 
@@ -295,8 +313,14 @@ namespace Voron.Trees
 
 	        var pageSize = SizeOf.NodeEntry(AbstractPager.PageMaxSpace, keyToInsert , _len) + Constants.NodeOffsetSize;
 
-			if(_tree.KeysPrefixing)
-				pageSize += (Constants.PrefixNodeHeaderSize + 1); // let's assume that prefix will be created to ensure the destination page will have enough space, + 1 because prefix node might require 2-byte alignment
+			if (prefixes != null)
+			{
+				// we are going to copy all existing prefixes so we need to take into account their sizes
+				for (var i = 0; i < prefixes.Length; i++)
+				{
+					pageSize += (Constants.PrefixNodeHeaderSize + prefixes[i].Header.PrefixLength) & 1; // & 1 because we need 2-byte alignment
+				}
+			}
 
             if (currentIndex <= splitIndex)
             {

--- a/Raven.Voron/Voron/Trees/PageSplitter.cs
+++ b/Raven.Voron/Voron/Trees/PageSplitter.cs
@@ -275,7 +275,7 @@ namespace Voron.Trees
 			{
 				_cursor.Push(p);
 
-				var pageSplitter = new PageSplitter(_tx, _tree, _newKey, _len, p.PageNumber, _nodeType, _nodeVersion, _cursor, _treeState);
+				var pageSplitter = new PageSplitter(_tx, _tree, _newKey, _len, _pageNumber, _nodeType, _nodeVersion, _cursor, _treeState);
 
 				return pageSplitter.Execute();
 			}


### PR DESCRIPTION
This is the first part of fixes in Voron. I also have failing tests for tree rebalancing that I am currently investigating.

I'm requesting this to 3.0 because of the bug fixed in this commit:
https://github.com/ayende/ravendb/commit/7dc3645fa4aa53a707ba569889002d7dc0e07d50
which wasn't related to prefixed trees at all.
