### PR TITLE
Load by unique constraint always hit server

### DIFF
--- a/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
+++ b/Bundles/Raven.Client.UniqueConstraints/UniqueConstraintExtensions.cs
@@ -97,13 +97,16 @@ namespace Raven.Client.UniqueConstraints
 											  Key = Util.EscapeUniqueValue(value, constraintInfo.Configuration.CaseInsensitive)
 										  }).ToList();
 
+                var constraintDocsIds = constraintsIds.Select(x => x.Id).ToList();
+                var inMemory = ((InMemoryDocumentSessionOperations)session);
+                constraintDocsIds.ForEach(inMemory.UnregisterMissing);
 
-				var constraintDocs = session
-					.Include<ConstraintDocument>(x => x.RelatedId)
-					.Include<ConstraintDocument>(x => x.Constraints.Values.Select(c => c.RelatedId))
-					.Load(constraintsIds.Select(x => x.Id).ToArray());
+                var constraintDocs = session
+                    .Include<ConstraintDocument>(x => x.RelatedId)
+                    .Include<ConstraintDocument>(x => x.Constraints.Values.Select(c => c.RelatedId))
+                    .Load(constraintDocsIds);
 
-				var existingDocsIds = new List<string>();
+                var existingDocsIds = new List<string>();
 				for (var i = 0; i < constraintDocs.Length; i++)
 				{
 					// simple way to maintain parallel results array - DummyId should never exist in the DB

--- a/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
@@ -1347,8 +1347,12 @@ more responsive application.
 		{
 			knownMissingIds.Add(id);
 		}
+        public void UnregisterMissing(string id)
+        {
+            knownMissingIds.RemoveWhere(r=> r == id);
+        }
 
-		public void RegisterMissingIncludes(IEnumerable<RavenJObject> results, ICollection<string> includes)
+        public void RegisterMissingIncludes(IEnumerable<RavenJObject> results, ICollection<string> includes)
 		{
 			if (includes == null || includes.Any() == false)
 				return;

--- a/Raven.Tests.Bundles/Raven.Tests.Bundles.csproj
+++ b/Raven.Tests.Bundles/Raven.Tests.Bundles.csproj
@@ -199,6 +199,7 @@
     <Compile Include="UniqueConstraints\Bugs\Troy2.cs" />
     <Compile Include="UniqueConstraints\Bugs\Troy3.cs" />
     <Compile Include="UniqueConstraints\Bugs\TroyMapReduce.cs" />
+    <Compile Include="UniqueConstraints\Bugs\ValerioBorioni.cs" />
     <Compile Include="UniqueConstraints\Bugs\viscious.cs" />
     <Compile Include="UniqueConstraints\CreateTests.cs" />
     <Compile Include="UniqueConstraints\DeleteTests.cs" />

--- a/Raven.Tests.Bundles/UniqueConstraints/Bugs/ValerioBorioni.cs
+++ b/Raven.Tests.Bundles/UniqueConstraints/Bugs/ValerioBorioni.cs
@@ -1,0 +1,45 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="Troy.cs" company="Hibernating Rhinos LTD">
+// //     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+// // </copyright>
+// //-----------------------------------------------------------------------
+using System;
+
+using Raven.Client.UniqueConstraints;
+
+using Xunit;
+
+namespace Raven.Tests.Bundles.UniqueConstraints.Bugs
+{
+	public class ValerioBorioni : UniqueConstraintsTest
+	{
+		public class MyEntity
+		{
+            public string Id { get; set; }
+            [UniqueConstraint(CaseInsensitive = true)]
+			public string ExternalReference { get; set; }
+		}
+
+		[Fact]
+		public void LoadByUniqueConstraintDocumentStoredOnCurrentSession()
+		{
+            string reference = "value";
+            var entity = new MyEntity { ExternalReference = reference };
+
+            using (var session = DocumentStore.OpenSession())
+			{
+                session.LoadByUniqueConstraint<MyEntity>(r => r.ExternalReference, reference);
+                session.Store(entity);
+				session.SaveChanges();
+                var loadedEntity = session.LoadByUniqueConstraint<MyEntity>(r => r.ExternalReference, reference);
+                Assert.Equal(entity.Id, loadedEntity.Id);
+			}
+			using (var session = DocumentStore.OpenSession())
+			{
+                var loadedEntity = session.LoadByUniqueConstraint<MyEntity>(r => r.ExternalReference, reference);
+                Assert.Equal(entity.Id, loadedEntity.Id);
+            }
+		}
+
+	}
+}


### PR DESCRIPTION
I don't like the solution very much due to the cast in the bundle : 
 var inMemory = ((InMemoryDocumentSessionOperations)session);

Is there a better way to do that ?