### PR TITLE
RavenDB-3947

### DIFF
--- a/Raven.Abstractions/Connection/CompressedContent.cs
+++ b/Raven.Abstractions/Connection/CompressedContent.cs
@@ -58,9 +58,6 @@ namespace Raven.Abstractions.Connection
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
-            //TODO: Use BufferedStream 
-
-
             using (var uncloseableStream = new UndisposableStream(stream))
             using (var bufferedStream = new BufferedStream(uncloseableStream))
             {

--- a/Raven.Abstractions/Connection/CompressedContent.cs
+++ b/Raven.Abstractions/Connection/CompressedContent.cs
@@ -1,0 +1,95 @@
+﻿using Raven.Abstractions.Util;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Raven.Abstractions.Connection
+{
+    public class CompressedContent : HttpContent
+    {
+        private readonly HttpContent originalContent;
+        private readonly string encodingType;
+        public HttpContent OriginalContent
+        {
+            get { return originalContent; }
+        }
+
+        public CompressedContent(HttpContent content, string encodingType)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException("content");
+            }
+
+            if (encodingType == null)
+            {
+                throw new ArgumentNullException("encodingType");
+            }
+
+            originalContent = content;
+            this.encodingType = encodingType.ToLowerInvariant();
+
+            if (this.encodingType != "gzip" && this.encodingType != "deflate")
+            {
+                throw new InvalidOperationException(string.Format("Encoding '{0}' is not supported. Only supports gzip or deflate encoding.", this.encodingType));
+            }
+
+            // copy the headers from the original content
+            foreach (KeyValuePair<string, IEnumerable<string>> header in originalContent.Headers)
+            {
+                Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            Headers.ContentEncoding.Add(encodingType);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = -1;
+
+            return false;
+        }
+
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            //TODO: Use BufferedStream 
+
+
+            using (var uncloseableStream = new UndisposableStream(stream))
+            using (var bufferedStream = new BufferedStream(uncloseableStream))
+            {
+                Stream compressedStream = null;
+
+                if (encodingType == "gzip")
+                {
+                    compressedStream = new GZipStream(bufferedStream, CompressionMode.Compress, leaveOpen: true);
+                }
+                else if (encodingType == "deflate")
+                {
+                    compressedStream = new DeflateStream(bufferedStream, CompressionMode.Compress, leaveOpen: true);
+                }
+                else throw new InvalidOperationException("This shouldn't happen, ever.");
+
+                await originalContent.CopyToAsync(compressedStream);
+
+                if (compressedStream != null)
+                {
+                    compressedStream.Dispose();
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (originalContent != null)
+                originalContent.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Raven.Abstractions/Connection/CompressedContent.cs
+++ b/Raven.Abstractions/Connection/CompressedContent.cs
@@ -15,6 +15,7 @@ namespace Raven.Abstractions.Connection
     {
         private readonly HttpContent originalContent;
         private readonly string encodingType;
+
         public HttpContent OriginalContent
         {
             get { return originalContent; }
@@ -86,6 +87,7 @@ namespace Raven.Abstractions.Connection
         {
             if (originalContent != null)
                 originalContent.Dispose();
+
             base.Dispose(disposing);
         }
     }

--- a/Raven.Abstractions/Connection/WebResponseExtensions.cs
+++ b/Raven.Abstractions/Connection/WebResponseExtensions.cs
@@ -26,6 +26,8 @@ namespace Raven.Abstractions.Connection
 		public static Stream GetResponseStreamWithHttpDecompression(this WebResponse response)
 		{
 			var stream = response.GetResponseStream();
+            stream = new BufferedStream(stream);
+
 			Debug.Assert(stream != null, "stream != null");
 			var encoding = response.Headers["Content-Encoding"];
 			if (encoding != null && encoding.Contains("gzip"))
@@ -43,6 +45,8 @@ namespace Raven.Abstractions.Connection
 		public static async Task<Stream> GetResponseStreamWithHttpDecompression(this HttpResponseMessage response)
 		{			
 			var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            stream = new BufferedStream(stream);
+
 			var encoding = response.Content.Headers.ContentEncoding.FirstOrDefault();
 			if (encoding != null && encoding.Contains("gzip"))
 				stream = new GZipStream(stream, CompressionMode.Decompress);

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Commands\DeleteCommandData.cs" />
     <Compile Include="Commands\PatchCommandData.cs" />
     <Compile Include="Commands\PutCommandData.cs" />
+    <Compile Include="Connection\CompressedContent.cs" />
     <Compile Include="Connection\CompressedStringContent.cs" />
     <Compile Include="Connection\CountingStream.cs" />
     <Compile Include="Connection\ErrorResponseException.cs" />
@@ -444,6 +445,7 @@
     <Compile Include="Util\Streams\IBufferPool.cs" />
     <Compile Include="Util\Streams\NoBufferPool.cs" />
     <Compile Include="Util\Streams\Substream.cs" />
+    <Compile Include="Util\UndisposableStream.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Imports\Newtonsoft.Json\Src\Newtonsoft.Json\Dynamic.snk">

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -416,6 +416,7 @@
     <Compile Include="Util\AsyncManualResetEvent.cs" />
     <Compile Include="Util\AtomicDictionary.cs" />
     <Compile Include="Util\Base62Util.cs" />
+    <Compile Include="Util\Streams\BufferPoolMemoryStream.cs" />
     <Compile Include="Util\ComparableByteArray.cs" />
     <Compile Include="Util\CompletedTask.cs" />
     <Compile Include="Util\DocumentHelpers.cs" />

--- a/Raven.Abstractions/Util/Streams/BufferPoolMemoryStream.cs
+++ b/Raven.Abstractions/Util/Streams/BufferPoolMemoryStream.cs
@@ -25,8 +25,8 @@ namespace Raven.Abstractions.Util.Streams
 
         public BufferPoolMemoryStream()
         {
-            _buffer = new byte[64];
-            _bufferPool = null;
+            _bufferPool = BufferSharedPools.MicroByteArray;
+            _buffer = _bufferPool.Allocate();          
         }
 
         protected override void Dispose(bool disposing)

--- a/Raven.Abstractions/Util/Streams/BufferPoolMemoryStream.cs
+++ b/Raven.Abstractions/Util/Streams/BufferPoolMemoryStream.cs
@@ -7,19 +7,16 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-
-using Raven.Abstractions.Util.Streams;
-using Raven.Abstractions.Util;
 using Sparrow;
 
-namespace Raven.Database.Util.Streams
+namespace Raven.Abstractions.Util.Streams
 {
     public class BufferPoolMemoryStream : Stream
     {       
         protected byte[] _buffer;
         protected ObjectPool<byte[]> _bufferPool;
 
-        private const int BufferPoolLimit = BufferSharedPools.ByteBufferSize / 2;
+        private const int BufferPoolLimit = BufferSharedPools.MicroByteBufferSize / 2;
 		
 		[CLSCompliant(false)]
         protected long _length;
@@ -113,11 +110,21 @@ namespace Raven.Database.Util.Streams
             if (newCapacity > BufferPoolLimit)
             {
                 // We will ensure to cap out to fit the capacity as best as we can.
-                if (newCapacity <= BufferSharedPools.ByteBufferSize)
+                if (newCapacity <= BufferSharedPools.MicroByteBufferSize)
+                {
+                    newCapacity = BufferSharedPools.MicroByteBufferSize;
+                    newBufferPool = BufferSharedPools.MicroByteArray;
+                }
+                else if (newCapacity <= BufferSharedPools.SmallByteBufferSize)
+                {
+                    newCapacity = BufferSharedPools.SmallByteBufferSize;
+                    newBufferPool = BufferSharedPools.SmallByteArray;
+                }
+                else if (newCapacity <= BufferSharedPools.ByteBufferSize)
                 {
                     newCapacity = BufferSharedPools.ByteBufferSize;
                     newBufferPool = BufferSharedPools.ByteArray;
-                }                    
+                }
                 else if (newCapacity <= BufferSharedPools.BigByteBufferSize)
                 {
                     newCapacity = BufferSharedPools.BigByteBufferSize;

--- a/Raven.Abstractions/Util/Streams/BufferPoolMemoryStream.cs
+++ b/Raven.Abstractions/Util/Streams/BufferPoolMemoryStream.cs
@@ -15,8 +15,6 @@ namespace Raven.Abstractions.Util.Streams
     {       
         protected byte[] _buffer;
         protected ObjectPool<byte[]> _bufferPool;
-
-        private const int BufferPoolLimit = BufferSharedPools.MicroByteBufferSize / 2;
 		
 		[CLSCompliant(false)]
         protected long _length;
@@ -107,35 +105,33 @@ namespace Raven.Abstractions.Util.Streams
                         
             // We reset the buffer pool
             ObjectPool<byte[]> newBufferPool = null;
-            if (newCapacity > BufferPoolLimit)
-            {
-                // We will ensure to cap out to fit the capacity as best as we can.
-                if (newCapacity <= BufferSharedPools.MicroByteBufferSize)
-                {
-                    newCapacity = BufferSharedPools.MicroByteBufferSize;
-                    newBufferPool = BufferSharedPools.MicroByteArray;
-                }
-                else if (newCapacity <= BufferSharedPools.SmallByteBufferSize)
-                {
-                    newCapacity = BufferSharedPools.SmallByteBufferSize;
-                    newBufferPool = BufferSharedPools.SmallByteArray;
-                }
-                else if (newCapacity <= BufferSharedPools.ByteBufferSize)
-                {
-                    newCapacity = BufferSharedPools.ByteBufferSize;
-                    newBufferPool = BufferSharedPools.ByteArray;
-                }
-                else if (newCapacity <= BufferSharedPools.BigByteBufferSize)
-                {
-                    newCapacity = BufferSharedPools.BigByteBufferSize;
-                    newBufferPool = BufferSharedPools.BigByteArray;
 
-                }                    
-                else if ( newCapacity <= BufferSharedPools.HugeByteBufferSize)
-                {
-                    newCapacity = BufferSharedPools.HugeByteBufferSize;
-                    newBufferPool = BufferSharedPools.HugeByteArray;
-                }
+            // We will ensure to cap out to fit the capacity as best as we can.
+            if (newCapacity <= BufferSharedPools.MicroByteBufferSize)
+            {
+                newCapacity = BufferSharedPools.MicroByteBufferSize;
+                newBufferPool = BufferSharedPools.MicroByteArray;
+            }
+            else if (newCapacity <= BufferSharedPools.SmallByteBufferSize)
+            {
+                newCapacity = BufferSharedPools.SmallByteBufferSize;
+                newBufferPool = BufferSharedPools.SmallByteArray;
+            }
+            else if (newCapacity <= BufferSharedPools.ByteBufferSize)
+            {
+                newCapacity = BufferSharedPools.ByteBufferSize;
+                newBufferPool = BufferSharedPools.ByteArray;
+            }
+            else if (newCapacity <= BufferSharedPools.BigByteBufferSize)
+            {
+                newCapacity = BufferSharedPools.BigByteBufferSize;
+                newBufferPool = BufferSharedPools.BigByteArray;
+
+            }                    
+            else if ( newCapacity <= BufferSharedPools.HugeByteBufferSize)
+            {
+                newCapacity = BufferSharedPools.HugeByteBufferSize;
+                newBufferPool = BufferSharedPools.HugeByteArray;
             }
 
             byte[] newBuffer = (newBufferPool == null) ? new byte[newCapacity] : newBufferPool.Allocate();

--- a/Raven.Abstractions/Util/Streams/BufferSharedPools.cs
+++ b/Raven.Abstractions/Util/Streams/BufferSharedPools.cs
@@ -15,6 +15,8 @@ namespace Raven.Abstractions.Util.Streams
         public const int HugeByteBufferSize = 4 * Megabyte;
         public const int BigByteBufferSize = 512 * Kilobyte;
         public const int ByteBufferSize = 64 * Kilobyte;
+        public const int SmallByteBufferSize = 4 * Kilobyte;
+        public const int MicroByteBufferSize = Kilobyte / 2;
 
         /// <summary>
         /// Used to reduce the # of temporary byte[]s created to satisfy serialization and
@@ -33,5 +35,19 @@ namespace Raven.Abstractions.Util.Streams
         /// other I/O requests
         /// </summary>
         public static readonly ObjectPool<byte[]> ByteArray = new ObjectPool<byte[]>(() => new byte[ByteBufferSize], 100);
+
+        /// <summary>
+        /// Used to reduce the # of temporary byte[]s created to satisfy serialization and
+        /// other I/O requests
+        /// </summary>
+        public static readonly ObjectPool<byte[]> SmallByteArray = new ObjectPool<byte[]>(() => new byte[SmallByteBufferSize], 100);
+
+
+        /// <summary>
+        /// Used to reduce the # of temporary byte[]s created to satisfy serialization and
+        /// other I/O requests
+        /// </summary>
+        public static readonly ObjectPool<byte[]> MicroByteArray = new ObjectPool<byte[]>(() => new byte[MicroByteBufferSize], 100);
+
     }
 }

--- a/Raven.Abstractions/Util/UndisposableStream.cs
+++ b/Raven.Abstractions/Util/UndisposableStream.cs
@@ -1,11 +1,6 @@
-﻿// -----------------------------------------------------------------------
-//  <copyright file="us.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-//  </copyright>
-// -----------------------------------------------------------------------
-using System.IO;
+﻿using System.IO;
 
-namespace Raven.Database.Storage.Voron
+namespace Raven.Abstractions.Util
 {
 	public class UndisposableStream : Stream
 	{

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -800,11 +800,12 @@ namespace Raven.Client.Connection.Async
 					var result = await request.ReadResponseJsonAsync().ConfigureAwait(false);
 					return await CompleteMultiGetAsync(operationMetadata, keys, includes, transformer, transformerParameters, result, token).ConfigureAwait(false);
 				}
-				request =
-					jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, path, "POST", metadata, operationMetadata.Credentials, convention)
-																 .AddOperationHeaders(OperationsHeaders));
+				request = jsonRequestFactory.CreateHttpJsonRequest(
+                                                new CreateHttpJsonRequestParams(this, path, "POST", metadata, operationMetadata.Credentials, convention)
+											            .AddOperationHeaders(OperationsHeaders));
+                               
+				await request.WriteAsync(new RavenJArray(uniqueIds)).WithCancellation(token).ConfigureAwait(false);                
 
-				await request.WriteAsync(new RavenJArray(uniqueIds)).WithCancellation(token).ConfigureAwait(false);
 				var responseResult = await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
 				return await CompleteMultiGetAsync(operationMetadata, keys, includes, transformer, transformerParameters, responseResult, token).ConfigureAwait(false);
 			}

--- a/Raven.Client.Lightweight/Connection/CompressedStreamContent.cs
+++ b/Raven.Client.Lightweight/Connection/CompressedStreamContent.cs
@@ -33,25 +33,25 @@ namespace Raven.Client.Connection
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
 		{
-			try
-			{
-                using (var uncloseableStream = new UndisposableStream(stream))
-                using (var bufferedStream = new BufferedStream(uncloseableStream))
+            using (var uncloseableStream = new UndisposableStream(stream))
+            using (var bufferedStream = new BufferedStream(uncloseableStream))
+            {
+                Stream innerStream = bufferedStream;
+                try
                 {
-                    Stream innerStream = bufferedStream;
 
                     if (disableRequestCompression == false)
-                        innerStream = new GZipStream(innerStream, CompressionMode.Compress, leaveOpen: true);
+                        innerStream = new GZipStream(innerStream, CompressionMode.Compress, leaveOpen: true);                
 
                     await data.CopyToAsync(innerStream).ConfigureAwait(false);
                     await innerStream.FlushAsync().ConfigureAwait(false);
                 }
-			}
-			finally
-			{
-				if (disableRequestCompression == false)
-					stream.Dispose();
-			}
+			    finally
+			    {
+				    if (disableRequestCompression == false)
+                        innerStream.Dispose();
+			    }
+            }
 		}
 
 		protected override bool TryComputeLength(out long length)

--- a/Raven.Client.Lightweight/Connection/CompressedStreamContent.cs
+++ b/Raven.Client.Lightweight/Connection/CompressedStreamContent.cs
@@ -33,8 +33,6 @@ namespace Raven.Client.Connection
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
 		{
-            //TODO: Use BufferedStream
-
 			try
 			{
                 using (var uncloseableStream = new UndisposableStream(stream))

--- a/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequest.cs
+++ b/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequest.cs
@@ -671,9 +671,14 @@ namespace Raven.Client.Connection.Implementation
         public Task WriteAsync(RavenJToken tokenToWrite)
         {
             writeCalled = true;
+
+            HttpContent content = new JsonContent(tokenToWrite);
+            if (!factory.DisableRequestCompression)
+                content = new CompressedContent(content, "gzip");
+
 	        return SendRequestInternal(() => new HttpRequestMessage(new HttpMethod(Method), Url)
 	        {
-		        Content = new JsonContent(tokenToWrite),
+                Content = content,
 		        Headers =
 		        {
 			        TransferEncodingChunked = true

--- a/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequest.cs
+++ b/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequest.cs
@@ -240,7 +240,7 @@ namespace Raven.Client.Connection.Implementation
 						e.StatusCode != HttpStatusCode.PreconditionFailed)
 						throw;
 
-					responseException = e;
+                    responseException = e;
 				}
 
 				if (Response.StatusCode == HttpStatusCode.Forbidden)
@@ -672,18 +672,21 @@ namespace Raven.Client.Connection.Implementation
         {
             writeCalled = true;
 
-            HttpContent content = new JsonContent(tokenToWrite);
-            if (!factory.DisableRequestCompression)
-                content = new CompressedContent(content, "gzip");
+	        return SendRequestInternal(() => 
+            {                    
+                HttpContent content = new JsonContent(tokenToWrite);
+                if (!factory.DisableRequestCompression)
+                    content = new CompressedContent(content, "gzip");
 
-	        return SendRequestInternal(() => new HttpRequestMessage(new HttpMethod(Method), Url)
-	        {
-                Content = content,
-		        Headers =
-		        {
-			        TransferEncodingChunked = true
-		        }
-	        });
+                return new HttpRequestMessage(new HttpMethod(Method), Url)
+                {
+                    Content = content,
+                    Headers =
+                    {
+                        TransferEncodingChunked = true
+                    }
+                };
+            });
         }
 
 		public Task WriteAsync(Stream streamToWrite)

--- a/Raven.Database/FileSystem/Storage/Voron/StorageActionsAccessor.cs
+++ b/Raven.Database/FileSystem/Storage/Voron/StorageActionsAccessor.cs
@@ -25,6 +25,7 @@ using RavenConstants = Raven.Abstractions.Data.Constants;
 
 using Raven.Abstractions.FileSystem;
 using Raven.Abstractions.Data;
+using Raven.Abstractions.Util;
 
 namespace Raven.Database.FileSystem.Storage.Voron
 {

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -1173,7 +1173,6 @@
     <Compile Include="Util\SizeHelper.cs" />
     <Compile Include="Util\SortedKeyList.cs" />
     <Compile Include="Util\Streams\PartialStream.cs" />
-    <Compile Include="Util\Streams\BufferPoolMemoryStream.cs" />
     <Compile Include="Util\WildcardMatcher.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -1155,7 +1155,6 @@
     <Compile Include="Storage\Voron\StorageActions\StorageActionsBase.cs" />
     <Compile Include="Storage\Voron\StorageActions\TasksStorageActions.cs" />
     <Compile Include="Storage\Voron\TransactionalStorage.cs" />
-    <Compile Include="Storage\Voron\UndisposableStream.cs" />
     <Compile Include="Storage\TransactionContextData.cs" />
     <Compile Include="Tasks\RemoveFromIndexTask.cs" />
     <Compile Include="Tasks\DatabaseTask.cs" />

--- a/Raven.Database/Server/AppBuilderExtensions.cs
+++ b/Raven.Database/Server/AppBuilderExtensions.cs
@@ -271,7 +271,7 @@ namespace Owin
 			public bool UseBufferedOutputStream(HttpResponseMessage response)
 			{
 				var content = response.Content;
-				var compressedContent = content as GZipToJsonAndCompressHandler.CompressedContent;
+				var compressedContent = content as CompressedContent;
 				if (compressedContent != null && response.StatusCode != HttpStatusCode.NoContent)
 					return ShouldBuffer(compressedContent.OriginalContent);
 				return ShouldBuffer(content);

--- a/Raven.Database/Server/Controllers/MultiGetController.cs
+++ b/Raven.Database/Server/Controllers/MultiGetController.cs
@@ -172,6 +172,7 @@ namespace Raven.Database.Server.Controllers
 
 				writer.WriteEndArray();
 				writer.Flush();
+
 				return new CompletedTask();
 			}
 

--- a/Raven.Database/Server/Controllers/RavenBaseApiController.cs
+++ b/Raven.Database/Server/Controllers/RavenBaseApiController.cs
@@ -128,7 +128,8 @@ namespace Raven.Database.Server.Controllers
 		public async Task<T> ReadJsonObjectAsync<T>()
 		{
 			using (var stream = await InnerRequest.Content.ReadAsStreamAsync())
-			using(var gzipStream = new GZipStream(stream, CompressionMode.Decompress))
+            using (var buffered = new BufferedStream(stream))
+            using (var gzipStream = new GZipStream(buffered, CompressionMode.Decompress))
 			using (var streamReader = new StreamReader(stream, GetRequestEncoding()))
 			{
 				using (var jsonReader = new JsonTextReader(streamReader))
@@ -143,7 +144,8 @@ namespace Raven.Database.Server.Controllers
 		public async Task<RavenJObject> ReadJsonAsync()
 		{
 			using (var stream = await InnerRequest.Content.ReadAsStreamAsync())
-			using (var streamReader = new StreamReader(stream, GetRequestEncoding()))
+            using (var buffered = new BufferedStream(stream))
+			using (var streamReader = new StreamReader(buffered, GetRequestEncoding()))
 			using (var jsonReader = new RavenJsonTextReader(streamReader))
 				return RavenJObject.Load(jsonReader);
 		}
@@ -151,7 +153,8 @@ namespace Raven.Database.Server.Controllers
 		public async Task<RavenJArray> ReadJsonArrayAsync()
 		{
 			using (var stream = await InnerRequest.Content.ReadAsStreamAsync())
-			using (var streamReader = new StreamReader(stream, GetRequestEncoding()))
+            using (var buffered = new BufferedStream(stream))
+			using (var streamReader = new StreamReader(buffered, GetRequestEncoding()))
 			using (var jsonReader = new RavenJsonTextReader(streamReader))
 				return RavenJArray.Load(jsonReader);
 		}
@@ -159,14 +162,16 @@ namespace Raven.Database.Server.Controllers
 		public async Task<string> ReadStringAsync()
 		{
 			using (var stream = await InnerRequest.Content.ReadAsStreamAsync())
-			using (var streamReader = new StreamReader(stream, GetRequestEncoding()))
+            using (var buffered = new BufferedStream(stream))
+			using (var streamReader = new StreamReader(buffered, GetRequestEncoding()))
 				return streamReader.ReadToEnd();
 		}
 
 		public async Task<RavenJArray> ReadBsonArrayAsync()
 		{
 			using (var stream = await InnerRequest.Content.ReadAsStreamAsync())
-			using (var jsonReader = new BsonReader(stream))
+            using (var buffered = new BufferedStream(stream))
+			using (var jsonReader = new BsonReader(buffered))
 			{
 				var jObject = RavenJObject.Load(jsonReader);
 				return new RavenJArray(jObject.Values<RavenJToken>());

--- a/Raven.Database/Storage/Voron/StorageActions/DocumentsStorageActions.cs
+++ b/Raven.Database/Storage/Voron/StorageActions/DocumentsStorageActions.cs
@@ -262,7 +262,8 @@ namespace Raven.Database.Storage.Voron.StorageActions
 		{
 			if (string.IsNullOrEmpty(key))
 			{
-				logger.Debug("Document with empty key was not found");
+                if (logger.IsDebugEnabled) { logger.Debug("Document with empty key was not found"); };
+
 				return null;
 			}
 
@@ -273,7 +274,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
 		    var metadataDocument = ReadDocumentMetadata(normalizedKey, sliceKey, out metadataSize);
 			if (metadataDocument == null)
 			{
-				logger.Debug("Document with key='{0}' was not found", key);
+                if (logger.IsDebugEnabled) { logger.Debug("Document with key='{0}' was not found", key); }				
 				return null;
 			}
 
@@ -281,7 +282,8 @@ namespace Raven.Database.Storage.Voron.StorageActions
             var documentData = ReadDocumentData(normalizedKey, sliceKey, metadataDocument.Etag, metadataDocument.Metadata, out sizeOnDisk);
 			if (documentData == null)
 			{
-				logger.Warn("Could not find data for {0}, but found the metadata", key);
+                if (logger.IsWarnEnabled ) { logger.Warn("Could not find data for {0}, but found the metadata", key); }
+				
 				return null;
 			}
 
@@ -310,7 +312,8 @@ namespace Raven.Database.Storage.Voron.StorageActions
 		        return ReadDocumentMetadata(normalizedKey, sliceKey, out _);
 		    }
 
-			logger.Debug("Document with key='{0}' was not found", key);
+            if (logger.IsDebugEnabled) { logger.Debug("Document with key='{0}' was not found", key); }
+
 			return null;
 		}
 
@@ -328,7 +331,8 @@ namespace Raven.Database.Storage.Voron.StorageActions
 			ushort? existingVersion;
             if (!tableStorage.Documents.Contains(Snapshot, normalizedKeyAsSlice, writeBatch.Value, out existingVersion))
 			{
-				logger.Debug("Document with key '{0}' was not found, and considered deleted", key);
+                if (logger.IsDebugEnabled) { logger.Debug("Document with key '{0}' was not found, and considered deleted", key); };
+
 				metadata = null;
 				deletedETag = null;
 				return false;
@@ -355,7 +359,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
 
 			documentCacher.RemoveCachedDocument(normalizedKey, etag);
 
-			logger.Debug("Deleted document with key = '{0}'", key);
+            if (logger.IsDebugEnabled) { logger.Debug("Deleted document with key = '{0}'", key); }
 
 			return true;
 		}
@@ -375,7 +379,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
             var normalizedKey = CreateKey(key);
             var isUpdate = WriteDocumentData(key, normalizedKey, etag, data, metadata, out newEtag, out existingEtag, out savedAt);
 
-			logger.Debug("AddDocument() - {0} document with key = '{1}'", isUpdate ? "Updated" : "Added", key);
+            if (logger.IsDebugEnabled) { logger.Debug("AddDocument() - {0} document with key = '{1}'", isUpdate ? "Updated" : "Added", key); }
 
 			return new AddDocumentResult
 			{
@@ -425,7 +429,8 @@ namespace Raven.Database.Storage.Voron.StorageActions
 
             if (!tableStorage.Documents.Contains(Snapshot, normalizedKeySlice, writeBatch.Value))
 			{
-				logger.Debug("Document with dataKey='{0}' was not found", key);
+                if (logger.IsDebugEnabled) { logger.Debug("Document with dataKey='{0}' was not found", key); }
+
 				preTouchEtag = null;
 				afterTouchEtag = null;
 				return;
@@ -447,7 +452,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
 			keyByEtagIndex.Add(writeBatch.Value, newEtag, normalizedKey);
 			etagTouches.Add(preTouchEtag, afterTouchEtag);
 
-			logger.Debug("TouchDocument() - document with key = '{0}'", key);
+            if (logger.IsDebugEnabled) { logger.Debug("TouchDocument() - document with key = '{0}'", key); }
 		}
 
 		public Etag GetBestNextDocumentEtag(Etag etag)

--- a/Raven.Database/Storage/Voron/StorageActions/MappedResultsStorageActions.cs
+++ b/Raven.Database/Storage/Voron/StorageActions/MappedResultsStorageActions.cs
@@ -28,6 +28,7 @@ namespace Raven.Database.Storage.Voron.StorageActions
     using Indexing;
     using Plugins;
     using Raven.Json.Linq;
+    using Raven.Abstractions.Util;
 
 	internal class MappedResultsStorageActions : StorageActionsBase, IMappedResultsStorageAction
 	{


### PR DESCRIPTION
I was able to diminish the amount of network trasference by more than 50% on bulk inserts and multiple entities loads. We were not compressing the data from client to server. 

Most of my tests were oriented toward batching and bulk processing where TCP latency influence should be minimal. TCP streams are more compact now, but because of the nature of the test set I havent seen any measurable effect.

Analysis of wireshark dumps suggest that we are already in the ballpark of what is achievable without a serious rework of the network streams infrastructure and use (something we should do when thinking of supporting HTTP/2 for v4.0). 