### PR TITLE
RavenDB-3985 Avoid collecting info about deleted documents if the ind…

### DIFF
--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -895,6 +895,16 @@ namespace Raven.Database.Prefetching
 
         public void AfterDelete(string key, Etag deletedEtag)
         {
+            if (context.RunIndexing == false && PrefetchingUser == PrefetchingUser.Indexer)
+            {
+                // no need to collect info about deleted documents for the indexer's prefetcher when the indexing is disabled
+                // we use documentsToRemove collection to filter out already deleted documents retrieved by the prefetcher (FilterDocuments)
+                // and in order to skip deletions of docs inserted for the first time from an index (ShouldSkipDeleteFromIndex)
+                // because those two cases are important for the live indexing process, we can safely omit that when the indexing is off
+
+                return;
+            }
+
             documentsToRemove.AddOrUpdate(key, s => new HashSet<Etag> { deletedEtag },
                                           (s, set) => new HashSet<Etag>(set) { deletedEtag });
         }

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -453,6 +453,7 @@
     <Compile Include="RavenDB_3929.cs" />
     <Compile Include="RavenDB_3938.cs" />
     <Compile Include="RavenDB_3970.cs" />
+    <Compile Include="RavenDB_3985.cs" />
     <Compile Include="RavenDB_406.cs" />
     <Compile Include="RavenDB_410.cs" />
     <Compile Include="RavenDB_421.cs" />

--- a/Raven.Tests.Issues/RavenDB_3985.cs
+++ b/Raven.Tests.Issues/RavenDB_3985.cs
@@ -1,0 +1,48 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_3985.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Linq;
+using Raven.Abstractions.Data;
+using Raven.Tests.Issues.Prefetcher;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_3985 : PrefetcherTestBase
+    {
+        [Fact]
+        public void when_indexing_disabled_then_indexer_prefetcher_should_not_record_deleted_items()
+        {
+            var prefetcher = CreatePrefetcher();
+
+            prefetcher.WorkContext.StopIndexing();
+
+            AddDocumentsToTransactionalStorage(prefetcher.TransactionalStorage, 1);
+
+            var document = prefetcher.PrefetchingBehavior.GetDocumentsBatchFrom(Etag.Empty, 1).First();
+
+            // here we verify if item is present on documentsToRemove collection by using FilterDocuments and ShouldSkipDeleteFromIndex methods
+
+            Assert.True(prefetcher.PrefetchingBehavior.FilterDocuments(document));
+            document.SkipDeleteFromIndex = true; // simulate first insert
+            Assert.True(prefetcher.PrefetchingBehavior.ShouldSkipDeleteFromIndex(document));
+
+            prefetcher.PrefetchingBehavior.AfterDelete(document.Key, document.Etag);
+
+            Assert.True(prefetcher.PrefetchingBehavior.FilterDocuments(document));
+            document.SkipDeleteFromIndex = true; // simulate first insert
+            Assert.True(prefetcher.PrefetchingBehavior.ShouldSkipDeleteFromIndex(document));
+
+            prefetcher.WorkContext.StartIndexing();
+
+            prefetcher.PrefetchingBehavior.AfterDelete(document.Key, document.Etag);
+
+            Assert.False(prefetcher.PrefetchingBehavior.FilterDocuments(document));
+            document.SkipDeleteFromIndex = true; // simulate first insert
+            Assert.False(prefetcher.PrefetchingBehavior.ShouldSkipDeleteFromIndex(document));
+
+        }
+    }
+}


### PR DESCRIPTION
…exing is disabled. Previously it has caused large memory consumption when we had large number of writes and disabled indexing.
