### PR TITLE
RavenDB-4241 Fixing the issue that passing duplicate document IDs to …

### DIFF
--- a/Raven.Client.Lightweight/Document/SessionOperations/MultiLoadOperation.cs
+++ b/Raven.Client.Lightweight/Document/SessionOperations/MultiLoadOperation.cs
@@ -93,34 +93,77 @@ namespace Raven.Client.Document.SessionOperations
             return finalResults;
         }
 
-        private T ApplyTrackingIfNeeded<T>(JsonDocument document)
-        {
-            if (document != null)
-                return sessionOperations.TrackEntity<T>(document);
-
-            return default(T);
-        }
-
         private T[] ReturnResultsById<T>()
         {
             var finalResults = new T[ids.Length];
-            var dic = new Dictionary<string, int>(ids.Length, StringComparer.OrdinalIgnoreCase);
+            var dic = new Dictionary<string, FinalResultPositionById>(ids.Length, StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < ids.Length; i++)
             {
                 if (ids[i] == null)
                     continue;
-                dic[ids[i]] = i;
+
+                FinalResultPositionById position;
+                if (dic.TryGetValue(ids[i], out position) == false)
+                {
+                    dic[ids[i]] = new FinalResultPositionById
+                    {
+                        SingleReturn = i
+                    };
+                }
+                else
+                {
+                    if (position.SingleReturn != null)
+                    {
+                        position.MultipleReturns = new List<int>(2)
+                        {
+                            position.SingleReturn.Value
+                        };
+
+                        position.SingleReturn = null;
+                    }
+
+                    position.MultipleReturns.Add(i);
+                }  
             }
+
             foreach (var jsonDocument in results)
             {
                 if (jsonDocument == null)
                     continue;
+
                 var id = jsonDocument.Metadata.Value<string>("@id");
-                int value;
-                if (dic.TryGetValue(id, out value))
-                    finalResults[value] = sessionOperations.TrackEntity<T>(jsonDocument);
+
+                if (id == null)
+                    continue;
+
+                FinalResultPositionById position;
+
+                if (dic.TryGetValue(id, out position))
+                {
+                    if (position.SingleReturn != null)
+                    {
+                        finalResults[position.SingleReturn.Value] = sessionOperations.TrackEntity<T>(jsonDocument);
+                    }
+                    else if (position.MultipleReturns != null)
+                    {
+                        T trackedEntity = sessionOperations.TrackEntity<T>(jsonDocument);
+
+                        foreach (var pos in position.MultipleReturns)
+                        {
+                            finalResults[pos] = trackedEntity;
+                        }
+                    }
+                }
             }
+
             return finalResults;
+        }
+
+        private class FinalResultPositionById
+        {
+            public int? SingleReturn;
+
+            public List<int> MultipleReturns;
         }
     }
 }

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -486,6 +486,7 @@
     <Compile Include="RavenDB_421.cs" />
     <Compile Include="RavenDB_422.cs" />
     <Compile Include="RavenDB_4226.cs" />
+    <Compile Include="RavenDB_4241.cs" />
     <Compile Include="RavenDB_425.cs" />
     <Compile Include="RavenDB_478.cs" />
     <Compile Include="RavenDB_483.cs" />

--- a/Raven.Tests.Issues/RavenDB_4241.cs
+++ b/Raven.Tests.Issues/RavenDB_4241.cs
@@ -1,0 +1,122 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_4241.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using Raven.Tests.Common;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_4241 : RavenTest
+    {
+        [Fact]
+        public void passing_duplicate_document_ids_to_Advanced_Lazily_Load_should_not_result_in_documents_failing_to_load()
+        {
+            using (var documentStore = NewDocumentStore())
+            {
+                var documentId = "TestDocuments/1";
+                using (var session = documentStore.OpenSession())
+                {
+                    session.Store(new TestDocument { Id = documentId, Value = 1 });
+
+                    session.SaveChanges();
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    session.Advanced.Lazily.Load<TestDocument>(new[] { documentId, documentId });
+                    session.Advanced.Eagerly.ExecuteAllPendingLazyOperations();
+
+                    var doc = session.Load<TestDocument>(documentId);
+
+                    Assert.NotNull(doc);
+                    Assert.Equal(1, doc.Value);
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    var lazyLoad = session.Advanced.Lazily.Load<TestDocument>(new[] { documentId, documentId });
+
+                    var docs = lazyLoad.Value;
+
+                    Assert.Equal(2, docs.Length);
+                    Assert.NotNull(docs[0]);
+                    Assert.NotNull(docs[1]);
+                    Assert.Same(docs[0], docs[1]);
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    var lazyLoad = session.Advanced.Lazily.Load<TestDocument>(new[] { documentId, documentId, documentId });
+
+                    var docs = lazyLoad.Value;
+
+                    Assert.Equal(3, docs.Length);
+                    Assert.NotNull(docs[0]);
+                    Assert.NotNull(docs[1]);
+                    Assert.NotNull(docs[2]);
+                    Assert.Same(docs[0], docs[1]);
+                    Assert.Same(docs[1], docs[2]);
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    var lazyLoad = session.Advanced.Lazily.Load<TestDocument>(new[] { documentId, "items/123", documentId });
+
+                    var docs = lazyLoad.Value;
+
+                    Assert.Equal(3, docs.Length);
+                    Assert.NotNull(docs[0]);
+                    Assert.Null(docs[1]);
+                    Assert.NotNull(docs[2]);
+                    Assert.Same(docs[0], docs[2]);
+                }
+            }
+        }
+
+        [Fact]
+        public void passing_duplicate_document_ids_to_Load_with_Include_should_not_throw()
+        {
+            using (var documentStore = NewDocumentStore())
+            {
+                var documentId = "TestDocuments/1";
+                using (var session = documentStore.OpenSession())
+                {
+                    session.Store(new TestDocument { Id = documentId, Value = 1 });
+
+                    session.SaveChanges();
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    TestDocument[] docs = null;
+
+                    Assert.DoesNotThrow(() => docs = session.Include("foo").Load<TestDocument>(new[] { documentId, documentId }));
+
+                    Assert.Equal(2, docs.Length);
+                    Assert.Same(docs[0], docs[1]);
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    TestDocument[] docs = null;
+
+                    Assert.DoesNotThrow(() => docs = session.Include("foo").Load<TestDocument>(new[] { documentId, "items/123", documentId }));
+
+                    Assert.Equal(3, docs.Length);
+                    Assert.NotNull(docs[0]);
+                    Assert.Null(docs[1]);
+                    Assert.NotNull(docs[2]);
+                    Assert.Same(docs[0], docs[2]);
+                }
+            }
+        }
+
+        public class TestDocument
+        {
+            public string Id { get; set; }
+            public int Value { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
…Advanced.Lazily.Load() and Include().Load() resulted in documents failed to load. The problem was that we didn't take into account that duplicate ids can be passed there.
