### PR TITLE
cosmetic: documents view will run a filter on collection labels, repl…

### DIFF
--- a/Raven.Studio.Html5/App/views/documents.html
+++ b/Raven.Studio.Html5/App/views/documents.html
@@ -14,7 +14,7 @@
                 <a href="javascript:void(0)">
                     <div class="collection-name">
                         <div class="collection-text pull-left collection-color-strip" data-bind="css: colorClass"></div>
-                        <span class="collection-text pull-left collection-name-part" data-bind=" text: name, attr: {title: name}"></span>
+                        <span class="collection-text pull-left collection-name-part" data-bind=" text: name.replace('__','\/'), attr: {title: name}"></span>
                         <span class="collection-text pull-left text-muted" data-bind="visible: !isSystemDocuments && !isAllDocuments, css: { 'text-muted': $data !== $parent.selectedCollection() }, text:  '&nbsp;(' + documentsCountWithThousandsSeparator() + ')'"></span>
                     </div>
                 </a>


### PR DESCRIPTION
pursuant to raven db google groups post: https://groups.google.com/forum/#!topic/ravendb/XlfVUSMsLOI

Cosmetic: documents view will run a filter on collection labels, replacing double underscore **(__)** with a forward slash **(/)**. This will give a way to group collections while preserving C# viable `Raven-Entity-Name`.

I did this out of my own OCD - having all of the collections just verbatim dumped into the list drives me crazy. I, and many programmers I know, work better when we've got some control over the way things are sorted and arranged.

It's a small change, and the ideal situation would just be a metadata **Raven-Entity-Label** that can keep it separate from the actual Entity Name. I am simply out of my depth for adding a new metadata into Raven. I was also advised to avoid that part of the problem, and focus only on the cosmetic I wished to achieve.

Since the Raven-Entity-Name has to conform to C# property standards, it cannot have any special characters except an underscore - it's not common to see two underscores together, though, so this seemed like a good convention.

I couldn't write any tests for this, I'm sorry. I do not know how to write unit tests for visual components. I did however compile and run the solution and experienced no troubles.

This would turn..

    entity
    entity__one
    entity__one__two

into

    entity
    entity/one
    entity/one/two

I realize this may seem like an extremely silly request, but please consider it. Little quirks like this are what compound to more user friendliness, and this one is fairly important to me. 