### PR TITLE
RavenDB-3853: Prevent NRE when setting MaxNumberOfCachedRequests before

### DIFF
--- a/Raven.Client.Lightweight/Document/DocumentStore.cs
+++ b/Raven.Client.Lightweight/Document/DocumentStore.cs
@@ -737,7 +737,8 @@ namespace Raven.Client.Document
 			set
 			{
 				maxNumberOfCachedRequests = value;
-                jsonRequestFactory.ResetCache(maxNumberOfCachedRequests);
+                if (initialized == true)
+                    jsonRequestFactory.ResetCache(maxNumberOfCachedRequests);
 			}
 		}
 


### PR DESCRIPTION
init
