### PR TITLE
RavenDB-3959

### DIFF
--- a/Raven.Voron/Voron/Impl/PagerState.cs
+++ b/Raven.Voron/Voron/Impl/PagerState.cs
@@ -8,6 +8,9 @@
 
     using Voron.Impl.Paging;
 
+    /// <summary>
+    /// Pager state is not thread-safe.
+    /// </summary>
     public unsafe class PagerState
     {
 	    private readonly AbstractPager _pager;
@@ -54,7 +57,6 @@
 #endif
          
             ReleaseInternal();
-            //_pager.RegisterDisposal(Task.Run(() => ReleaseInternal()));
         }
 
         private void ReleaseInternal()

--- a/Raven.Voron/Voron/Impl/Scratch/PageFromScratchBuffer.cs
+++ b/Raven.Voron/Voron/Impl/Scratch/PageFromScratchBuffer.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 namespace Voron.Impl.Scratch
 {
 	public sealed class PageFromScratchBuffer

--- a/Raven.Voron/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/Raven.Voron/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -5,13 +5,11 @@
 // -----------------------------------------------------------------------
 
 using Sparrow;
-using Sparrow.Collections;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Voron.Impl.Paging;
 using Voron.Trees;
-using Voron.Util;
 
 namespace Voron.Impl.Scratch
 {
@@ -24,15 +22,17 @@ namespace Voron.Impl.Scratch
 			public long ValidAfterTransactionId;
 		}
 
-		private readonly IVirtualPager _scratchPager;
-		private readonly int _scratchNumber;
+        // Locks are released faster at this level than at the caller. 
+        private readonly object _syncRoot = new object();
+
+        private readonly IVirtualPager _scratchPager;
+		private readonly int _scratchNumber;        
 
         private readonly SortedList<long, long> _freePagesByTransaction = new SortedList<long, long>(NumericDescendingComparer.Instance);
         private readonly Dictionary<long, LinkedList<PendingPage>> _freePagesBySize = new Dictionary<long, LinkedList<PendingPage>>();
 		private readonly Dictionary<long, LinkedList<long>> _freePagesBySizeAvailableImmediately = new Dictionary<long, LinkedList<long>>();
 		private readonly Dictionary<long, PageFromScratchBuffer> _allocatedPages = new Dictionary<long, PageFromScratchBuffer>();
         
-
         private long _allocatedPagesUsedSize;
 		private long _lastUsedPage;
 
@@ -67,140 +67,153 @@ namespace Voron.Impl.Scratch
 
 		public PageFromScratchBuffer Allocate(Transaction tx, int numberOfPages, long size)
 		{
-			_scratchPager.EnsureContinuous(tx, _lastUsedPage, (int) size);
+            lock (_syncRoot)
+            {
+                _scratchPager.EnsureContinuous(tx, _lastUsedPage, (int)size);
 
-            var result = new PageFromScratchBuffer(_scratchNumber, _lastUsedPage, size, numberOfPages);
+                var result = new PageFromScratchBuffer(_scratchNumber, _lastUsedPage, size, numberOfPages);
 
-            _allocatedPagesUsedSize += numberOfPages;
-			_allocatedPages.Add(_lastUsedPage, result);
-			_lastUsedPage += size;
+                _allocatedPagesUsedSize += numberOfPages;
+                _allocatedPages.Add(_lastUsedPage, result);
+                _lastUsedPage += size;
 
-			return result;
-		}
+                return result;
+            }
+        }
 
 		public bool HasDiscontinuousSpaceFor(Transaction tx, long size, int scratchFilesInUse)
 		{
-			long available = 0;
+            long available = 0;
 
-			if (scratchFilesInUse == 1)
-			{
-				// we can consider the space from the end of a file as available only if we have the single scratch buffer file
-				// if a scratch limit is controller over multiple files then we can use only free pages to calculate available space
+            if (scratchFilesInUse == 1)
+            {
+                // we can consider the space from the end of a file as available only if we have the single scratch buffer file
+                // if a scratch limit is controller over multiple files then we can use only free pages to calculate available space
 
-				available += (_scratchPager.NumberOfAllocatedPages - _lastUsedPage);
-			}
+                available += (_scratchPager.NumberOfAllocatedPages - _lastUsedPage);
+            }
 
-			available += _freePagesBySizeAvailableImmediately.Sum(x => x.Key * x.Value.Count);
+            lock (_syncRoot)
+            {
+                // TODO: Potentially required sum optimization to avoid allocation of lambda expression.
+                available += _freePagesBySizeAvailableImmediately.Sum(x => x.Key * x.Value.Count);
+                if (available >= size)
+                    return true;
 
-			if (available >= size)
-				return true;
+                var sizesFromLargest = _freePagesBySize.Keys.OrderByDescending(x => x).ToList();
 
-			var sizesFromLargest = _freePagesBySize.Keys.OrderByDescending(x => x).ToList();
+                var oldestTransaction = tx.Environment.OldestTransaction;
 
-			var oldestTransaction = tx.Environment.OldestTransaction;
+                foreach (var sizeKey in sizesFromLargest)
+                {
+                    var item = _freePagesBySize[sizeKey].Last;
 
-			foreach (var sizeKey in sizesFromLargest)
-			{
-				var item = _freePagesBySize[sizeKey].Last;
+                    while (item != null && (oldestTransaction == 0 || item.Value.ValidAfterTransactionId < oldestTransaction))
+                    {
+                        available += sizeKey;
 
-				while (item != null && (oldestTransaction == 0 || item.Value.ValidAfterTransactionId < oldestTransaction))
-				{
-					available += sizeKey;
+                        if (available >= size)
+                            break;
 
-					if(available >= size)
-						break;
+                        item = item.Previous;
+                    }
 
-					item = item.Previous;
-				}
+                    if (available >= size)
+                        break;
+                }
 
-				if(available >= size)
-					break;
-			}
-
-			return available >= size;
+                return available >= size;
+            }
 		}
 
 		public bool TryGettingFromAllocatedBuffer(Transaction tx, int numberOfPages, long size, out PageFromScratchBuffer result)
 		{
 			result = null;
 
-			LinkedList<long> listOfAvailableImmediately;
-			if (_freePagesBySizeAvailableImmediately.TryGetValue(size, out listOfAvailableImmediately) && listOfAvailableImmediately.Count > 0)
-			{
-				var freeAndAvailablePageNumber = listOfAvailableImmediately.Last.Value;
+            lock (_syncRoot)
+            {
+                LinkedList<long> listOfAvailableImmediately;
+                if (_freePagesBySizeAvailableImmediately.TryGetValue(size, out listOfAvailableImmediately) && listOfAvailableImmediately.Count > 0)
+                {
+                    var freeAndAvailablePageNumber = listOfAvailableImmediately.Last.Value;
 
-				listOfAvailableImmediately.RemoveLast();
+                    listOfAvailableImmediately.RemoveLast();
 
-				result = new PageFromScratchBuffer ( _scratchNumber, freeAndAvailablePageNumber, size, numberOfPages );
-                
+                    result = new PageFromScratchBuffer(_scratchNumber, freeAndAvailablePageNumber, size, numberOfPages);
+
+                    _allocatedPagesUsedSize += numberOfPages;
+                    _allocatedPages.Add(freeAndAvailablePageNumber, result);
+                    return true;
+                }
+
+                LinkedList<PendingPage> list;
+                if (!_freePagesBySize.TryGetValue(size, out list) || list.Count <= 0)
+                    return false;
+
+                var val = list.Last.Value;
+                var oldestTransaction = tx.Environment.OldestTransaction;
+                if (oldestTransaction != 0 && val.ValidAfterTransactionId >= oldestTransaction) // OldestTransaction can be 0 when there are none other transactions and we are in process of new transaction header allocation
+                    return false;
+
+                list.RemoveLast();
+                result = new PageFromScratchBuffer(_scratchNumber, val.Page, size, numberOfPages);
+
                 _allocatedPagesUsedSize += numberOfPages;
-				_allocatedPages.Add(freeAndAvailablePageNumber, result);
-				return true;
-			}
+                _allocatedPages.Add(val.Page, result);
 
-			LinkedList<PendingPage> list;
-			if (!_freePagesBySize.TryGetValue(size, out list) || list.Count <= 0)
-				return false;
-
-			var val = list.Last.Value;
-			var oldestTransaction = tx.Environment.OldestTransaction;
-			if (oldestTransaction != 0 && val.ValidAfterTransactionId >= oldestTransaction) // OldestTransaction can be 0 when there are none other transactions and we are in process of new transaction header allocation
-				return false;
-
-			list.RemoveLast();
-			result = new PageFromScratchBuffer ( _scratchNumber, val.Page, size, numberOfPages );
-
-            _allocatedPagesUsedSize += numberOfPages;
-			_allocatedPages.Add(val.Page, result);
-			return true;
+                return true;
+            }
 		}
 
 		public void Free(long page, long asOfTxId)
 		{
-			PageFromScratchBuffer value;
-			if (_allocatedPages.TryGetValue(page, out value) == false)
-			{
-				throw new InvalidOperationException("Attempt to free page that wasn't currently allocated: " + page);
-			}
+            lock (_syncRoot)
+            {
+                PageFromScratchBuffer value;
+                if (_allocatedPages.TryGetValue(page, out value) == false)
+                {
+                    throw new InvalidOperationException("Attempt to free page that wasn't currently allocated: " + page);
+                }
 
-            _allocatedPagesUsedSize -= value.NumberOfPages;
-			_allocatedPages.Remove(page);
-			
-			if (asOfTxId == -1)
-			{
-				LinkedList<long> list;
+                _allocatedPagesUsedSize -= value.NumberOfPages;
+                _allocatedPages.Remove(page);
 
-				if (_freePagesBySizeAvailableImmediately.TryGetValue(value.Size, out list) == false)
-				{
-					list = new LinkedList<long>();
-					_freePagesBySizeAvailableImmediately[value.Size] = list;
-				}
-				list.AddFirst(value.PositionInScratchBuffer);
-			}
-			else
-			{
-				LinkedList<PendingPage> list;
+                if (asOfTxId == -1)
+                {
+                    LinkedList<long> list;
 
-				if (_freePagesBySize.TryGetValue(value.Size, out list) == false)
-				{
-					list = new LinkedList<PendingPage>();
-					_freePagesBySize[value.Size] = list;
-				}
-
-				list.AddFirst(new PendingPage
-				{
-					Page = value.PositionInScratchBuffer,
-					NumberOfPages = value.NumberOfPages,
-					ValidAfterTransactionId = asOfTxId
-				});
-
-                // If it is already there we address by position
-                int position =  _freePagesByTransaction.IndexOfKey(asOfTxId);
-                if (position == -1)
-                    _freePagesByTransaction.Add(asOfTxId, value.NumberOfPages);
+                    if (_freePagesBySizeAvailableImmediately.TryGetValue(value.Size, out list) == false)
+                    {
+                        list = new LinkedList<long>();
+                        _freePagesBySizeAvailableImmediately[value.Size] = list;
+                    }
+                    list.AddFirst(value.PositionInScratchBuffer);
+                }
                 else
-                    _freePagesByTransaction[asOfTxId] = _freePagesByTransaction.Values[position] + value.NumberOfPages;
-			}
+                {
+                    LinkedList<PendingPage> list;
+
+                    if (_freePagesBySize.TryGetValue(value.Size, out list) == false)
+                    {
+                        list = new LinkedList<PendingPage>();
+                        _freePagesBySize[value.Size] = list;
+                    }
+
+                    list.AddFirst(new PendingPage
+                    {
+                        Page = value.PositionInScratchBuffer,
+                        NumberOfPages = value.NumberOfPages,
+                        ValidAfterTransactionId = asOfTxId
+                    });
+
+                    // If it is already there we address by position
+                    int position = _freePagesByTransaction.IndexOfKey(asOfTxId);
+                    if (position == -1)
+                        _freePagesByTransaction.Add(asOfTxId, value.NumberOfPages);
+                    else
+                        _freePagesByTransaction[asOfTxId] = _freePagesByTransaction.Values[position] + value.NumberOfPages;
+                }
+            }
 		}
 
 		public Page ReadPage(long p, PagerState pagerState = null)
