### PR TITLE
RavenDB-4098 Getting rid of timers created manually in file system in…

### DIFF
--- a/Raven.Database/FileSystem/Actions/TaskActions.cs
+++ b/Raven.Database/FileSystem/Actions/TaskActions.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,21 +22,17 @@ namespace Raven.Database.FileSystem.Actions
     {
         private readonly ConcurrentDictionary<long, PendingTaskWithStateAndDescription> pendingTasks = new ConcurrentDictionary<long, PendingTaskWithStateAndDescription>();
 
-        private readonly IObservable<long> timer;
-
         private long pendingTaskCounter;
 
         public TaskActions(RavenFileSystem fileSystem, ILog log)
             : base(fileSystem, log)
         {
-            timer = Observable.Interval(TimeSpan.FromMinutes(1));
-
             InitializeTimer();
         }
 
         private void InitializeTimer()
         {
-            timer.Subscribe(tick => ClearCompletedPendingTasks());
+            FileSystem.TimerManager.NewTimer(state => ClearCompletedPendingTasks(), TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
         }
 
         private void ClearCompletedPendingTasks()

--- a/Raven.Database/FileSystem/RavenFileSystem.cs
+++ b/Raven.Database/FileSystem/RavenFileSystem.cs
@@ -96,6 +96,8 @@ namespace Raven.Database.FileSystem
 
                 conflictArtifactManager = new ConflictArtifactManager(storage, search);
 
+                TimerManager = new ResourceTimerManager();
+
                 Tasks = new TaskActions(this, Log);
                 Files = new FileActions(this, Log);
                 Synchronizations = new SynchronizationActions(this, Log);
@@ -123,6 +125,8 @@ namespace Raven.Database.FileSystem
         public FileActions Files { get; private set; }
 
         public SynchronizationActions Synchronizations { get; private set; }
+
+        public ResourceTimerManager TimerManager { get; }
 
         public void Initialize()
         {
@@ -411,6 +415,9 @@ namespace Raven.Database.FileSystem
 
             if (Tasks != null)
                 Tasks.Dispose(exceptionAggregator);
+
+            if (TimerManager != null)
+                exceptionAggregator.Execute(TimerManager.Dispose);
 
             exceptionAggregator.ThrowIfNeeded();
         }

--- a/Raven.Tests.FileSystem/Issues/RavenDB_4164.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_4164.cs
@@ -3,22 +3,20 @@
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Exceptions;
 using Raven.Abstractions.FileSystem;
 using Raven.Database.FileSystem.Actions;
-using Raven.Tests.FileSystem;
 using Raven.Tests.FileSystem.Synchronization.IO;
-
 using Xunit;
 
-namespace Raven.Tests.Issues
+namespace Raven.Tests.FileSystem.Issues
 {
     public class RavenDB_4164 : RavenFilesTestWithLogs
     {


### PR DESCRIPTION
… favor of the usage of ResourceTimerManager to prevent from leaking. Fixing namespace in one file system test.
