### PR TITLE
RavenDB-3628 when we increase ScratchBuffer size above certain thresh…

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -256,7 +256,8 @@ namespace Raven.Abstractions.Data
             public const string InitialSize = "Raven/Voron/InitialSize";
             public const string MaxScratchBufferSize = "Raven/Voron/MaxScratchBufferSize";
 	        public const string AllowOn32Bits = "Raven/Voron/AllowOn32Bits";
-        }
+			public const string ScratchBufferSizeNotificationThreshold = "Raven/Voron/ScratchBufferSizeNotificationThreshold";
+		}
 
 	    public static class Smuggler
 	    {

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -284,6 +284,7 @@ namespace Raven.Database.Config
 		    Storage.Voron.MaxBufferPoolSize = Math.Max(2, ravenSettings.Voron.MaxBufferPoolSize.Value);
 			Storage.Voron.InitialFileSize = ravenSettings.Voron.InitialFileSize.Value;
 			Storage.Voron.MaxScratchBufferSize = ravenSettings.Voron.MaxScratchBufferSize.Value;
+			Storage.Voron.ScratchBufferSizeNotificationThreshold = ravenSettings.Voron.ScratchBufferSizeNotificationThreshold.Value;
 			Storage.Voron.AllowIncrementalBackups = ravenSettings.Voron.AllowIncrementalBackups.Value;
 			Storage.Voron.TempPath = ravenSettings.Voron.TempPath.Value;
 			Storage.Voron.JournalsStoragePath = ravenSettings.Voron.JournalsStoragePath.Value;
@@ -1324,9 +1325,18 @@ namespace Raven.Database.Config
 
 				/// <summary>
 				/// The maximum scratch buffer size that can be used by Voron. The value is in megabytes. 
-				/// Default: 512.
+				/// Default: 6144.
 				/// </summary>
 				public int MaxScratchBufferSize { get; set; }
+
+				/// <summary>
+				/// The minimum number of megabytes after which each scratch buffer size increase will create a notification. Used for indexing batch size tuning.
+				/// Default: 
+				/// 1024 when MaxScratchBufferSize > 1024, 
+				/// 512 when MaxScratchBufferSize > 512
+				/// -1 otherwise (disabled) 
+				/// </summary>
+				public int ScratchBufferSizeNotificationThreshold { get; set; }
 
 				/// <summary>
 				/// If you want to use incremental backups, you need to turn this to true, but then journal files will not be deleted after applying them to the data file. They will be deleted only after a successful backup. 

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -215,8 +215,17 @@ namespace Raven.Database.Config
 
             Voron.MaxBufferPoolSize = new IntegerSetting(settings[Constants.Voron.MaxBufferPoolSize], 4);
             Voron.InitialFileSize = new NullableIntegerSetting(settings[Constants.Voron.InitialFileSize], (int?)null);
-			Voron.MaxScratchBufferSize = new IntegerSetting(settings[Constants.Voron.MaxScratchBufferSize], 1024);
-            Voron.AllowIncrementalBackups = new BooleanSetting(settings[Constants.Voron.AllowIncrementalBackups], false);
+			Voron.MaxScratchBufferSize = new IntegerSetting(settings[Constants.Voron.MaxScratchBufferSize], 6144);
+
+			var maxScratchBufferSize = Voron.MaxScratchBufferSize.Value;
+			var scratchBufferSizeNotificationThreshold = -1;
+			if (maxScratchBufferSize > 1024)
+				scratchBufferSizeNotificationThreshold = 1024;
+			else if (maxScratchBufferSize > 512)
+				scratchBufferSizeNotificationThreshold = 512;
+			Voron.ScratchBufferSizeNotificationThreshold = new IntegerSetting(settings[Constants.Voron.ScratchBufferSizeNotificationThreshold], scratchBufferSizeNotificationThreshold);
+
+			Voron.AllowIncrementalBackups = new BooleanSetting(settings[Constants.Voron.AllowIncrementalBackups], false);
 			Voron.AllowOn32Bits = new BooleanSetting(settings[Constants.Voron.AllowOn32Bits], false);
             Voron.TempPath = new StringSetting(settings[Constants.Voron.TempPath], (string)null);
 
@@ -430,6 +439,8 @@ namespace Raven.Database.Config
 			public NullableIntegerSetting InitialFileSize { get; set; }
 
 			public IntegerSetting MaxScratchBufferSize { get; set; }
+
+			public IntegerSetting ScratchBufferSizeNotificationThreshold { get; set; }
 
 			public BooleanSetting AllowIncrementalBackups { get; set; }
 

--- a/Raven.Database/Indexing/BaseBatchSizeAutoTuner.cs
+++ b/Raven.Database/Indexing/BaseBatchSizeAutoTuner.cs
@@ -5,13 +5,15 @@ using Raven.Abstractions;
 using Raven.Database.Config;
 using System.Linq;
 using System.Collections.Generic;
+
+using Raven.Database.Storage;
 using Raven.Database.Util;
 
 namespace Raven.Database.Indexing
 {
 	using Raven.Abstractions.Util;
 
-	public abstract class BaseBatchSizeAutoTuner : ILowMemoryHandler
+	public abstract class BaseBatchSizeAutoTuner : ILowMemoryHandler, ITransactionalStorageNotificationHandler
 	{
 		protected readonly WorkContext context;
 
@@ -30,6 +32,7 @@ namespace Raven.Database.Indexing
 // ReSharper disable once DoNotCallOverridableMethodsInConstructor
 			NumberOfItemsToProcessInSingleBatch = InitialNumberOfItems;
 			MemoryStatistics.RegisterLowMemoryHandler(this);
+			context.TransactionalStorage.RegisterTransactionalStorageNotificationHandler(this);
 			_currentlyUsedBatchSizesInBytes = new ConcurrentDictionary<Guid, long>();
 		}
 
@@ -42,6 +45,11 @@ namespace Raven.Database.Indexing
 		public void SoftMemoryRelease()
 		{
 			
+		}
+
+		public void HandleTransactionalStorageNotification()
+		{
+			HandleLowMemory();
 		}
 
 		public virtual LowMemoryHandlerStatistics GetStats()

--- a/Raven.Database/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Esent/TransactionalStorage.cs
@@ -121,7 +121,12 @@ namespace Raven.Storage.Esent
 	    {
 			scheduledReductionsPerViewAndLevel.Clear();
 	    }
-        public TableColumnsCache TableColumnsCache
+
+	    public void RegisterTransactionalStorageNotificationHandler(ITransactionalStorageNotificationHandler handler)
+	    {
+	    }
+
+	    public TableColumnsCache TableColumnsCache
         {
             get { return tableColumnsCache; }
         }

--- a/Raven.Database/Storage/ITransactionalStorage.cs
+++ b/Raven.Database/Storage/ITransactionalStorage.cs
@@ -62,5 +62,12 @@ namespace Raven.Database.Storage
 		/// The reset must occur while there are no map/reduce indexing activity going on.
 		/// </summary>
 		void ResetScheduledReductionsTracking();
+
+		void RegisterTransactionalStorageNotificationHandler(ITransactionalStorageNotificationHandler handler);
+	}
+
+	public interface ITransactionalStorageNotificationHandler
+	{
+		void HandleTransactionalStorageNotification();
 	}
 }

