### PR TITLE
RavenDB-4208 File streaming should respect pageSize parameter. Also c…

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
+++ b/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
@@ -302,153 +302,41 @@ namespace Raven.Client.FileSystem
 
             var operationMetadata = new OperationMetadata(this.BaseUrl, this.CredentialsThatShouldBeUsedOnlyInOperationsWithoutReplication);
 
-            if (pageSize != int.MaxValue)
+            var sb = new StringBuilder(operationMetadata.Url)
+                .Append("/streams/files?etag=")
+                .Append(fromEtag)
+                .Append("&pageSize=")
+                .Append(pageSize);
+
+            var request = RequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, sb.ToString(), "GET", operationMetadata.Credentials, this.Conventions)
+                                        .AddOperationHeaders(OperationsHeaders));
+
+            request.RemoveAuthorizationHeader();
+
+            var tokenRetriever = new SingleAuthTokenRetriever(this, RequestFactory, Conventions, OperationsHeaders, operationMetadata);
+
+            var token = await tokenRetriever.GetToken().ConfigureAwait(false);
+            try
             {
-                return new EtagStreamResults(this, fromEtag, pageSize);
+                token = await tokenRetriever.ValidateThatWeCanUseToken(token).ConfigureAwait(false);
             }
-            else
+            catch (Exception e)
             {
-                var sb = new StringBuilder(operationMetadata.Url)
-                    .Append("/streams/files?etag=")
-                    .Append(fromEtag)
-                    .Append("&pageSize=")
-                    .Append(pageSize);
+                request.Dispose();
 
-                var request = RequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, sb.ToString(), "GET", operationMetadata.Credentials, this.Conventions)
-                                            .AddOperationHeaders(OperationsHeaders));
-
-                request.RemoveAuthorizationHeader();
-
-                var tokenRetriever = new SingleAuthTokenRetriever(this, RequestFactory, Conventions, OperationsHeaders, operationMetadata);
-
-                var token = await tokenRetriever.GetToken().ConfigureAwait(false);
-                try
-                {
-                    token = await tokenRetriever.ValidateThatWeCanUseToken(token).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    request.Dispose();
-
-                    throw new InvalidOperationException(
-                        "Could not authenticate token for query streaming, if you are using ravendb in IIS make sure you have Anonymous Authentication enabled in the IIS configuration",
-                        e);
-                }
-                request.AddOperationHeader("Single-Use-Auth-Token", token);
-
-                var response = await request.ExecuteRawResponseAsync()
-                                            .ConfigureAwait(false);
-
-                await response.AssertNotFailingResponse().ConfigureAwait(false);
-
-                return new YieldStreamResults(request, await response.GetResponseStreamWithHttpDecompression().ConfigureAwait(false));
-            }
-        }
-
-        internal class EtagStreamResults : IAsyncEnumerator<FileHeader>
-        {
-            private readonly AsyncFilesServerClient client;
-            private readonly OperationMetadata operationMetadata;
-            private readonly NameValueCollection headers;
-            private readonly Etag startEtag;
-            private readonly int pageSize;
-            private readonly FilesConvention conventions;
-            private readonly HttpJsonRequestFactory requestFactory;
-
-            private bool complete;
-            private bool wasInitialized;
-
-            private FileHeader current;
-            private YieldStreamResults currentStream;
-
-            private Etag currentEtag;
-            private int currentPageCount = 0;
-
-
-            public EtagStreamResults(AsyncFilesServerClient client, Etag startEtag, int pageSize)
-            {
-                this.client = client;
-                this.startEtag = startEtag;
-                this.pageSize = pageSize;
-
-                this.requestFactory = client.RequestFactory;
-                this.operationMetadata = new OperationMetadata(client.BaseUrl, client.CredentialsThatShouldBeUsedOnlyInOperationsWithoutReplication);
-                this.headers = client.OperationsHeaders;
-                this.conventions = client.Conventions;
+                throw new InvalidOperationException(
+                    "Could not authenticate token for query streaming, if you are using ravendb in IIS make sure you have Anonymous Authentication enabled in the IIS configuration",
+                    e);
             }
 
-            private async Task RequestPage(Etag etag)
-            {
-                if (currentStream != null)
-                    currentStream.Dispose();
+            request.AddOperationHeader("Single-Use-Auth-Token", token);
 
-                var sb = new StringBuilder(operationMetadata.Url)
-                       .Append("/streams/files?etag=")
-                       .Append(etag)
-                       .Append("&pageSize=")
-                       .Append(pageSize);
+            var response = await request.ExecuteRawResponseAsync()
+                                        .ConfigureAwait(false);
 
-                var request = requestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(client, sb.ToString(), "GET", operationMetadata.Credentials, conventions)
-                                            .AddOperationHeaders(headers));
+            await response.AssertNotFailingResponse().ConfigureAwait(false);
 
-                var response = await request.ExecuteRawResponseAsync()
-                                            .ConfigureAwait(false);
-
-                await response.AssertNotFailingResponse().ConfigureAwait(false);
-
-                currentPageCount = 0;
-                currentEtag = etag;
-                currentStream = new YieldStreamResults(request, await response.GetResponseStreamWithHttpDecompression().ConfigureAwait(false));
-            }
-
-            public async Task<bool> MoveNextAsync()
-            {
-                if (complete)
-                {
-                    // to parallel IEnumerable<T>, subsequent calls to MoveNextAsync after it has returned false should
-                    // also return false, rather than throwing
-                    return false;
-                }
-
-                if (wasInitialized == false)
-                {
-                    await RequestPage(startEtag).ConfigureAwait(false);
-                    wasInitialized = true;
-                }
-
-                if (await currentStream.MoveNextAsync().ConfigureAwait(false) == false)
-                {
-                    // We didn't finished the page, so there is no more data to retrieve.
-                    if (currentPageCount < pageSize)
-                    {
-                        complete = true;
-                        return false;
-                    }
-                    else
-                    {
-                        await RequestPage(current.Etag).ConfigureAwait(false);
-                        return await this.MoveNextAsync().ConfigureAwait(false);
-                    }
-                }
-                else
-                {
-                    current = currentStream.Current;
-                    currentPageCount++;
-
-                    return true;
-                }
-            }
-
-            public FileHeader Current
-            {
-                get { return current; }
-            }
-
-            public void Dispose()
-            {
-                if (currentStream != null)
-                    currentStream.Dispose();
-            }
+            return new YieldStreamResults(request, await response.GetResponseStreamWithHttpDecompression().ConfigureAwait(false));
         }
 
         internal class YieldStreamResults : IAsyncEnumerator<FileHeader>

