### PR TITLE
Fix a bug - Time Series, Counters and File System should not inherit …

### DIFF
--- a/Raven.Database/Counters/Controllers/AdminCounterStorageController.cs
+++ b/Raven.Database/Counters/Controllers/AdminCounterStorageController.cs
@@ -11,7 +11,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
-
 using Raven.Abstractions;
 using Raven.Abstractions.Counters;
 using Raven.Abstractions.Data;

--- a/Raven.Database/Counters/Controllers/BaseAdminCountersApiController.cs
+++ b/Raven.Database/Counters/Controllers/BaseAdminCountersApiController.cs
@@ -4,15 +4,13 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 using System;
-using System.Web.Http.Controllers;
-
 using Raven.Database.Common;
 using Raven.Database.Config;
-using Raven.Database.Server.Controllers.Admin;
+using Raven.Database.Server.Tenancy;
 
 namespace Raven.Database.Counters.Controllers
 {
-	public abstract class BaseAdminCountersApiController : BaseAdminDatabaseApiController
+	public abstract class BaseAdminCountersApiController : AdminResourceApiController<CounterStorage, CountersLandlord>
 	{
 		public override InMemoryRavenConfiguration ResourceConfiguration
 		{
@@ -22,48 +20,11 @@ namespace Raven.Database.Counters.Controllers
 			}
 		}
 
-		public override DocumentDatabase Database
-		{
-			get
-			{
-				throw new NotSupportedException("Use SystemDatabase instead.");
-			}
-		}
+		public string CounterName => ResourceName;
 
-		public override string DatabaseName
-		{
-			get
-			{
-				throw new NotSupportedException();
-			}
-		}
+		public CounterStorage Counters => Resource;
 
-		public string CounterName { get; private set; }
-
-		private CounterStorage _counters;
-		public CounterStorage Counters
-		{
-			get
-			{
-				if (_counters != null)
-					return _counters;
-
-				var resource = CountersLandlord.GetResourceInternal(CounterName);
-				if (resource == null)
-				{
-					throw new InvalidOperationException("Could not find a counter named: " + CounterName);
-				}
-
-				return _counters = resource.Result;
-			}
-		}
-
-		protected override void InnerInitialization(HttpControllerContext controllerContext)
-		{
-			base.InnerInitialization(controllerContext);
-
-			CounterName = GetResourceName(controllerContext, ResourceType.Counter);
-		}
+		public override ResourceType ResourceType => ResourceType.Counter;
 
 		public override void MarkRequestDuration(long duration)
 		{

--- a/Raven.Database/FileSystem/Controllers/BaseAdminFileSystemApiController.cs
+++ b/Raven.Database/FileSystem/Controllers/BaseAdminFileSystemApiController.cs
@@ -4,15 +4,13 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 using System;
-using System.Web.Http.Controllers;
-
 using Raven.Database.Common;
 using Raven.Database.Config;
-using Raven.Database.Server.Controllers.Admin;
+using Raven.Database.Server.Tenancy;
 
 namespace Raven.Database.FileSystem.Controllers
 {
-	public class BaseAdminFileSystemApiController : BaseAdminDatabaseApiController
+	public class BaseAdminFileSystemApiController : AdminResourceApiController<RavenFileSystem, FileSystemsLandlord>
 	{
 		public override InMemoryRavenConfiguration ResourceConfiguration
 		{
@@ -22,48 +20,11 @@ namespace Raven.Database.FileSystem.Controllers
 			}
 		}
 
-		public override DocumentDatabase Database
-		{
-			get
-			{
-				throw new NotSupportedException("Use SystemDatabase instead.");
-			}
-		}
+		public string FileSystemName => ResourceName;
 
-		public override string DatabaseName
-		{
-			get
-			{
-				throw new NotSupportedException();
-			}
-		}
+		public RavenFileSystem FileSystem => Resource;
 
-		public string FileSystemName { get; private set; }
-
-		private RavenFileSystem _fileSystem;
-		public RavenFileSystem FileSystem
-		{
-			get
-			{
-				if (_fileSystem != null)
-					return _fileSystem;
-
-				var resource = FileSystemsLandlord.GetResourceInternal(FileSystemName);
-				if (resource == null)
-				{
-					throw new InvalidOperationException("Could not find a file system named: " + FileSystemName);
-				}
-
-				return _fileSystem = resource.Result;
-			}
-		}
-
-		protected override void InnerInitialization(HttpControllerContext controllerContext)
-		{
-			base.InnerInitialization(controllerContext);
-
-			FileSystemName = GetResourceName(controllerContext, ResourceType.FileSystem);
-		}
+		public override ResourceType ResourceType => ResourceType.FileSystem;
 
 		public override void MarkRequestDuration(long duration)
 		{

--- a/Raven.Database/Server/Controllers/Admin/BaseAdminDatabaseApiController.cs
+++ b/Raven.Database/Server/Controllers/Admin/BaseAdminDatabaseApiController.cs
@@ -10,29 +10,11 @@ namespace Raven.Database.Server.Controllers.Admin
 {
 	public class BaseAdminDatabaseApiController : AdminResourceApiController<DocumentDatabase, DatabasesLandlord>
 	{
-		public virtual string DatabaseName
-		{
-			get
-			{
-				return ResourceName;
-			}
-		}
+		public override ResourceType ResourceType => ResourceType.Database;
 
-		public virtual DocumentDatabase Database
-		{
-			get
-			{
-				return Resource;
-			}
-		}
+		public string DatabaseName => ResourceName;
 
-		public override ResourceType ResourceType
-		{
-			get
-			{
-				return ResourceType.Database;
-			}
-		}
+		public DocumentDatabase Database => Resource;
 
 		public override void MarkRequestDuration(long duration)
 		{

--- a/Raven.Database/TimeSeries/Controllers/BaseAdminTimeSeriesApiController.cs
+++ b/Raven.Database/TimeSeries/Controllers/BaseAdminTimeSeriesApiController.cs
@@ -4,15 +4,13 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 using System;
-using System.Web.Http.Controllers;
-
 using Raven.Database.Common;
 using Raven.Database.Config;
-using Raven.Database.Server.Controllers.Admin;
+using Raven.Database.Server.Tenancy;
 
 namespace Raven.Database.TimeSeries.Controllers
 {
-	public class BaseAdminTimeSeriesApiController : BaseAdminDatabaseApiController
+	public class BaseAdminTimeSeriesApiController : AdminResourceApiController<TimeSeriesStorage, TimeSeriesLandlord>
 	{
 		public override InMemoryRavenConfiguration ResourceConfiguration
 		{
@@ -22,56 +20,11 @@ namespace Raven.Database.TimeSeries.Controllers
 			}
 		}
 
-		public override DocumentDatabase Database
-		{
-			get
-			{
-				throw new NotSupportedException("Use SystemDatabase instead.");
-			}
-		}
+		public string TimeSeriesName => ResourceName;
 
-		public override string DatabaseName
-		{
-			get
-			{
-				throw new NotSupportedException();
-			}
-		}
+		public TimeSeriesStorage TimeSeries => Resource;
 
-		public string TimeSeriesName { get; private set; }
-
-		private TimeSeriesStorage _timeSeries;
-		public TimeSeriesStorage TimeSeries
-		{
-			get
-			{
-				if (_timeSeries != null)
-					return _timeSeries;
-
-				var resource = TimeSeriesLandlord.GetResourceInternal(TimeSeriesName);
-				if (resource == null)
-				{
-					throw new InvalidOperationException("Could not find a time series named: " + TimeSeriesName);
-				}
-
-				return _timeSeries = resource.Result;
-			}
-		}
-
-		protected override void InnerInitialization(HttpControllerContext controllerContext)
-		{
-			base.InnerInitialization(controllerContext);
-
-			TimeSeriesName = GetResourceName(controllerContext, ResourceType.TimeSeries);
-		}
-
-		public override ResourceType ResourceType
-		{
-			get
-			{
-				return ResourceType.TimeSeries;
-			}
-		}
+		public override ResourceType ResourceType => ResourceType.TimeSeries;
 
 		public override void MarkRequestDuration(long duration)
 		{

--- a/Raven.Database/TimeSeries/Controllers/BaseTimeSeriesApiController.cs
+++ b/Raven.Database/TimeSeries/Controllers/BaseTimeSeriesApiController.cs
@@ -11,29 +11,11 @@ namespace Raven.Database.TimeSeries.Controllers
 {
 	public abstract class BaseTimeSeriesApiController : ResourceApiController<TimeSeriesStorage, TimeSeriesLandlord>
 	{
-		protected string TimeSeriesName
-		{
-			get
-			{
-				return ResourceName;
-			}
-		}
+		protected string TimeSeriesName => ResourceName;
 
-		protected TimeSeriesStorage TimeSeries
-		{
-			get
-			{
-				return Resource;
-			}
-		}
+		protected TimeSeriesStorage TimeSeries => Resource;
 
-		public override ResourceType ResourceType
-		{
-			get
-			{
-				return ResourceType.TimeSeries;
-			}
-		}
+		public override ResourceType ResourceType => ResourceType.TimeSeries;
 
 		public override void MarkRequestDuration(long duration)
 		{


### PR DESCRIPTION
…from BaseAdminDatabaseApiController which intended to be used only by Documents. They should instead implement AdminResourceApiController at their own.

This should fix failing tests in Time Series, Counters and File System, but for now, I still see failing tests in Time Series, but from a different reason: the time series document is not exist in the system db.  Still I created the PR to share this fix, which I suspect fixed other tests.