### PR TITLE
Changed Voron detailed-storage-breakdown report format

### DIFF
--- a/Raven.Database/Server/Controllers/Admin/AdminController.cs
+++ b/Raven.Database/Server/Controllers/Admin/AdminController.cs
@@ -790,8 +790,11 @@ namespace Raven.Database.Server.Controllers.Admin
 		[RavenRoute("databases/{databaseName}/admin/detailed-storage-breakdown")]
 		public HttpResponseMessage DetailedStorageBreakdown()
 		{
-			var x = Database.TransactionalStorage.ComputeDetailedStorageInformation();
-			return GetMessageWithObject(x);
+			var detailedReport = GetQueryStringValue("DetailedReport");
+			bool isDetailedReport;
+			if (detailedReport != null && bool.TryParse(detailedReport, out isDetailedReport) && isDetailedReport)
+				return GetMessageWithObject(Database.TransactionalStorage.ComputeDetailedStorageInformation(true));
+			return GetMessageWithObject(Database.TransactionalStorage.ComputeDetailedStorageInformation());
 		}
 
 		[HttpPost]

--- a/Raven.Database/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorage.cs
@@ -452,7 +452,7 @@ namespace Raven.Storage.Esent
             });
         }
 
-        public IList<string> ComputeDetailedStorageInformation()
+		public IList<string> ComputeDetailedStorageInformation(bool computeExactSizes = false)
         {
             return StorageSizes.ReportOn(this);
         }

--- a/Raven.Database/Storage/ITransactionalStorage.cs
+++ b/Raven.Database/Storage/ITransactionalStorage.cs
@@ -50,7 +50,7 @@ namespace Raven.Database.Storage
 		void ClearCaches();
 		void DumpAllStorageTables();
 		InFlightTransactionalState GetInFlightTransactionalState(DocumentDatabase self, Func<string, Etag, RavenJObject, RavenJObject, TransactionInformation, PutResult> put, Func<string, Etag, TransactionInformation, bool> delete);
-        IList<string> ComputeDetailedStorageInformation();
+        IList<string> ComputeDetailedStorageInformation(bool computeExactSizes = false);
         List<TransactionContextData> GetPreparedTransactions();
 
 		object GetInFlightTransactionsInternalStateForDebugOnly();

--- a/Raven.Database/Storage/Voron/Impl/TableStorage.cs
+++ b/Raven.Database/Storage/Voron/Impl/TableStorage.cs
@@ -65,39 +65,13 @@ namespace Raven.Database.Storage.Voron.Impl
 			Initialize();
 		}
 
-		internal Dictionary<string, object> GenerateReportOnStorage()
+		internal StorageReport GenerateReportOnStorage(bool computeExactSizes = false)
 		{
-			var reportData = new Dictionary<string, object>
-	        {
-	            {"NumberOfAllocatedPages", _options.DataPager.NumberOfAllocatedPages},
-                {"UsedPages", env.State.NextPageNumber-1},
-	            {"MaxNodeSize", AbstractPager.NodeMaxSize},
-	            {"PageMinSpace", _options.DataPager.PageMinSpace},
-	            {"PageMaxSpace", AbstractPager.PageMaxSpace},
-	            {"PageSize", AbstractPager.PageSize},
-                {"Root",  System.Environment.NewLine + env.State.Root.State},
-                {"FreeSpace", System.Environment.NewLine +  env.State.FreeSpaceRoot.State},
-	        };
 
-		    using (var tx = env.NewTransaction(TransactionFlags.Read))
-		    {
-		        var root = env.State.Root;
-
-
-		        using (var it = root.Iterate())
-		        {
-		            if (it.Seek(Slice.BeforeAllKeys))
-		            {
-		                do
-		                {
-		                    var tree = tx.ReadTree(it.CurrentKey.ToString());
-		                    reportData[tree.Name] = System.Environment.NewLine + tree.State.ToString();
-		                } while (it.MoveNext());
-		            }
-		        }
-		    }
-
-			return reportData;
+			using (var tran = env.NewTransaction(TransactionFlags.Read))
+			{
+				return env.GenerateReport(tran, computeExactSizes);
+			}
 		}
 
 		public SnapshotReader CreateSnapshot()

--- a/Raven.Voron/Voron/StorageEnvironment.cs
+++ b/Raven.Voron/Voron/StorageEnvironment.cs
@@ -544,7 +544,7 @@ namespace Voron
             return results;
         }
 
-	    public StorageReport GenerateReport(Transaction tx)
+		public StorageReport GenerateReport(Transaction tx, bool computeExactSizes = false)
 	    {
 			var numberOfAllocatedPages = Math.Max(_dataPager.NumberOfAllocatedPages, NextPageNumber - 1); // async apply to data file task
 		    var numberOfFreePages = _freeSpaceHandling.AllPages(tx).Count;
@@ -570,7 +570,8 @@ namespace Voron
 				NumberOfFreePages = numberOfFreePages,
 				NextPageNumber = NextPageNumber,
 				Journals = Journal.Files.ToList(),
-				Trees = trees
+				Trees = trees,
+				IsLightReport = !computeExactSizes
 		    });
 	    }
 


### PR DESCRIPTION
Added DetailedReport parameter to databases/{databaseName}/admin/detailed-storage-breakdown endpoint
if DetailedReport is set to true the exact used size of the trees will be calculated (heavy read operation)
The default behavior is the same as DetailedReport=false