--- a/Raven.Database/FileSystem/Controllers/FilesStreamsController.cs
+++ b/Raven.Database/FileSystem/Controllers/FilesStreamsController.cs
@@ -57,17 +57,39 @@ namespace Raven.Database.FileSystem.Controllers
 
                 Storage.Batch(accessor =>
                 {
-                    var files = accessor.GetFilesAfter(etag, pageSize);
-                    foreach (var file in files)
+                    var returnedCount = 0;
+
+                    while (true)
                     {
-                        if (readTriggers.CanReadFile(file.FullPath, file.Metadata, ReadOperation.Load) == false)
-                            continue;
+                        var files = accessor.GetFilesAfter(etag, pageSize);
 
-                        timeout.Delay();
-                        var doc = RavenJObject.FromObject(file);
-                        doc.WriteTo(writer);
+                        var fileCount = 0;
 
-                        writer.WriteRaw(Environment.NewLine);
+                        foreach (var file in files)
+                        {
+                            fileCount++;
+
+                            cts.Token.ThrowIfCancellationRequested();
+
+                            etag = file.Etag;
+
+                            if (readTriggers.CanReadFile(file.FullPath, file.Metadata, ReadOperation.Load) == false)
+                                continue;
+
+                            timeout.Delay();
+
+                            var doc = RavenJObject.FromObject(file);
+                            doc.WriteTo(writer);
+                            writer.WriteRaw(Environment.NewLine);
+
+                            returnedCount++;
+                        }
+
+                        if (fileCount == 0)
+                            break;
+
+                        if (returnedCount == pageSize)
+                            break;
                     }
                 });
 

