### PR TITLE
RavenDB-3590 we should not rely on query string value, just the key e…

### DIFF
--- a/Raven.Database/Server/Controllers/Admin/AdminController.cs
+++ b/Raven.Database/Server/Controllers/Admin/AdminController.cs
@@ -758,11 +758,8 @@ namespace Raven.Database.Server.Controllers.Admin
 						DebugInfoProvider.CreateInfoPackageForDatabase(package, database, RequestManager, prefix + "/");
 					});
 
-					var stacktraceRequsted = GetQueryStringValue("stacktrace");
-					if (stacktraceRequsted != null)
-					{
+					if (ContainsQueryStringKey("stacktrace"))
 						DumpStacktrace(package);
-					}
 				}
 
 				var response = new HttpResponseMessage();
@@ -787,61 +784,56 @@ namespace Raven.Database.Server.Controllers.Admin
 			}
 		}
 
-		private void DumpStacktrace(ZipArchive package)
+		private static void DumpStacktrace(ZipArchive package)
 		{
-			var stacktraceRequsted = GetQueryStringValue("stacktrace");
+			var stacktrace = package.CreateEntry("stacktraces.txt", CompressionLevel.Optimal);
 
-			if (stacktraceRequsted != null)
+			var jsonSerializer = JsonExtensions.CreateDefaultJsonSerializer();
+			jsonSerializer.Formatting = Formatting.Indented;
+
+			using (var stacktraceStream = stacktrace.Open())
 			{
-				var stacktrace = package.CreateEntry("stacktraces.txt", CompressionLevel.Optimal);
+				string ravenDebugDir = null;
 
-				var jsonSerializer = JsonExtensions.CreateDefaultJsonSerializer();
-				jsonSerializer.Formatting = Formatting.Indented;
-
-				using (var stacktraceStream = stacktrace.Open())
+				try
 				{
-					string ravenDebugDir = null;
+					if (Debugger.IsAttached) throw new InvalidOperationException("Cannot get stacktraces when debugger is attached");
 
-					try
+					ravenDebugDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+					var ravenDebugExe = Path.Combine(ravenDebugDir, "Raven.Debug.exe");
+					var ravenDebugOutput = Path.Combine(ravenDebugDir, "stacktraces.txt");
+
+					Directory.CreateDirectory(ravenDebugDir);
+
+					if (Environment.Is64BitProcess) ExtractResource("Raven.Database.Util.Raven.Debug.x64.Raven.Debug.exe", ravenDebugExe);
+					else ExtractResource("Raven.Database.Util.Raven.Debug.x86.Raven.Debug.exe", ravenDebugExe);
+
+					var process = new Process { StartInfo = new ProcessStartInfo { Arguments = string.Format("-pid={0} /stacktrace -output={1}", Process.GetCurrentProcess().Id, ravenDebugOutput), FileName = ravenDebugExe, WindowStyle = ProcessWindowStyle.Hidden, } };
+
+					process.Start();
+
+					process.WaitForExit();
+
+					if (process.ExitCode != 0)
+						throw new InvalidOperationException("Raven.Debug exit code is: " + process.ExitCode);
+
+					using (var stackDumpOutputStream = File.Open(ravenDebugOutput, FileMode.Open))
 					{
-						if (Debugger.IsAttached) throw new InvalidOperationException("Cannot get stacktraces when debugger is attached");
-
-						ravenDebugDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-						var ravenDebugExe = Path.Combine(ravenDebugDir, "Raven.Debug.exe");
-						var ravenDebugOutput = Path.Combine(ravenDebugDir, "stacktraces.txt");
-
-						Directory.CreateDirectory(ravenDebugDir);
-
-						if (Environment.Is64BitProcess) ExtractResource("Raven.Database.Util.Raven.Debug.x64.Raven.Debug.exe", ravenDebugExe);
-						else ExtractResource("Raven.Database.Util.Raven.Debug.x86.Raven.Debug.exe", ravenDebugExe);
-
-						var process = new Process { StartInfo = new ProcessStartInfo { Arguments = string.Format("-pid={0} /stacktrace -output={1}", Process.GetCurrentProcess().Id, ravenDebugOutput), FileName = ravenDebugExe, WindowStyle = ProcessWindowStyle.Hidden, } };
-
-						process.Start();
-
-						process.WaitForExit();
-
-						if (process.ExitCode != 0)
-							throw new InvalidOperationException("Raven.Debug exit code is: " + process.ExitCode);
-
-						using (var stackDumpOutputStream = File.Open(ravenDebugOutput, FileMode.Open))
-						{
-							stackDumpOutputStream.CopyTo(stacktraceStream);
-						}
+						stackDumpOutputStream.CopyTo(stacktraceStream);
 					}
-					catch (Exception ex)
-					{
-						var streamWriter = new StreamWriter(stacktraceStream);
-						jsonSerializer.Serialize(streamWriter, new { Error = "Exception occurred during getting stacktraces of the RavenDB process. Exception: " + ex });
-						streamWriter.Flush();
-					}
-					finally
-					{
-						if (ravenDebugDir != null && Directory.Exists(ravenDebugDir)) IOExtensions.DeleteDirectory(ravenDebugDir);
-					}
-
-					stacktraceStream.Flush();
 				}
+				catch (Exception ex)
+				{
+					var streamWriter = new StreamWriter(stacktraceStream);
+					jsonSerializer.Serialize(streamWriter, new { Error = "Exception occurred during getting stacktraces of the RavenDB process. Exception: " + ex });
+					streamWriter.Flush();
+				}
+				finally
+				{
+					if (ravenDebugDir != null && Directory.Exists(ravenDebugDir)) IOExtensions.DeleteDirectory(ravenDebugDir);
+				}
+
+				stacktraceStream.Flush();
 			}
 		}
 

--- a/Raven.Database/Server/Controllers/RavenBaseApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenBaseApiController.cs
@@ -270,6 +270,11 @@ namespace Raven.Database.Server.Controllers
 			return items.Select(pair => (pair.Value != null) ? Uri.UnescapeDataString(pair.Value) : null ).ToArray();
 		}
 
+	    public bool ContainsQueryStringKey(string key)
+	    {
+		    return InnerRequest.GetQueryNameValuePairs().Any(x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase));
+	    }
+
 		public Etag GetEtagFromQueryString()
 		{
 			var etagAsString = GetQueryStringValue("etag");


### PR DESCRIPTION
…xistence when creating debug info package and requesting stacktraces