### PR TITLE
RavenDB-4215 IndexDoesNotExistsException: There is no reduce index named

### DIFF
--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -325,9 +325,16 @@ namespace Raven.Database.Prefetching
 
                 docsLoaded = TryGetDocumentsFromQueue(nextEtagToIndex, result, take);
 
-                // we removed some documents from the queue
-                // we'll try to create a new future batch, if possible
-                MaybeAddFutureBatch(result.LastOrDefault());
+                // we don't need to add a future batch to a prefetcher that
+                // gets the documents after commit -> the default o,
+                // except when we disabled collecting documents after commit
+                if (ShouldHandleUnusedDocumentsAddedAfterCommit == false || 
+                    DisableCollectingDocumentsAfterCommit)
+                {
+                    // we removed some documents from the queue
+                    // we'll try to create a new future batch, if possible
+                    MaybeAddFutureBatch(result.LastOrDefault());
+                }
 
                 if (docsLoaded)
                 {

--- a/Raven.Database/Storage/Esent/StorageActions/Indexing.cs
+++ b/Raven.Database/Storage/Esent/StorageActions/Indexing.cs
@@ -331,8 +331,11 @@ namespace Raven.Database.Storage.Esent.StorageActions
             Api.JetSetCurrentIndex(session, IndexesEtags, "by_key");
             Api.MakeKey(session, IndexesEtags, id, MakeKeyGrbit.NewKey);
             if (Api.TrySeek(session, IndexesEtags, SeekGrbit.SeekEQ) == false)
-                throw new IndexDoesNotExistsException("There is no reduce index named: " + id);
-
+            {
+                // index doesn't exist
+                return;
+            }
+                
             Api.EscrowUpdate(session, IndexesEtags, tableColumnsCache.IndexesEtagsColumns["touches"], 1);
         }
 

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -138,6 +138,7 @@
     <Compile Include="1379\RavenDB_1379_Client_Lazy.cs" />
     <Compile Include="1379\RavenDB_1379_Client_Remote.cs" />
     <Compile Include="ActualValueInJsonReaderException.cs" />
+    <Compile Include="RavenDB_4215.cs" />
     <Compile Include="RavenDB-4210.cs" />
     <Compile Include="RavenDB-4153.cs" />
     <Compile Include="RavenDB-4144.cs" />

--- a/Raven.Tests.Issues/RavenDB_4215.cs
+++ b/Raven.Tests.Issues/RavenDB_4215.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------
+//  <copyright file="RavenDB-4215.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using Raven.Tests.Common;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_4215 : RavenTest
+    {
+        [Theory]
+        [PropertyData("Storages")]
+        public void touch_index_etag_if_index_doesnt_exist(string requestedStorage)
+        {
+            using (var storage = NewTransactionalStorage(requestedStorage))
+            {
+                storage.Batch(accessor => accessor.Indexing.AddIndex(101, true));
+
+                storage.Batch(accessor =>
+                {
+                    var stat1 = accessor.Indexing.GetIndexStats(101);
+                    Assert.Equal(101, stat1.Id);
+                    Assert.Equal(0, stat1.TouchCount);
+                });
+
+                storage.Batch(accessor => accessor.Indexing.TouchIndexEtag(101));
+
+                storage.Batch(accessor =>
+                {
+                    var stat1 = accessor.Indexing.GetIndexStats(101);
+                    Assert.Equal(101, stat1.Id);
+                    Assert.Equal(1, stat1.TouchCount);
+                });
+
+                storage.Batch(accessor => accessor.Indexing.PrepareIndexForDeletion(101));
+
+                storage.Batch(accessor => accessor.Indexing.TouchIndexEtag(101));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will prevent an infinite loop when executing a RemoveFromIndex task.