### PR TITLE
fix handling AllowMultipleIndexEntriesForSameDocumentToResultTransformer flag

### DIFF
--- a/Raven.Abstractions/Json/Linq/DictionaryWithParentSnapshot.cs
+++ b/Raven.Abstractions/Json/Linq/DictionaryWithParentSnapshot.cs
@@ -34,17 +34,20 @@ namespace Raven.Json.Linq
 
         private DictionaryWithParentSnapshot(DictionaryWithParentSnapshot previous)
         {
-            comparer = previous.comparer;
-            if (previous.parentSnapshot != null)
-            {
-                if(previous.localChanges != null)
-                    localChanges = new Dictionary<string, RavenJToken>(previous.localChanges, comparer);
-                parentSnapshot = previous.parentSnapshot;
-            }
-            else
-            {
-                parentSnapshot = previous;
-            }
+	        lock (this)
+	        {
+		        comparer = previous.comparer;
+		        if (previous.parentSnapshot != null)
+		        {
+			        if (previous.localChanges != null)
+				        localChanges = new Dictionary<string, RavenJToken>(previous.localChanges, comparer);
+			        parentSnapshot = previous.parentSnapshot;
+		        }
+		        else
+		        {
+			        parentSnapshot = previous;
+		        }
+	        }
         }
 
         #region Dictionary<string,TValue> Members

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -142,7 +142,6 @@
     <Compile Include="RavenDB_3928.cs" />
     <Compile Include="RavenDB-4227.cs" />
     <Compile Include="RavenDB_4053.cs" />
-
     <Compile Include="RavenDB-4222.cs" />
     <Compile Include="RavenDB-4221.cs" />
     <Compile Include="RavenDB_4215.cs" />
@@ -548,6 +547,7 @@
     <Compile Include="RavenDB_3113.cs" />
     <Compile Include="RavenDB_3106.cs" />
     <Compile Include="RavenDB-3225.cs" />
+    <Compile Include="ThorMigrationIssues.cs" />
     <Compile Include="WaitForStaleOnAbandonedIndexShouldWork.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Raven.Tests.Issues/ThorMigrationIssues.cs
