### PR TITLE
RavenDB-3566 Fixing a bottleneck in multi-task upload scenario caused…

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/Impl/UploadFileOperation.cs
+++ b/Raven.Client.Lightweight/FileSystem/Impl/UploadFileOperation.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.FileSystem.Impl
         {
             var commands = session.Commands;
 
-            var pipe = new BlockingStream(10);           
+            var pipe = new BlockingStream();           
 
             Task.Run(() => StreamWriter(pipe))
                                 .ContinueWith(x => pipe.CompleteWriting())

--- a/Raven.Client.Lightweight/Util/BlockingStream.cs
+++ b/Raven.Client.Lightweight/Util/BlockingStream.cs
@@ -15,6 +15,11 @@ namespace Raven.Client.Util
         private byte[] _currentBlock;
         private int _currentBlockIndex;
 
+		public BlockingStream()
+		{
+			_blocks = new BlockingCollection<byte[]>();
+		}
+
         public BlockingStream(int streamWriteCountCache)
         {
             _blocks = new BlockingCollection<byte[]>(streamWriteCountCache);


### PR DESCRIPTION
… by limited capacity of BlockingCollection during uploading files by using a session.
