### PR TITLE
RavenDB-3919 Files which uploads has been aborted must not exist in a…

### DIFF
--- a/Raven.Database/FileSystem/Actions/FileActions.cs
+++ b/Raven.Database/FileSystem/Actions/FileActions.cs
@@ -131,10 +131,6 @@ namespace Raven.Database.FileSystem.Actions
 
 					if (size != null && readFileToDatabase.TotalSizeRead != size)
 					{
-						using (FileSystem.DisableAllTriggersForCurrentThread())
-						{
-							IndicateFileToDelete(name, null);
-						}
 						throw new HttpResponseException(HttpStatusCode.BadRequest);
 					}
 

--- a/Raven.Database/FileSystem/Controllers/FilesController.cs
+++ b/Raven.Database/FileSystem/Controllers/FilesController.cs
@@ -267,13 +267,7 @@ namespace Raven.Database.FileSystem.Controllers
 
 				Historian.UpdateLastModified(metadata);
 
-				var operation = new RenameFileOperation
-				{
-					FileSystem = FileSystem.Name,
-					Name = name,
-					Rename = rename,
-					MetadataAfterOperation = metadata
-				};
+				var operation = new RenameFileOperation(name, rename, existingFile.Etag, metadata);
 
 				accessor.SetConfig(RavenFileNameHelper.RenameOperationConfigNameForFile(name), JsonExtensions.ToJObject(operation));
 				accessor.PulseTransaction(); // commit rename operation config

--- a/Raven.Database/FileSystem/Storage/Esent/StorageActionsAccessor.cs
+++ b/Raven.Database/FileSystem/Storage/Esent/StorageActionsAccessor.cs
@@ -193,9 +193,9 @@ namespace Raven.Database.FileSystem.Storage.Esent
 			return Api.RetrieveColumnAsInt32(session, Pages, tableColumnsCache.PagesColumns["id"]).Value;
 		}
 
