### PR TITLE
Fixing RavenDB_3109

### DIFF
--- a/Raven.Database/Actions/MaintenanceActions.cs
+++ b/Raven.Database/Actions/MaintenanceActions.cs
@@ -163,7 +163,7 @@ namespace Raven.Database.Actions
                     string ex;
 
                     DocumentDatabase.IndexFailDetails failDetails;
-                    if (reason.TryGetValue(id, out failDetails) == false)
+                    if (reason == null || reason.TryGetValue(id, out failDetails) == false)
                     {
                         indexName = "Unknown Name";
                         msg = string.Format("Index '{0}-({1})' couldn't be found or invalid", id, indexName);

--- a/Raven.Tests.Issues/RavenDB_3109.cs
+++ b/Raven.Tests.Issues/RavenDB_3109.cs
@@ -60,8 +60,8 @@ namespace Raven.Tests.Issues
 				{
 					var alerts = session.Load<AlertsDocument>(Constants.RavenAlerts);
 
-					Assert.Equal(1, alerts.Alerts.Count);
-					Assert.Contains("Replication error. Multiple databases replicating at the same time with same DatabaseId", alerts.Alerts[0].Title);
+					Assert.Equal(5, alerts.Alerts.Count);
+					Assert.Contains("Replication error. Multiple databases replicating at the same time with same DatabaseId", alerts.Alerts[4].Title);
 				}
 
 				SystemTime.UtcDateTime = () => DateTime.Now.AddMinutes(11);


### PR DESCRIPTION
The problem was a NRE in the initialize of the document database.
Also the number of alerts changed.