--- a/Raven.Database/Storage/Voron/TransactionalStorage.cs
+++ b/Raven.Database/Storage/Voron/TransactionalStorage.cs
@@ -16,7 +16,6 @@ using Raven.Database;
 using Raven.Database.Config;
 using Raven.Database.Impl;
 using Raven.Database.Impl.DTC;
-using Raven.Database.Indexing;
 using Raven.Database.Plugins;
 using Raven.Database.Storage;
 using Raven.Database.Storage.Voron;
@@ -24,6 +23,8 @@ using Raven.Database.Storage.Voron.Backup;
 using Raven.Database.Storage.Voron.Impl;
 using Raven.Database.Storage.Voron.Schema;
 using Raven.Json.Linq;
+
+using Sparrow.Collections;
 
 using Voron;
 using Voron.Impl;
@@ -37,6 +38,8 @@ namespace Raven.Storage.Voron
 	public class TransactionalStorage : ITransactionalStorage
 	{
 		private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+
+		private readonly ConcurrentSet<WeakReference<ITransactionalStorageNotificationHandler>> lowMemoryHandlers = new ConcurrentSet<WeakReference<ITransactionalStorageNotificationHandler>>();
 
 		private readonly ThreadLocal<IStorageActionsAccessor> current = new ThreadLocal<IStorageActionsAccessor>();
 		private readonly ThreadLocal<object> disableBatchNesting = new ThreadLocal<object>();
@@ -57,8 +60,8 @@ namespace Raven.Storage.Voron
 		private TableStorage tableStorage;
 
 	    private readonly IBufferPool bufferPool;
-		private Action onNestedTransactionExit;
-		private Action onNestedTransactionEnter;
+		private readonly Action onNestedTransactionExit;
+		private readonly Action onNestedTransactionEnter;
 
 		private Lazy<ConcurrentDictionary<int, RemainingReductionPerLevel>> scheduledReductionsPerViewAndLevel
 			= new Lazy<ConcurrentDictionary<int, RemainingReductionPerLevel>>(() => new ConcurrentDictionary<int, RemainingReductionPerLevel>());
@@ -118,6 +121,37 @@ namespace Raven.Storage.Voron
 			if (configuration.Indexing.DisableMapReduceInMemoryTracking) return;
 			scheduledReductionsPerViewAndLevel = new Lazy<ConcurrentDictionary<int, RemainingReductionPerLevel>>(() => new ConcurrentDictionary<int, RemainingReductionPerLevel>());
 		}
