### PR TITLE
RavenDB-4154

### DIFF
--- a/Raven.Abstractions/Replication/ReplicationStatistics.cs
+++ b/Raven.Abstractions/Replication/ReplicationStatistics.cs
@@ -34,6 +34,7 @@ namespace Raven.Abstractions.Replication
         public DateTime? LastHeartbeatReceived { get; set; }
         public Etag LastEtagCheckedForReplication { get; set; }
         public Etag LastReplicatedEtag { get; set; }
+        public Etag LastReplicatedAttachmentEtag { get; set; }
         public DateTime? LastReplicatedLastModified { get; set; }
         public DateTime? LastSuccessTimestamp { get; set; }
         public DateTime? LastFailureTimestamp { get; set; }

--- a/Raven.Studio.Html5/App/models/dto.ts
+++ b/Raven.Studio.Html5/App/models/dto.ts
@@ -336,6 +336,7 @@ interface replicationStatsDto {
     LastHeartbeatReceived: string;
     LastEtagCheckedForReplication: string;
     LastReplicatedEtag: string;
+    LastReplicatedAttachmentEtag: string;
     LastReplicatedLastModified: string;
     LastSuccessTimestamp: string;
     LastFailureTimestamp: string;

--- a/Raven.Studio.Html5/App/views/replicationStats.html
+++ b/Raven.Studio.Html5/App/views/replicationStats.html
@@ -87,6 +87,12 @@
                                 </div>
                             </div>
                             <div class="form-group">
+                                <label class="col-md-2 control-label">Last replicated Attachment ETag</label>
+                                <div class="col-md-8">
+                                    <p class="form-control-static" data-bind="text: LastReplicatedAttachmentEtag"></p>
+                                </div>
+                            </div>
+                            <div class="form-group">
                                 <label class="col-md-2 control-label">Last checked ETag</label>
                                 <div class="col-md-8">
                                     <p class="form-control-static" data-bind="text: LastEtagCheckedForReplication"></p>


### PR DESCRIPTION
RavenDB-4154:
seperated DestinationStats LastReplicatedEtag into LastReplicatedAttachmentEtag and LastReplicatedDocumentEtag
