### PR TITLE
RDoc-339 CanExposeConfigOverTheWire should be case insensitive and sh…

### DIFF
--- a/Raven.Database/Server/Controllers/RavenDbApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenDbApiController.cs
@@ -776,7 +776,7 @@ namespace Raven.Database.Server.Controllers
 
 		protected bool CanExposeConfigOverTheWire()
 		{
-			if (SystemConfiguration.ExposeConfigOverTheWire == "AdminOnly" && SystemConfiguration.AnonymousUserAccessMode == AnonymousUserAccessMode.None)
+			if (string.Equals(SystemConfiguration.ExposeConfigOverTheWire, "AdminOnly", StringComparison.OrdinalIgnoreCase) && SystemConfiguration.AnonymousUserAccessMode != AnonymousUserAccessMode.Admin)
 			{
 				var authorizer = (MixedModeRequestAuthorizer)ControllerContext.Configuration.Properties[typeof(MixedModeRequestAuthorizer)];
 				var user = authorizer.GetUser(this);


### PR DESCRIPTION
…ould check for admin rights when AnonymousUserAccessMode is not Admin