### PR TITLE
RavenDB-3885: Set breadcrumb to 'No Collection' if document Id doesn'…

### DIFF
--- a/Raven.Studio.Html5/App/viewmodels/database/documents/editDocument.ts
+++ b/Raven.Studio.Html5/App/viewmodels/database/documents/editDocument.ts
@@ -60,6 +60,7 @@ class editDocument extends viewModelBase {
     isFirstDocumenNavtDisabled: KnockoutComputed<boolean>;
     isLastDocumentNavDisabled: KnockoutComputed<boolean>;
     newLineToggle = '\\n';
+    isSystemDocumentByDocTitle = ko.observable(false);
     
     static editDocSelector = "#editDocumentContainer";
     static recentDocumentsInDatabases = ko.observableArray<{ databaseName: string; recentDocuments: KnockoutObservableArray<string> }>();
@@ -122,9 +123,15 @@ class editDocument extends viewModelBase {
         this.docTitle = ko.computed(() => {
             if (this.isInDocMode() == true) {
                 if (this.isCreatingNewDocument() === true) {
+                    this.isSystemDocumentByDocTitle(false);
                     return 'New Document';
                 } else {
                     var editedDocId = this.editedDocId();
+
+                    if (editedDocId.indexOf("Raven/") === 0)
+                        this.isSystemDocumentByDocTitle(true);
+                    else
+                        this.isSystemDocumentByDocTitle(false);
 
                     if (!!editedDocId) {
                         var lastIndexInEditedDocId = editedDocId.lastIndexOf('/') + 1;

--- a/Raven.Studio.Html5/App/views/database/documents/editDocument.html
+++ b/Raven.Studio.Html5/App/views/database/documents/editDocument.html
@@ -11,9 +11,9 @@
         </li>
         <!-- ko ifnot: isCreatingNewDocument -->
         <li data-bind="with: metadata" style="display: inline-block">
-            <a style="display: inline-block" href="#" data-bind="text: $root.isInDocMode() === true?(ravenEntityName ===undefined)?'System Documents':ravenEntityName:$root.queryIndex, 
-            attr: {title:ravenEntityName, href: '#documents?collection=' + (ravenEntityName ===undefined)?'System Documents':ravenEntityName }, click: $root.navigateToCollection.bind($root,
-            (ravenEntityName ===undefined)?'System Documents':ravenEntityName)"></a>
+            <a style="display: inline-block" href="#" data-bind="text: $root.isInDocMode() === true?(ravenEntityName ===undefined)?($root.isSystemDocumentByDocTitle() === true?'System Documents':'No Collection'):ravenEntityName:$root.queryIndex, 
+            attr: {title:ravenEntityName, href: '#documents?collection=' + (ravenEntityName ===undefined)?($root.isSystemDocumentByDocTitle() === true?'System Documents':'No Collection'):ravenEntityName }, click: $root.navigateToCollection.bind($root,
+            (ravenEntityName ===undefined)?($root.isSystemDocumentByDocTitle() === true?'System Documents':'No Collection'):ravenEntityName)"></a>
         </li>
         <!-- /ko -->
         <li class="active" data-bind="text: docTitle, attr:{ title: docTitle }" style="display: inline-block">


### PR DESCRIPTION
…t start with 'Raven/' and has no 'Raven-Entity-Name' metadata attribute
