### PR TITLE
minor fix for replication from specific collections

### DIFF
--- a/Raven.Abstractions/Replication/ReplicationDestination.cs
+++ b/Raven.Abstractions/Replication/ReplicationDestination.cs
@@ -55,10 +55,15 @@ namespace Raven.Abstractions.Replication
 		/// </summary>
 		public string[] SourceCollections
 		{
-			get { return _sourceCollections ?? (_sourceCollections = new string[0]); }
+			get
+			{
+				return _sourceCollections ?? (_sourceCollections = new string[0]);
+			}
 			set
 			{
 				_sourceCollections = value;
+				if (_sourceCollections.Length > 0)
+					IgnoredClient = true;
 			}
 		}
 

--- a/Raven.Tests.Bundles/Replication/CollectionSpecific.cs
+++ b/Raven.Tests.Bundles/Replication/CollectionSpecific.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
-using System.Web.Http;
 using Raven.Abstractions.Replication;
 using Raven.Client;
 using Raven.Client.Connection.Async;


### PR DESCRIPTION
minor change - bringing back IgnoredClient = true on SourceCollection's set