### PR TITLE
Fix for SmugglerCanUnderstandPeriodicBackupFormat

### DIFF
--- a/Raven.Database/Server/Security/MixedModeRequestAuthorizer.cs
+++ b/Raven.Database/Server/Security/MixedModeRequestAuthorizer.cs
@@ -171,7 +171,8 @@ namespace Raven.Database.Server.Security
             object result;
             HttpStatusCode statusCode;
             IPrincipal user;
-            var success = TryAuthorizeSingleUseAuthToken(token, controller.ResourcePrefix + controller.ResourceName, out result, out statusCode, out user);
+	        var resourceName = controller.ResourceName == null ? null : controller.ResourcePrefix + controller.ResourceName;
+			var success = TryAuthorizeSingleUseAuthToken(token, resourceName, out result, out statusCode, out user);
             controller.User = user;
             msg = success == false ? controller.GetMessageWithObject(result, statusCode) : controller.GetEmptyMessage();
 

--- a/Raven.Tests/Smuggler/SmugglerExecutionTests.cs
+++ b/Raven.Tests/Smuggler/SmugglerExecutionTests.cs
@@ -335,12 +335,12 @@ namespace Raven.Tests.Smuggler
                 }
                 store.DatabaseCommands.PutAttachment("attach/1", null, new MemoryStream(new byte[] { 1, 2, 3, 4 }), new RavenJObject());
 
-                WaitForPeriodicExport(store.SystemDatabase, backupStatus);
+                WaitForPeriodicExport(store.SystemDatabase, backupStatus,PeriodicExportStatus.PeriodicExportStatusEtags.LastAttachmentsEtag);
 
                 store.DatabaseCommands.Delete(userId, null);
                 store.DatabaseCommands.DeleteAttachment("attach/1", null);
 
-                WaitForPeriodicExport(store.SystemDatabase, backupStatus);
+				WaitForPeriodicExport(store.SystemDatabase, backupStatus, PeriodicExportStatus.PeriodicExportStatusEtags.LastAttachmentDeletionEtag);
 
             }
 


### PR DESCRIPTION
Problem when resource name is null and resource prefix is string empty.
Also there is a race condition in the wait for periodic export