### PR TITLE
RavenDB-4132: Root Objects headers should be more uniform.

### DIFF
--- a/RavenDB-Dnx.sln
+++ b/RavenDB-Dnx.sln
@@ -89,4 +89,7 @@ Global
 		{BE39FC8A-4668-43A0-972C-73827DE07CC1} = {02838C57-DE0E-465D-9FBB-248DA87BEAAE}
 		{FB4ACC78-7620-4C29-A46E-C1620409B3F2} = {764C36EA-83A0-4BA3-BA36-53A6808C13A9}
 	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = 6944aade-3195-477c-8aed-9ebe2902fc57
+	EndGlobalSection
 EndGlobal

--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -172,7 +172,7 @@ namespace Voron.Data.BTrees
 		{
 			Slice valueToInsert = value;
 
-			var requiredPageSize = Constants.TreePageHeaderSize + SizeOf.LeafEntry(-1, valueToInsert, 0) + Constants.NodeOffsetSize;
+			var requiredPageSize = Constants.TreePageHeaderSize + TreeSizeOf.LeafEntry(-1, valueToInsert, 0) + Constants.NodeOffsetSize;
 			if (requiredPageSize > maxNodeSize)
 			{
 				// no choice, very big value, we might as well just put it in its own tree from the get go...

--- a/src/Voron/Data/BTrees/TreeFlags.cs
+++ b/src/Voron/Data/BTrees/TreeFlags.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Voron.Impl.FileHeaders
+namespace Voron.Data.BTrees
 {
     [Flags]
     public enum TreeFlags : byte

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -269,7 +269,7 @@ namespace Voron.Data.BTrees
                 KeysOffsets[i] = KeysOffsets[i - 1];
             }
 
-            var nodeSize = SizeOf.NodeEntry(PageMaxSpace, key, len);
+            var nodeSize = TreeSizeOf.NodeEntry(PageMaxSpace, key, len);
             var node = AllocateNewNode(index, nodeSize, previousNodeVersion);
 
             node->KeySize = key.Size;
@@ -290,9 +290,9 @@ namespace Voron.Data.BTrees
         {
             var index = NumberOfEntries;
 
-            Debug.Assert(HasSpaceFor(SizeOf.NodeEntryWithAnotherKey(other, key) + Constants.NodeOffsetSize));
+            Debug.Assert(HasSpaceFor(TreeSizeOf.NodeEntryWithAnotherKey(other, key) + Constants.NodeOffsetSize));
 
-            var nodeSize = SizeOf.NodeEntryWithAnotherKey(other, key);
+            var nodeSize = TreeSizeOf.NodeEntryWithAnotherKey(other, key);
 
             Debug.Assert(IsBranch == false || index != 0 || key.KeyLength == 0);// branch page's first item must be the implicit ref
 
@@ -477,7 +477,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetRequiredSpace(Slice key, int len)
         {
-            return SizeOf.NodeEntry(PageMaxSpace, key, len) + Constants.NodeOffsetSize;
+            return TreeSizeOf.NodeEntry(PageMaxSpace, key, len) + Constants.NodeOffsetSize;
         }
 
         public int PageMaxSpace

--- a/src/Voron/Data/BTrees/TreePageSplitter.cs
+++ b/src/Voron/Data/BTrees/TreePageSplitter.cs
@@ -294,7 +294,7 @@ namespace Voron.Data.BTrees
         {
             var pos = _parentPage.NodePositionFor(separatorKey); // select the appropriate place for this
 
-            if (_parentPage.HasSpaceFor(_tx, SizeOf.BranchEntry(separatorKey) + Constants.NodeOffsetSize) == false)
+            if (_parentPage.HasSpaceFor(_tx, TreeSizeOf.BranchEntry(separatorKey) + Constants.NodeOffsetSize) == false)
             {
                 var pageSplitter = new TreePageSplitter(_tx, _tree, separatorKey, -1, pageNumber, TreeNodeFlags.PageRef,
                     0, _cursor);
@@ -308,7 +308,7 @@ namespace Voron.Data.BTrees
         {
             Slice keyToInsert = _newKey;
 
-            int pageSize = SizeOf.NodeEntry(_tx.DataPager.PageMaxSpace, keyToInsert, _len) + Constants.NodeOffsetSize;
+            int pageSize = TreeSizeOf.NodeEntry(_tx.DataPager.PageMaxSpace, keyToInsert, _len) + Constants.NodeOffsetSize;
 
             if (toRight == false)
             {

--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -142,7 +142,7 @@ namespace Voron.Data.BTrees
 					var key = GetActualKey(right, right.LastSearchPositionOrLastEntry);
 					var node = right.GetNode(i);
 
-					if (mergedPage.HasSpaceFor(_tx, SizeOf.NodeEntryWithAnotherKey(node, key) + Constants.NodeOffsetSize ) == false)
+					if (mergedPage.HasSpaceFor(_tx, TreeSizeOf.NodeEntryWithAnotherKey(node, key) + Constants.NodeOffsetSize ) == false)
 					{
 						right.LastSearchPosition = previousSearchPosition; //previous position --> prevent mutation of parameter
 						return false;
@@ -240,7 +240,7 @@ namespace Voron.Data.BTrees
 
 		private void AddSeparatorToParentPage(TreePage parentPage, long pageNumber, Slice separatorKey, int separatorKeyPosition)
 		{
-			if (parentPage.HasSpaceFor(_tx, SizeOf.BranchEntry(separatorKey) + Constants.NodeOffsetSize) == false)
+			if (parentPage.HasSpaceFor(_tx, TreeSizeOf.BranchEntry(separatorKey) + Constants.NodeOffsetSize) == false)
 			{
 				var pageSplitter = new TreePageSplitter(_tx, _tree, separatorKey, -1, pageNumber, TreeNodeFlags.PageRef, 0, _cursor);
 				pageSplitter.Execute();

--- a/src/Voron/Data/BTrees/TreeRootHeader.cs
+++ b/src/Voron/Data/BTrees/TreeRootHeader.cs
@@ -1,12 +1,18 @@
 using System.Runtime.InteropServices;
+using Voron.Impl.FileHeaders;
 
-namespace Voron.Impl.FileHeaders
+namespace Voron.Data.BTrees
 {
+    /// <summary>
+    /// The BTree Root Header.
+    /// </summary>    
+    /// <remarks>This header extends the <see cref="RootHeader"/> structure.</remarks>
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public struct TreeRootHeader
     {
         [FieldOffset(0)]
         public RootObjectType RootObjectType;
+
         [FieldOffset(1)]
         public TreeFlags Flags;
         [FieldOffset(2)]

--- a/src/Voron/Data/BTrees/TreeSizeOf.cs
+++ b/src/Voron/Data/BTrees/TreeSizeOf.cs
@@ -5,7 +5,7 @@ using Voron.Data.BTrees;
 
 namespace Voron.Impl
 {
-    internal unsafe class SizeOf
+    internal unsafe class TreeSizeOf
     {
         /// <summary>
         /// Calculate the size of a leaf node.

--- a/src/Voron/Data/Fixed/FixedSizeTreeHeader.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTreeHeader.cs
@@ -11,6 +11,10 @@ namespace Voron.Data.Fixed
 {
     public class FixedSizeTreeHeader
     {
+        /// <summary>
+        /// The Embedded Fixed Size Tree Root Header.
+        /// </summary>    
+        /// <remarks>This header extends the <see cref="RootHeader"/> structure.</remarks>
         [StructLayout(LayoutKind.Explicit, Pack = 1)]
         public struct Embedded
         {
@@ -24,6 +28,10 @@ namespace Voron.Data.Fixed
             public ushort NumberOfEntries;
         }
 
+        /// <summary>
+        /// The Large Fixed Size Tree Root Header.
+        /// </summary>    
+        /// <remarks>This header extends the <see cref="RootHeader"/> structure.</remarks>
         [StructLayout(LayoutKind.Explicit, Pack = 1)]
         public struct Large
         {

--- a/src/Voron/Data/Fixed/FixedSizeTreePage.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTreePage.cs
@@ -8,21 +8,6 @@ namespace Voron.Data.Fixed
         private readonly byte* _ptr;
         private readonly int _pageSize;
         private readonly string _source;
-        private FixedSizeTreePageHeader* Header
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return (FixedSizeTreePageHeader*)_ptr;
-            }
-        }
-
-        public string Source
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return _source; }
-        }
 
         public int LastMatch;
         public int LastSearchPosition;
@@ -35,98 +20,93 @@ namespace Voron.Data.Fixed
             _pageSize = pageSize;
         }
 
+        private FixedSizeTreePageHeader* Header
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return (FixedSizeTreePageHeader*)_ptr; }
+        }
+
+        public string Source
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _source; }
+        }
 
         public long PageNumber
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return Header->PageNumber; }
+            get { return Header->PageNumber; }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set
-            { Header->PageNumber = value; }
+            set { Header->PageNumber = value; }
         }
 
         public FixedSizeTreePageFlags FixedTreeFlags
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return Header->TreeFlags; }
+            get { return Header->TreeFlags; }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set
-            { Header->TreeFlags = value; }
+            set { Header->TreeFlags = value; }
         }
 
         public int PageSize
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return _pageSize; }
+            get { return _pageSize; }
         }
 
         public bool IsLeaf
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return (Header->TreeFlags & FixedSizeTreePageFlags.Leaf) == FixedSizeTreePageFlags.Leaf; }
+            get { return (Header->TreeFlags & FixedSizeTreePageFlags.Leaf) == FixedSizeTreePageFlags.Leaf; }
         }
 
         public bool IsBranch
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return (Header->TreeFlags & FixedSizeTreePageFlags.Branch) == FixedSizeTreePageFlags.Branch; }
+            get { return (Header->TreeFlags & FixedSizeTreePageFlags.Branch) == FixedSizeTreePageFlags.Branch; }
         }
 
         public bool IsOverflow
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return (Header->Flags & PageFlags.Overflow) == PageFlags.Overflow; }
+            get { return (Header->Flags & PageFlags.Overflow) == PageFlags.Overflow; }
         }
 
         public int PageMaxSpace
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return _pageSize - Constants.FixedSizeTreePageHeaderSize; }
+            get { return _pageSize - Constants.FixedSizeTreePageHeaderSize; }
         }
 
 
         public ushort NumberOfEntries
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return Header->NumberOfEntries; }
+            get { return Header->NumberOfEntries; }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set
-            { Header->NumberOfEntries = value; }
+            set { Header->NumberOfEntries = value; }
         }
 
         public ushort StartPosition
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return Header->StartPosition; }
+            get { return Header->StartPosition; }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set
-            { Header->StartPosition = value; }
+            set { Header->StartPosition = value; }
         }
 
         public ushort ValueSize
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return Header->ValueSize; }
+            get { return Header->ValueSize; }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set
-            { Header->ValueSize = value; }
+            set { Header->ValueSize = value; }
         }
 
         public byte* Pointer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return _ptr; }