+
+		public void RegisterTransactionalStorageNotificationHandler(ITransactionalStorageNotificationHandler handler)
+		{
+			lowMemoryHandlers.Add(new WeakReference<ITransactionalStorageNotificationHandler>(handler));
+		}
+
+		private void RunTransactionalStorageNotificationHandlers()
+		{
+			var inactiveHandlers = new List<WeakReference<ITransactionalStorageNotificationHandler>>();
+
+			foreach (var lowMemoryHandler in lowMemoryHandlers)
+			{
+				ITransactionalStorageNotificationHandler handler;
+				if (lowMemoryHandler.TryGetTarget(out handler))
+				{
+					try
+					{
+						handler.HandleTransactionalStorageNotification();
+					}
+					catch (Exception e)
+					{
+						Log.Error("Failure to process transactional storage notification (handler - " + handler + ")", e);
+					}
+				}
+				else
+					inactiveHandlers.Add(lowMemoryHandler);
+			}
+
+			inactiveHandlers.ForEach(x => lowMemoryHandlers.TryRemove(x));
+		}
+
 		public Guid Id { get; private set; }
 		public IDocumentCacher DocumentCacher { get { return documentCacher; }}
 
@@ -290,7 +324,18 @@ namespace Raven.Storage.Voron
 				CreateMemoryStorageOptionsFromConfiguration(configuration) :
 		        CreateStorageOptionsFromConfiguration(configuration);
 
-		    tableStorage = new TableStorage(options, bufferPool);
+			options.OnScratchBufferSizeChanged += size =>
+			{
+				if (configuration.Storage.Voron.ScratchBufferSizeNotificationThreshold < 0)
+					return;
+
+				if (size < configuration.Storage.Voron.ScratchBufferSizeNotificationThreshold * 1024L * 1024)
+					return;
+
+				RunTransactionalStorageNotificationHandlers();
+			};
+
+			tableStorage = new TableStorage(options, bufferPool);
 			var schemaCreator = new SchemaCreator(configuration, tableStorage, Output, Log);
 			schemaCreator.CreateSchema();
 			schemaCreator.SetupDatabaseIdAndSchemaVersion();
@@ -309,7 +354,7 @@ namespace Raven.Storage.Voron
 		{
 			var options = StorageEnvironmentOptions.CreateMemoryOnly();
 			options.InitialFileSize = configuration.Storage.Voron.InitialFileSize;
-			options.MaxScratchBufferSize = configuration.Storage.Voron.MaxScratchBufferSize * 1024 * 1024;
+			options.MaxScratchBufferSize = configuration.Storage.Voron.MaxScratchBufferSize * 1024L * 1024L;
 
 			return options;
 		}

--- a/Raven.Voron/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/Raven.Voron/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -250,6 +250,7 @@ namespace Voron.Impl.Scratch
 
 			// we don't have free pages to give out, need to allocate some
 			result = _current.Allocate(tx, numberOfPages, size);
+			_options.OnScratchBufferSizeChanged(sizeAfterAllocation);
 
 			return result;
 		}

--- a/Raven.Voron/Voron/StorageEnvironmentOptions.cs
+++ b/Raven.Voron/Voron/StorageEnvironmentOptions.cs
@@ -34,6 +34,8 @@ namespace Voron
 			handler(this, new RecoveryErrorEventArgs(message, e));
 		}
 
+		public Action<long> OnScratchBufferSizeChanged = delegate { };
+
 		public long? InitialFileSize { get; set; }
 
 		public long MaxLogFileSize
@@ -101,7 +103,6 @@ namespace Voron
 			ScratchBufferOverflowTimeout = 5000;
 
 			MaxNumberOfPagesInMergedTransaction = 1024 * 128;// Ends up being 512 MB
-
 
 			OwnsPagers = true;
 			IncrementalBackupEnabled = false;
@@ -472,6 +473,5 @@ namespace Voron
 				}
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
…old, we will start decreasing indexing/reducing batch sizes, increased MaxScratchBufferSize to 6144 and introduced ScratchBufferSizeNotificationThreshold (1024 when MaxScratchBufferSize > 1024, 512 when MaxScratchBufferSize > 512, -1 otherwise (disabled))