### PR TITLE
Some optimizations RavenDB-3724

### DIFF
--- a/Raven.Database/Indexing/BaseBatchSizeAutoTuner.cs
+++ b/Raven.Database/Indexing/BaseBatchSizeAutoTuner.cs
@@ -195,28 +195,28 @@ namespace Raven.Database.Indexing
 	        var isIndexingUsingTooMuchMemory = IsProcessingUsingTooMuchMemory;
 	        if (isIndexingUsingTooMuchMemory == false) //skip all other heuristics if indexing takes too much memory
 	        {
-			if (
-				// we had as much work to do as we are currently capable of handling,
-				// we might need to increase, but certainly not decrease the batch size
-				amountOfItemsToProcess >= NumberOfItemsToProcessInSingleBatch ||
-				// we haven't gone over the max latency limit, no reason to decrease yet
-				processingDuration < context.Configuration.MaxProcessingRunLatency)
-			{
-				return false;
-			}
+			    if (
+				    // we had as much work to do as we are currently capable of handling,
+				    // we might need to increase, but certainly not decrease the batch size
+				    amountOfItemsToProcess >= NumberOfItemsToProcessInSingleBatch ||
+				    // we haven't gone over the max latency limit, no reason to decrease yet
+				    processingDuration < context.Configuration.MaxProcessingRunLatency)
+			    {
+				    return false;
+			    }
 
-			if ((SystemTime.UtcNow - lastIncrease).TotalMinutes < 3)
-				return true;
+			    if ((SystemTime.UtcNow - lastIncrease).TotalMinutes < 3)
+				    return true;
 
-			// we didn't have a lot of work to do, so let us see if we can reduce the batch size
+			    // we didn't have a lot of work to do, so let us see if we can reduce the batch size
 
-			// we are at the configured minimum, nothing to do
-			if (NumberOfItemsToProcessInSingleBatch == InitialNumberOfItems)
-				return true;
+			    // we are at the configured minimum, nothing to do
+			    if (NumberOfItemsToProcessInSingleBatch == InitialNumberOfItems)
+				    return true;
 
-			// we were above the max/2 the last few times, we can't reduce the work load now
-			if (GetLastAmountOfItems().Any(x => x > NumberOfItemsToProcessInSingleBatch/2))
-				return true;
+			    // we were above the max/2 the last few times, we can't reduce the work load now
+			    if (GetLastAmountOfItems().Any(x => x > NumberOfItemsToProcessInSingleBatch/2))
+				    return true;
 	        }
 
 			var old = NumberOfItemsToProcessInSingleBatch;
@@ -225,7 +225,7 @@ namespace Raven.Database.Indexing
 			// we just reduced the batch size because we have two concurrent runs where we had
 			// less to do than the previous runs. That indicate the the busy period is over, maybe we
 			// run out of data? Or the rate of data entry into the system was just reduce?
-			// At any rate, there is a strong likelyhood of having a lot of garbage in the system
+			// At any rate, there is a strong likelihood of having a lot of garbage in the system
 			// let us ask the GC nicely to clean it
 
 			// but we only want to do it if the change was significant 

--- a/Raven.Database/Indexing/MapReduceIndex.cs
+++ b/Raven.Database/Indexing/MapReduceIndex.cs
@@ -676,15 +676,14 @@ namespace Raven.Database.Indexing
                 parent.Write((indexWriter, analyzer, stats) =>
                 {
                     stats.Operation = IndexingWorkStats.Status.Reduce;
-                    try
-                    {
-                        performance = parent.RecordCurrentBatch("Current Reduce #" + Level, "Reduce Level " + Level, MappedResultsByBucket.Sum(x => x.Count()));
 
+                    try
+                    {                                                
                         if (Level == 2)
                         {
                             RemoveExistingReduceKeysFromIndex(indexWriter, deleteExistingDocumentsDuration);
                         }
-
+                        
                         foreach (var mappedResults in MappedResultsByBucket)
                         {
                             var input = mappedResults.Select(x =>
@@ -715,7 +714,7 @@ namespace Raven.Database.Indexing
 
                                 stats.ReduceSuccesses++;
                             }
-                        }
+                        }                        
                     }
                     catch (Exception e)
                     {
@@ -743,6 +742,9 @@ namespace Raven.Database.Indexing
                                 },
                                 x => x.Dispose());
                         }
+
+                        // TODO: Check if we need to report "Bucket Counts" or "Total Input Elements"?
+                        performance = parent.RecordCurrentBatch("Current Reduce #" + Level, "Reduce Level " + Level, sourceCount);
                     }
 
                     return new IndexedItemsInfo(null)

--- a/Raven.Database/Indexing/ReducingExecuter.cs
+++ b/Raven.Database/Indexing/ReducingExecuter.cs
@@ -35,31 +35,30 @@ namespace Raven.Database.Indexing
 			bool operationCanceled = false;
 			var itemsToDelete = new ConcurrentSet<object>();
 