@@ -216,14 +229,17 @@ namespace Voron.Impl.Scratch
 		public long ActivelyUsedBytes(long oldestActiveTransaction)
 		{
             long result = _allocatedPagesUsedSize;
-
-            var keys = _freePagesByTransaction.Keys;
-            var values = _freePagesByTransaction.Values;
-            for (int i = 0; i < keys.Count; i++ )
+            lock (_syncRoot)
             {
-                if (keys[i] < oldestActiveTransaction)
-                    break;
-                result += values[i];
+                var keys = _freePagesByTransaction.Keys;
+                var values = _freePagesByTransaction.Values;
+                for (int i = 0; i < keys.Count; i++)
+                {
+                    if (keys[i] < oldestActiveTransaction)
+                        break;
+
+                    result += values[i];
+                }
             }
 
 			return result * AbstractPager.PageSize;
@@ -231,19 +247,22 @@ namespace Voron.Impl.Scratch
 
 		internal Dictionary<long, long> GetMostAvailableFreePagesBySize()
 		{
-			return _freePagesBySize.Keys.ToDictionary(size => size, size =>
-			{
-				var list = _freePagesBySize[size].Last;
+            lock (_syncRoot)
+            {
+                return _freePagesBySize.Keys.ToDictionary(size => size, size =>
+                {
+                    var list = _freePagesBySize[size].Last;
 
-				if (list == null)
-					return -1;
+                    if (list == null)
+                        return -1;
 
-				var value = list.Value;
-				if (value == null)
-					return -1;
+                    var value = list.Value;
+                    if (value == null)
+                        return -1;
 
-				return value.ValidAfterTransactionId;
-			});
+                    return value.ValidAfterTransactionId;
+                });
+            }
 		}
 
 		public void Dispose()

--- a/Raven.Voron/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/Raven.Voron/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -22,9 +22,6 @@ namespace Voron.Impl.Scratch
 			public long ValidAfterTransactionId;
 		}
 
