### PR TITLE
Force FutureBatchCompleted event to be called _after_ the future batc…

### DIFF
--- a/Raven.Tests.Issues/Prefetcher/RavenDB_3581.cs
+++ b/Raven.Tests.Issues/Prefetcher/RavenDB_3581.cs
@@ -180,13 +180,9 @@ namespace Raven.Tests.Issues.Prefetcher
                 count += i;
 
                 if (count == 1536)
-                    {
-                    //The reason i have added this wait is because the 'FutureBatchCompleted'
-                    //event is fired before the task ends resulting in prefetcher.PrefetchingBehavior.InMemoryFutureIndexBatchesSize
-                    //not calculating the correct batches size. 
-                    SpinWait.SpinUntil(() => false, TimeSpan.FromMilliseconds(16));
-                        mre.Set();
-                    }
+                {
+                    mre.Set();
+                }
             };
 
             AddDocumentsToTransactionalStorage(prefetcher.TransactionalStorage, 2048);


### PR DESCRIPTION
…h task ends. This way we don't need to wait inside RavenDB_3581.MaybeAddFutureBatchWillFireUpAfterDownloadingSingleDocument test.

@talweiss1982 please take a look at this. This is instead of this b75d212838316677cebb17dd87e778f3299ab683
