### PR TITLE
RavenDB-3854 fix

### DIFF
--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -72,7 +72,7 @@ namespace Raven.Database.Config
 
 			IndexingClassifier = new DefaultIndexingClassifier();
 
-			Catalog = new AggregateCatalog(new AssemblyCatalog(typeof(DocumentDatabase).Assembly));
+			Catalog = new AggregateCatalog(CurrentAssemblyCatalog);
 
 			Catalog.Changed += (sender, args) => ResetContainer();
 		}
@@ -936,6 +936,9 @@ namespace Raven.Database.Config
 		
 		private string countersDataDirectory;
 		private int? maxNumberOfParallelIndexTasks;
+
+		//this is static so repeated initializations in the same process would not trigger reflection on all MEF plugins
+		private readonly static AssemblyCatalog CurrentAssemblyCatalog = new AssemblyCatalog(typeof (DocumentDatabase).Assembly);
 
 		/// <summary>
 		/// The expiration value for documents in the internal managed cache


### PR DESCRIPTION
make assembly catalog static so it is evaluated once per process