-        // Locks are released faster at this level than at the caller. 
-        private readonly object _syncRoot = new object();
-
         private readonly IVirtualPager _scratchPager;
 		private readonly int _scratchNumber;        
 
@@ -67,24 +64,20 @@ namespace Voron.Impl.Scratch
 
 		public PageFromScratchBuffer Allocate(Transaction tx, int numberOfPages, long size)
 		{
-            lock (_syncRoot)
-            {
-                _scratchPager.EnsureContinuous(tx, _lastUsedPage, (int)size);
+            _scratchPager.EnsureContinuous(tx, _lastUsedPage, (int)size);
 
-                var result = new PageFromScratchBuffer(_scratchNumber, _lastUsedPage, size, numberOfPages);
+            var result = new PageFromScratchBuffer(_scratchNumber, _lastUsedPage, size, numberOfPages);
 
-                _allocatedPagesUsedSize += numberOfPages;
-                _allocatedPages.Add(_lastUsedPage, result);
-                _lastUsedPage += size;
+            _allocatedPagesUsedSize += numberOfPages;
+            _allocatedPages.Add(_lastUsedPage, result);
+            _lastUsedPage += size;
 
-                return result;
-            }
+            return result;
         }
 
 		public bool HasDiscontinuousSpaceFor(Transaction tx, long size, int scratchFilesInUse)
 		{
             long available = 0;
-
             if (scratchFilesInUse == 1)
             {
                 // we can consider the space from the end of a file as available only if we have the single scratch buffer file
@@ -93,126 +86,117 @@ namespace Voron.Impl.Scratch
                 available += (_scratchPager.NumberOfAllocatedPages - _lastUsedPage);
             }
 
-            lock (_syncRoot)
+            foreach ( var freePage in _freePagesBySizeAvailableImmediately )
+                available += freePage.Key * freePage.Value.Count;
+
+            if (available >= size)
+                return true;
+
+            var oldestTransaction = tx.Environment.OldestTransaction;
+
+            var sizesFromLargest = _freePagesBySize.Keys.OrderByDescending(x => x);
+            foreach (var sizeKey in sizesFromLargest)
             {
-                // TODO: Potentially required sum optimization to avoid allocation of lambda expression.
-                available += _freePagesBySizeAvailableImmediately.Sum(x => x.Key * x.Value.Count);
-                if (available >= size)
-                    return true;
+                var item = _freePagesBySize[sizeKey].Last;
 
-                var sizesFromLargest = _freePagesBySize.Keys.OrderByDescending(x => x).ToList();
-
-                var oldestTransaction = tx.Environment.OldestTransaction;
-
-                foreach (var sizeKey in sizesFromLargest)
+                while (item != null && (oldestTransaction == 0 || item.Value.ValidAfterTransactionId < oldestTransaction))
                 {
-                    var item = _freePagesBySize[sizeKey].Last;
-
-                    while (item != null && (oldestTransaction == 0 || item.Value.ValidAfterTransactionId < oldestTransaction))
-                    {
-                        available += sizeKey;
-
-                        if (available >= size)
-                            break;
-
-                        item = item.Previous;
-                    }
+                    available += sizeKey;
 
                     if (available >= size)
                         break;
+
+                    item = item.Previous;
                 }
 
-                return available >= size;
+                if (available >= size)
+                    break;
             }
+
+            return available >= size;
 		}
 
 		public bool TryGettingFromAllocatedBuffer(Transaction tx, int numberOfPages, long size, out PageFromScratchBuffer result)
 		{
 			result = null;
 
-            lock (_syncRoot)
+            LinkedList<long> listOfAvailableImmediately;
+            if (_freePagesBySizeAvailableImmediately.TryGetValue(size, out listOfAvailableImmediately) && listOfAvailableImmediately.Count > 0)
             {
-                LinkedList<long> listOfAvailableImmediately;
-                if (_freePagesBySizeAvailableImmediately.TryGetValue(size, out listOfAvailableImmediately) && listOfAvailableImmediately.Count > 0)
-                {
-                    var freeAndAvailablePageNumber = listOfAvailableImmediately.Last.Value;
+                var freeAndAvailablePageNumber = listOfAvailableImmediately.Last.Value;
 
-                    listOfAvailableImmediately.RemoveLast();
+                listOfAvailableImmediately.RemoveLast();
 
-                    result = new PageFromScratchBuffer(_scratchNumber, freeAndAvailablePageNumber, size, numberOfPages);
-
-                    _allocatedPagesUsedSize += numberOfPages;
-                    _allocatedPages.Add(freeAndAvailablePageNumber, result);
-                    return true;
-                }
-
-                LinkedList<PendingPage> list;
-                if (!_freePagesBySize.TryGetValue(size, out list) || list.Count <= 0)
-                    return false;
-
-                var val = list.Last.Value;
-                var oldestTransaction = tx.Environment.OldestTransaction;
-                if (oldestTransaction != 0 && val.ValidAfterTransactionId >= oldestTransaction) // OldestTransaction can be 0 when there are none other transactions and we are in process of new transaction header allocation
-                    return false;
-
-                list.RemoveLast();
-                result = new PageFromScratchBuffer(_scratchNumber, val.Page, size, numberOfPages);
+                result = new PageFromScratchBuffer(_scratchNumber, freeAndAvailablePageNumber, size, numberOfPages);
 
                 _allocatedPagesUsedSize += numberOfPages;
-                _allocatedPages.Add(val.Page, result);
-
+                _allocatedPages.Add(freeAndAvailablePageNumber, result);
                 return true;
             }
+
+            LinkedList<PendingPage> list;
+            if (!_freePagesBySize.TryGetValue(size, out list) || list.Count <= 0)
+                return false;
+
+            var val = list.Last.Value;
+            var oldestTransaction = tx.Environment.OldestTransaction;
+            if (oldestTransaction != 0 && val.ValidAfterTransactionId >= oldestTransaction) // OldestTransaction can be 0 when there are none other transactions and we are in process of new transaction header allocation
+                return false;
+
+            list.RemoveLast();
+            result = new PageFromScratchBuffer(_scratchNumber, val.Page, size, numberOfPages);
+
+            _allocatedPagesUsedSize += numberOfPages;
+            _allocatedPages.Add(val.Page, result);
+
+            return true;       
 		}
 
 		public void Free(long page, long asOfTxId)