-        public MetadataUpdateResult PutFile(string filename, long? totalSize, RavenJObject metadata, bool tombstone = false)
+        public FileUpdateResult PutFile(string filename, long? totalSize, RavenJObject metadata, bool tombstone = false)
         {
-	        MetadataUpdateResult result;
+	        FileUpdateResult result;
 
             using (var update = new Update(session, Files, JET_prep.Insert))
             {
@@ -213,7 +213,7 @@ namespace Raven.Database.FileSystem.Storage.Esent
 
                 update.Save();
 
-				result = new MetadataUpdateResult
+				result = new FileUpdateResult
 				{
 					PrevEtag = null,
 					Etag = newEtag
@@ -535,7 +535,7 @@ namespace Raven.Database.FileSystem.Storage.Esent
 			Api.JetDelete(session, Files);
 		}
 
-        public MetadataUpdateResult UpdateFileMetadata(string filename, RavenJObject metadata, Etag etag)
+        public FileUpdateResult UpdateFileMetadata(string filename, RavenJObject metadata, Etag etag)
         {
             Api.JetSetCurrentIndex(session, Files, "by_name");
             Api.MakeKey(session, Files, filename, Encoding.Unicode, MakeKeyGrbit.NewKey);
@@ -562,7 +562,7 @@ namespace Raven.Database.FileSystem.Storage.Esent
 
                 update.Save();
 
-	            return new MetadataUpdateResult
+	            return new FileUpdateResult
 	            {
 		            PrevEtag = existingEtag,
 		            Etag = newEtag

--- a/Raven.Database/FileSystem/Storage/IStorageActionsAccessor.cs
+++ b/Raven.Database/FileSystem/Storage/IStorageActionsAccessor.cs
@@ -20,7 +20,7 @@ namespace Raven.Database.FileSystem.Storage
 
         int InsertPage(byte[] buffer, int size);
 
-        MetadataUpdateResult PutFile(string filename, long? totalSize, RavenJObject metadata, bool tombstone = false);
+        FileUpdateResult PutFile(string filename, long? totalSize, RavenJObject metadata, bool tombstone = false);
 
         void AssociatePage(string filename, int pageId, int pagePositionInFile, int pageSize);
 
@@ -38,7 +38,7 @@ namespace Raven.Database.FileSystem.Storage
 
         void Delete(string filename);
        
-        MetadataUpdateResult UpdateFileMetadata(string filename, RavenJObject metadata, Etag etag);
+        FileUpdateResult UpdateFileMetadata(string filename, RavenJObject metadata, Etag etag);
 
         void CompleteFileUpload(string filename);
 
@@ -77,7 +77,7 @@ namespace Raven.Database.FileSystem.Storage
 		bool IsNested { get; set; }
     }
 
-	public class MetadataUpdateResult
+	public class FileUpdateResult
 	{
 		public Etag Etag;
 		public Etag PrevEtag;

--- a/Raven.Database/FileSystem/Storage/RenameFileOperation.cs
+++ b/Raven.Database/FileSystem/Storage/RenameFileOperation.cs
@@ -1,15 +1,24 @@
 ﻿using Raven.Json.Linq;
-using System.Collections.Specialized;
+using Raven.Abstractions.Data;
 
 namespace Raven.Database.FileSystem.Storage
 {
 	public class RenameFileOperation
 	{
-        public string FileSystem { get; set; }
-		public string Name { get; set; }
+		public RenameFileOperation(string name, string rename, Etag currentEtag, RavenJObject metadataAfterOperation)
+		{
+			Name = name;
+			Rename = rename;
+			Etag = currentEtag;
+			MetadataAfterOperation = metadataAfterOperation;
+		}
 
-		public string Rename { get; set; }
+		public string Name { get; private set; }
 
-		public RavenJObject MetadataAfterOperation { get; set; }
+		public string Rename { get; private set; }
+
+		public Etag Etag { get; private set; }
+
+		public RavenJObject MetadataAfterOperation { get; private set; }
 	}
 }

--- a/Raven.Database/FileSystem/Storage/Voron/StorageActionsAccessor.cs
+++ b/Raven.Database/FileSystem/Storage/Voron/StorageActionsAccessor.cs
@@ -120,7 +120,7 @@ namespace Raven.Database.FileSystem.Storage.Voron
             return newPageId;
         }
 
-        public MetadataUpdateResult PutFile(string filename, long? totalSize, RavenJObject metadata, bool tombstone = false)
+        public FileUpdateResult PutFile(string filename, long? totalSize, RavenJObject metadata, bool tombstone = false)
         {
 			var filesByEtag = storage.Files.GetIndex(Tables.Files.Indices.ByEtag);
 
@@ -158,7 +158,7 @@ namespace Raven.Database.FileSystem.Storage.Voron
                 fileCount.Add(writeBatch.Value, keySlice, keyString);
 	        }
 
-	        return new MetadataUpdateResult()
+	        return new FileUpdateResult()
 	        {
 		        Etag = newEtag
 	        };
@@ -384,7 +384,7 @@ namespace Raven.Database.FileSystem.Storage.Voron
             DeleteFile(filename);
         }
 
-        public MetadataUpdateResult UpdateFileMetadata(string filename, RavenJObject metadata, Etag etag)
+        public FileUpdateResult UpdateFileMetadata(string filename, RavenJObject metadata, Etag etag)
         {
             var key = CreateKey(filename);
             var keySlice = (Slice)key;
@@ -416,7 +416,7 @@ namespace Raven.Database.FileSystem.Storage.Voron
             filesByEtag.Delete(writeBatch.Value, CreateKey(existingEtag));
             filesByEtag.Add(writeBatch.Value, (Slice)CreateKey(newEtag), key);
 
-	        return new MetadataUpdateResult()
+	        return new FileUpdateResult()
 	        {
 		        PrevEtag = existingEtag,
 		        Etag = newEtag

--- a/Raven.Database/FileSystem/Synchronization/Conflictuality/ConflictArtifactManager.cs
+++ b/Raven.Database/FileSystem/Synchronization/Conflictuality/ConflictArtifactManager.cs
@@ -24,7 +24,7 @@ namespace Raven.Database.FileSystem.Synchronization.Conflictuality
 		public void Create(string fileName, ConflictItem conflict)
 		{
             RavenJObject metadata = null;
-			MetadataUpdateResult updateMetadata = null;
+			FileUpdateResult updateMetadata = null;
 
 			storage.Batch(
 				accessor =>
@@ -42,7 +42,7 @@ namespace Raven.Database.FileSystem.Synchronization.Conflictuality
 		public void Delete(string fileName, IStorageActionsAccessor actionsAccessor = null)
 		{
             RavenJObject metadata = null;
-			MetadataUpdateResult updateResult = null;
+			FileUpdateResult updateResult = null;
 
 			Action<IStorageActionsAccessor> delete = accessor =>
 			{

--- a/Raven.Database/FileSystem/Synchronization/SynchronizationBehavior.cs
+++ b/Raven.Database/FileSystem/Synchronization/SynchronizationBehavior.cs
@@ -294,7 +294,7 @@ namespace Raven.Database.FileSystem.Synchronization
 				synchronizingFile.Dispose();
 				metadata["Content-MD5"] = synchronizingFile.FileHash;
 
-				MetadataUpdateResult updateResult = null;
+				FileUpdateResult updateResult = null;
 				fs.Storage.Batch(accessor => updateResult = accessor.UpdateFileMetadata(tempFileName, metadata, null));
 
 				fs.Storage.Batch(accessor =>

--- a/Raven.Database/FileSystem/Synchronization/SynchronizationBehavior.cs
+++ b/Raven.Database/FileSystem/Synchronization/SynchronizationBehavior.cs
@@ -24,16 +24,16 @@ namespace Raven.Database.FileSystem.Synchronization
 
 		private readonly string fileName;
 		private readonly Etag sourceFileEtag;
-		private readonly RavenJObject metadata;
+		private readonly RavenJObject sourceMetadata;
 		private readonly FileSystemInfo sourceFs;
 		private readonly SynchronizationType type;
 		private readonly RavenFileSystem fs;
 
-		public SynchronizationBehavior(string fileName, Etag sourceFileEtag, RavenJObject metadata, FileSystemInfo sourceFs, SynchronizationType type, RavenFileSystem fs)
+		public SynchronizationBehavior(string fileName, Etag sourceFileEtag, RavenJObject sourceMetadata, FileSystemInfo sourceFs, SynchronizationType type, RavenFileSystem fs)
 		{
 			this.fileName = fileName;
 			this.sourceFileEtag = sourceFileEtag;
-			this.metadata = metadata;
+			this.sourceMetadata = sourceMetadata;
 			this.sourceFs = sourceFs;
 			this.type = type;
 			this.fs = fs;
@@ -60,7 +60,7 @@ namespace Raven.Database.FileSystem.Synchronization
 				bool conflictResolved;
 				AssertConflictDetection(localMetadata, out conflictResolved);
 
-				fs.SynchronizationTriggers.Apply(trigger => trigger.BeforeSynchronization(fileName, metadata, type));
+				fs.SynchronizationTriggers.Apply(trigger => trigger.BeforeSynchronization(fileName, sourceMetadata, type));
 
 				dynamic afterSynchronizationTriggerData = null;
 
@@ -88,7 +88,7 @@ namespace Raven.Database.FileSystem.Synchronization
 				}
 
 
-				fs.SynchronizationTriggers.Apply(trigger => trigger.AfterSynchronization(fileName, metadata, type, afterSynchronizationTriggerData));
+				fs.SynchronizationTriggers.Apply(trigger => trigger.AfterSynchronization(fileName, sourceMetadata, type, afterSynchronizationTriggerData));
 
 				if (conflictResolved)
 				{
@@ -125,7 +125,7 @@ namespace Raven.Database.FileSystem.Synchronization
 				fs.Synchronizations.AssertFileIsNotBeingSynced(fileName);
 
 				if (type == SynchronizationType.ContentUpdate)
-					fs.Files.AssertPutOperationNotVetoed(fileName, metadata);
+					fs.Files.AssertPutOperationNotVetoed(fileName, sourceMetadata);
 
 				fs.FileLockManager.LockByCreatingSyncConfiguration(fileName, sourceFs, accessor);
 			});
@@ -184,7 +184,7 @@ namespace Raven.Database.FileSystem.Synchronization
 				return;
 			}
 
-			var conflict = fs.ConflictDetector.Check(fileName, localMetadata, metadata, sourceFs.Url);
+			var conflict = fs.ConflictDetector.Check(fileName, localMetadata, sourceMetadata, sourceFs.Url);
 			if (conflict == null)
 			{
 				isConflictResolved = false;
@@ -197,7 +197,7 @@ namespace Raven.Database.FileSystem.Synchronization
 				return;
 
 			ConflictResolutionStrategy strategy;
-			if (fs.ConflictResolver.TryResolveConflict(fileName, conflict, localMetadata, metadata, out strategy))
+			if (fs.ConflictResolver.TryResolveConflict(fileName, conflict, localMetadata, sourceMetadata, out strategy))
 			{
 				switch (strategy)
 				{
@@ -249,18 +249,19 @@ namespace Raven.Database.FileSystem.Synchronization
 
 		private void ExecuteMetadataUpdate()
 		{
-			fs.Files.UpdateMetadata(fileName, metadata, null);
+			fs.Files.UpdateMetadata(fileName, sourceMetadata, null);
 		}
 
 		private void ExecuteRename(string rename)
 		{
-			fs.Files.ExecuteRenameOperation(new RenameFileOperation
+			Etag currentEtag = null;
+
+			fs.Storage.Batch(accessor =>
 			{
-				FileSystem = fs.Name,
-				Name = fileName,
-				Rename = rename,
-				MetadataAfterOperation = metadata.DropRenameMarkers()
+				currentEtag = accessor.ReadFile(fileName).Etag;
 			});
+
+			fs.Files.ExecuteRenameOperation(new RenameFileOperation(fileName, rename, currentEtag, sourceMetadata.DropRenameMarkers()));
 		}
 
 		private async Task ExecuteContentUpdate(RavenJObject localMetadata, SynchronizationReport report)
@@ -269,13 +270,13 @@ namespace Raven.Database.FileSystem.Synchronization
 
 			using (var localFile = localMetadata != null ? StorageStream.Reading(fs.Storage, fileName) : null)
 			{
-				fs.PutTriggers.Apply(trigger => trigger.OnPut(tempFileName, metadata));
+				fs.PutTriggers.Apply(trigger => trigger.OnPut(tempFileName, sourceMetadata));
 
-				fs.Historian.UpdateLastModified(metadata);
+				fs.Historian.UpdateLastModified(sourceMetadata);
 
-				var synchronizingFile = SynchronizingFileStream.CreatingOrOpeningAndWriting(fs, tempFileName, metadata);
+				var synchronizingFile = SynchronizingFileStream.CreatingOrOpeningAndWriting(fs, tempFileName, sourceMetadata);
 
-				fs.PutTriggers.Apply(trigger => trigger.AfterPut(tempFileName, null, metadata));
+				fs.PutTriggers.Apply(trigger => trigger.AfterPut(tempFileName, null, sourceMetadata));
 
 				var provider = new MultipartSyncStreamProvider(synchronizingFile, localFile);
 
@@ -292,10 +293,10 @@ namespace Raven.Database.FileSystem.Synchronization
 				synchronizingFile.PreventUploadComplete = false;
 				synchronizingFile.Flush();
 				synchronizingFile.Dispose();
-				metadata["Content-MD5"] = synchronizingFile.FileHash;
+				sourceMetadata["Content-MD5"] = synchronizingFile.FileHash;
 
 				FileUpdateResult updateResult = null;
-				fs.Storage.Batch(accessor => updateResult = accessor.UpdateFileMetadata(tempFileName, metadata, null));
+				fs.Storage.Batch(accessor => updateResult = accessor.UpdateFileMetadata(tempFileName, sourceMetadata, null));
 
 				fs.Storage.Batch(accessor =>
 				{
@@ -307,7 +308,7 @@ namespace Raven.Database.FileSystem.Synchronization
 					accessor.RenameFile(tempFileName, fileName);
 
 					fs.Search.Delete(tempFileName);
-					fs.Search.Index(fileName, metadata, updateResult.Etag);
+					fs.Search.Index(fileName, sourceMetadata, updateResult.Etag);
 				});
 
 				if (localFile == null)

--- a/Raven.Tests.FileSystem/Issues/RavenDB_3919.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_3919.cs
@@ -1,0 +1,94 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_3919.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.FileSystem;
+using Raven.Tests.Common.Util;
+using Xunit;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+	public class RavenDB_3919 : RavenFilesTestWithLogs
+	{
+		[Fact]
+		public async Task after_failed_upload_file_should_not_exist()
+		{
+			const int fileSize = 1024*1024*2; // 2 MB
+			const string fileName = "test.bin";
+			const int portIndex = 0;
+
+			using (var initialStore = NewStore(portIndex))
+			{
+				var alreadyReset = false;
+				var port = 8070;
+				var putInitialized = false;
+				var uploaded = 0;
+
+				using (new ProxyServer(ref port, Ports[portIndex])
+				{
+					VetoTransfer = (totalRead, buffer) =>
+					{
+						var numOfBytes = buffer.Count - buffer.Offset;
+						var s = Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count);
+
+						if (s.StartsWith("PUT"))
+						{
+							putInitialized = true;
+							uploaded = numOfBytes;
+							return false;
+						}
+
+						if (putInitialized && alreadyReset == false)
+						{
+							uploaded += numOfBytes;
+
+							if (uploaded > fileSize / 2)
+							{
+								alreadyReset = true;
+								return true;
+							}
+						}
+
+						return false;
+					}
+				})
+				{
+					using (var storeUsingProxy = new FilesStore
+					{
+						Url = "http://localhost:" + port,
+						DefaultFileSystem = initialStore.DefaultFileSystem
+					}.Initialize())
+					{
+						HttpRequestException hre = null;
+
+						try
+						{
+							await storeUsingProxy.AsyncFilesCommands.UploadAsync(fileName, new MemoryStream(new byte[fileSize]));
+						}
+						catch (HttpRequestException e)
+						{
+							hre = e;
+						}
+
+						Assert.NotNull(hre);
+
+						// the exception we caught was actually the client side exception because our proxy server forced the connection to be closed
+						// wait a bit to make sure the actual request completed and the file has been marked as deleted on the server side
+
+						Thread.Sleep(1000);
+
+						var fileMetadata = await storeUsingProxy.AsyncFilesCommands.GetMetadataForAsync(fileName);
+
+						Assert.Null(fileMetadata);
+					}
+				}
+			}
+		}
+	}
+}

--- a/Raven.Tests.FileSystem/Issues/RavenDB_3920.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_3920.cs
@@ -78,12 +78,7 @@ namespace Raven.Tests.FileSystem.Issues
 				// await store.AsyncFilesCommands.RenameAsync(fileName, newName);
 				// let's create a config to indicate rename operation - for example restart in the middle could happen
 				var renameOpConfig = RavenFileNameHelper.RenameOperationConfigNameForFile(name);
-				var renameOperation = new RenameFileOperation
-				{
-					Name = name,
-					Rename = renamed,
-					MetadataAfterOperation = new RavenJObject { { "version", 1 } }
-				};
+				var renameOperation = new RenameFileOperation(name, renamed, (await store.AsyncFilesCommands.GetAsync(new [] {name}))[0].Etag, new RavenJObject {{"version", 1}});
 
 				rfs.Storage.Batch(accessor => accessor.SetConfigurationValue(renameOpConfig, renameOperation));
 
@@ -95,6 +90,8 @@ namespace Raven.Tests.FileSystem.Issues
 				var version2 = await store.AsyncFilesCommands.GetMetadataForAsync(name);
 				Assert.NotNull(version2);
 				Assert.Equal(2, version2["version"]);
+
+				Assert.DoesNotContain(RavenFileNameHelper.RenameOperationConfigNameForFile(renameOperation.Name), await store.AsyncFilesCommands.Configuration.GetKeyNamesAsync());
 			}
 		}
 	}

--- a/Raven.Tests.FileSystem/Issues/RavenDB_3920.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_3920.cs
@@ -1,0 +1,60 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_3920.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Abstractions.Exceptions;
+using Xunit;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+	public class RavenDB_3920 : RavenFilesTestWithLogs
+	{
+		[Fact]
+		public async Task ShouldWork()
+		{
+			const string fileName = "file.bin";
+
+			using (var store = NewStore())
+			{
+				var rfs = GetFileSystem();
+
+				await store.AsyncFilesCommands.UploadAsync(fileName, new MemoryStream(new byte[2 * 1024 * 1024]));
+
+				using (var session = store.OpenAsyncSession())
+				{
+					session.RegisterUpload(fileName, 10, s =>
+					{
+						s.WriteByte(1);
+						s.WriteByte(2);
+						s.WriteByte(3);
+					});
+
+					await ThrowsAsync<BadRequestException>(() => session.SaveChangesAsync()); // 10 bytes declared but only 3 has been uploaded, IndicateFileToDelete is going to be called underhood
+				}
+
+				using (var session = store.OpenAsyncSession())
+				{
+					session.RegisterUpload(fileName, 3, s =>
+					{
+						s.WriteByte(1);
+						s.WriteByte(2);
+						s.WriteByte(3);
+					});
+
+					await session.SaveChangesAsync();
+				}
+
+				await rfs.Files.CleanupDeletedFilesAsync(); // should not delete existing file
+
+				var downloaded = new MemoryStream();
+
+				(await store.AsyncFilesCommands.DownloadAsync(fileName)).CopyTo(downloaded);
+				
+				Assert.Equal(3, downloaded.Length);
+			}
+		}
+	}
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -135,6 +135,7 @@
     <Compile Include="FileNamingTests.cs" />
     <Compile Include="Folders.cs" />
     <Compile Include="Issues\RavenDB_3887.cs" />
+    <Compile Include="Issues\RavenDB_3920.cs" />
     <Compile Include="Issues\RavenDB_FEI_2.cs" />
     <Compile Include="Issues\RavenDB_3648.cs" />
     <Compile Include="Issues\RavenDB_2889.cs" />

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Issues\RavenDB_3499.cs" />
     <Compile Include="Issues\RavenDB_3692.cs" />
     <Compile Include="Issues\RavenDB_3742.cs" />
+    <Compile Include="Issues\RavenDB_3919.cs" />
     <Compile Include="Migration\MigrationTests.cs" />
     <Compile Include="Synchronization\FailoverReadFromAllServers.cs" />
     <Compile Include="Synchronization\RavenSynchronizationTestBase.cs" />

--- a/Raven.Tests.FileSystem/Storage/StorageOperationsTests.cs
+++ b/Raven.Tests.FileSystem/Storage/StorageOperationsTests.cs
@@ -217,12 +217,7 @@ namespace Raven.Tests.FileSystem
 
 			// create config to say to the server that rename operation performed last time were not finished
 			var renameOpConfig = RavenFileNameHelper.RenameOperationConfigNameForFile(fileName);
-            var renameOperation =  new RenameFileOperation
-				                        {
-					                        Name = fileName,
-					                        Rename = rename,
-                                            MetadataAfterOperation = new RavenJObject()
-				                        };
+			var renameOperation = new RenameFileOperation(fileName, rename, client.GetAsync(new[] { fileName }).Result[0].Etag, new RavenJObject());
 
             rfs.Storage.Batch(accessor => accessor.SetConfigurationValue(renameOpConfig, renameOperation));
 
@@ -256,12 +251,7 @@ namespace Raven.Tests.FileSystem
 
 			// create config to say to the server that rename operation performed last time were not finished
 			var renameOpConfig = RavenFileNameHelper.RenameOperationConfigNameForFile(fileName);
-            var renameOperation = new RenameFileOperation
-				                    {
-					                    Name = fileName,
-					                    Rename = rename,
-                                        MetadataAfterOperation = new RavenJObject()
-				                    };
+			var renameOperation = new RenameFileOperation(fileName, rename, client.GetAsync(new[] {fileName}).Result[0].Etag, new RavenJObject());
 
             rfs.Storage.Batch(accessor => accessor.SetConfigurationValue(renameOpConfig, renameOperation ));
 


### PR DESCRIPTION
… file system since we return an error response to the client (that behavior is consistent with a case where we put fewer bytes than declared). Also fixing logging inside PutAsync method (ETags) and renaming MetadataUpdateResult -> FileUpdateResult.