-			IList<ReduceTypePerKey> mappedResultsInfo = null;
-			transactionalStorage.Batch(actions =>
-			{
-				mappedResultsInfo = actions
-					.MapReduce
-					.GetReduceTypesPerKeys(indexToWorkOn.IndexId, context.CurrentNumberOfItemsToReduceInSingleBatch, context.NumberOfItemsToExecuteReduceInSingleStep, token)
-					.ToList();
-			});
-
 			var singleStepReduceKeys = new List<string>();
 			var multiStepsReduceKeys = new List<string>();
-			foreach (var key in mappedResultsInfo)
-			{
-				token.ThrowIfCancellationRequested();
 
-				switch (key.OperationTypeToPerform)
-				{
-					case ReduceType.SingleStep:
-						singleStepReduceKeys.Add(key.ReduceKey);
-						break;
-					case ReduceType.MultiStep:
-						multiStepsReduceKeys.Add(key.ReduceKey);
-						break;
-				}
-			}
+			transactionalStorage.Batch(actions =>
+			{
+                var mappedResultsInfo = actions.MapReduce.GetReduceTypesPerKeys(indexToWorkOn.IndexId, 
+                                                                    context.CurrentNumberOfItemsToReduceInSingleBatch, 
+                                                                    context.NumberOfItemsToExecuteReduceInSingleStep, token);
+
+			    foreach (var key in mappedResultsInfo)
+			    {
+				    token.ThrowIfCancellationRequested();
+
+				    switch (key.OperationTypeToPerform)
+				    {
+					    case ReduceType.SingleStep:
+						    singleStepReduceKeys.Add(key.ReduceKey);
+						    break;
+					    case ReduceType.MultiStep:
+						    multiStepsReduceKeys.Add(key.ReduceKey);
+						    break;
+				    }
+			    }
+			});
 
 			currentlyProcessedIndexes.TryAdd(indexToWorkOn.IndexId, indexToWorkOn.Index);
 
