### PR TITLE
Bug fix - missing "CiHost" connection string in app.config of Raven.T…

### DIFF
--- a/Raven.Database/Server/WebApi/Handlers/ThrottlingHandler.cs
+++ b/Raven.Database/Server/WebApi/Handlers/ThrottlingHandler.cs
@@ -46,6 +46,11 @@ namespace Raven.Database.Server.WebApi.Handlers
                 }
                 return await base.SendAsync(request, cancellationToken);
             }
+            catch (TaskCanceledException e)
+            {
+                Logger.Info("Got task canceled exception: " + e);
+                return await HandleTooBusyError(request);
+            }
             finally
             {
                 if (waiting)

--- a/Raven.Tests.Bundles/app.config
+++ b/Raven.Tests.Bundles/app.config
@@ -8,8 +8,9 @@
         <add key="Raven/Bundles/LiveTest/Tenants/MaxIdleTimeForTenantResource" value="10" />
     </appSettings>
     <connectionStrings>
-        <add name="SqlExpress" providerName="System.Data.SqlClient" connectionString="Data Source=.\sqlexpress;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
-        <add name="LocalHost" providerName="System.Data.SqlClient" connectionString="Data Source=.;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
+      <add name="SqlExpress" providerName="System.Data.SqlClient" connectionString="Data Source=.\sqlexpress;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
+      <add name="LocalHost" providerName="System.Data.SqlClient" connectionString="Data Source=.;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
+      <add name="CiHost" providerName="System.Data.SqlClient" connectionString="Data Source=ci1\sqlexpress;Initial Catalog=Raven.Tests;Integrated Security=SSPI;Connection Timeout=1" />
     </connectionStrings>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
…ests.Bundles causes the SQL Replication tests to be skipped