+            get { return _ptr; }
         }
 
         public override string ToString()
@@ -134,16 +114,13 @@ namespace Voron.Data.Fixed
             return "#" + PageNumber + " (count: " + NumberOfEntries + ") " + FixedTreeFlags;
         }
 
-
         public PageFlags Flags
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            { return Header->Flags; }
+            get { return Header->Flags; }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set
-            { Header->Flags = value; }
+            set { Header->Flags = value; }
         }
     }
 }

--- a/src/Voron/Data/RootHeader.cs
+++ b/src/Voron/Data/RootHeader.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Voron.Data
+{
+    [StructLayout(LayoutKind.Explicit, Pack = 1)]
+    public struct RootHeader
+    {
+        [FieldOffset(0)]
+        public RootObjectType RootObjectType;
+    }
+}

--- a/src/Voron/Data/RootObjectType.cs
+++ b/src/Voron/Data/RootObjectType.cs
@@ -1,4 +1,4 @@
-﻿namespace Voron.Impl.FileHeaders
+﻿namespace Voron.Data
 {
     public enum RootObjectType : byte
     {

--- a/src/Voron/Debugging/DebugStuff.cs
+++ b/src/Voron/Debugging/DebugStuff.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Impl;

--- a/src/Voron/Debugging/StorageReport.cs
+++ b/src/Voron/Debugging/StorageReport.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 using System.Collections.Generic;
+using Voron.Data;
 using Voron.Impl.FileHeaders;
 
 namespace Voron.Debugging

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Exceptions;

--- a/src/Voron/Impl/Compaction/StorageCompaction.cs
+++ b/src/Voron/Impl/Compaction/StorageCompaction.cs
@@ -5,10 +5,9 @@
 // -----------------------------------------------------------------------
 using System;
 using System.IO;
+using Voron.Data;
 using Voron.Data.BTrees;
-using Voron.Impl.FileHeaders;
 using Voron.Impl.FreeSpace;
-using Voron.Impl.Paging;
 
 namespace Voron.Impl.Compaction
 {

--- a/src/Voron/Impl/FileHeaders/FileHeader.cs
+++ b/src/Voron/Impl/FileHeaders/FileHeader.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Voron.Data.BTrees;
 using Voron.Impl.Backup;
 using Voron.Impl.Journal;
 

--- a/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
@@ -9,7 +9,6 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Voron.Util;
 
 namespace Voron.Impl.FileHeaders
 {

--- a/src/Voron/Impl/Journal/TransactionHeader.cs
+++ b/src/Voron/Impl/Journal/TransactionHeader.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System.Runtime.InteropServices;
-using Voron.Impl.FileHeaders;
+using Voron.Data.BTrees;
 
 namespace Voron.Impl.Journal
 {

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -82,7 +82,7 @@ namespace Voron.Impl.Scratch
         {
             if (tx == null)
                 throw new ArgumentNullException(nameof(tx));
-            var size = (int)Bits.NextPowerOf2(numberOfPages);
+            var size = Bits.NextPowerOf2(numberOfPages);
 
             PageFromScratchBuffer result;
             var current = _current;

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Compact;
 using Voron.Data.Fixed;
@@ -236,7 +237,7 @@ namespace Voron.Impl
             if (val == null)
                 return RootObjectType.None;
 
-            return ((TreeRootHeader*) val)->RootObjectType;
+            return ((RootHeader*) val)->RootObjectType;
         }
     }
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Debugging;

--- a/test/Sparrow.Tests/BitVectors.cs
+++ b/test/Sparrow.Tests/BitVectors.cs
@@ -36,7 +36,8 @@ namespace Sparrow.Tests
         public void Constants()
         {
             Assert.Equal(64, BitVector.BitsPerWord);
-            Assert.Equal((uint)Math.Log(BitVector.BitsPerWord, 2), BitVector.Log2BitsPerWord);
+            // Workaround for https://github.com/dotnet/coreclr/issues/2683
+            Assert.Equal((uint) (Math.Log(BitVector.BitsPerWord) / Math.Log(2)), BitVector.Log2BitsPerWord);
         }
 
         [Fact]

--- a/test/Sparrow.Tests/Properties/launchSettings.json
+++ b/test/Sparrow.Tests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "test": {
+      "commandName": "test",
+      "sdkVersion": "dnx-coreclr-win-x64.1.0.0-rc1-update1"
+    }
+  }
+}

--- a/test/Voron.Tests/Bugs/UpdateLastItem.cs
+++ b/test/Voron.Tests/Bugs/UpdateLastItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Voron.Data.BTrees;
 using Voron.Impl;
 using Voron.Impl.FileHeaders;
 using Xunit;

--- a/test/Voron.Tests/Properties/launchSettings.json
+++ b/test/Voron.Tests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "test": {
+      "commandName": "test",
+      "sdkVersion": "dnx-coreclr-win-x64.1.0.0-rc1-update1"
+    }
+  }
+}

--- a/test/Voron.Tests/ValidHeaders.cs
+++ b/test/Voron.Tests/ValidHeaders.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Voron.Data;
+using Voron.Data.BTrees;
 using Voron.Impl;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Journal;


### PR DESCRIPTION
Now there is an explicit shared RootObject header we can use instead of casting to a TreeRootObject to know the type of the object. Also moved the shared object from an internal implementation detail to the Voron.Data namespace.