@@ -69,7 +68,9 @@ namespace Raven.Database.Indexing
 			{
 				if (singleStepReduceKeys.Count > 0)
 				{
-					Log.Debug("SingleStep reduce for keys: {0}", singleStepReduceKeys.Select(x => x + ","));
+                    if ( Log.IsDebugEnabled )
+                        Log.Debug("SingleStep reduce for keys: {0}", singleStepReduceKeys.Select(x => x + ","));
+                    
 					var singleStepStats = SingleStepReduce(indexToWorkOn, singleStepReduceKeys, viewGenerator, itemsToDelete, token);
 
 					performanceStats.Add(singleStepStats);
@@ -77,7 +78,9 @@ namespace Raven.Database.Indexing
 
 				if (multiStepsReduceKeys.Count > 0)
 				{
-					Log.Debug("MultiStep reduce for keys: {0}", multiStepsReduceKeys.Select(x => x + ","));
+                    if ( Log.IsDebugEnabled )
+                        Log.Debug("MultiStep reduce for keys: {0}", multiStepsReduceKeys.Select(x => x + ","));
+
 					var multiStepStats = MultiStepReduce(indexToWorkOn, multiStepsReduceKeys, viewGenerator, itemsToDelete, token);
 
 					performanceStats.Add(multiStepStats);
@@ -176,6 +179,7 @@ namespace Raven.Database.Indexing
 
 					if (lastPerformedReduceType != ReduceType.SingleStep)
 						continue;
+
 					// we exceeded the limit of items to reduce in single step
 					// now we need to schedule reductions at level 0 for all map results with given reduce key
 					var mappedItems = actions.MapReduce.GetMappedBuckets(index.IndexId, localReduceKey, token).ToList();
@@ -187,6 +191,8 @@ namespace Raven.Database.Indexing
 			});
 
 			var reducePerformance = new ReducingPerformanceStats(ReduceType.MultiStep);
+
+            var keysToReduceSet = new HashSet<string>(keysToReduce);
 
 			for (int i = 0; i < 3; i++)
 			{
@@ -200,12 +206,12 @@ namespace Raven.Database.Indexing
 
 				var reduceParams = new GetItemsToReduceParams(
 					index.IndexId,
-					keysToReduce,
+                    keysToReduceSet,
 					level,
 					true,
 					itemsToDelete);
 
-				var gettigItemsToReduceDuration = new Stopwatch();
+				var gettingItemsToReduceDuration = new Stopwatch();
 				var scheduleReductionsDuration = new Stopwatch();
 				var removeReduceResultsDuration = new Stopwatch();
 				var storageCommitDuration = new Stopwatch();
@@ -227,61 +233,67 @@ namespace Raven.Database.Indexing
 
 							reduceParams.Take = context.CurrentNumberOfItemsToReduceInSingleBatch;
 
-							List<MappedResultInfo> persistedResults;
-							using (StopwatchScope.For(gettigItemsToReduceDuration))
+                            int size = 0;                            
+                            MappedResultInfo[] persistedResults;
+                            var reduceKeys = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+							using (StopwatchScope.For(gettingItemsToReduceDuration))
 							{
-								persistedResults = actions.MapReduce.GetItemsToReduce(reduceParams, token).ToList();
+                                persistedResults = actions.MapReduce.GetItemsToReduce(reduceParams, token).ToArray();                                
+
+                                foreach (var item in persistedResults)
+                                {
+                                    reduceKeys.Add(item.ReduceKey);
+                                    size += item.Size;
+                                }
 							}
 
-							if (persistedResults.Count == 0)
+                            if (persistedResults.Length == 0)
 							{
 								retry = false;
 								return;
 							}
 
-							var count = persistedResults.Count;
-							var size = persistedResults.Sum(x => x.Size);
+                            var count = persistedResults.Length;
+
 							autoTuner.CurrentlyUsedBatchSizesInBytes.GetOrAdd(reduceBatchAutoThrottlerId, size);
 
 							if (Log.IsDebugEnabled)
 							{
-								if (persistedResults.Count > 0)
-									Log.Debug(() => string.Format("Found {0} results for keys [{1}] for index {2} at level {3} in {4}",
-										persistedResults.Count,
-										string.Join(", ", persistedResults.Select(x => x.ReduceKey).Distinct()),
-										index.IndexId, level, batchTimeWatcher.Elapsed));
+                                if (persistedResults.Length > 0)
+                                {
+                                    Log.Debug(() => string.Format("Found {0} results for keys [{1}] for index {2} at level {3} in {4}",
+                                        persistedResults.Length,
+                                        string.Join(", ", persistedResults.Select(x => x.ReduceKey).Distinct()),
+                                        index.IndexId, level, batchTimeWatcher.Elapsed));
+                                }
 								else
-									Log.Debug("No reduce keys found for {0}", index.IndexId);
+                                {
+                                    Log.Debug("No reduce keys found for {0}", index.IndexId);
+                                }									
 							}
 
 							token.ThrowIfCancellationRequested();
 
-							var requiredReduceNextTime = persistedResults.Select(x => new ReduceKeyAndBucket(x.Bucket, x.ReduceKey))
-								.OrderBy(x => x.Bucket)
-								.Distinct()
-								.ToArray();
+
+                            var requiredReduceNextTimeSet = new HashSet<ReduceKeyAndBucket>(persistedResults.Select(x => new ReduceKeyAndBucket(x.Bucket, x.ReduceKey)));
 
 							using (StopwatchScope.For(removeReduceResultsDuration))
 							{
-								foreach (var mappedResultInfo in requiredReduceNextTime)
+                                foreach (var mappedResultInfo in requiredReduceNextTimeSet)//.OrderBy(x => x.Bucket))
 								{
 									token.ThrowIfCancellationRequested();
 
-									actions.MapReduce.RemoveReduceResults(index.IndexId, level + 1, mappedResultInfo.ReduceKey,
-										mappedResultInfo.Bucket);
+									actions.MapReduce.RemoveReduceResults(index.IndexId, level + 1, mappedResultInfo.ReduceKey, mappedResultInfo.Bucket);
 								}
 							}
 
 							if (level != 2)
 							{
-								var reduceKeysAndBuckets = requiredReduceNextTime
-									.Select(x => new ReduceKeyAndBucket(x.Bucket / 1024, x.ReduceKey))
-									.Distinct()
-									.ToArray();
+                                var reduceKeysAndBucketsSet = new HashSet<ReduceKeyAndBucket>(requiredReduceNextTimeSet.Select(x => new ReduceKeyAndBucket(x.Bucket / 1024, x.ReduceKey)));
 
 								using (StopwatchScope.For(scheduleReductionsDuration))
 								{
-									foreach (var reduceKeysAndBucket in reduceKeysAndBuckets)
+                                    foreach (var reduceKeysAndBucket in reduceKeysAndBucketsSet)
 									{
 										token.ThrowIfCancellationRequested();
 
@@ -290,25 +302,25 @@ namespace Raven.Database.Indexing
 								}
 							}
 
-							var results = persistedResults
-								.Where(x => x.Data != null)
-								.GroupBy(x => x.Bucket, x => JsonToExpando.Convert(x.Data))
-								.ToArray();
-							var reduceKeys = new HashSet<string>(persistedResults.Select(x => x.ReduceKey),
-								StringComparer.InvariantCultureIgnoreCase);
-
-							context.MetricsCounters.ReducedPerSecond.Mark(results.Length);
-
 							token.ThrowIfCancellationRequested();
+
 							var reduceTimeWatcher = Stopwatch.StartNew();
 
-							var performance = context.IndexStorage.Reduce(index.IndexId, viewGenerator, results, level, context, actions, reduceKeys, persistedResults.Count);
+                            var results = persistedResults.Where(x => x.Data != null)
+                                                          .GroupBy(x => x.Bucket, x => JsonToExpando.Convert(x.Data));                            
+
+                            var performance = context.IndexStorage.Reduce(index.IndexId, viewGenerator, results, level, context, actions, reduceKeys, persistedResults.Length);
+
+                            context.MetricsCounters.ReducedPerSecond.Mark(results.Count());
 
 							reduceLevelStats.Add(performance);
 
 							var batchDuration = batchTimeWatcher.Elapsed;
-							Log.Debug("Indexed {0} reduce keys in {1} with {2} results for index {3} in {4} on level {5}", reduceKeys.Count, batchDuration,
-								results.Length, index.IndexId, reduceTimeWatcher.Elapsed, level);
+
+                            if ( Log.IsDebugEnabled )
+                            {
+                                Log.Debug("Indexed {0} reduce keys in {1} with {2} results for index {3} in {4} on level {5}", reduceKeys.Count, batchDuration, performance.ItemsCount, index.IndexId, reduceTimeWatcher.Elapsed, level);
+                            }
 
 							autoTuner.AutoThrottleBatchSize(count, size, batchDuration);
 						});
@@ -323,7 +335,7 @@ namespace Raven.Database.Indexing
 				reduceLevelStats.Completed = SystemTime.UtcNow;
 				reduceLevelStats.Duration = reduceLevelStats.Completed - reduceLevelStats.Started;
 
-				reduceLevelStats.Operations.Add(PerformanceStats.From(IndexingOperation.Reduce_GetItemsToReduce, gettigItemsToReduceDuration.ElapsedMilliseconds));
+				reduceLevelStats.Operations.Add(PerformanceStats.From(IndexingOperation.Reduce_GetItemsToReduce, gettingItemsToReduceDuration.ElapsedMilliseconds));
 				reduceLevelStats.Operations.Add(PerformanceStats.From(IndexingOperation.Reduce_ScheduleReductions, scheduleReductionsDuration.ElapsedMilliseconds));
 				reduceLevelStats.Operations.Add(PerformanceStats.From(IndexingOperation.Reduce_RemoveReduceResults, removeReduceResultsDuration.ElapsedMilliseconds));
 				reduceLevelStats.Operations.Add(PerformanceStats.From(IndexingOperation.StorageCommit, storageCommitDuration.ElapsedMilliseconds));
@@ -345,16 +357,17 @@ namespace Raven.Database.Indexing
 		}
 
 		private ReducingPerformanceStats SingleStepReduce(IndexToWorkOn index, List<string> keysToReduce, AbstractViewGenerator viewGenerator,
-												ConcurrentSet<object> itemsToDelete, CancellationToken token)
+												          ConcurrentSet<object> itemsToDelete, CancellationToken token)
 		{
 			var needToMoveToSingleStepQueue = new ConcurrentQueue<HashSet<string>>();
 
-			Log.Debug(() => string.Format("Executing single step reducing for {0} keys [{1}]", keysToReduce.Count, string.Join(", ", keysToReduce)));
+            if ( Log.IsDebugEnabled )
+			    Log.Debug(() => string.Format("Executing single step reducing for {0} keys [{1}]", keysToReduce.Count, string.Join(", ", keysToReduce)));
+
 			var batchTimeWatcher = Stopwatch.StartNew();
+
 			var reducingBatchThrottlerId = Guid.NewGuid();
-
 			var reducePerformanceStats = new ReducingPerformanceStats(ReduceType.SingleStep);
-
 			var reduceLevelStats = new ReduceLevelPeformanceStats
 			{
 				Started = SystemTime.UtcNow,
@@ -386,37 +399,39 @@ namespace Raven.Database.Indexing
 
 					transactionalStorage.Batch(actions =>
 					{
-						var getItemsToReduceParams = new GetItemsToReduceParams(index: index.IndexId, reduceKeys: localKeys, level: 0,
-							loadData: false,
-							itemsToDelete: itemsToDelete)
+						var getItemsToReduceParams = new GetItemsToReduceParams(index: index.IndexId, reduceKeys: localKeys, level: 0, loadData: false, itemsToDelete: itemsToDelete)
 						{
 							Take = int.MaxValue // just get all, we do the rate limit when we load the number of keys to reduce, anyway
 						};
 
 						var getItemsToReduceDuration = Stopwatch.StartNew();
 
-						List<MappedResultInfo> scheduledItems;
+                        int scheduledItemsSum = 0;
+                        int scheduledItemsCount = 0;
+                        List<int> scheduledItemsMappedBuckets = new List<int>();
 						using (StopwatchScope.For(getItemsToReduceDuration))
 						{
-							scheduledItems = actions.MapReduce.GetItemsToReduce(getItemsToReduceParams, token).ToList();
+                            foreach (var item in actions.MapReduce.GetItemsToReduce(getItemsToReduceParams, token))
+                            {
+                                scheduledItemsMappedBuckets.Add(item.Bucket);
+                                scheduledItemsSum += item.Size;
+                                scheduledItemsCount++;
+                            }
 						}
 
 						parallelStats.Operations.Add(PerformanceStats.From(IndexingOperation.Reduce_GetItemsToReduce, getItemsToReduceDuration.ElapsedMilliseconds));
 
-						autoTuner.CurrentlyUsedBatchSizesInBytes.GetOrAdd(reducingBatchThrottlerId, scheduledItems.Sum(x => x.Size));
+						autoTuner.CurrentlyUsedBatchSizesInBytes.GetOrAdd(reducingBatchThrottlerId, scheduledItemsSum);
 
-						if (scheduledItems.Count == 0)
-						{
-							if (Log.IsWarnEnabled)
-							{
-								Log.Warn("Found single reduce items ({0}) that didn't have any items to reduce. Deleting level 1 & level 2 items for those keys. (If you can reproduce this, please contact support@ravendb.net)",
-									string.Join(", ", keysToReduce));
-							}
+                        if (scheduledItemsCount == 0)
+						{						    
 							// Here we have an interesting issue. We have scheduled reductions, because GetReduceTypesPerKeys() returned them
 							// and at the same time, we don't have any at level 0. That probably means that we have them at level 1 or 2.
 							// They shouldn't be here, and indeed, we remove them just a little down from here in this function.
 							// That said, they might have smuggled in between versions, or something happened to cause them to be here.
 							// In order to avoid that, we forcibly delete those extra items from the scheduled reductions, and move on
+
+                            Log.Warn("Found single reduce items ({0}) that didn't have any items to reduce. Deleting level 1 & level 2 items for those keys. (If you can reproduce this, please contact support@ravendb.net)", string.Join(", ", keysToReduce));
 
 							var deletingScheduledReductionsDuration = Stopwatch.StartNew();
 
@@ -448,18 +463,18 @@ namespace Raven.Database.Indexing
 							if (lastPerformedReduceType != ReduceType.MultiStep)
 								continue;
 
-							Log.Debug("Key {0} was moved from multi step to single step reduce, removing existing reduce results records",
-								reduceKey);
-
-							// now we are in single step but previously multi step reduce was performed for the given key
-							var mappedBuckets = actions.MapReduce.GetMappedBuckets(index.IndexId, reduceKey, token).ToList();
-
-							// add scheduled items too to be sure we will delete reduce results of already deleted documents
-							mappedBuckets.AddRange(scheduledItems.Select(x => x.Bucket));
+                            if ( Log.IsDebugEnabled )
+                            {
+                                Log.Debug("Key {0} was moved from multi step to single step reduce, removing existing reduce results records", reduceKey);
+                            }
 
 							using (StopwatchScope.For(removeReduceResultsDuration))
 							{
-								foreach (var mappedBucket in mappedBuckets.Distinct())
+                                // now we are in single step but previously multi step reduce was performed for the given key
+                                var mappedBuckets = actions.MapReduce.GetMappedBuckets(index.IndexId, reduceKey, token);        
+
+                                // add scheduled items too to be sure we will delete reduce results of already deleted documents
+								foreach (var mappedBucket in mappedBuckets.Union(scheduledItemsMappedBuckets))
 								{
 									actions.MapReduce.RemoveReduceResults(index.IndexId, 1, reduceKey, mappedBucket);
 									actions.MapReduce.RemoveReduceResults(index.IndexId, 2, reduceKey, mappedBucket / 1024);
@@ -480,48 +495,44 @@ namespace Raven.Database.Indexing
 					BatchedOperations = parallelOperations.ToList()
 				});
 
-				var getMappedResultsDuration = new Stopwatch();
-
-				var keysLeftToReduce = new HashSet<string>(keysToReduce);
+				var getMappedResultsDuration = new Stopwatch();				
 
 				var reductionPerformanceStats = new List<IndexingPerformanceStats>();
 
+                var keysLeftToReduce = new HashSet<string>(keysToReduce);
 				while (keysLeftToReduce.Count > 0)
-				{
-					List<MappedResultInfo> mappedResults = null;
+				{					
 					var keysReturned = new HashSet<string>();
 
-					context.TransactionalStorage.Batch(actions =>
+                    List<MappedResultInfo> mappedResults = null;
+                    context.TransactionalStorage.Batch(actions =>
 					{
 						var take = context.CurrentNumberOfItemsToReduceInSingleBatch;
 
 						using (StopwatchScope.For(getMappedResultsDuration))
 						{
-							mappedResults = actions
-								.MapReduce
-								.GetMappedResults(
-									index.IndexId,
-									keysLeftToReduce,
-									true,
-									take,
-									keysReturned,
-									token)
-								.ToList();
+                            mappedResults = actions.MapReduce.GetMappedResults(index.IndexId, keysLeftToReduce, true, take, keysReturned, token)
+                                                             .Where(x => x.Data != null)
+                                                             .ToList();
 						}
 					});
 
 					var count = mappedResults.Count;
-					var size = mappedResults.Sum(x => x.Size);
 
-					mappedResults.ApplyIfNotNull(x => x.Bucket = 0);
-
-					var results = mappedResults.Where(x => x.Data != null).GroupBy(x => x.Bucket, x => JsonToExpando.Convert(x.Data)).ToArray();
+                    int size = 0;
+                    foreach ( var item in mappedResults )
+                    {
+                        item.Bucket = 0;
+                        size += item.Size;
+                    }
+                        
+                    var results = mappedResults.GroupBy(x => x.Bucket, x => JsonToExpando.Convert(x.Data)).ToArray();
 
 					context.MetricsCounters.ReducedPerSecond.Mark(results.Length);
 
 					token.ThrowIfCancellationRequested();
 
-					var performance = context.IndexStorage.Reduce(index.IndexId, viewGenerator, results, 2, context, null, keysReturned, mappedResults.Count);
+                    var performance = context.IndexStorage.Reduce(index.IndexId, viewGenerator, results, 2, context, null, keysReturned, count);
 
 					reductionPerformanceStats.Add(performance);
 
@@ -529,6 +540,7 @@ namespace Raven.Database.Indexing
 				}
 
 				var needToMoveToSingleStep = new HashSet<string>();
+
 				HashSet<string> set;
 				while (needToMoveToSingleStepQueue.TryDequeue(out set))
 				{

--- a/Raven.Database/Indexing/ReducingExecuter.cs
+++ b/Raven.Database/Indexing/ReducingExecuter.cs
@@ -275,11 +275,11 @@ namespace Raven.Database.Indexing
 							token.ThrowIfCancellationRequested();
 
 
-                            var requiredReduceNextTimeSet = new HashSet<ReduceKeyAndBucket>(persistedResults.Select(x => new ReduceKeyAndBucket(x.Bucket, x.ReduceKey)));
+                            var requiredReduceNextTimeSet = new HashSet<ReduceKeyAndBucket>(persistedResults.Select(x => new ReduceKeyAndBucket(x.Bucket, x.ReduceKey)), ReduceKeyAndBucketEqualityComparer.Instance);
 
 							using (StopwatchScope.For(removeReduceResultsDuration))
 							{
-                                foreach (var mappedResultInfo in requiredReduceNextTimeSet)//.OrderBy(x => x.Bucket))
+                                foreach (var mappedResultInfo in requiredReduceNextTimeSet)
 								{
 									token.ThrowIfCancellationRequested();
 
@@ -289,7 +289,7 @@ namespace Raven.Database.Indexing
 
 							if (level != 2)
 							{
-                                var reduceKeysAndBucketsSet = new HashSet<ReduceKeyAndBucket>(requiredReduceNextTimeSet.Select(x => new ReduceKeyAndBucket(x.Bucket / 1024, x.ReduceKey)));
+                                var reduceKeysAndBucketsSet = new HashSet<ReduceKeyAndBucket>(requiredReduceNextTimeSet.Select(x => new ReduceKeyAndBucket(x.Bucket / 1024, x.ReduceKey)), ReduceKeyAndBucketEqualityComparer.Instance);
 
 								using (StopwatchScope.For(scheduleReductionsDuration))
 								{

--- a/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
@@ -228,8 +228,10 @@ namespace Raven.Database.Storage.Esent.StorageActions
 		public IEnumerable<MappedResultInfo> GetItemsToReduce(GetItemsToReduceParams getItemsToReduceParams, CancellationToken cancellationToken)
 		{
 			Api.JetSetCurrentIndex(session, ScheduledReductions, "by_view_level_and_hashed_reduce_key_and_bucket");
-			var seenLocally = new HashSet<Tuple<string, int>>();
-			foreach (var reduceKey in getItemsToReduceParams.ReduceKeys.ToArray())
+			
+            var seenLocally = new HashSet<Tuple<string, int>>();
+            var keysToRemove = new List<string>();
+			foreach (var reduceKey in getItemsToReduceParams.ReduceKeys)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
 
@@ -278,8 +280,7 @@ namespace Raven.Database.Storage.Esent.StorageActions
 					if (string.Equals(reduceKeyFromDb, reduceKey, StringComparison.Ordinal) == false)
 						continue;
 
-					var bucket =
-							Api.RetrieveColumnAsInt32(session, ScheduledReductions, tableColumnsCache.ScheduledReductionColumns["bucket"]).Value;
+					var bucket = Api.RetrieveColumnAsInt32(session, ScheduledReductions, tableColumnsCache.ScheduledReductionColumns["bucket"]).Value;
 
 					var rowKey = Tuple.Create(reduceKeyFromDb, bucket);
 					var thisIsNewScheduledReductionRow = reader.Add(session, ScheduledReductions);
@@ -298,13 +299,17 @@ namespace Raven.Database.Storage.Esent.StorageActions
 
 					if (getItemsToReduceParams.Take <= 0)
 						yield break;
-				} while (Api.TryMoveNext(session, ScheduledReductions));
+				} 
+                while (Api.TryMoveNext(session, ScheduledReductions));
 
-				getItemsToReduceParams.ReduceKeys.Remove(reduceKey);
+                keysToRemove.Add(reduceKey);
 
 				if (getItemsToReduceParams.Take <= 0)
 					break;
 			}
+
+            foreach (var keyToRemove in keysToRemove)
+                getItemsToReduceParams.ReduceKeys.Remove(keyToRemove);
 		}
 
 		private IEnumerable<MappedResultInfo> GetResultsForBucket(int view, int level, string reduceKey, int bucket, bool loadData, CancellationToken cancellationToken)

--- a/Raven.Database/Storage/IMappedResultsStorageAction.cs
+++ b/Raven.Database/Storage/IMappedResultsStorageAction.cs
@@ -50,14 +50,14 @@ namespace Raven.Database.Storage
 	public class GetItemsToReduceParams
 	{
 
-		public GetItemsToReduceParams(int index, IEnumerable<string> reduceKeys, int level, bool loadData, ConcurrentSet<object> itemsToDelete)
+		public GetItemsToReduceParams(int index, HashSet<string> reduceKeys, int level, bool loadData, ConcurrentSet<object> itemsToDelete)
 		{
 			Index = index;
 			Level = level;
 			LoadData = loadData;
 			ItemsToDelete = itemsToDelete;
 			ItemsAlreadySeen = new HashSet<Tuple<string, int>>();
-			ReduceKeys = new HashSet<string>(reduceKeys);
+			ReduceKeys = reduceKeys;
 		}
 
 		public int Index { get; private set; }

--- a/Raven.Tests.Issues/RavenDB_766.cs
+++ b/Raven.Tests.Issues/RavenDB_766.cs
@@ -104,10 +104,10 @@ namespace Raven.Tests.Issues
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce.GetItemsToReduce(new GetItemsToReduceParams(a, new[] { "a" }, 1, true, new ConcurrentSet<object>()) { Take = 10 }, CancellationToken.None);
+                    var results = accessor.MapReduce.GetItemsToReduce(new GetItemsToReduceParams(a, new HashSet<string> { "a" }, 1, true, new ConcurrentSet<object>()) { Take = 10 }, CancellationToken.None);
 					Assert.Equal(0, results.Count());
 
-					results = accessor.MapReduce.GetItemsToReduce(new GetItemsToReduceParams(b, new[] { "b" }, 1, true, new ConcurrentSet<object>()) { Take = 10 }, CancellationToken.None);
+                    results = accessor.MapReduce.GetItemsToReduce(new GetItemsToReduceParams(b, new HashSet<string> { "b" }, 1, true, new ConcurrentSet<object>()) { Take = 10 }, CancellationToken.None);
 					Assert.Equal(2, results.Count());
 				});
 			}

--- a/Raven.Tests.Issues/RavenDB_863.cs
+++ b/Raven.Tests.Issues/RavenDB_863.cs
@@ -45,7 +45,7 @@ namespace Raven.Tests.Issues
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce.GetItemsToReduce(new GetItemsToReduceParams(test, new[] { "a", "b" }, 0, true, new ConcurrentSet<object>()) { Take = 2 }, CancellationToken.None).ToList();
+                    var results = accessor.MapReduce.GetItemsToReduce(new GetItemsToReduceParams(test, new HashSet<string> { "a", "b" }, 0, true, new ConcurrentSet<object>()) { Take = 2 }, CancellationToken.None).ToList();
 					Assert.Equal(2, results.Count);
 					Assert.Equal(results[0].Bucket, results[1].Bucket);
 				});
@@ -73,7 +73,7 @@ namespace Raven.Tests.Issues
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce.GetItemsToReduce(new GetItemsToReduceParams(test, new[] { "a", "b" }, 0, true, new ConcurrentSet<object>()) { Take = 3 }, CancellationToken.None).ToList();
+                    var results = accessor.MapReduce.GetItemsToReduce(new GetItemsToReduceParams(test, new HashSet<string> { "a", "b" }, 0, true, new ConcurrentSet<object>()) { Take = 3 }, CancellationToken.None).ToList();
 					Assert.Equal(4, results.Count);
 				});
 			}

--- a/Raven.Tests/Storage/Voron/MappedResultsStorageActionsTests.cs
+++ b/Raven.Tests/Storage/Voron/MappedResultsStorageActionsTests.cs
@@ -1219,7 +1219,7 @@ namespace Raven.Tests.Storage.Voron
 			using (var storage = NewTransactionalStorage(requestedStorage))
 			{
 				storage.Batch(accessor => Assert.Equal(0, accessor.MapReduce
-					.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string>(), 0, true, new ConcurrentSet<object>()), CancellationToken.None)
+                    .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string>(), 0, true, new ConcurrentSet<object>()), CancellationToken.None)
 					.Count()));
 
 				storage.Batch(accessor =>
@@ -1233,13 +1233,13 @@ namespace Raven.Tests.Storage.Voron
 				storage.Batch(accessor =>
 				{
 					var results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1" }, 1, false, new ConcurrentSet<object>()), CancellationToken.None)
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1" }, 1, false, new ConcurrentSet<object>()), CancellationToken.None)
 						.ToList();
 
 					Assert.Equal(0, results.Count);
 
 					results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1" }, 1, false, new ConcurrentSet<object>())
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1" }, 1, false, new ConcurrentSet<object>())
 										  {
 											  Take = 10
 										  }, CancellationToken.None)
@@ -1250,13 +1250,13 @@ namespace Raven.Tests.Storage.Voron
 					Assert.Equal(bucket1, results[0].Bucket);
 
 					results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1" }, 0, false, new ConcurrentSet<object>()), CancellationToken.None)
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1" }, 0, false, new ConcurrentSet<object>()), CancellationToken.None)
 						.ToList();
 
 					Assert.Equal(0, results.Count);
 
 					results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1" }, 0, false, new ConcurrentSet<object>())
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1" }, 0, false, new ConcurrentSet<object>())
 						{
 							Take = 10
 						}, CancellationToken.None)
@@ -1270,13 +1270,13 @@ namespace Raven.Tests.Storage.Voron
 				storage.Batch(accessor =>
 				{
 					var results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1", "reduceKey2" }, 1, false, new ConcurrentSet<object>()), CancellationToken.None)
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1", "reduceKey2" }, 1, false, new ConcurrentSet<object>()), CancellationToken.None)
 						.ToList();
 
 					Assert.Equal(0, results.Count);
 
 					results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1", "reduceKey2" }, 1, false, new ConcurrentSet<object>())
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1", "reduceKey2" }, 1, false, new ConcurrentSet<object>())
 						{
 							Take = 10
 						}, CancellationToken.None)
@@ -1285,13 +1285,13 @@ namespace Raven.Tests.Storage.Voron
 					Assert.Equal(2, results.Count);
 
 					results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1", "reduceKey2" }, 0, false, new ConcurrentSet<object>()), CancellationToken.None)
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1", "reduceKey2" }, 0, false, new ConcurrentSet<object>()), CancellationToken.None)
 						.ToList();
 
 					Assert.Equal(0, results.Count);
 
 					results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1", "reduceKey2" }, 0, false, new ConcurrentSet<object>())
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1", "reduceKey2" }, 0, false, new ConcurrentSet<object>())
 						{
 							Take = 10
 						}, CancellationToken.None)
@@ -1311,7 +1311,7 @@ namespace Raven.Tests.Storage.Voron
 				storage.Batch(accessor =>
 				{
 					var results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1" }, 0, true, new ConcurrentSet<object>())
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1" }, 0, true, new ConcurrentSet<object>())
 						{
 							Take = 10
 						}, CancellationToken.None)
@@ -1322,7 +1322,7 @@ namespace Raven.Tests.Storage.Voron
 					Assert.True(results.Any(x => x.Source == null && x.Data["data"].ToString() == "data4"));
 
 					results = accessor.MapReduce
-						.GetItemsToReduce(new GetItemsToReduceParams(303, new List<string> { "reduceKey1" }, 1, true, new ConcurrentSet<object>())
+                        .GetItemsToReduce(new GetItemsToReduceParams(303, new HashSet<string> { "reduceKey1" }, 1, true, new ConcurrentSet<object>())
 						{
 							Take = 10
 						}, CancellationToken.None)

--- a/Raven.Voron/Voron/Trees/TreeMutableState.cs
+++ b/Raven.Voron/Voron/Trees/TreeMutableState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Voron.Impl.FileHeaders;
+using Voron.Impl.Paging;
 
 namespace Voron.Trees
 {
@@ -82,7 +83,8 @@ namespace Voron.Trees
             return string.Format(@" Pages: {1:#,#}, Entries: {2:#,#}
     Depth: {0}, Flags: {3}
     Root Page: {4}
-    Leaves: {5:#,#} Overflow: {6:#,#} Branches: {7:#,#}", Depth, PageCount, EntriesCount, Flags, RootPageNumber, LeafPages, OverflowPages, BranchPages);
+    Leaves: {5:#,#} Overflow: {6:#,#} Branches: {7:#,#}
+    Size: {8:F2} Mb", Depth, PageCount, EntriesCount, Flags, RootPageNumber, LeafPages, OverflowPages, BranchPages, ((float)(PageCount * AbstractPager.PageSize) / (1024 * 1024)));
         }
     }
 }


### PR DESCRIPTION
This is the best I could do without seriously rethinking how map-reduce works. I must say that the constraints of the data model does not help the case. RavenDB-3724 is a must to be done for RavenDB rethinking the storage model. 

Another thing that will improve this is changing the storage to a binary representation as Json Serialization/Deserialization is insanely costly in this scenario.

After I finish the prefix trees POC I will look into what we can do for multi-step map-reduce and if they could not be for 4.0 at least know what we need in order to not closing the door to it when we rethink the indexing storage model (which is a must for 4.0). 