### PR TITLE
cosmetic: added new pretty label display to edit document page

### DIFF
--- a/Raven.Studio.Html5/App/models/documentMetadata.ts
+++ b/Raven.Studio.Html5/App/models/documentMetadata.ts
@@ -54,7 +54,9 @@ class documentMetadata {
             }
         }
     }
-
+    prettyLabel(text: string) {
+        return text.replace(/__/g, '/');
+    }
     toDto(): documentMetadataDto {
         var dto: any = {
             'Raven-Entity-Name': this.ravenEntityName,

--- a/Raven.Studio.Html5/App/views/editDocument.html
+++ b/Raven.Studio.Html5/App/views/editDocument.html
@@ -11,7 +11,7 @@
         </li>
         <!-- ko ifnot: isCreatingNewDocument -->
         <li data-bind="with: metadata" style="display: inline-block">
-            <a style="display: inline-block" href="#" data-bind="text: $root.isInDocMode() === true?(ravenEntityName ===undefined)?'System Documents':ravenEntityName:$root.queryIndex, 
+            <a style="display: inline-block" href="#" data-bind="text: $root.isInDocMode() === true?(ravenEntityName ===undefined)?'System Documents':prettyLabel(ravenEntityName):$root.queryIndex, 
             attr: {title:ravenEntityName, href: '#documents?collection=' + (ravenEntityName ===undefined)?'System Documents':ravenEntityName }, click: $root.navigateToCollection.bind($root,
             (ravenEntityName ===undefined)?'System Documents':ravenEntityName)"></a>
         </li>
@@ -71,7 +71,7 @@
 
                     <div class="row">
                         <label class="col-md-5">Raven-Entity-Name</label>
-                        <span class="col-md-7" data-bind="text: ravenEntityName, attr: {title:ravenEntityName}"></span>
+                        <span class="col-md-7" data-bind="text: prettyLabel(ravenEntityName), attr: {title:ravenEntityName}"></span>
                     </div>
                     <div class="row">
                         <label class="col-md-5">Etag</label>


### PR DESCRIPTION
Updated the "Edit Document" page to understand the "prettified labels" display added in my last set of pull requests.

Display is understood in both the upper pane, and the right pane.

![Image](http://i.imgur.com/D0rmw02.jpg)
![Image](http://i.imgur.com/ti6Al3R.jpg)