+++ b/Raven.Tests.Issues/ThorMigrationIssues.cs
@@ -1,0 +1,207 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Abstractions.Indexing;
+using Raven.Client;
+using Raven.Client.Document;
+using Raven.Client.Indexes;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+	public class ThorMigrationIssues : RavenTestBase
+	{
+		private readonly IDocumentStore _docStore;
+
+		public ThorMigrationIssues()
+		{
+			_docStore = NewRemoteDocumentStore(fiddler:true);
+			_docStore.Conventions.DefaultQueryingConsistency = ConsistencyOptions.AlwaysWaitForNonStaleResultsAsOfLastWrite;
+
+			var dut = new OrgUnit
+			{
+				Id = "OrgUnit/1",
+				OrgUnitName = "School1",
+				Rooms = new List<OrgUnit.Room>
+				{
+					new OrgUnit.Room
+					{
+						RoomId = "1",
+						RoomName = "ClassRoom1"
+					},
+					new OrgUnit.Room
+					{
+						RoomId = "2",
+						RoomName = "DarkRoom1"
+					},
+					new OrgUnit.Room
+					{
+						RoomId = "3",
+						RoomName = "Gym1"
+					}
+				}
+			};
+
+			using (var session = _docStore.OpenSession())
+			{
+
+				new UnitRoomsIndexStoreAll().Execute(_docStore);
+				new UnitRoomsIndexStoreLess().Execute(_docStore);
+				new UnitRoomsTransformer().Execute(_docStore);
+
+				session.Store(dut);
+				session.SaveChanges();
+
+				// Ensure transaction completed and index is non-stale
+				session.Advanced.AllowNonAuthoritativeInformation = false;
+
+				session.Load<OrgUnit>("OrgUnit/1");
+			}
+		}
+
+		public override void Dispose()
+		{
+			base.Dispose();
+
+			if (_docStore.WasDisposed == false)
+				_docStore.Dispose();
+		}
+
+		[Fact]
+		public void CanPreventMultipleResultsFromFanoutIndexStoreAll()
+		{
+			using (var session = _docStore.OpenSession())
+			{
+				var query = session.Query<UnitRoomsIndexResult, UnitRoomsIndexStoreAll>()
+					.Customize(x => x.SetAllowMultipleIndexEntriesForSameDocumentToResultTransformer(false))					
+					.TransformWith<UnitRoomsTransformer, UnitRoomsIndexResult>();
+
+				var results = query.ToList();
+
+				Assert.Equal(1, results.Count);
+			}
+		}
+
+		[Fact]
+		public void CanTransferMultipleResultsFromFanoutIndexStoreAll()
+		{
+			using (var session = _docStore.OpenSession())
+			{
+				var query = session.Query<UnitRoomsIndexResult, UnitRoomsIndexStoreAll>()
+					.Customize(x => x.SetAllowMultipleIndexEntriesForSameDocumentToResultTransformer(true))
+					.TransformWith<UnitRoomsTransformer, UnitRoomsIndexResult>();
+
+				var results = query.ToList();
+
+				Assert.Equal(3, results.Count);
+			}
+		}
+
+		[Fact]
+		public void CanPreventMultipleResultsFromFanoutIndexStoreLess()
+		{
+			using (var session = _docStore.OpenSession())
+			{
+				var query = session.Query<UnitRoomsIndexResult, UnitRoomsIndexStoreLess>()
+					.Customize(x => x.SetAllowMultipleIndexEntriesForSameDocumentToResultTransformer(false))
+					.TransformWith<UnitRoomsTransformer, UnitRoomsIndexResult>();
+
+				var results = query.ToList();
+
+				Assert.Equal(1, results.Count);
+			}
+		}
+
+		[Fact]
+		public void CanTransferMultipleResultsFromFanoutIndexStoreLess()
+		{
+			using (var session = _docStore.OpenSession())
+			{
+				var query = session.Query<UnitRoomsIndexResult, UnitRoomsIndexStoreLess>()
+					.Customize(x => x.SetAllowMultipleIndexEntriesForSameDocumentToResultTransformer(true))
+					.TransformWith<UnitRoomsTransformer, UnitRoomsIndexResult>();
+
+				var results = query.ToList();
+
+				Assert.Equal(3, results.Count);
+			}
+		}
+	}
+
+	public class UnitRoomsTransformer : AbstractTransformerCreationTask<UnitRoomsIndexResult>
+	{
+		public UnitRoomsTransformer()
+		{
+			TransformResults = result => from item in result
+										 select new
+										 {
+											 item.OrgUnitId,
+											 item.OrgUnitName,
+											 item.RoomId,
+											 item.RoomName
+										 };
+		}
+	}
+
+	public class UnitRoomsIndexResult
+	{
+		public string OrgUnitId { get; set; }
+		public string OrgUnitName { get; set; }
+
+		public string RoomId { get; set; }
+		public string RoomName { get; set; }
+	}
+
+	public class UnitRoomsIndexStoreAll : AbstractMultiMapIndexCreationTask<UnitRoomsIndexResult>
+	{
+		public UnitRoomsIndexStoreAll()
+		{
+			AddMap<OrgUnit>(items => from orgunit in items
+									 from room in orgunit.Rooms
+									 select new
+									 {
+										 OrgUnitId = orgunit.Id,
+										 OrgUnitName = orgunit.OrgUnitName,
+
+										 RoomId = room.RoomId,
+										 RoomName = room.RoomName
+									 });
+			StoreAllFields(FieldStorage.Yes);
+		}
+	}
+
+	public class UnitRoomsIndexStoreLess : AbstractMultiMapIndexCreationTask<UnitRoomsIndexResult>
+	{
+		public UnitRoomsIndexStoreLess()
+		{
+			AddMap<OrgUnit>(items => from orgunit in items
+									 from room in orgunit.Rooms
+									 select new
+									 {
+										 OrgUnitId = orgunit.Id,
+										 OrgUnitName = orgunit.OrgUnitName,
+
+										 RoomId = room.RoomId,
+										 RoomName = room.RoomName
+									 });
+			Stores.Add(f => f.OrgUnitId, FieldStorage.Yes);
+			Stores.Add(f => f.RoomName, FieldStorage.Yes);
+		}
+	}
+
+	public class OrgUnit
+	{
+		public string Id { get; set; }
+		public string OrgUnitName { get; set; }
+
+		public List<Room> Rooms { get; set; }
+
+		public class Room
+		{
+			public string RoomId { get; set; }
+			public string RoomName { get; set; }
+		}
+	}
+}
+
+


### PR DESCRIPTION
Properly handle the flag if we have a transformer in the query, in case of cross-product indexes