### PR TITLE
RavenDB-3921 Make sure logs in tests (TestMemoryTarget) are cleaned u…

### DIFF
--- a/Raven.Tests.Common/RavenTest.cs
+++ b/Raven.Tests.Common/RavenTest.cs
@@ -54,12 +54,20 @@ namespace Raven.Tests.Common
 
         private void ShowLogsIfNecessary()
         {
-            if (!ShowLogs)
+            var testMemoryTarget = LogManager.GetTarget<TestMemoryTarget>();
+
+            if (testMemoryTarget == null)
                 return;
+
+            if (ShowLogs == false)
+            {
+                testMemoryTarget.ClearAll();
+                return;
+            }
             
             foreach (var databaseName in DatabaseNames)
             {
-                var target = LogManager.GetTarget<TestMemoryTarget>()[databaseName];
+                var target = testMemoryTarget[databaseName];
                 if (target == null)
                     continue;
 
@@ -77,6 +85,8 @@ namespace Raven.Tests.Common
                     WriteLine(writer);
                 }
             }
+
+            testMemoryTarget.ClearAll();
         }
 
         private static void WriteLine(TextWriter writer, string message = "")


### PR DESCRIPTION
…p after the test disposal - especially important for <system> database which would contain logs from previous tests.
