### PR TITLE
RavenJValue recognize NaN float is equal to NaN string

### DIFF
--- a/Raven.Abstractions/Json/Linq/RavenJValue.cs
+++ b/Raven.Abstractions/Json/Linq/RavenJValue.cs
@@ -444,7 +444,17 @@ namespace Raven.Json.Linq
 							return false;
 					}
 					break;
-				default:
+                case JTokenType.Float:
+                    switch (v2._valueType)
+                    {
+                        case JTokenType.String:
+                        case JTokenType.Float:
+                            break;
+                        default:
+                            return false;
+                    }
+                    break;
+                default:
 					if (v1._valueType != v2._valueType)
 						return false;
 					break;

--- a/Raven.Tests.MailingList/Raven.Tests.MailingList.csproj
+++ b/Raven.Tests.MailingList/Raven.Tests.MailingList.csproj
@@ -467,6 +467,7 @@
     <Compile Include="UriProperty.cs" />
     <Compile Include="UrlInIdsRepro.cs" />
     <Compile Include="VacancyCampaignsTests.cs" />
+    <Compile Include="ValerioBorioni.cs" />
     <Compile Include="Vicente.cs" />
     <Compile Include="Victor.cs" />
     <Compile Include="Vitaliy.cs" />

--- a/Raven.Tests.MailingList/ValerioBorioni.cs
+++ b/Raven.Tests.MailingList/ValerioBorioni.cs
@@ -1,0 +1,54 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AaronSt.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Document;
+using Raven.Tests.Common;
+
+using Xunit;
+
+namespace Raven.Tests.MailingList
+{
+    public class ValerioBorioni : RavenTest
+    {
+        [Fact]
+        public void RavenJValue_recognize_NAN_Float_isEqual_to_NAN_String()
+        {
+            using (var store = NewDocumentStore())
+            {
+                store.Configuration.RunInMemory = true;
+                store.Initialize();
+
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new MyEntity());
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var all = session.Query<MyEntity>().Customize(r=> r.WaitForNonStaleResults()).ToList();
+                    var changes = session.Advanced.WhatChanged();
+                    Assert.Empty(changes);
+                }
+            };
+
+        }
+
+        public class MyEntity
+        {
+            public double Value { get; set; }
+
+            public MyEntity()
+            {
+                Value = double.NaN;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
this causes the IDocumentSession to detect frequently used reference documents as changed, making a lot of unnecessary optimistic concurrency and index invalidations.

I think this happens because RavenJValue parsed from entity instance knows the property type, while it has no clue when it comes from server.