### PR TITLE
RavenDB-4125 (Failing raft tests)

### DIFF
--- a/Raven.Abstractions/Replication/ReplicationDocument.cs
+++ b/Raven.Abstractions/Replication/ReplicationDocument.cs
@@ -59,12 +59,13 @@ namespace Raven.Abstractions.Replication
     {
         public ReplicationDocumentWithClusterInformation()
         {
-            ClusterInformation = ClusterInformation.NotInCluster;
+            ClusterInformation = new ClusterInformation(false,false);
             ClusterCommitIndex = -1;
+            Term = -1;
         }
 
         public ClusterInformation ClusterInformation { get; set; }
-
+        public long Term { get; set; }
         public long ClusterCommitIndex { get; set; }
     }
 }

--- a/Raven.Client.Lightweight/Connection/Request/ClusterAwareRequestExecuter.cs
+++ b/Raven.Client.Lightweight/Connection/Request/ClusterAwareRequestExecuter.cs
@@ -346,7 +346,12 @@ namespace Raven.Client.Connection.Request
 
                         var newestTopology = replicationDocuments
                             .Where(x => x.Task.Result != null)
-                            .OrderByDescending(x => x.Task.Result.ClusterCommitIndex)
+                            .OrderByDescending(x=>x.Task.Result.Term)
+                            .ThenBy(x =>
+                            {
+                                var index = x.Task.Result.ClusterCommitIndex;
+                                return x.Task.Result.ClusterInformation.IsLeader ? index + 1 : index;
+                            })
                             .FirstOrDefault();
 
                         if (newestTopology == null && FailoverServers != null && FailoverServers.Length > 0 && tryFailoverServers == false)

--- a/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
+++ b/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
@@ -173,6 +173,7 @@ namespace Raven.Database.Bundles.Replication.Controllers
 
             var isInCluster = ClusterManager.IsActive() && Database.IsClusterDatabase();
             var commitIndex = isInCluster ? ClusterManager.Engine.CommitIndex : -1;
+            var term = isInCluster ? ClusterManager.Engine.PersistentState.CurrentTerm : -1;
             var currentTopology = isInCluster ? ClusterManager.Engine.CurrentTopology : null;
             var currentLeader = ClusterManager.Engine.CurrentLeader;
             var isLeader = currentLeader == ClusterManager.Engine.Options.SelfConnection.Name;
@@ -182,7 +183,8 @@ namespace Raven.Database.Bundles.Replication.Controllers
                 ClientConfiguration = mergedDocument.ClientConfiguration,
                 Id = mergedDocument.Id,
                 Source = mergedDocument.Source,
-                ClusterCommitIndex = commitIndex
+                ClusterCommitIndex = commitIndex,
+                Term = term
             };
 
             if (isInCluster)


### PR DESCRIPTION
Fixing an issue where we would take the latest topology from the first node that claims to be the leader while there could be multiple such nodes.
Now we pick the one with the highest Term first only then we look at the commit index.