### PR TITLE
We need to pass a new instance here since internally those items are …

### DIFF
--- a/Raven.Database/Indexing/ReducingExecuter.cs
+++ b/Raven.Database/Indexing/ReducingExecuter.cs
@@ -400,7 +400,7 @@ namespace Raven.Database.Indexing
 
 					transactionalStorage.Batch(actions =>
 					{
-						var getItemsToReduceParams = new GetItemsToReduceParams(index: index.IndexId, reduceKeys: localKeys, level: 0, loadData: false, itemsToDelete: itemsToDelete)
+						var getItemsToReduceParams = new GetItemsToReduceParams(index: index.IndexId, reduceKeys: new HashSet<string>(localKeys), level: 0, loadData: false, itemsToDelete: itemsToDelete)
 						{
 							Take = int.MaxValue // just get all, we do the rate limit when we load the number of keys to reduce, anyway
 						};


### PR DESCRIPTION
…removed (inside GetItemsToReduce method)

We need that because of that:
https://github.com/ayende/ravendb/blob/master/Raven.Database/Storage/Esent/StorageActions/MappedResults.cs#L374

and the change made here:
https://github.com/ayende/ravendb/commit/56b3da760eddaa9193630418fbed8986ad0d55fa#diff-8da055ff075aace4e7ab7cae8f711491L60
