### PR TITLE
Double escape only for older client version (under 3.0)

### DIFF
--- a/Raven.Database/Server/Controllers/QueriesController.cs
+++ b/Raven.Database/Server/Controllers/QueriesController.cs
@@ -103,7 +103,7 @@ namespace Raven.Database.Server.Controllers
                                         : Database.Documents.GetWithTransformer(value, transformer, transactionInformation, transformerParameters, out includedIds);
 				    if (documentByKey == null)
 				    {
-                        if(ClientIsV3OrHigher)
+                        if(ClientIsV3OrHigher(Request))
                             result.Results.Add(null); 
                         continue;
 				    }

--- a/Raven.Database/Server/Controllers/RavenBaseApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenBaseApiController.cs
@@ -284,8 +284,12 @@ namespace Raven.Database.Server.Controllers
 			IEnumerable<string> values;
 			if (req.Headers.TryGetValues("Raven-Client-Version", out values) == false)
 				return false; // probably 1.0 client?
-
-			return values.All(x => string.IsNullOrEmpty(x) == false && (x[0] != '1' && x[0] != '2'));
+			foreach (var value in values)
+			{
+				if (string.IsNullOrEmpty(value) ) return false;
+				if (value[0] == '1' || value[0] == '2') return false;
+			}
+			return true;
 		}
 
 	    protected string[] GetQueryStringValues(string key)

--- a/Raven.Database/Server/Controllers/RavenDbApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenDbApiController.cs
@@ -660,18 +660,6 @@ namespace Raven.Database.Server.Controllers
 			Database.WorkContext.MetricsCounters.RequestDurationLastMinute.AddRecord(duration);
 	    }
 
-		protected bool ClientIsV3OrHigher
-	    {
-	        get
-	        {
-	            IEnumerable<string> values;
-	            if (Request.Headers.TryGetValues("Raven-Client-Version", out values) == false)
-                    return false; // probably 1.0 client?
-
-	            return values.All(x => string.IsNullOrEmpty(x) == false && (x[0] != '1' && x[0] != '2'));
-	        }
-	    }
-
 		protected Etag GetLastDocEtag()
 		{
 			var lastDocEtag = Etag.Empty;


### PR DESCRIPTION
Fixing : 
 http://issues.hibernatingrhinos.com/issue/RavenDB-3713
The issue was that double escaping would remove '+' from the Lucene query string
resulting in the wrong query been processed. 