### PR TITLE
Linq Query in PruneToFailureLinqQueryAsStringToWorkableCode contains …

### DIFF
--- a/Raven.Client.Lightweight/Indexes/IndexDefinitionHelper.cs
+++ b/Raven.Client.Lightweight/Indexes/IndexDefinitionHelper.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Raven.Abstractions.Exceptions;
 using Raven.Client.Document;
 using Raven.Client.Util;
+using Raven.Abstractions;
 
 namespace Raven.Client.Indexes
 {
@@ -60,6 +61,12 @@ namespace Raven.Client.Indexes
             linqQuery = ReplaceAnonymousTypeBraces(linqQuery);
             linqQuery = Regex.Replace(linqQuery, @"<>([a-z])_", "__$1_"); // replace <>h_ in transparent identifiers
             linqQuery = Regex.Replace(linqQuery, @"__h__TransparentIdentifier(\w)+", "this$1");
+
+            if (EnvironmentUtils.RunningOnPosix)
+            {
+                linqQuery = Regex.Replace(linqQuery, @"<>__TranspIdent(\w)+", "this$1");
+            }
+            
             linqQuery = JSBeautify.Apply(linqQuery);
             return linqQuery;
         }


### PR DESCRIPTION
…in mono <>__TranspIdent instead of windows' __h__TransparentIdentifier

Solves Test.Core : CanUseMoreLikeThisWithTransformer (among other test..)