-		{
-            lock (_syncRoot)
+		{        
+            PageFromScratchBuffer value;
+            if (_allocatedPages.TryGetValue(page, out value) == false)
             {
-                PageFromScratchBuffer value;
-                if (_allocatedPages.TryGetValue(page, out value) == false)
+                throw new InvalidOperationException("Attempt to free page that wasn't currently allocated: " + page);
+            }
+
+            _allocatedPagesUsedSize -= value.NumberOfPages;
+            _allocatedPages.Remove(page);
+
+            if (asOfTxId == -1)
+            {
+                LinkedList<long> list;
+
+                if (_freePagesBySizeAvailableImmediately.TryGetValue(value.Size, out list) == false)
                 {
-                    throw new InvalidOperationException("Attempt to free page that wasn't currently allocated: " + page);
+                    list = new LinkedList<long>();
+                    _freePagesBySizeAvailableImmediately[value.Size] = list;
+                }
+                list.AddFirst(value.PositionInScratchBuffer);
+            }
+            else
+            {
+                LinkedList<PendingPage> list;
+
+                if (_freePagesBySize.TryGetValue(value.Size, out list) == false)
+                {
+                    list = new LinkedList<PendingPage>();
+                    _freePagesBySize[value.Size] = list;
                 }
 
-                _allocatedPagesUsedSize -= value.NumberOfPages;
-                _allocatedPages.Remove(page);
-
-                if (asOfTxId == -1)
+                list.AddFirst(new PendingPage
                 {
-                    LinkedList<long> list;
+                    Page = value.PositionInScratchBuffer,
+                    NumberOfPages = value.NumberOfPages,
+                    ValidAfterTransactionId = asOfTxId
+                });
 
-                    if (_freePagesBySizeAvailableImmediately.TryGetValue(value.Size, out list) == false)
-                    {
-                        list = new LinkedList<long>();
-                        _freePagesBySizeAvailableImmediately[value.Size] = list;
-                    }
-                    list.AddFirst(value.PositionInScratchBuffer);
-                }
+                // If it is already there we address by position
+                int position = _freePagesByTransaction.IndexOfKey(asOfTxId);
+                if (position == -1)
+                    _freePagesByTransaction.Add(asOfTxId, value.NumberOfPages);
                 else
-                {
-                    LinkedList<PendingPage> list;
-
-                    if (_freePagesBySize.TryGetValue(value.Size, out list) == false)
-                    {
-                        list = new LinkedList<PendingPage>();
-                        _freePagesBySize[value.Size] = list;
-                    }
-
-                    list.AddFirst(new PendingPage
-                    {
-                        Page = value.PositionInScratchBuffer,
-                        NumberOfPages = value.NumberOfPages,
-                        ValidAfterTransactionId = asOfTxId
-                    });
-
-                    // If it is already there we address by position
-                    int position = _freePagesByTransaction.IndexOfKey(asOfTxId);
-                    if (position == -1)
-                        _freePagesByTransaction.Add(asOfTxId, value.NumberOfPages);
-                    else
-                        _freePagesByTransaction[asOfTxId] = _freePagesByTransaction.Values[position] + value.NumberOfPages;
-                }
+                    _freePagesByTransaction[asOfTxId] = _freePagesByTransaction.Values[position] + value.NumberOfPages;
             }
 		}
 
