### PR TITLE
fix for RavenDB-3868

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -71,6 +71,7 @@ namespace Raven.Abstractions.Data
 		public const string RavenPrefetchingDurationLimit = "Raven/Prefetching/DurationLimit";
 		public const int DefaultPrefetchingDurationLimit = 5000;
 		public const string BulkImportBatchTimeout = "Raven/BulkImport/BatchTimeout";
+		public const string BulkImportHeartbeatDocKey = "Raven/BulkImport/Heartbeat";
 		public const int BulkImportDefaultTimeoutInMs = 60000;
 	    public const string IndexingDisabled = "Raven/IndexingDisabled";
 		public const string MaxNumberOfItemsToProcessInTestIndexes = "Raven/Indexing/MaxNumberOfItemsToProcessInTestIndexes";

--- a/Raven.Abstractions/Smuggler/SmugglerDatabaseOptions.cs
+++ b/Raven.Abstractions/Smuggler/SmugglerDatabaseOptions.cs
@@ -35,6 +35,7 @@ namespace Raven.Abstractions.Smuggler
 		    MaxStepsForTransformScript = 10*1000;
 	        ExportDeletions = false;
 		    TotalDocumentSizeInChunkLimitInBytes = DefaultDocumentSizeInChunkLimitInBytes;
+	        HeartbeatLatencyInMilliseconds = TimeSpan.FromSeconds(30);
 		}
 
         private void ConfigureDefaultFilters()
@@ -55,6 +56,9 @@ namespace Raven.Abstractions.Smuggler
 
         private string continuationFile;
         private bool useContinuationFile = false;
+
+		public TimeSpan HeartbeatLatencyInMilliseconds { get; set; }
+
         public string ContinuationToken 
         {
             get { return continuationFile; }

--- a/Raven.Database/Server/Controllers/BulkInsertController.cs
+++ b/Raven.Database/Server/Controllers/BulkInsertController.cs
@@ -208,7 +208,7 @@ namespace Raven.Database.Server.Controllers
                     var doc = (RavenJObject)RavenJToken.ReadFrom(new BsonReader(reader)
                                                                  {
                                                                      DateTimeKindHandling = DateTimeKind.Unspecified
-                                                                 });
+                                                                 });					
 
                     var metadata = doc.Value<RavenJObject>("@metadata");
 
@@ -219,6 +219,13 @@ namespace Raven.Database.Server.Controllers
                     if (string.IsNullOrEmpty(id))
                         throw new InvalidOperationException("Could not get id from metadata");
 
+	                if (id.Equals(Constants.BulkImportHeartbeatDocKey, StringComparison.InvariantCultureIgnoreCase))
+		                continue; //its just a token document, should not get written into the database
+								  //the purpose of the heartbeat document is to make sure that the connection doesn't time-out
+								  //during long pauses in the bulk insert operation.
+								  // Currently used by smuggler to make sure that the connection doesn't time out if there is a 
+								  //continuation token and lots of document skips
+								  
                     doc.Remove("@metadata");
 
                     yield return new JsonDocument

--- a/Raven.Tests/Smuggler/SmugglerExecutionTests.cs
+++ b/Raven.Tests/Smuggler/SmugglerExecutionTests.cs
@@ -14,7 +14,6 @@ using Raven.Database.Smuggler;
 using Raven.Json.Linq;
 using Raven.Smuggler;
 using Raven.Tests.Common;
-using Raven.Tests.Common.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -989,7 +988,6 @@ namespace Raven.Tests.Smuggler
                 this.Payload = value;
             }
         }
-
 
         [Fact, Trait("Category", "Smuggler")]
         public async Task CanSkipFilesWhenUsingContinuations()


### PR DESCRIPTION
make sure Smuggler sends heartbeat documents if skipping lots of documents due to continuation token for large dump files