--- a/Raven.Tests.FileSystem/Issues/RavenDB_4208.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_4208.cs
@@ -1,0 +1,116 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_4208.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Threading.Tasks;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.FileSystem;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+    public class RavenDB_4208 : RavenFilesTestBase
+    {
+        [Fact]
+        public async Task streaming_of_file_headers_respects_pageSize_parameter()
+        {
+            using (var store = NewStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 20; i++)
+                        session.RegisterUpload(i + ".file", CreateRandomFileStream(5));
+
+                    await session.SaveChangesAsync();
+                }
+                
+                using (var session = store.OpenAsyncSession())
+                {
+                    int count = 0;
+
+                    using (var reader = await session.Commands.StreamFileHeadersAsync(Etag.Empty, pageSize: 10))
+                    {
+                        while (await reader.MoveNextAsync())
+                        {
+                            count++;
+                            Assert.IsType<FileHeader>(reader.Current);
+                        }
+                    }
+
+                    Assert.Equal(10, count);
+                }
+            } 
+        }
+
+        [Fact]
+        public async Task streaming_of_file_headers_can_return_fewer_results_than_specified_pageSize_parameter_if_there_is_no_more_files()
+        {
+            using (var store = NewStore())
+            {
+                Etag etagOfFifteenthFile;
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 20; i++)
+                        session.RegisterUpload(i + ".file", CreateRandomFileStream(5));
+
+                    await session.SaveChangesAsync();
+
+                    var fifeteenth = await session.LoadFileAsync("14.file");
+                    etagOfFifteenthFile = fifeteenth.Etag;
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    int count = 0;
+
+                    using (var reader = await session.Commands.StreamFileHeadersAsync(etagOfFifteenthFile, pageSize: 10))
+                    {
+                        while (await reader.MoveNextAsync())
+                        {
+                            count++;
+                            Assert.IsType<FileHeader>(reader.Current);
+                        }
+                    }
+
+                    Assert.Equal(5, count);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task streaming_of_file_headers_does_not_return_deleting_files_RavenDB_3047_and_respects_pageSize_parameter()
+        {
+            using (var store = NewStore())
+            {
+                for (int i = 0; i < 20; i++)
+                {
+                    await store.AsyncFilesCommands.UploadAsync(i + ".file", CreateRandomFileStream(5));
+                    await store.AsyncFilesCommands.UploadAsync(i + ".file", CreateRandomFileStream(5)); // override is going to create .deleting file
+                }
+
+                for (int i = 20; i < 33; i++)
+                {
+                    await store.AsyncFilesCommands.UploadAsync(i + ".file", CreateRandomFileStream(5));
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    int count = 0;
+
+                    using (var reader = await session.Commands.StreamFileHeadersAsync(Etag.Empty, pageSize: 10))
+                    {
+                        while (await reader.MoveNextAsync())
+                        {
+                            count++;
+                            Assert.IsType<FileHeader>(reader.Current);
+                        }
+                    }
+
+                    Assert.Equal(10, count);
+                }
+            }
+        }
+    }
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Issues\RavenDB_4092.cs" />
     <Compile Include="Issues\RavenDB_4164.cs" />
     <Compile Include="Issues\RavenDB_4206.cs" />
+    <Compile Include="Issues\RavenDB_4208.cs" />
     <Compile Include="Issues\RavenDB_FEI_2.cs" />
     <Compile Include="Issues\RavenDB_3648.cs" />
     <Compile Include="Issues\RavenDB_2889.cs" />

--- a/Raven.Tests.FileSystem/StreamingTests.cs
+++ b/Raven.Tests.FileSystem/StreamingTests.cs
@@ -64,6 +64,9 @@ namespace Raven.Tests.FileSystem
                         session.RegisterUpload(i + ".file", CreateUniformFileStream(10));
 
                     await session.SaveChangesAsync();
+
+                    var tenthFile = await session.LoadFileAsync("9.file");
+                    fromEtag = tenthFile.Etag;
                 }
 
                 int count = 0;
@@ -78,7 +81,7 @@ namespace Raven.Tests.FileSystem
                         }
                     }
                 }
-                Assert.Equal(50, count);
+                Assert.Equal(10, count);
             }
         }
     }


### PR DESCRIPTION
…hanging the fix for RavenDB-3047 (and actually fixing it) by moving the retrieval of streamed files to server side completely - getting rid of EtagStreamResults class used to gather more files if they has been filtered on the server side.