@@ -229,17 +213,15 @@ namespace Voron.Impl.Scratch
 		public long ActivelyUsedBytes(long oldestActiveTransaction)
 		{
             long result = _allocatedPagesUsedSize;
-            lock (_syncRoot)
-            {
-                var keys = _freePagesByTransaction.Keys;
-                var values = _freePagesByTransaction.Values;
-                for (int i = 0; i < keys.Count; i++)
-                {
-                    if (keys[i] < oldestActiveTransaction)
-                        break;
 
-                    result += values[i];
-                }
+            var keys = _freePagesByTransaction.Keys;
+            var values = _freePagesByTransaction.Values;
+            for (int i = 0; i < keys.Count; i++)
+            {
+                if (keys[i] < oldestActiveTransaction)
+                    break;
+
+                result += values[i];
             }
 
 			return result * AbstractPager.PageSize;
@@ -247,22 +229,19 @@ namespace Voron.Impl.Scratch
 
 		internal Dictionary<long, long> GetMostAvailableFreePagesBySize()
 		{
-            lock (_syncRoot)
+            return _freePagesBySize.Keys.ToDictionary(size => size, size =>
             {
-                return _freePagesBySize.Keys.ToDictionary(size => size, size =>
-                {
-                    var list = _freePagesBySize[size].Last;
+                var list = _freePagesBySize[size].Last;
 
-                    if (list == null)
-                        return -1;
+                if (list == null)
+                    return -1;
 
-                    var value = list.Value;
-                    if (value == null)
-                        return -1;
+                var value = list.Value;
+                if (value == null)
+                    return -1;
 
-                    return value.ValidAfterTransactionId;
-                });
-            }
+                return value.ValidAfterTransactionId;
+            });
 		}
 
 		public void Dispose()

--- a/Raven.Voron/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/Raven.Voron/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -1,5 +1,6 @@
 ﻿using Sparrow;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -19,17 +20,24 @@ namespace Voron.Impl.Scratch
 	/// created them. The pages will be kept around until the flush for the journals
 	/// send them to the data file.
 	/// 
-	/// This class relies on external synchronization and is not meant to be used in multiple
-	/// threads at the same time
+	/// This class relies on internal synchronization and it's multi-threaded safe. 
+    /// However, object returned by method calls on the pool are not strictly thread-safe.
 	/// </summary>
 	public unsafe class ScratchBufferPool : IDisposable
 	{
-		private readonly long _sizeLimit;
-		private ScratchBufferFile _current;
-		private StorageEnvironmentOptions _options;
-		private int _currentScratchNumber = -1;
-		private long _oldestTransactionWhenFlushWasForced = -1;
-        private readonly Dictionary<int, ScratchBufferFile> _scratchBuffers = new Dictionary<int, ScratchBufferFile>(NumericEqualityComparer.Instance);
+        private const int InvalidScratchFileNumber = -1;
+
+        // Immutable state. 
+        private readonly long _sizeLimit;
+        private readonly StorageEnvironmentOptions _options;
+        
+        // Local per scratch file potentially read delayed inconsistent (need guards). All must be modified atomically (but it wont necessarily require a memory barrier)
+        private ScratchBufferItem _current;		     
+        private ScratchBufferItem lastScratchBuffer = new ScratchBufferItem(InvalidScratchFileNumber, null);
+
+        // Local writable state. Can perform multiple reads, but must never do multiple writes simultaneously.
+        private int _currentScratchNumber = -1;
+        private readonly ConcurrentDictionary<int, ScratchBufferItem> _scratchBuffers = new ConcurrentDictionary<int, ScratchBufferItem>(NumericEqualityComparer.Instance);
 
 		public ScratchBufferPool(StorageEnvironment env)
 		{
@@ -40,41 +48,60 @@ namespace Voron.Impl.Scratch
 
 		public Dictionary<int, PagerState> GetPagerStatesOfAllScratches()
 		{
-            return _scratchBuffers.ToDictionary(x => x.Key, y => y.Value.PagerState, NumericEqualityComparer.Instance);
+            // This is not risky anymore, but the caller must understand this is a monotonically incrementing snapshot. 
+            return _scratchBuffers.ToDictionary(x => x.Key, y => y.Value.File.PagerState, NumericEqualityComparer.Instance);
 		}
 
 		internal long GetNumberOfAllocations(int scratchNumber)
 		{
-			return _scratchBuffers[scratchNumber].NumberOfAllocations;
-		}
+            // While used only in tests, there is no multithread risk. 
+            return _scratchBuffers[scratchNumber].File.NumberOfAllocations;
+        }
 
-		private ScratchBufferFile NextFile()
+		private ScratchBufferItem NextFile()
 		{
-			_currentScratchNumber++;
-			var scratchPager = _options.CreateScratchPager(StorageEnvironmentOptions.ScratchBufferName(_currentScratchNumber));
-			scratchPager.AllocateMorePages(null, Math.Max(_options.InitialFileSize ?? 0, _options.InitialLogFileSize));
+            // Must happen atomically (always). 
+            lock ( _scratchBuffers )
+            {
+                _currentScratchNumber++; // This is used only here, so we dont need a memory barrier.
 
-			var scratchFile = new ScratchBufferFile(scratchPager, _currentScratchNumber);
-			_scratchBuffers.Add(_currentScratchNumber, scratchFile);
+                var scratchPager = _options.CreateScratchPager(StorageEnvironmentOptions.ScratchBufferName(_currentScratchNumber));
+                scratchPager.AllocateMorePages(null, Math.Max(_options.InitialFileSize ?? 0, _options.InitialLogFileSize));
 
-			_oldestTransactionWhenFlushWasForced = -1;
+                var scratchFile = new ScratchBufferFile(scratchPager, _currentScratchNumber);
+                var item = new ScratchBufferItem(scratchFile.Number, scratchFile);
 
-			return scratchFile;
-		}
+                _scratchBuffers.TryAdd(item.Number, item);
+
+                return item;
+            }
+        }
 
 		public PagerState GetPagerState(int scratchNumber)
 		{
-			return _scratchBuffers[scratchNumber].PagerState;
+            // Multi-read safety. 
+            var bufferFile = _scratchBuffers[scratchNumber].File;
+            lock (bufferFile)
+            {
+                return bufferFile.PagerState;
+            }
 		}
 
 		public PageFromScratchBuffer Allocate(Transaction tx, int numberOfPages)
 		{
 			if (tx == null)
 				throw new ArgumentNullException("tx");
+
 			var size = Utils.NearestPowerOfTwo(numberOfPages);
 
 			PageFromScratchBuffer result;
-			if (_current.TryGettingFromAllocatedBuffer(tx, numberOfPages, size, out result))
+
+            // Copy to ensure we dont lose a reference if a new file is created meanwhile. 
+            // In a multithreaded call what could happen is that we have created an scratch buffer which will only have a handful of transactions and will get discarded fast.
+            var current = _current;
+            var currentFile = current.File;
+
+			if (currentFile.TryGettingFromAllocatedBuffer(tx, numberOfPages, size, out result))
 				return result;
 
 			long sizeAfterAllocation;
@@ -82,7 +109,7 @@ namespace Voron.Impl.Scratch
 
 			if (_scratchBuffers.Count == 1)
 			{
-				sizeAfterAllocation = _current.SizeAfterAllocation(size);
+				sizeAfterAllocation = currentFile.SizeAfterAllocation(size);
 			}
 			else
 			{
@@ -90,16 +117,16 @@ namespace Voron.Impl.Scratch
 
 				var scratchesToDelete = new List<int>();
 
-				// determine how many bytes of older scratches are still in use
+				// determine how many bytes of older scratches are still in use (at least when this snapshot is taken)
 				foreach (var scratch in _scratchBuffers.Values)
 				{
-					var bytesInUse = scratch.ActivelyUsedBytes(oldestActiveTransaction);
+                    var bytesInUse = scratch.File.ActivelyUsedBytes(oldestActiveTransaction);
 
 					if (bytesInUse > 0)
 						sizeAfterAllocation += bytesInUse;
 					else
 					{
-						if(scratch != _current)
+						if(scratch != current)
 							scratchesToDelete.Add(scratch.Number);
 					}
 				}
@@ -107,13 +134,15 @@ namespace Voron.Impl.Scratch
 				// delete inactive scratches
 				foreach (var scratchNumber in scratchesToDelete)
 				{
-					var scratchBufferFile = _scratchBuffers[scratchNumber];
-					_scratchBuffers.Remove(scratchNumber);
-					scratchBufferFile.Dispose();
+                    ScratchBufferItem scratchBufferToRemove;
+                    if ( _scratchBuffers.TryRemove(scratchNumber, out scratchBufferToRemove) )
+                    {
+                        scratchBufferToRemove.File.Dispose();
+                    }					
 				}
 			}
 
-			if (sizeAfterAllocation >= (_sizeLimit*3)/4 && oldestActiveTransaction > _oldestTransactionWhenFlushWasForced)
+			if (sizeAfterAllocation >= (_sizeLimit*3)/4 && oldestActiveTransaction > current.OldestTransactionWhenFlushWasForced)
 			{
 				// we may get recursive flushing, so we want to avoid it
 				if (tx.Environment.Journal.Applicator.IsCurrentThreadInFlushOperation == false)
@@ -130,7 +159,7 @@ namespace Voron.Impl.Scratch
 							try
 							{
 								tx.Environment.ForceLogFlushToDataFile(tx, allowToFlushOverwrittenPages: true);
-								_oldestTransactionWhenFlushWasForced = oldestActiveTransaction;
+                                current.OldestTransactionWhenFlushWasForced = oldestActiveTransaction;
 							}
 							catch (TimeoutException)
 							{
@@ -158,7 +187,7 @@ namespace Voron.Impl.Scratch
 
 				while (sp.ElapsedMilliseconds < tx.Environment.Options.ScratchBufferOverflowTimeout)
 				{
-					if (_current.TryGettingFromAllocatedBuffer(tx, numberOfPages, size, out result))
+					if (currentFile.TryGettingFromAllocatedBuffer(tx, numberOfPages, size, out result))
 						return result;
 					Thread.Sleep(32);
 				}
@@ -167,15 +196,15 @@ namespace Voron.Impl.Scratch
 
 				bool createNextFile = false;
 
-				if (_current.HasDiscontinuousSpaceFor(tx, size, _scratchBuffers.Count))
+				if (currentFile.HasDiscontinuousSpaceFor(tx, size, _scratchBuffers.Count))
 				{
 					// there is enough space for the requested allocation but the problem is its fragmentation
 					// so we will create a new scratch file and will allow to allocate new continuous range from there
 
 					createNextFile = true;
 				}
-				else if (_scratchBuffers.Count == 1 && _current.Size < _sizeLimit && 
-						(_current.ActivelyUsedBytes(oldestActiveTransaction) + size * AbstractPager.PageSize) < _sizeLimit)
+				else if (_scratchBuffers.Count == 1 && currentFile.Size < _sizeLimit && 
+						(currentFile.ActivelyUsedBytes(oldestActiveTransaction) + size * AbstractPager.PageSize) < _sizeLimit)
 				{
 					// there is only one scratch file that hasn't reach the size limit yet and
 					// the number of bytes being in active use allows to allocate the requested size
@@ -186,12 +215,21 @@ namespace Voron.Impl.Scratch
 
 				if (createNextFile)
 				{
-					_current = NextFile();
+                    // We need to ensure that _current stays constant through the codepath until return. 
+                    current = NextFile();
 
-					_current.PagerState.AddRef();
-					tx.AddPagerState(_current.PagerState);
+                    try
+                    {
+                        current.File.PagerState.AddRef();
+                        tx.AddPagerState(current.File.PagerState);
 
-					return _current.Allocate(tx, numberOfPages, size);
+                        return current.File.Allocate(tx, numberOfPages, size);
+                    }
+                    finally
+                    {                        
+                        // That's why we update only after exiting. 
+                        _current = current;
+                    }
 				}
 
 				var debugInfoBuilder = new StringBuilder();
@@ -199,7 +237,7 @@ namespace Voron.Impl.Scratch
 				debugInfoBuilder.AppendFormat("Current transaction id: {0}\r\n", tx.Id);
 				debugInfoBuilder.AppendFormat("Requested number of pages: {0} (adjusted size: {1} == {2:#,#;;0} KB)\r\n", numberOfPages, size, size * AbstractPager.PageSize / 1024);
 				debugInfoBuilder.AppendFormat("Oldest active transaction: {0} (snapshot: {1})\r\n", tx.Environment.OldestTransaction, oldestActiveTransaction);
-				debugInfoBuilder.AppendFormat("Oldest active transaction when flush was forced: {0}\r\n", _oldestTransactionWhenFlushWasForced);
+				debugInfoBuilder.AppendFormat("Oldest active transaction when flush was forced: {0}\r\n", current.OldestTransactionWhenFlushWasForced);
 				debugInfoBuilder.AppendFormat("Next write transaction id: {0}\r\n", tx.Environment.NextWriteTransactionId + 1);
 
 				debugInfoBuilder.AppendLine("Active transactions:");
@@ -209,9 +247,9 @@ namespace Voron.Impl.Scratch
 				}
 
 				debugInfoBuilder.AppendLine("Scratch files usage:");
-				foreach (var scratchBufferFile in _scratchBuffers.OrderBy(x => x.Key))
+				foreach (var scratchBufferItem in _scratchBuffers.Values.OrderBy(x => x.Number))
 				{
-					debugInfoBuilder.AppendFormat("\t{0} - size: {1:#,#;;0} KB, in active use: {2:#,#;;0} KB\r\n", StorageEnvironmentOptions.ScratchBufferName(scratchBufferFile.Value.Number), scratchBufferFile.Value.Size / 1024, scratchBufferFile.Value.ActivelyUsedBytes(oldestActiveTransaction) / 1024);
+					debugInfoBuilder.AppendFormat("\t{0} - size: {1:#,#;;0} KB, in active use: {2:#,#;;0} KB\r\n", StorageEnvironmentOptions.ScratchBufferName(scratchBufferItem.File.Number), scratchBufferItem.File.Size / 1024, scratchBufferItem.File.ActivelyUsedBytes(oldestActiveTransaction) / 1024);
 				}
 
 				debugInfoBuilder.AppendLine("Most available free pages:");
@@ -219,7 +257,7 @@ namespace Voron.Impl.Scratch
 				{
 					debugInfoBuilder.AppendFormat("\t{0}\r\n", StorageEnvironmentOptions.ScratchBufferName(scratchBufferFile.Value.Number));
 
-					foreach (var freePage in scratchBufferFile.Value.GetMostAvailableFreePagesBySize())
+					foreach (var freePage in scratchBufferFile.Value.File.GetMostAvailableFreePagesBySize())
 					{
 						debugInfoBuilder.AppendFormat("\t\tSize:{0}, ValidAfterTransactionId: {1}\r\n", freePage.Key, freePage.Value);
 					}
@@ -237,8 +275,8 @@ namespace Voron.Impl.Scratch
 											   "Already flushed and waited for {4:#,#;;0} ms for read transactions to complete.\r\n" +
 											   "Do you have a long running read transaction executing?\r\n" + 
 											   "Debug info:\r\n{5}",
-					_current.Size / 1024L,
-					_current.SizeAfterAllocation(size) / 1024L,
+                    currentFile.Size / 1024L,
+                    currentFile.SizeAfterAllocation(size) / 1024L,
 					sizeAfterAllocation / 1024L,
 					_sizeLimit / 1024L,
 					sp.ElapsedMilliseconds,
@@ -249,7 +287,7 @@ namespace Voron.Impl.Scratch
 			}
 
 			// we don't have free pages to give out, need to allocate some
-			result = _current.Allocate(tx, numberOfPages, size);
+			result = currentFile.Allocate(tx, numberOfPages, size);
 			_options.OnScratchBufferSizeChanged(sizeAfterAllocation);
 
 			return result;
@@ -257,53 +295,52 @@ namespace Voron.Impl.Scratch
 
 		public void Free(int scratchNumber, long page, long asOfTxId)
 		{
-			_scratchBuffers[scratchNumber].Free(page, asOfTxId);
+            var scratch = _scratchBuffers[scratchNumber];
+            scratch.File.Free(page, asOfTxId);           
 		}
 
 		public void Dispose()
 		{
-			foreach (var scratchBufferFile in _scratchBuffers)
+			foreach (var scratch in _scratchBuffers)
 			{
-				scratchBufferFile.Value.Dispose();
+                scratch.Value.File.Dispose();
 			}
 		}
 
-        private class ScratchBufferCacheItem
+        private class ScratchBufferItem
         {
             public readonly int Number;
             public readonly ScratchBufferFile File;
+            public long OldestTransactionWhenFlushWasForced;
 
-            public ScratchBufferCacheItem(int number, ScratchBufferFile file)
+            public ScratchBufferItem(int number, ScratchBufferFile file)
             {
                 this.Number = number;
                 this.File = file;
+                this.OldestTransactionWhenFlushWasForced = -1;
             }
         }
 
-        private const int InvalidScratchFileNumber = -1;
-        private ScratchBufferCacheItem lastScratchBuffer = new ScratchBufferCacheItem( InvalidScratchFileNumber, null );
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public Page ReadPage(int scratchNumber, long p, PagerState pagerState = null)
+        public Page ReadPage(int scratchNumber, long p, PagerState pagerState = null)
 		{
-            ScratchBufferFile bufferFile;
-            ScratchBufferCacheItem item = lastScratchBuffer;
-            if ( item.Number == scratchNumber )
-            {
-                bufferFile = item.File;
-            }
-            else
-            {
-                bufferFile = _scratchBuffers[scratchNumber];
-                lastScratchBuffer = new ScratchBufferCacheItem( scratchNumber, bufferFile );
-            }
+            ScratchBufferItem item = lastScratchBuffer;
+            if (item.Number != scratchNumber)
+                item = _scratchBuffers[scratchNumber];
 
-			return bufferFile.ReadPage(p, pagerState);
+            ScratchBufferFile bufferFile = item.File;
+            return bufferFile.ReadPage(p, pagerState);
 		}
 
-		public byte* AcquirePagePointer(int scratchNumber, long p)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public byte* AcquirePagePointer(int scratchNumber, long p)
 		{
-			return _scratchBuffers[scratchNumber].AcquirePagePointer(p);
+            ScratchBufferItem item = lastScratchBuffer;
+            if (item.Number != scratchNumber)
+                item = _scratchBuffers[scratchNumber];
+
+            ScratchBufferFile bufferFile = item.File;
+            return bufferFile.AcquirePagePointer(p);       
 		}
 	}
 }


### PR DESCRIPTION
Multiple transactions can issue Put, Get and Iterate at the same time. The whole internal state is mutable (not only _scratchBuffers) and therefore unsafe under multi-thread scenarios. It is unrealistic to rely on external synchronization for the ScratchBufferPool, the change would require to ensure multi-thread safety. 

In my test I havent seen much difference, but I dont have any really deep test which would stress this scenario.

ESENT: 00:00:28.4825153
Voron (after): 00:00:23.1832327
Voron (before):  00:00:23.0949927