### PR TITLE
RavenDB-3486 Don't allow sharding RavenFS where dictionary defines mo…

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/Shard/ShardStrategy.cs
+++ b/Raven.Client.Lightweight/FileSystem/Shard/ShardStrategy.cs
@@ -22,6 +22,32 @@ namespace Raven.Client.FileSystem.Shard
 			if (shards.Count == 0)
 				throw new ArgumentException("Shards collection must have at least one item", "shards");
 
+            var shardsKeyIdList = shards.Select(x => new
+            {
+                ID = x.Value.GetServerIdAsync(),
+                Key = x.Key,
+
+            }).ToList();
+
+            shardsKeyIdList.ForEach(x =>
+            {
+                try
+                {
+                    x.ID.Wait();
+                }
+                catch
+                {
+                    // we'll just ignore any connection erros here
+                }
+            });
+
+            var shardsPointingToSameDb = shardsKeyIdList.Where(x => x.ID.Status == TaskStatus.RanToCompletion)
+                .GroupBy(x => x.ID.Result).FirstOrDefault(x => x.Count() > 1);
+
+            if (shardsPointingToSameDb != null)
+                throw new NotSupportedException(string.Format("Multiple keys in shard dictionary for {0} are not supported.",
+                    string.Join(", ", shardsPointingToSameDb.Select(x => x.Key))));
+
             this.shards = new Dictionary<string, IAsyncFilesCommands>(shards, StringComparer.OrdinalIgnoreCase);
 
 

--- a/Raven.Tests.FileSystem/Shard/CustomShardResolutionStrategy.cs
+++ b/Raven.Tests.FileSystem/Shard/CustomShardResolutionStrategy.cs
@@ -116,5 +116,35 @@ namespace Raven.Tests.FileSystem.Shard
 
 			Assert.Equal("/Asia/test2", fileName);
 		}
-	}
+
+        [Fact]
+        public void CanIgnoreMultiKeysToShard()
+        {
+            var client1 = NewAsyncClient(0, fileSystemName: "shard1");
+            var client2 = NewAsyncClient(1, fileSystemName: "shard2");
+            var client3 = client2;
+
+            var shards = new Dictionary<string, IAsyncFilesCommands>
+		    {
+			    {"Europe", client1},
+			    {"Asia", client2},
+                {"Middle-East", client3},
+		    };
+
+            NotSupportedException notSuppotedEx = null;
+
+            try
+            {
+                var strategy = new ShardStrategy(shards);
+            }
+            catch (Exception ex)
+            {
+                notSuppotedEx = ex as NotSupportedException;
+            }
+
+            Assert.NotNull(notSuppotedEx);
+            Assert.Contains("Multiple keys in shard dictionary for", notSuppotedEx.Message);
+        }
+    
+    }
 }


### PR DESCRIPTION
Don't allow sharding RavenFS where dictionary defines more than one key per server
Same situation as in 3471