### PR TITLE
Mostly avoiding allocations without changing the performance-memory tradeoff.

### DIFF
--- a/Raven.Database/Indexing/AbstractIndexingExecuter.cs
+++ b/Raven.Database/Indexing/AbstractIndexingExecuter.cs
@@ -43,8 +43,10 @@ namespace Raven.Database.Indexing
             using (LogContext.WithDatabase(context.DatabaseName))
             {
                 Init();
+
                 var name = GetType().Name;
                 var workComment = "WORK BY " + name;
+
                 bool isIdle = false;
                 while (context.RunIndexing)
                 {
@@ -130,7 +132,7 @@ namespace Raven.Database.Indexing
                         }, name);
                     }
                     else // notify the tasks executer that it has work to do
-                    {
+                    {                       
                         context.ShouldNotifyAboutWork(() => workComment);
                         context.NotifyAboutWork();
                     }
@@ -172,7 +174,9 @@ namespace Raven.Database.Indexing
 
                 context.UpdateFoundWork();
 
-                Log.Debug("Executing task: {0}", task);
+                if (Log.IsDebugEnabled)
+                    Log.Debug("Executing task: {0}", task);
+
                 foundWork = true;
 
                 context.CancellationToken.ThrowIfCancellationRequested();

--- a/Raven.Database/Indexing/IndexStorage.cs
+++ b/Raven.Database/Indexing/IndexStorage.cs
@@ -1026,7 +1026,9 @@ namespace Raven.Database.Indexing
 			Index value = TryIndexByName(indexName);
 			if (value == null)
 			{
-				log.Debug("Query on non existing index '{0}'", indexName);
+                if (log.IsDebugEnabled)
+                    log.Debug("Query on non existing index '{0}'", indexName);
+				
 				throw new InvalidOperationException("Index '" + indexName + "' does not exists");
 			}
 
@@ -1039,8 +1041,10 @@ namespace Raven.Database.Indexing
 			Index value = indexes[index];
 			if (value == null)
 			{
-				log.Debug("Removing from non existing index '{0}', ignoring", index);
-				return;
+                if (log.IsDebugEnabled)
+                    log.Debug("Removing from non existing index '{0}', ignoring", index);
+
+                return;
 			}
 			value.Remove(keys, context);
 			context.RaiseIndexChangeNotification(new IndexChangeNotification

--- a/Raven.Database/Indexing/ReducingExecuter.cs
+++ b/Raven.Database/Indexing/ReducingExecuter.cs
@@ -499,17 +499,14 @@ namespace Raven.Database.Indexing
 				var getMappedResultsDuration = new Stopwatch();				
 
 				var reductionPerformanceStats = new List<IndexingPerformanceStats>();
-
-                // Try to diminish the allocations happening because of .Resize()
-                var keysLeftToReduce = new HashSet<string>(keysToReduce);
-                var mappedResults = new List<MappedResultInfo>(keysLeftToReduce.Count);
-                var keysReturned = new HashSet<string>();                  
-                             
+                
+                var keysLeftToReduce = new HashSet<string>(keysToReduce);                                              
 				while (keysLeftToReduce.Count > 0)
-				{					            					                    
-                    // This will clear the data of the list but will not release the memory already allocated, allowing to avoid allocations.
-                    mappedResults.Clear(); 
-                    keysReturned.Clear();                    
+				{
+                    var keysReturned = new HashSet<string>();       
+
+                    // Try to diminish the allocations happening because of .Resize()
+                    var mappedResults = new List<MappedResultInfo>(keysLeftToReduce.Count);                             
                     
                     context.TransactionalStorage.Batch(actions =>
 					{

--- a/Raven.Database/Indexing/ReducingExecuter.cs
+++ b/Raven.Database/Indexing/ReducingExecuter.cs
@@ -233,12 +233,13 @@ namespace Raven.Database.Indexing
 
 							reduceParams.Take = context.CurrentNumberOfItemsToReduceInSingleBatch;
 
-                            int size = 0;                            
-                            MappedResultInfo[] persistedResults;
+                            int size = 0;                  
+          
+                            IList<MappedResultInfo> persistedResults;
                             var reduceKeys = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
 							using (StopwatchScope.For(gettingItemsToReduceDuration))
 							{
-                                persistedResults = actions.MapReduce.GetItemsToReduce(reduceParams, token).ToArray();                                
+                                persistedResults = actions.MapReduce.GetItemsToReduce(reduceParams, token);                                
 
                                 foreach (var item in persistedResults)
                                 {
@@ -247,22 +248,22 @@ namespace Raven.Database.Indexing
                                 }
 							}
 
-                            if (persistedResults.Length == 0)
+                            if (persistedResults.Count == 0)
 							{
 								retry = false;
 								return;
 							}
 
-                            var count = persistedResults.Length;
+                            var count = persistedResults.Count;
 
 							autoTuner.CurrentlyUsedBatchSizesInBytes.GetOrAdd(reduceBatchAutoThrottlerId, size);
 
 							if (Log.IsDebugEnabled)
 							{
-                                if (persistedResults.Length > 0)
+                                if (persistedResults.Count > 0)
                                 {
                                     Log.Debug(() => string.Format("Found {0} results for keys [{1}] for index {2} at level {3} in {4}",
-                                        persistedResults.Length,
+                                        persistedResults.Count,
                                         string.Join(", ", persistedResults.Select(x => x.ReduceKey).Distinct()),
                                         index.IndexId, level, batchTimeWatcher.Elapsed));
                                 }
@@ -309,7 +310,7 @@ namespace Raven.Database.Indexing
                             var results = persistedResults.Where(x => x.Data != null)
                                                           .GroupBy(x => x.Bucket, x => JsonToExpando.Convert(x.Data));                            
 
-                            var performance = context.IndexStorage.Reduce(index.IndexId, viewGenerator, results, level, context, actions, reduceKeys, persistedResults.Length);
+                            var performance = context.IndexStorage.Reduce(index.IndexId, viewGenerator, results, level, context, actions, reduceKeys, persistedResults.Count);
 
                             context.MetricsCounters.ReducedPerSecond.Mark(results.Count());
 

--- a/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs
@@ -1078,10 +1078,11 @@ namespace Raven.Database.Storage.Esent.StorageActions
 
                     if (indexFromDb != view || hashReduceKey.SequenceEqual(hashKeyFromDb) == false)
                         break;
-
                     
                     var timestamp = Api.RetrieveColumnAsInt64(session, MappedResults, tableColumnsCache.MappedResultsColumns["timestamp"]).Value;
                     var keyFromDb = Api.RetrieveColumnAsString(session, MappedResults, tableColumnsCache.MappedResultsColumns["reduce_key"]);
+
+                    take--; // We have worked with this reduce key, so we consider it an output even if we don't add it. 
 
                     RavenJObject data = null;
                     if ( loadData )

--- a/Raven.Database/Storage/IMappedResultsStorageAction.cs
+++ b/Raven.Database/Storage/IMappedResultsStorageAction.cs
@@ -35,7 +35,7 @@ namespace Raven.Database.Storage
 		IEnumerable<ScheduledReductionDebugInfo> GetScheduledReductionForDebug(int index, int start, int take);
 
 		void ScheduleReductions(int index, int level, ReduceKeyAndBucket reduceKeysAndBuckets);
-		IEnumerable<MappedResultInfo> GetItemsToReduce(GetItemsToReduceParams getItemsToReduceParams, CancellationToken cancellationToken);
+		IList<MappedResultInfo> GetItemsToReduce(GetItemsToReduceParams getItemsToReduceParams, CancellationToken cancellationToken);
 		ScheduledReductionInfo DeleteScheduledReduction(IEnumerable<object> itemsToDelete);
 		Dictionary<int, RemainingReductionPerLevel> GetRemainingScheduledReductionPerIndex();
 		void DeleteScheduledReduction(int index, int level, string reduceKey);
@@ -149,15 +149,20 @@ namespace Raven.Database.Storage
 
 	public class MappedResultInfo
 	{
-		public string ReduceKey { get; set; }
+        // These 3 are a compound key. 
+		public string ReduceKey { get; set; }        
+        public int Bucket { get; set; }
+
+
 		public DateTime Timestamp { get; set; }
 		public Etag Etag { get; set; }
 
 		public RavenJObject Data { get; set; }
+
+        public string Source { get; set; }
+
 		[JsonIgnore]
 		public int Size { get; set; }
-		public int Bucket { get; set; }
-		public string Source { get; set; }
 
 		public override string ToString()
 		{

--- a/Raven.Database/Storage/IMappedResultsStorageAction.cs
+++ b/Raven.Database/Storage/IMappedResultsStorageAction.cs
@@ -45,8 +45,10 @@ namespace Raven.Database.Storage
 		void UpdatePerformedReduceType(int index, string reduceKey, ReduceType performedReduceType);
 		ReduceType GetLastPerformedReduceType(int index, string reduceKey);
 		IEnumerable<int> GetMappedBuckets(int index, string reduceKey, CancellationToken cancellationToken);
-		IEnumerable<MappedResultInfo> GetMappedResults(int view, HashSet<string> keysLeftToReduce, bool loadData, int take, HashSet<string> keysReturned, CancellationToken cancellationToken);
-		IEnumerable<ReduceTypePerKey> GetReduceKeysAndTypes(int view, int start, int take);
+
+        List<MappedResultInfo> GetMappedResults(int view, HashSet<string> keysLeftToReduce, bool loadData, int take, HashSet<string> keysReturned, CancellationToken cancellationToken, List<MappedResultInfo> outputCollection = null);
+	
+        IEnumerable<ReduceTypePerKey> GetReduceKeysAndTypes(int view, int start, int take);
 	}
 
 	public class GetItemsToReduceParams

--- a/Raven.Database/Storage/Voron/StorageActions/MappedResultsStorageActions.cs
+++ b/Raven.Database/Storage/Voron/StorageActions/MappedResultsStorageActions.cs
@@ -1013,6 +1013,8 @@ namespace Raven.Database.Storage.Voron.StorageActions
 
                         var readReduceKey = value.ReadString(MappedResultFields.ReduceKey);
 
+                        take--; // We have worked with this reduce key, so we consider it an output even if we don't add it. 
+
                         RavenJObject data = null;
                         if ( loadData )
                         {
@@ -1037,9 +1039,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
                 }
 
                 if (take < 0)
-                {
                     return outputCollection;
-                }
             }
 
             return outputCollection;

--- a/Raven.Database/Storage/Voron/StorageActions/MappedResultsStorageActions.cs
+++ b/Raven.Database/Storage/Voron/StorageActions/MappedResultsStorageActions.cs
@@ -1,38 +1,32 @@
-﻿using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-using ICSharpCode.NRefactory.CSharp.Refactoring;
+﻿using Raven.Abstractions;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Extensions;
+using Raven.Abstractions.MEF;
 using Raven.Abstractions.Util.Encryptors;
 using Raven.Abstractions.Util.Streams;
 using Raven.Database.Storage.Voron.StorageActions.StructureSchemas;
-using Raven.Database.Util;
+using Sparrow.Collections;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
 using Voron.Trees;
+using VoronIndex = Raven.Database.Storage.Voron.Impl.Index;
 
 namespace Raven.Database.Storage.Voron.StorageActions
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Globalization;
-	using System.IO;
-	using System.Linq;
-
-	using Abstractions;
-	using Abstractions.Data;
-	using Abstractions.Extensions;
-	using Abstractions.MEF;
-	using Database.Impl;
-	using Indexing;
-	using Plugins;
-	using Impl;
-	using Raven.Json.Linq;
-
-	using global::Voron;
-	using global::Voron.Impl;
-
-	using Index = Raven.Database.Storage.Voron.Impl.Index;
-    using Sparrow.Collections;
+    using Database.Impl;
+    using global::Voron;
+    using global::Voron.Impl;
+    using Impl;
+    using Indexing;
+    using Plugins;
+    using Raven.Json.Linq;
 
 	internal class MappedResultsStorageActions : StorageActionsBase, IMappedResultsStorageAction
 	{
@@ -509,7 +503,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
 				scheduledReductionsPerViewAndLevel.AddOrUpdate(view, new RemainingReductionPerLevel(level), (key, oldvalue) => oldvalue.IncrementPerLevelCounters(level));
 		}
 
-		public IEnumerable<MappedResultInfo> GetItemsToReduce(GetItemsToReduceParams getItemsToReduceParams, CancellationToken cancellationToken)
+		public IList<MappedResultInfo> GetItemsToReduce(GetItemsToReduceParams getItemsToReduceParams, CancellationToken cancellationToken)
 		{
 			var scheduledReductionsByViewAndLevelAndReduceKey = tableStorage.ScheduledReductions.GetIndex(Tables.ScheduledReductions.Indices.ByViewAndLevelAndReduceKey);
             var deleter = new ScheduledReductionDeleter(getItemsToReduceParams.ItemsToDelete, o =>
@@ -521,66 +515,76 @@ namespace Raven.Database.Storage.Voron.StorageActions
                 return (Slice)etag.ToString();
             });
 
-            var seenLocally = new HashSet<ReduceKeyAndBucket>(ReduceKeyAndBucketEqualityComparer.Instance);
-
             var keysToRemove = new List<string>();
-			foreach (var reduceKey in getItemsToReduceParams.ReduceKeys)
-			{
-				cancellationToken.ThrowIfCancellationRequested();
 
-			    var reduceKeyHash = HashKey(reduceKey);
-                var viewAndLevelAndReduceKey = (Slice) CreateKey(getItemsToReduceParams.Index, getItemsToReduceParams.Level, ReduceKeySizeLimited(reduceKey), reduceKeyHash);
-				using (var iterator = scheduledReductionsByViewAndLevelAndReduceKey.MultiRead(Snapshot, viewAndLevelAndReduceKey))
-				{
-					if (!iterator.Seek(Slice.BeforeAllKeys))
-						continue;
+            try
+            {
+                var seenLocally = new HashSet<ReduceKeyAndBucket>(ReduceKeyAndBucketEqualityComparer.Instance);
+                var mappedResults = new List<MappedResultInfo>();
 
-					do
-					{
-						cancellationToken.ThrowIfCancellationRequested();
+                foreach (var reduceKey in getItemsToReduceParams.ReduceKeys)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
 
-						if (getItemsToReduceParams.Take <= 0)
-							break;
-
-						ushort version;
-					    var value = LoadStruct(tableStorage.ScheduledReductions, iterator.CurrentKey, writeBatch.Value, out version);
-                        if (value == null) // TODO: Check if this is correct. 
+                    var reduceKeyHash = HashKey(reduceKey);
+                    var viewAndLevelAndReduceKey = (Slice)CreateKey(getItemsToReduceParams.Index, getItemsToReduceParams.Level, ReduceKeySizeLimited(reduceKey), reduceKeyHash);
+                    using (var iterator = scheduledReductionsByViewAndLevelAndReduceKey.MultiRead(Snapshot, viewAndLevelAndReduceKey))
+                    {
+                        if (!iterator.Seek(Slice.BeforeAllKeys))
                             continue;
 
-						var reduceKeyFromDb = value.ReadString(ScheduledReductionFields.ReduceKey);                        
+                        do
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
 
-						var bucket = value.ReadInt(ScheduledReductionFields.Bucket);
-                        var rowKey = new ReduceKeyAndBucket(bucket, reduceKeyFromDb);
+                            if (getItemsToReduceParams.Take <= 0)
+                                break;
 
-					    var thisIsNewScheduledReductionRow = deleter.Delete(iterator.CurrentKey, Etag.Parse(value.ReadBytes(ScheduledReductionFields.Etag)));
-						var neverSeenThisKeyAndBucket = getItemsToReduceParams.ItemsAlreadySeen.Add(rowKey);
+                            ushort version;
+                            var value = LoadStruct(tableStorage.ScheduledReductions, iterator.CurrentKey, writeBatch.Value, out version);
+                            if (value == null) // TODO: Check if this is correct. 
+                                continue;
 
-						if (thisIsNewScheduledReductionRow || neverSeenThisKeyAndBucket)
-						{
-							if (seenLocally.Add(rowKey))
-							{
-								foreach (var mappedResultInfo in GetResultsForBucket(getItemsToReduceParams.Index, getItemsToReduceParams.Level, reduceKeyFromDb, bucket, getItemsToReduceParams.LoadData, cancellationToken))
-								{
-									getItemsToReduceParams.Take--;
-									yield return mappedResultInfo;
-								}
-							}
-						}
+                            var reduceKeyFromDb = value.ReadString(ScheduledReductionFields.ReduceKey);
 
-						if (getItemsToReduceParams.Take <= 0)
-							yield break;
-					}
-					while (iterator.MoveNext());
-				}
+                            var bucket = value.ReadInt(ScheduledReductionFields.Bucket);
+                            var rowKey = new ReduceKeyAndBucket(bucket, reduceKeyFromDb);
 
-                keysToRemove.Add(reduceKey);
+                            var thisIsNewScheduledReductionRow = deleter.Delete(iterator.CurrentKey, Etag.Parse(value.ReadBytes(ScheduledReductionFields.Etag)));
+                            var neverSeenThisKeyAndBucket = getItemsToReduceParams.ItemsAlreadySeen.Add(rowKey);
 
-				if (getItemsToReduceParams.Take <= 0)
-                    yield break;
-			}
+                            if (thisIsNewScheduledReductionRow || neverSeenThisKeyAndBucket)
+                            {
+                                if (seenLocally.Add(rowKey))
+                                {
+                                    foreach (var mappedResultInfo in GetResultsForBucket(getItemsToReduceParams.Index, getItemsToReduceParams.Level, reduceKeyFromDb, bucket, getItemsToReduceParams.LoadData, cancellationToken))
+                                    {
+                                        getItemsToReduceParams.Take--;
 
-            foreach (var keyToRemove in keysToRemove)
-                getItemsToReduceParams.ReduceKeys.Remove(keyToRemove);
+                                        mappedResults.Add(mappedResultInfo);
+                                    }
+                                }
+                            }
+
+                            if (getItemsToReduceParams.Take <= 0)
+                                return mappedResults;
+                        }
+                        while (iterator.MoveNext());
+                    }
+
+                    keysToRemove.Add(reduceKey);
+
+                    if (getItemsToReduceParams.Take <= 0)
+                        break;
+                }
+
+                return mappedResults;
+            }
+            finally
+            {
+                foreach (var keyToRemove in keysToRemove)
+                    getItemsToReduceParams.ReduceKeys.Remove(keyToRemove);
+            }
 		}
 
 		private IEnumerable<MappedResultInfo> GetResultsForBucket(int view, int level, string reduceKey, int bucket, bool loadData, CancellationToken cancellationToken)
@@ -1025,7 +1029,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
 			}
 		}
 
-		private RavenJObject LoadMappedResult(Slice key, string reduceKey, Index dataIndex)
+		private RavenJObject LoadMappedResult(Slice key, string reduceKey, VoronIndex dataIndex)
 		{
 			var read = dataIndex.Read(Snapshot, key, writeBatch.Value);
 			if (read == null)

--- a/Raven.Tests/Storage/Voron/MappedResultsStorageActionsTests.cs
+++ b/Raven.Tests/Storage/Voron/MappedResultsStorageActionsTests.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using Raven.Database.Util;
 using Raven.Tests.Common;
 
-namespace Raven.Tests.Storage.Voron
+namespace Raven.Tests.Storage
 {
 	using System;
 	using System.Collections.Generic;
@@ -347,9 +347,7 @@ namespace Raven.Tests.Storage.Voron
 
 				storage.Batch(x =>
 				{
-					var results = x.MapReduce
-						.GetMappedResults(303, new HashSet<string> { "reduceKey1" }, true,100, new HashSet<string>(), CancellationToken.None)
-						.ToList();
+					var results = x.MapReduce.GetMappedResults(303, new HashSet<string> { "reduceKey1" }, true,100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(1, results.Count);
 
@@ -366,9 +364,7 @@ namespace Raven.Tests.Storage.Voron
 
 				storage.Batch(x =>
 				{
-					var results = x.MapReduce
-						.GetMappedResults(303, new HashSet<string> { "reduceKey1" }, true, 100, new HashSet<string>(), CancellationToken.None)
-						.ToList();
+					var results = x.MapReduce.GetMappedResults(303, new HashSet<string> { "reduceKey1" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(2, results.Count);
 
@@ -409,9 +405,7 @@ namespace Raven.Tests.Storage.Voron
 				storage.Batch(
 					x =>
 					{
-						var results = x.MapReduce
-							.GetMappedResults(303, new HashSet<string>() { "reduceKey1" }, true, 100, new HashSet<string>(), CancellationToken.None)
-							.ToList();
+						var results = x.MapReduce.GetMappedResults(303, new HashSet<string>() { "reduceKey1" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 						Assert.Equal(1, results.Count);
 					});
@@ -427,9 +421,7 @@ namespace Raven.Tests.Storage.Voron
 				storage.Batch(
 					x =>
 					{
-						var results = x.MapReduce
-							.GetMappedResults(303, new HashSet<string>() { "reduceKey1" }, true, 100, new HashSet<string>(), CancellationToken.None)
-							.ToList();
+						var results = x.MapReduce.GetMappedResults(303, new HashSet<string>() { "reduceKey1" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 						Assert.Equal(0, results.Count);
 					});
@@ -448,9 +440,7 @@ namespace Raven.Tests.Storage.Voron
 				storage.Batch(
 					x =>
 					{
-						var results = x.MapReduce
-							.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-							.ToList();
+						var results = x.MapReduce.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 						Assert.Equal(3, results.Count);
 					});
@@ -470,9 +460,7 @@ namespace Raven.Tests.Storage.Voron
 				storage.Batch(
 					x =>
 					{
-						var results = x.MapReduce
-							.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-							.ToList();
+						var results = x.MapReduce.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 						Assert.Equal(1, results.Count);
 					});
@@ -572,15 +560,11 @@ namespace Raven.Tests.Storage.Voron
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce
-						.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-						.ToList();
+					var results = accessor.MapReduce.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(0, results.Count);
 
-					results = accessor.MapReduce
-					   .GetMappedResults(404, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-					   .ToList();
+					results = accessor.MapReduce.GetMappedResults(404, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(0, results.Count);
 				});
@@ -598,9 +582,7 @@ namespace Raven.Tests.Storage.Voron
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce
-						.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-						.ToList();
+					var results = accessor.MapReduce.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(3, results.Count);
 
@@ -639,9 +621,7 @@ namespace Raven.Tests.Storage.Voron
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce
-						.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-						.ToList();
+					var results = accessor.MapReduce.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(0, results.Count);
 
@@ -651,9 +631,7 @@ namespace Raven.Tests.Storage.Voron
 					var keyStats = accessor.MapReduce.GetKeysStats(303, 0, 10).ToList();
 					Assert.Equal(0, keyStats.Count);
 
-					results = accessor.MapReduce
-					   .GetMappedResults(404, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-					   .ToList();
+					results = accessor.MapReduce.GetMappedResults(404, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(1, results.Count);
 
@@ -672,9 +650,7 @@ namespace Raven.Tests.Storage.Voron
 
 				storage.Batch(accessor =>
 				{
-					var results = accessor.MapReduce
-						.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-						.ToList();
+					var results = accessor.MapReduce.GetMappedResults(303, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(0, results.Count);
 
@@ -684,9 +660,7 @@ namespace Raven.Tests.Storage.Voron
 					var keyStats = accessor.MapReduce.GetKeysStats(303, 0, 10).ToList();
 					Assert.Equal(0, keyStats.Count);
 
-					results = accessor.MapReduce
-					   .GetMappedResults(404, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None)
-					   .ToList();
+					results = accessor.MapReduce.GetMappedResults(404, new HashSet<string>() { "reduceKey1", "reduceKey2" }, true, 100, new HashSet<string>(), CancellationToken.None);
 
 					Assert.Equal(0, results.Count);
 

--- a/Raven.Voron/Voron/Impl/WriteBatch.cs
+++ b/Raven.Voron/Voron/Impl/WriteBatch.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Sparrow;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -13,13 +14,16 @@ namespace Voron.Impl
 {
 	public class WriteBatch : IDisposable
 	{
+        private static readonly ObjectPool<Dictionary<Slice, BatchOperation>> _lastOperationsPool = new ObjectPool<Dictionary<Slice, BatchOperation>>(() => new Dictionary<Slice, BatchOperation>(SliceComparer.Instance), 50);
+        private static readonly ObjectPool<Dictionary<Slice, List<BatchOperation>>> _multiTreeOperationsPool = new ObjectPool<Dictionary<Slice, List<BatchOperation>>>(() => new Dictionary<Slice, List<BatchOperation>>(SliceComparer.Instance), 50);
+
 		private readonly Dictionary<string, Dictionary<Slice, BatchOperation>> _lastOperations;
-		private readonly Dictionary<string, Dictionary<Slice, List<BatchOperation>>> _multiTreeOperations;
+        private readonly Dictionary<string, Dictionary<Slice, List<BatchOperation>>> _multiTreeOperations;
 
 		private readonly HashSet<string> _trees = new HashSet<string>();
 
-        private readonly SliceComparer _sliceEqualityComparer;
 		private bool _disposeAfterWrite = true;
+        private volatile bool _disposed = false;
 
 		public HashSet<string> Trees
 		{
@@ -34,7 +38,7 @@ namespace Voron.Impl
 			Dictionary<Slice, BatchOperation> operations;
 			if (_lastOperations.TryGetValue(treeName, out operations))
 			{
-				foreach (var operation in operations.OrderBy(x => x.Key, _sliceEqualityComparer))
+                foreach (var operation in operations.OrderBy(x => x.Key, SliceComparer.Instance))
 					yield return operation.Value;
 			}
 
@@ -47,8 +51,8 @@ namespace Voron.Impl
 
             var orderedOperations = multiOperations
                         				.SelectMany(x => x.Value)
-				                        .OrderBy(x => x.ValueSlice, _sliceEqualityComparer)
-                                        .ThenBy(x => x.Key, _sliceEqualityComparer);
+                                        .OrderBy(x => x.ValueSlice, SliceComparer.Instance)
+                                        .ThenBy(x => x.Key, SliceComparer.Instance);
 
             foreach (var operation in orderedOperations)
 				yield return operation;
@@ -119,7 +123,6 @@ namespace Voron.Impl
 		{
 			_lastOperations = new Dictionary<string, Dictionary<Slice, BatchOperation>>();
 			_multiTreeOperations = new Dictionary<string, Dictionary<Slice, List<BatchOperation>>>();
-			_sliceEqualityComparer = new SliceComparer();
 		}
 
 		public void Add(Slice key, Slice value, string treeName, ushort? version = null, bool shouldIgnoreConcurrencyExceptions = false)
@@ -217,8 +220,8 @@ namespace Voron.Impl
 				Dictionary<Slice, List<BatchOperation>> multiTreeOperationsOfTree;
 				if (_multiTreeOperations.TryGetValue(treeName, out multiTreeOperationsOfTree) == false)
 				{
-					_multiTreeOperations[treeName] =
-						multiTreeOperationsOfTree = new Dictionary<Slice, List<BatchOperation>>(_sliceEqualityComparer);
+                    _multiTreeOperations[treeName] = multiTreeOperationsOfTree = _multiTreeOperationsPool.Allocate();
+                    Debug.Assert(multiTreeOperationsOfTree.Count == 0);
 				}
 
 				List<BatchOperation> specificMultiTreeOperations;
@@ -234,7 +237,8 @@ namespace Voron.Impl
 				Dictionary<Slice, BatchOperation> lastOpsForTree;
 				if (_lastOperations.TryGetValue(treeName, out lastOpsForTree) == false)
 				{
-					_lastOperations[treeName] = lastOpsForTree = new Dictionary<Slice, BatchOperation>(_sliceEqualityComparer);
+                    _lastOperations[treeName] = lastOpsForTree = _lastOperationsPool.Allocate();
+                    Debug.Assert(lastOpsForTree.Count == 0); // Make sure we didn't mess up when cleaning up.
 				}
 
 				BatchOperation old;
@@ -452,19 +456,34 @@ namespace Voron.Impl
 
 		public void Dispose()
 		{
-			foreach (var operation in _lastOperations)
-			{
-				foreach (var val in operation.Value)
-				{
-					if (val.Value.ValueStream == null)
-						continue;
+            // Guard to avoid multiple disposing scenarios. 
+            if (_disposed == false )
+            {
+                _disposed = true;
 
-					val.Value.ValueStream.Dispose();
-				}
+                foreach (var operation in _lastOperations)
+                {
+                    foreach (var val in operation.Value)
+                    {
+                        if (val.Value.ValueStream == null)
+                            continue;
 
-			}
+                        val.Value.ValueStream.Dispose();
+                    }
 
-			_lastOperations.Clear();
+                    operation.Value.Clear();
+                    _lastOperationsPool.Free(operation.Value);
+
+                }
+
+                foreach (var item in _multiTreeOperations)
+                {
+                    item.Value.Clear();
+                    _multiTreeOperationsPool.Free(item.Value);
+                }
+
+                _lastOperations.Clear();
+            }
 		}
 	}
 }

--- a/Raven.Voron/Voron/Trees/TreeIterator.cs
+++ b/Raven.Voron/Voron/Trees/TreeIterator.cs
@@ -187,6 +187,7 @@ namespace Voron.Trees
 
 		public void Dispose()
 		{
+            _cursor.Dispose();
 		}
 
 		public Slice RequiredPrefix { get; set; }


### PR DESCRIPTION
I tried several approaches to diminish allocations on Map-Reduce and other places. Some worked, some didnt and ended up reverting some of them. I tried to keep the tradeoff leaning toward performance, lost a couple of seconds in my test environment, but allocations diminish a lot in the process so it should be less taxing when we are memory starved. 

I still have a couple of ideas to bounce over the code, but I didnt want to deviate too much from the current unstable. Took me a bit to rebase everything at this point. 