### PR TITLE
RavenDB-3955 Fixing IndicateFileToDelete method which didn't take int…

### DIFF
--- a/Raven.Database/FileSystem/Util/RandomProvider.cs
+++ b/Raven.Database/FileSystem/Util/RandomProvider.cs
@@ -1,0 +1,24 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RandomProvider.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+namespace Raven.Database.FileSystem.Util
+{
+	using System;
+	using System.Threading;
+
+	public static class RandomProvider
+	{
+		private static int seed = Environment.TickCount;
+
+		private static readonly ThreadLocal<Random> RandomWrapper = new ThreadLocal<Random>(() =>
+			new Random(Interlocked.Increment(ref seed))
+		);
+
+		public static Random GetThreadRandom()
+		{
+			return RandomWrapper.Value;
+		}
+	}
+}

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -276,6 +276,7 @@
     <Compile Include="FileSystem\Synchronization\SynchronizationBehavior.cs" />
     <Compile Include="FileSystem\Synchronization\SynchronizationConfigAccessor.cs" />
     <Compile Include="FileSystem\Synchronization\SynchronizationTaskContext.cs" />
+    <Compile Include="FileSystem\Util\RandomProvider.cs" />
     <Compile Include="Indexing\PropertyAccessor.cs" />
     <Compile Include="Indexing\Sorting\Custom\CustomSortField.cs" />
     <Compile Include="Indexing\Sorting\Custom\CustomSortFieldCompartor.cs" />

--- a/Raven.Tests.FileSystem/Issues/RavenDB_3955.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_3955.cs
@@ -1,0 +1,42 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_3955.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Client.FileSystem;
+using Raven.Database.Extensions;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+	public class RavenDB_3955 : RavenFilesTestWithLogs
+	{
+		[Theory]
+		[PropertyData("Storages")]
+		public async Task uploading_file_multiple_times_must_not_throw_key_duplicate_exception_on_esent_and_concurrency_exception_on_voron(string storage)
+		{
+			var r = new Random(1);
+			var bytes = new byte[1024];
+
+			r.NextBytes(bytes);
+
+			var ms = new MemoryStream(bytes);
+			var expectedHash = ms.GetMD5Hash();
+
+			var client = NewAsyncClient(requestedStorage: storage);
+			for (int i = 0; i < 500; i++)
+			{
+				ms.Position = 0;
+				await client.UploadAsync("abc.bin", ms);
+			}
+			
+			var stream = await client.DownloadAsync("abc.bin");
+			
+			Assert.Equal(expectedHash, stream.GetMD5Hash());
+		}
+	}
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Folders.cs" />
     <Compile Include="Issues\RavenDB_3887.cs" />
     <Compile Include="Issues\RavenDB_3920.cs" />
+    <Compile Include="Issues\RavenDB_3955.cs" />
     <Compile Include="Issues\RavenDB_FEI_2.cs" />
     <Compile Include="Issues\RavenDB_3648.cs" />
     <Compile Include="Issues\RavenDB_2889.cs" />

--- a/Raven.Tests.FileSystem/Storage/StorageOperationsTests.cs
+++ b/Raven.Tests.FileSystem/Storage/StorageOperationsTests.cs
@@ -193,15 +193,12 @@ namespace Raven.Tests.FileSystem
             rfs.Storage.Batch(
                 accessor =>
                 configNames =
-                accessor.GetConfigNames(0, 10).ToArray().Where(x => x.StartsWith(RavenFileNameHelper.DeleteOperationConfigPrefix)).ToList());
+                accessor.GetConfigNames(0, 10).ToArray().Where(x => x.StartsWith(RavenFileNameHelper.DeleteOperationConfigPrefix)).OrderBy(x => x.Length).ToList());
 
-            Assert.Equal(2, configNames.Count());
-
-            foreach (var configName in configNames)
-            {
-                Assert.True(RavenFileNameHelper.DeleteOperationConfigPrefix + RavenFileNameHelper.DeletingFileName("file.bin") == configName ||
-                            RavenFileNameHelper.DeleteOperationConfigPrefix + RavenFileNameHelper.DeletingFileName("file.bin1") == configName); // 1 indicate delete version
-            }
+            Assert.Equal(2, configNames.Count);
+			Assert.Equal(RavenFileNameHelper.DeleteOperationConfigPrefix + RavenFileNameHelper.DeletingFileName("file.bin"), configNames[0]);
+			Assert.True(configNames[1].StartsWith(RavenFileNameHelper.DeleteOperationConfigPrefix + "/file.bin") &&
+				configNames[1].EndsWith(RavenFileNameHelper.DeletingFileSuffix)); // number in the middle is used to avoid duplicates
         }
 
 		[Fact]


### PR DESCRIPTION
…o account that there might be more than 128 ".deleting" files. The solution was to include random number to their names instead of "version" number (we don't need to version them anyway).
