### PR TITLE
RavenDB-3796 - fix of Can_get_stats_for_all_active_file_systems

### DIFF
--- a/Raven.Tests.FileSystem/CommandsUsage.cs
+++ b/Raven.Tests.FileSystem/CommandsUsage.cs
@@ -547,7 +547,7 @@ namespace Raven.Tests.FileSystem
 	            var stats2 = stats.FirstOrDefault(x => x.Name == anotherClient.FileSystemName);
 	            Assert.NotNull(stats2);
 
-                Assert.Equal(2, stats1.Metrics.Requests.Count);
+                Assert.Equal(3, stats1.Metrics.Requests.Count);
                 Assert.Equal(1, stats2.Metrics.Requests.Count);
 
                 Assert.Equal(0, stats1.ActiveSyncs.Count);


### PR DESCRIPTION
"fs/{fileSystemName}/config"  is now called on FS init
The assertion in the test didn't count that as a request.