### PR TITLE
RavenDB-4058 Fixing RavenDB_2244.Does_not_throw_snapshot_error_on_tra…

### DIFF
--- a/Raven.Tests.Issues/RavenDB_2244.cs
+++ b/Raven.Tests.Issues/RavenDB_2244.cs
@@ -21,7 +21,7 @@ namespace Raven.Tests.Issues
         [Fact]
         public void Does_not_throw_snapshot_error_on_transaction_patch_batch()
         {
-            using (var documentStore = this.NewDocumentStore())
+            using (var documentStore = this.NewDocumentStore(requestedStorage: "esent"))
             {
                 documentStore.DatabaseCommands.Put("Company/1", null, new RavenJObject(), new RavenJObject());
 


### PR DESCRIPTION
…nsaction_patch_batch test by forcing it to use Esent which supports DTC
