### PR TITLE
RavenDB-3808 InitializeTopology and InitializeEmptyTopologyWithId don…

### DIFF
--- a/Raven.Database/Raft/ClusterManagerFactory.cs
+++ b/Raven.Database/Raft/ClusterManagerFactory.cs
@@ -25,8 +25,6 @@ namespace Raven.Database.Raft
 {
 	public static class ClusterManagerFactory
 	{
-		private static readonly ILog Log = LogManager.GetCurrentClassLogger();
-
 		public static NodeConnectionInfo CreateSelfConnection(DocumentDatabase database)
 		{
 			var configuration = database.Configuration;
@@ -83,46 +81,6 @@ namespace Raven.Database.Raft
 			stateMachine.RaftEngine = raftEngine;
 
 			return new ClusterManager(raftEngine);
-		}
-
-		public static void InitializeTopology(NodeConnectionInfo nodeConnection, ClusterManager clusterManager, bool isPartOfExistingCluster = false)
-		{
-			var topologyId = Guid.NewGuid();
-			var topology = new Topology(topologyId, new List<NodeConnectionInfo> { nodeConnection }, Enumerable.Empty<NodeConnectionInfo>(), Enumerable.Empty<NodeConnectionInfo>());
-
-			var tcc = new TopologyChangeCommand
-					  {
-						  Requested = topology,
-						  Previous = isPartOfExistingCluster ? clusterManager.Engine.CurrentTopology : null
-					  };
-
-			clusterManager.Engine.PersistentState.SetCurrentTopology(tcc.Requested, 0);
-			clusterManager.Engine.StartTopologyChange(tcc);
-			clusterManager.Engine.CommitTopologyChange(tcc);
-
-		    clusterManager.Engine.ForceCandidateState();
-
-			Log.Info("Initialized Topology: " + topologyId);
-		}
-
-		public static void InitializeEmptyTopologyWithId(ClusterManager clusterManager, Guid id)
-		{
-			var tcc = new TopologyChangeCommand
-			{
-				Requested = new Topology(id),
-				Previous = clusterManager.Engine.CurrentTopology
-			};
-
-			clusterManager.Engine.PersistentState.SetCurrentTopology(tcc.Requested, 0);
-			clusterManager.Engine.StartTopologyChange(tcc);
-			clusterManager.Engine.CommitTopologyChange(tcc);
-
-			Log.Info("Changed topology id: " + id + " and set the empty cluster topology");
-		}
-
-		public static void InitializeTopology(ClusterManager engine)
-		{
-			InitializeTopology(engine.Engine.Options.SelfConnection, engine);
 		}
 	}
 }

--- a/Raven.Database/Raft/Controllers/ClusterAdminController.cs
+++ b/Raven.Database/Raft/Controllers/ClusterAdminController.cs
@@ -97,7 +97,7 @@ namespace Raven.Database.Raft.Controllers
 			var nodeConnectionInfo = await ReadJsonObjectAsync<NodeConnectionInfo>().ConfigureAwait(false);
 			nodeConnectionInfo.Name = ClusterManager.Engine.Name;
 
-			ClusterManagerFactory.InitializeTopology(nodeConnectionInfo, ClusterManager);
+			ClusterManager.InitializeTopology(nodeConnectionInfo);
 
 			return GetEmptyMessage(HttpStatusCode.Created);
 		}
@@ -107,9 +107,9 @@ namespace Raven.Database.Raft.Controllers
 		public HttpResponseMessage InitializeNewCluster(string id)
 		{
 			if (string.IsNullOrEmpty(id))
-				ClusterManagerFactory.InitializeTopology(ClusterManager.Engine.Options.SelfConnection, ClusterManager, isPartOfExistingCluster: true);
+				ClusterManager.InitializeTopology(isPartOfExistingCluster: true);
 			else
-				ClusterManagerFactory.InitializeEmptyTopologyWithId(ClusterManager, Guid.Parse(id));
+				ClusterManager.InitializeEmptyTopologyWithId(Guid.Parse(id));
 
 			return GetEmptyMessage(HttpStatusCode.NoContent);
 		}

--- a/Raven.Tests.Raft/ClusterBasic.cs
+++ b/Raven.Tests.Raft/ClusterBasic.cs
@@ -110,6 +110,8 @@ namespace Raven.Tests.Raft
 			// initialize new single node cluster
 			nodeClient.DatabaseCommands.ForSystemDatabase().CreateRequest("/admin/cluster/initialize-new-cluster", new HttpMethod("PATCH")).ExecuteRequest();
 
+			Assert.True(nodeRaftEngine.WaitForLeader());
+
 			var newClusterId = nodeRaftEngine.CurrentTopology.TopologyId;
 
 			Assert.NotEqual(oldClusterId, newClusterId);

--- a/Raven.Tests.Raft/RaftTestBase.cs
+++ b/Raven.Tests.Raft/RaftTestBase.cs
@@ -89,7 +89,7 @@ namespace Raven.Tests.Raft
 
 			Console.WriteLine("Leader: " + leader.Options.ClusterManager.Value.Engine.Options.SelfConnection.Uri);
 
-			ClusterManagerFactory.InitializeTopology(leader.Options.ClusterManager.Value);
+			leader.Options.ClusterManager.Value.InitializeTopology();
 
 			Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader());
 

--- a/Raven.Tests.Raft/RaftWithAuth.cs
+++ b/Raven.Tests.Raft/RaftWithAuth.cs
@@ -33,7 +33,7 @@ namespace Raven.Tests.Raft
 			NodeConnectionInfo leaderNci;
 			var leader = CreateServerWithOAuth(8079, "Ayende/abc", out leaderNci);
 
-			ClusterManagerFactory.InitializeTopology(leaderNci, leader.Options.ClusterManager.Value);
+			leader.Options.ClusterManager.Value.InitializeTopology(leaderNci);
 			Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader());
 
 			NodeConnectionInfo secondConnectionInfo;
@@ -71,7 +71,7 @@ namespace Raven.Tests.Raft
 			NodeConnectionInfo leaderNci;
 			var leader = CreateServerWithWindowsCredentials(8079, username, password, domain, out leaderNci);
 
-			ClusterManagerFactory.InitializeTopology(leaderNci, leader.Options.ClusterManager.Value);
+			leader.Options.ClusterManager.Value.InitializeTopology(leaderNci);
 			Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader());
 
 			NodeConnectionInfo secondConnectionInfo;
@@ -108,7 +108,7 @@ namespace Raven.Tests.Raft
 			NodeConnectionInfo leaderNci;
 			var leader = CreateServerWithOAuth(8079, "Ayende/abc", out leaderNci);
 
-			ClusterManagerFactory.InitializeTopology(leaderNci, leader.Options.ClusterManager.Value);
+			leader.Options.ClusterManager.Value.InitializeTopology(leaderNci);
 			Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader());
 
 			NodeConnectionInfo secondConnectionInfo;
@@ -148,7 +148,7 @@ namespace Raven.Tests.Raft
 			NodeConnectionInfo leaderNci;
 			var leader = CreateServerWithWindowsCredentials(8079, username, password, domain, out leaderNci);
 
-			ClusterManagerFactory.InitializeTopology(leaderNci, leader.Options.ClusterManager.Value);
+			leader.Options.ClusterManager.Value.InitializeTopology(leaderNci);
 			Assert.True(leader.Options.ClusterManager.Value.Engine.WaitForLeader());
 
 			NodeConnectionInfo secondConnectionInfo;


### PR DESCRIPTION
…'t have to be static. Fixing the condition when we force engine to be a candidate after we initialize new cluster.
