### PR TITLE
RavenDB-3887 RavenFS using Esent storage corrupts files greater than …

### DIFF
--- a/Raven.Database/FileSystem/Storage/Esent/Schema/Updates/From06To07.cs
+++ b/Raven.Database/FileSystem/Storage/Esent/Schema/Updates/From06To07.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.Isam.Esent.Interop;
+using Raven.Database.Config;
+
+namespace Raven.Database.FileSystem.Storage.Esent.Schema.Updates
+{
+	public class From06To07 : IFileSystemSchemaUpdate
+	{
+		public string FromSchemaVersion
+		{
+			get { return "0.6"; }
+		}
+		public void Init(InMemoryRavenConfiguration configuration)
+		{
+		}
+
+		public void Update(Session session, JET_DBID dbid, Action<string> output)
+		{
+			using (var tbl = new Table(session, dbid, "usage", OpenTableGrbit.None))
+			{
+				var indexDef = "+name\0+file_pos\0\0";
+				Api.JetDeleteIndex(session, tbl, "by_name_and_pos");
+				Api.JetCreateIndex2(session, tbl, new[]
+				{
+					new JET_INDEXCREATE
+					{
+						szIndexName = "by_name_and_pos",
+						cbKey = indexDef.Length,
+						cbKeyMost = SystemParameters.KeyMost,
+						cbVarSegMac = SystemParameters.KeyMost,
+						szKey = indexDef,
+						grbit = CreateIndexGrbit.None,
+						ulDensity = 80
+					}
+				}, 1);
+			}
+
+			SchemaCreator.UpdateVersion(session, dbid, "0.7");
+		}
+	}
+}

--- a/Raven.Database/FileSystem/Storage/Esent/SchemaCreator.cs
+++ b/Raven.Database/FileSystem/Storage/Esent/SchemaCreator.cs
@@ -7,7 +7,7 @@ namespace Raven.Database.FileSystem.Storage.Esent
 {
 	public class SchemaCreator
 	{
-		public const string SchemaVersion = "0.6";
+		public const string SchemaVersion = "0.7";
 		private readonly Session session;
 
 		public SchemaCreator(Session session)
@@ -220,8 +220,20 @@ namespace Raven.Database.FileSystem.Storage.Esent
 							   80);
 
 			indexDef = "+name\0+file_pos\0\0";
-			Api.JetCreateIndex(session, tableid, "by_name_and_pos", CreateIndexGrbit.None, indexDef, indexDef.Length,
-							   80);
+
+			Api.JetCreateIndex2(session, tableid, new[]
+			{
+				new JET_INDEXCREATE
+				{
+					szIndexName = "by_name_and_pos",
+					cbKey = indexDef.Length,
+					cbKeyMost = SystemParameters.KeyMost,
+					cbVarSegMac = SystemParameters.KeyMost,
+					szKey = indexDef,
+					grbit = CreateIndexGrbit.None,
+					ulDensity = 80
+				}
+			}, 1);
 		}
 		private void CreateFilesTable(JET_DBID dbid)
 		{

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -270,6 +270,7 @@
     <Compile Include="FileSystem\Plugins\TriggerExtensions.cs" />
     <Compile Include="FileSystem\Smuggler\SmugglerEmbeddedFilesOperations.cs" />
     <Compile Include="FileSystem\Storage\Esent\Schema\Updates\From04To05.cs" />
+    <Compile Include="FileSystem\Storage\Esent\Schema\Updates\From06To07.cs" />
     <Compile Include="FileSystem\Storage\Esent\Schema\Updates\From05To06.cs" />
     <Compile Include="FileSystem\Storage\Voron\Schema\Updates\From10To11.cs" />
     <Compile Include="FileSystem\Synchronization\SynchronizationBehavior.cs" />

--- a/Raven.Tests.FileSystem/Issues/RavenDB_3887.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_3887.cs
@@ -1,0 +1,82 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_3887.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Abstractions.Extensions;
+using Raven.Json.Linq;
+using Raven.Tests.Helpers;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+	public class RavenDB_3887 : RavenFilesTestBase
+	{
+		[Theory]
+		[InlineData(4194304, "esent")]
+		[InlineData(4194304, "voron")]
+		[InlineData(4194305, "esent")]
+		[InlineData(4194305, "voron")]
+		[InlineData(9 * 1024 * 1024, "esent")]
+		[InlineData(9 * 1024 * 1024, "voron")]
+		public async Task ShouldNotReturnCorruptedFileContent(int size, string storage)
+		{
+			const string path = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789abc";
+
+			byte[] originalFileData = new byte[size];
+			byte[] originalFileHash;
+			byte[] storedFileData;
+			byte[] storedFileHash;
+
+			using (var rng = RNGCryptoServiceProvider.Create())
+			using (var sha1 = SHA1.Create())
+			{
+				rng.GetBytes(originalFileData);
+				originalFileHash = sha1.ComputeHash(originalFileData);
+			}
+
+			using (var filesStore = NewStore(requestedStorage: storage))
+			{
+				using (var session = filesStore.OpenAsyncSession())
+				{
+					session.RegisterUpload(path, new MemoryStream(originalFileData));
+					await session.SaveChangesAsync();
+				}
+
+				using (var session = filesStore.OpenAsyncSession())
+				{
+					var refMetadata = new Reference<RavenJObject>();
+					var stream = await session.DownloadAsync(path, refMetadata);
+					storedFileData = await stream.ReadDataAsync();
+
+					Assert.Equal(originalFileData.Length, storedFileData.Length);
+
+					using (var sha1 = SHA1.Create())
+					{
+						storedFileHash = sha1.ComputeHash(storedFileData);
+					}
+				}
+
+				Assert.Equal(ToHexString(originalFileHash), ToHexString(storedFileHash));
+			}
+		}
+
+		string ToHexString(byte[] data)
+		{
+			if (data == null) return null;
+
+			const string hexDigits = "0123456789abcdef";
+			var sb = new StringBuilder(data.Length * 2);
+			foreach (byte b in data)
+			{
+				sb.Append(hexDigits[(b >> 4) & 0x0F]).Append(hexDigits[b & 0x0F]);
+			}
+			return sb.ToString();
+		}
+	}
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -134,6 +134,7 @@
     <Compile Include="FileHandling.cs" />
     <Compile Include="FileNamingTests.cs" />
     <Compile Include="Folders.cs" />
+    <Compile Include="Issues\RavenDB_3887.cs" />
     <Compile Include="Issues\RavenDB_FEI_2.cs" />
     <Compile Include="Issues\RavenDB_3648.cs" />
     <Compile Include="Issues\RavenDB_2889.cs" />


### PR DESCRIPTION
…4194304 bytes whose path exceeds 121 characters
