### PR TITLE
RavenDB-4129 [4.0] Fixing changes API usage in bulk insert tests - we must …

### DIFF
--- a/Raven.Tests.Core/BulkInsert/ChunkedBulkInsert.cs
+++ b/Raven.Tests.Core/BulkInsert/ChunkedBulkInsert.cs
@@ -1,11 +1,9 @@
 using Raven.Abstractions.Data;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+
 using Xunit;
 
 namespace Raven.Tests.Core.BulkInsert
@@ -32,25 +30,27 @@ namespace Raven.Tests.Core.BulkInsert
             var bulkInsertStartsCounter = 0;
             using (var store = GetDocumentStore())
             {
-                using (var bulkInsert = store.BulkInsert(options:new Abstractions.Data.BulkInsertOptions{
-                ChunkedBulkInsertOptions = new ChunkedBulkInsertOptions{
-                    MaxChunkVolumeInBytes = 5
-                }
+                store.Changes().Task.Result.ForBulkInsert().Task.Result.Subscribe(x =>
+                {
+                    if (x.Type == DocumentChangeTypes.BulkInsertStarted)
+                        Interlocked.Increment(ref bulkInsertStartsCounter);
+                });
+
+                using (var bulkInsert = store.BulkInsert(options: new BulkInsertOptions
+                {
+                    ChunkedBulkInsertOptions = new ChunkedBulkInsertOptions
+                    {
+                        MaxChunkVolumeInBytes = 5
+                    }
                 }))
                 {
-                    store.Changes().Task.Result.ForBulkInsert(bulkInsert.OperationId).Task.Result.Subscribe(x =>
-                    {
-                        if (x.Type == DocumentChangeTypes.BulkInsertStarted)
-                            Interlocked.Increment(ref bulkInsertStartsCounter);
-                    });
-                    
                     for (int i = 0; i < 20; i++)
                     {
                         bulkInsert.Store(new Node
-                                {
-                                    Name = "Parent",
-                                    Children = Enumerable.Range(0, 5).Select(x => new Node { Name = "Child" + x }).ToArray()
-                                }); 
+                        {
+                            Name = "Parent",
+                            Children = Enumerable.Range(0, 5).Select(x => new Node { Name = "Child" + x }).ToArray()
+                        });
                     }
                 }
                 Assert.Equal(20, bulkInsertStartsCounter);
@@ -58,7 +58,7 @@ namespace Raven.Tests.Core.BulkInsert
                 using (var session = store.OpenSession())
                 {
                     var count = session.Query<Node>().Count();
-                    Assert.Equal(20,count);
+                    Assert.Equal(20, count);
                 }
             }
 
@@ -70,33 +70,36 @@ namespace Raven.Tests.Core.BulkInsert
             var bulkInsertStartsCounter = 0;
             using (var store = GetDocumentStore())
             {
-                using (var bulkInsert = store.BulkInsert(options:new Abstractions.Data.BulkInsertOptions{
-                ChunkedBulkInsertOptions = new ChunkedBulkInsertOptions{
-                    MaxChunkVolumeInBytes = 10*1024
-                }
+                store.Changes().Task.Result.ForBulkInsert().Task.Result.Subscribe(x =>
+                {
+                    if (x.Type == DocumentChangeTypes.BulkInsertStarted)
+                        Interlocked.Increment(ref bulkInsertStartsCounter);
+                });
+
+                using (var bulkInsert = store.BulkInsert(options: new Abstractions.Data.BulkInsertOptions
+                {
+                    ChunkedBulkInsertOptions = new ChunkedBulkInsertOptions
+                    {
+                        MaxChunkVolumeInBytes = 10 * 1024
+                    }
                 }))
                 {
-                    store.Changes().Task.Result.ForBulkInsert(bulkInsert.OperationId).Task.Result.Subscribe(x =>
-                    {
-                        if (x.Type == DocumentChangeTypes.BulkInsertStarted)
-                            Interlocked.Increment(ref bulkInsertStartsCounter);
-                    });
-                    
                     for (int i = 0; i < 20; i++)
                     {
                         bulkInsert.Store(new Node
-                                {
-                                    Name = "Parent",
-                                    Children = Enumerable.Range(0, 5).Select(x => new Node { Name = "Child" + x }).ToArray()
-                                }); 
+                        {
+                            Name = "Parent",
+                            Children = Enumerable.Range(0, 5).Select(x => new Node { Name = "Child" + x }).ToArray()
+                        });
                     }
                 }
+
                 Assert.Equal(1, bulkInsertStartsCounter);
                 WaitForIndexing(store);
                 using (var session = store.OpenSession())
                 {
                     var count = session.Query<Node>().Count();
-                    Assert.Equal(20,count);
+                    Assert.Equal(20, count);
                 }
             }
 
@@ -108,6 +111,13 @@ namespace Raven.Tests.Core.BulkInsert
             var bulkInsertStartsCounter = 0;
             using (var store = GetDocumentStore())
             {
+                store.Changes().Task.Result.ForBulkInsert().Task.Result.Subscribe(x =>
+                {
+                    if (x.Type == DocumentChangeTypes.BulkInsertStarted)
+                        Interlocked.Increment(ref bulkInsertStartsCounter);
+                });
+
+
                 using (var bulkInsert = store.BulkInsert(options: new Abstractions.Data.BulkInsertOptions
                 {
                     ChunkedBulkInsertOptions = new ChunkedBulkInsertOptions
@@ -116,12 +126,6 @@ namespace Raven.Tests.Core.BulkInsert
                     }
                 }))
                 {
-                    store.Changes().Task.Result.ForBulkInsert(bulkInsert.OperationId).Task.Result.Subscribe(x =>
-                    {
-                        if (x.Type == DocumentChangeTypes.BulkInsertStarted)
-                            Interlocked.Increment(ref bulkInsertStartsCounter);
-                    });
-
                     for (int i = 0; i < 20; i++)
                     {
                         bulkInsert.Store(new Node
@@ -146,8 +150,18 @@ namespace Raven.Tests.Core.BulkInsert
         public void DocumentsInChunkConstraintMakeSureUnneedConnectionsNotCreated()
         {
             var bulkInsertStartsCounter = 0;
+            var mre = new ManualResetEventSlim();
             using (var store = GetDocumentStore())
             {
+                store.Changes().Task.Result.ForBulkInsert().Task.Result.Subscribe(x =>
+                {
+                    if (x.Type == DocumentChangeTypes.BulkInsertStarted)
+                    {
+                        Interlocked.Increment(ref bulkInsertStartsCounter);
+                        mre.Set();
+                    }
+                });
+
                 using (var bulkInsert = store.BulkInsert(options: new Abstractions.Data.BulkInsertOptions
                 {
                     ChunkedBulkInsertOptions = new ChunkedBulkInsertOptions
@@ -156,12 +170,6 @@ namespace Raven.Tests.Core.BulkInsert
                     }
                 }))
                 {
-                    store.Changes().Task.Result.ForBulkInsert(bulkInsert.OperationId).Task.Result.Subscribe(x =>
-                    {
-                        if (x.Type == DocumentChangeTypes.BulkInsertStarted)
-                            Interlocked.Increment(ref bulkInsertStartsCounter);
-                    });
-
                     for (int i = 0; i < 20; i++)
                     {
                         bulkInsert.Store(new Node
@@ -170,7 +178,7 @@ namespace Raven.Tests.Core.BulkInsert
                         });
                     }
                 }
-
+                mre.Wait(1000);
                 Assert.Equal(1, bulkInsertStartsCounter);
                 WaitForIndexing(store);
                 using (var session = store.OpenSession())
@@ -187,24 +195,25 @@ namespace Raven.Tests.Core.BulkInsert
             var bulkInsertStartsCounter = new ConcurrentDictionary<Guid, BulkInsertChangeNotification>();
             using (var store = GetDocumentStore())
             {
-                for (var i=0; i<10; i++)
+                store.Changes().Task.Result.ForBulkInsert().Task.Result.Subscribe(x =>
+                {
+                    if (x.Type == DocumentChangeTypes.BulkInsertStarted)
+                        Assert.True(bulkInsertStartsCounter.TryAdd(x.OperationId, x));
+                });
+
+                for (var i = 0; i < 10; i++)
                 {
                     using (var bulkInsert = store.BulkInsert())
                     {
-                        store.Changes().Task.Result.ForBulkInsert(bulkInsert.OperationId).Task.Result.Subscribe(x =>
-                        {
-                            if (x.Type == DocumentChangeTypes.BulkInsertStarted)
-                                Assert.True(bulkInsertStartsCounter.TryAdd(x.OperationId,x));
-                        });
-                        
                         bulkInsert.Store(new Node
                         {
                             Name = "Parent",
-                            Children = Enumerable.Range(0, 5).Select(x => new Node {Name = "Child" + x}).ToArray()
+                            Children = Enumerable.Range(0, 5).Select(x => new Node { Name = "Child" + x }).ToArray()
                         });
                     }
                 }
             }
+
             Assert.Equal(10, bulkInsertStartsCounter.Count);
 
         }


### PR DESCRIPTION
…not subscribe to BulkInsertStarted notification after we already started it.
