### PR TITLE
Prefetching improvements

### DIFF
--- a/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
+++ b/Raven.Database/Bundles/SqlReplication/SqlReplicationTask.cs
@@ -440,7 +440,8 @@ namespace Raven.Database.Bundles.SqlReplication
         {
             foreach (var prefetchingBehavior in prefetchingBehaviors)
             {
-                if (prefetchingBehavior.CanUsePrefetcherToLoadFrom(fromEtag) && usedPrefetchers.TryAdd(prefetchingBehavior))
+                if (prefetchingBehavior.CanUsePrefetcherToLoadFrom(fromEtag, prefetchingBehavior == defaultPrefetchingBehavior) 
+                        && usedPrefetchers.TryAdd(prefetchingBehavior))
                     return prefetchingBehavior;
             }
 

--- a/Raven.Database/Indexing/IndexingExecuter.cs
+++ b/Raven.Database/Indexing/IndexingExecuter.cs
@@ -246,17 +246,12 @@ namespace Raven.Database.Indexing
         {
             foreach (var prefetchingBehavior in prefetchingBehaviors)
             {
-                if (prefetchingBehavior.CanUsePrefetcherToLoadFrom(fromEtag) && usedPrefetchers.TryAdd(prefetchingBehavior))
+                if (prefetchingBehavior.CanUsePrefetcherToLoadFrom(fromEtag, prefetchingBehavior == defaultPrefetchingBehavior)
+                        && usedPrefetchers.TryAdd(prefetchingBehavior))
                     return prefetchingBehavior;
             }
 
-            var newPrefetcher = prefetcher.CreatePrefetchingBehavior(PrefetchingUser.Indexer, autoTuner,string.Format("Etags from: {0}", fromEtag));
-
-            var recentEtag = Etag.Empty;
-            context.Database.TransactionalStorage.Batch(accessor =>
-            {
-                recentEtag = accessor.Staleness.GetMostRecentDocumentEtag();
-            });
+            var newPrefetcher = prefetcher.CreatePrefetchingBehavior(PrefetchingUser.Indexer, autoTuner, string.Format("Etags from: {0}", fromEtag));
 
             prefetchingBehaviors.Add(newPrefetcher);
             usedPrefetchers.Add(newPrefetcher);

--- a/Raven.Studio.Html5/App/views/indexes.html
+++ b/Raven.Studio.Html5/App/views/indexes.html
@@ -145,7 +145,7 @@
                                         <small class="badge" data-bind="visible: willReplaceIndex()"><i class="fa fa-arrow-left"></i> Side-by-side index (new)</small>
                                         <small class="badge" data-bind="visible: willBeReplacedByIndex()"><i class="fa fa-arrow-right"></i> Side-by-side index (old)</small>
                                         <small class="text-muted" data-bind="visible: isDisabled">Disabled</small>
-                                        <small class="text-muted" data-bind="text: ' - ' + docsCount + ' entries' " title=" the number of documents affected by this index"></small>
+                                        <small class="text-muted" data-bind="text: ' - ' + docsCount.toLocaleString() + ' entries' " title=" the number of documents affected by this index"></small>
                                         <label>
                                             <i class="fa" data-bind="css: { 'fa-unlock': lockMode() === 'Unlock' || lockMode() === 'LockedError', 'text-danger': lockMode() === 'LockedError', 'fa-lock': lockMode() === 'LockedIgnore' || lockMode() === 'SideBySide' }"></i>
                                         </label>


### PR DESCRIPTION
and RavenDB-4009 When early exist is used in loading docs from disk, emit a log warning