### PR TITLE
RavenDB-3452 Fixing occasionally failing ShouldStopPullingDocsIfRelea…

### DIFF
--- a/Raven.Tests.Issues/RavenDB_2627.cs
+++ b/Raven.Tests.Issues/RavenDB_2627.cs
@@ -912,8 +912,10 @@ namespace Raven.Tests.Issues
 
 				Thread.Sleep(TimeSpan.FromSeconds(5));
 
-				Assert.False(docs.TryTake(out doc, waitForDocTimeout));
-				Assert.False(docs.TryTake(out doc, waitForDocTimeout));
+				doc = null;
+
+				Assert.False(docs.TryTake(out doc, waitForDocTimeout), doc != null ? doc.ToString() : string.Empty);
+				Assert.False(docs.TryTake(out doc, waitForDocTimeout), doc != null ? doc.ToString() : string.Empty);
 
 				Assert.True(subscription.IsClosed);
 


### PR DESCRIPTION
…sed test. The problem was that AssertNotFailingResponse threw InvalidOperationException while the subscription expected  ErrorResponseException. Throwing ErrorResponseException is also more consistent with HttpJsonRequest's behavior.
