### PR TITLE
RavenDB-4308 cosmetic: added feature to use Raven-Entity-Label metadata for collection name display in HTML5 studio, to keep it separate from Raven-Entity-Name, which is used in other things.

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -182,6 +182,7 @@ namespace Raven.Abstractions.Data
         public const string DefaultRequestEncoding = "UTF-8";
 
         public const string DocumentsByEntityNameIndex = "Raven/DocumentsByEntityName";
+        public const string LabelsByCollectionNameTransformer = "Raven/LabelsByCollectionName";
 
         //Counters
         public static partial class Counter

--- a/Raven.Client.Lightweight/Raven.Client.Lightweight.csproj
+++ b/Raven.Client.Lightweight/Raven.Client.Lightweight.csproj
@@ -178,6 +178,7 @@
     <Compile Include="FileSystem\Shard\IShardResolutionStrategy.cs" />
     <Compile Include="FileSystem\SynchronizationServerClient.cs" />
     <Compile Include="Helpers\EnvironmentHelper.cs" />
+    <Compile Include="Transformers\RavenCollectionLabelTransformer.cs" />
     <Compile Include="Util\Auth\SingleAuthTokenRetriever.cs" />
     <Compile Include="Indexes\AbstractScriptedIndexCreationTask.cs" />
     <Compile Include="Util\DisposableStream.cs" />

--- a/Raven.Client.Lightweight/Transformers/RavenCollectionLabelTransformer.cs
+++ b/Raven.Client.Lightweight/Transformers/RavenCollectionLabelTransformer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Raven.Abstractions.Indexing;
+
+
+namespace Raven.Client.Transformers {
+    ///<summary>
+    /// Create a transformer that retrieves collection label metadata.
+    ///</summary>
+    public class RavenLabelsByCollectionNameTransformer {
+        public TransformerDefinition Transformer {
+            get {
+                return new TransformerDefinition {
+                    Name = Raven.Abstractions.Data.Constants.LabelsByCollectionNameTransformer,
+                    TransformResults = @"from result in results select new { Label = result[""@metadata""][""Raven-Entity-Label""] }"
+                };
+            }
+        }
+    }
+}

--- a/Raven.Database/Plugins/Builtins/CreateSilverlightIndexes.cs
+++ b/Raven.Database/Plugins/Builtins/CreateSilverlightIndexes.cs
@@ -1,6 +1,7 @@
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Indexing;
 using Raven.Client.Indexes;
+using Raven.Client.Transformers;
 
 namespace Raven.Database.Plugins.Builtins
 {
@@ -8,9 +9,17 @@ namespace Raven.Database.Plugins.Builtins
     {
         public void SilverlightWasRequested(DocumentDatabase database)
         {
-            var ravenDocumentsByEntityName = new RavenDocumentsByEntityName {};
+            var ravenDocumentsByEntityName = new RavenDocumentsByEntityName { };
             database.Indexes.PutIndex(Constants.DocumentsByEntityNameIndex,
                 ravenDocumentsByEntityName.CreateIndexDefinition());
+
+            SilverlightTransformerWasRequested(database);
+        }
+
+        public void SilverlightTransformerWasRequested(DocumentDatabase database) {
+            var ravenLabelsByCollectionName = new RavenLabelsByCollectionNameTransformer { };
+            database.Transformers.PutTransform(Constants.LabelsByCollectionNameTransformer,
+                ravenLabelsByCollectionName.Transformer);
         }
     }
 }

--- a/Raven.Database/Server/Controllers/SilverlightController.cs
+++ b/Raven.Database/Server/Controllers/SilverlightController.cs
@@ -17,6 +17,7 @@ namespace Raven.Database.Server.Controllers
         [RavenRoute("databases/{databaseName}/silverlight/ensureStartup")]
         public HttpResponseMessage SilverlightEnsureStartup()
         {
+            new CreateSilverlightIndexes().SilverlightTransformerWasRequested(Database);
             Database.ExtensionsState.GetOrAdd("SilverlightUI.NotifiedAboutSilverlightBeingRequested", s =>
             {
                 var skipCreatingStudioIndexes = Database.Configuration.Settings["Raven/SkipCreatingStudioIndexes"];
@@ -28,6 +29,16 @@ namespace Raven.Database.Server.Controllers
                 return true;
             });
 
+            
+
+            return GetMessageWithObject(new { ok = true });
+        }
+
+        [HttpGet]
+        [RavenRoute("silverlight/ensureTransformer")]
+        [RavenRoute("databases/{databaseName}/silverlight/ensureTransformer")]
+        public HttpResponseMessage SilverlightEnsureTransformer() {
+            new CreateSilverlightIndexes().SilverlightTransformerWasRequested(Database);
             return GetMessageWithObject(new { ok = true });
         }
 

--- a/Raven.Studio.Html5/App/commands/getCollectionsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/getCollectionsCommand.ts
@@ -3,6 +3,7 @@ import database = require("models/database");
 import collection = require("models/collection");
 import getIndexTermsCommand = require("commands/getIndexTermsCommand");
 import getCollectionsCountCommand = require("commands/getCollectionsCountCommand");
+import getCollectionsLabelCommand = require("commands/getCollectionsLabelCommand");
 import getCachedCollectionsCount = require("commands/getCachedCollectionsCount");
 
 class getCollectionsCommand extends commandBase {
@@ -57,6 +58,11 @@ class getCollectionsCommand extends commandBase {
                         .execute()
                         .done(result => task.resolve(result))
                         .fail(result => task.reject(result));
+
+                    new getCollectionsLabelCommand(collections, this.ownerDb)
+                        .execute()
+                        .done(result => task.resolve(result))
+                        .fail(result => task.reject(result));
                 }
                 if (this.lastQueryDate != null) {
                     this.lastQueryDate(xhr.getResponseHeader('Date'));
@@ -73,7 +79,6 @@ class getCollectionsCommand extends commandBase {
     createSystemIndexAndTryAgain(deferred: JQueryDeferred<collection[]>, originalReadError: JQueryXHR) {
         // Most often, failure to get the collections is due to the missing system index, Raven/DocumentsByEntityName.
         // This appears to be new behavior as of 3.0: Raven doesn't create this index automatically for the system database.
-
         // Calling silverlight/ensureStartup creates the system index.
         this.query("/silverlight/ensureStartup", null, this.ownerDb)
             .done(() => this.retryQuery(deferred, originalReadError))

--- a/Raven.Studio.Html5/App/commands/getCollectionsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/getCollectionsCommand.ts
@@ -35,7 +35,6 @@ class getCollectionsCommand extends commandBase {
             .done((terms: string[], status, xhr) => {
 
                 if (this.previousValues.length > 0 && this.lastQueryDate()) {
-
                     var collections = this.previousValues.filter(v => !v.isAllDocuments && !v.isSystemDocuments).map(v => new collection(v.name, this.ownerDb, v.documentCount()));
                     // apply optimalization fetch only changes, based on last query time. 
                     new getCachedCollectionsCount(this.ownerDb, this.lastQueryDate())
@@ -56,13 +55,13 @@ class getCollectionsCommand extends commandBase {
                     var collections = terms.map(term => new collection(term, this.ownerDb, 0));
                     new getCollectionsCountCommand(collections, this.ownerDb)
                         .execute()
-                        .done(result => task.resolve(result))
-                        .fail(result => task.reject(result));
+                        .done(result =>
+                            new getCollectionsLabelCommand(collections, this.ownerDb)
+                                .execute()
+                                .done(result => task.resolve(result))
+                                .fail(result => task.reject(result))
+                        ).fail(result => task.reject(result));
 
-                    new getCollectionsLabelCommand(collections, this.ownerDb)
-                        .execute()
-                        .done(result => task.resolve(result))
-                        .fail(result => task.reject(result));
                 }
                 if (this.lastQueryDate != null) {
                     this.lastQueryDate(xhr.getResponseHeader('Date'));

--- a/Raven.Studio.Html5/App/commands/getCollectionsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/getCollectionsCommand.ts
@@ -79,6 +79,7 @@ class getCollectionsCommand extends commandBase {
     createSystemIndexAndTryAgain(deferred: JQueryDeferred<collection[]>, originalReadError: JQueryXHR) {
         // Most often, failure to get the collections is due to the missing system index, Raven/DocumentsByEntityName.
         // This appears to be new behavior as of 3.0: Raven doesn't create this index automatically for the system database.
+        
         // Calling silverlight/ensureStartup creates the system index.
         this.query("/silverlight/ensureStartup", null, this.ownerDb)
             .done(() => this.retryQuery(deferred, originalReadError))

--- a/Raven.Studio.Html5/App/commands/getCollectionsLabelCommand.ts
+++ b/Raven.Studio.Html5/App/commands/getCollectionsLabelCommand.ts
@@ -40,7 +40,10 @@ class getCollectionsLabelCommand extends commandBase {
                         if (result[i].Result.Results[0].Label)
                             this.collections[i].label = result[i].Result.Results[0].Label;
                 }
-                task.resolve(this.collections);
+                // ensure that the collections are sorted by either entity name or label name.
+                task.resolve(this.collections.sort(function(n, r){
+                    return (n.getLabel() == r.getLabel()) ? 0 : (n.getLabel() > r.getLabel()) ? 1 : -1;
+                }));
             })
             .fail((response: JQueryXHR) => {
                 this.reportError("the result transformer: Raven/LabelsByCollectionName was not found", response.responseText, response.statusText);

--- a/Raven.Studio.Html5/App/commands/getCollectionsLabelCommand.ts
+++ b/Raven.Studio.Html5/App/commands/getCollectionsLabelCommand.ts
@@ -1,0 +1,54 @@
+﻿import commandBase = require("commands/commandBase");
+import database = require("models/database");
+import collection = require("models/collection");
+import getIndexTermsCommand = require("commands/getIndexTermsCommand");
+
+class getCollectionsLabelCommand extends commandBase {
+
+    /**
+    * @param ownerDb The database the collections will belong to.
+    */
+    constructor(private collections: collection[], private ownerDb: database) {
+        super();
+
+        if (!this.ownerDb) {
+            throw new Error("Must specify a database.");
+        }
+    }
+
+    execute(): JQueryPromise<collection[]> {
+        var task = $.Deferred();
+
+        var requests = this.collections.map(collection => {
+            return {
+                Url: "/indexes/Raven/DocumentsByEntityName",
+                Headers: {},
+                Query: "?&query=Tag:" + collection.name + "&pageSize=1" + "&resultsTransformer=Raven/LabelsByCollectionName"
+            }
+        });
+
+        this.post("/multi_get?parallel=yes", JSON.stringify(requests), this.ownerDb, null, 0)
+            .done((result) => {
+                // if the transformer was not found, we will be sure to create it at this time.
+                if (result == null || result[0].Status == 500)
+                    this.query("/silverlight/ensureTransformer", null, this.ownerDb)
+                        .done(() => task.resolve(this.collections))
+                        .fail(() => task.reject("the result transformer: Raven/LabelsByCollectionName was not found"));
+
+                for (var i = 0; i < this.collections.length; i++) {
+                    if (result[i].Result.Results != null && result[i].Result.Results.length > 0)
+                        if (result[i].Result.Results[0].Label)
+                            this.collections[i].label = result[i].Result.Results[0].Label;
+                }
+                task.resolve(this.collections);
+            })
+            .fail((response: JQueryXHR) => {
+                this.reportError("the result transformer: Raven/LabelsByCollectionName was not found", response.responseText, response.statusText);
+                task.reject(response);
+            });
+
+        return task;
+    }
+}
+
+export = getCollectionsLabelCommand;

--- a/Raven.Studio.Html5/App/models/collection.ts
+++ b/Raven.Studio.Html5/App/models/collection.ts
@@ -9,6 +9,7 @@ import database = require("models/database");
 
 class collection {
 
+    label: string = "";
     colorClass = ""; 
     documentCount: any = ko.observable(0);
     documentsCountWithThousandsSeparator = ko.computed(() => this.documentCount().toLocaleString());
@@ -25,6 +26,14 @@ class collection {
         this.isSystemDocuments = name === collection.systemDocsCollectionName;
         this.colorClass = collection.getCollectionCssClass(name, ownerDatabase);
         this.documentCount(docCount);
+    }
+
+    getLabel() {
+        return this.label.length > 0
+            ? this.label            // display custom label defined in metadata
+            : this.name != null     // display native raven entity name
+                ? this.name.replace(/__/g, '/') // prettify double underscores
+                : "";
     }
 
     // Notifies consumers that this collection should be the selected one.

--- a/Raven.Studio.Html5/App/models/documentMetadata.ts
+++ b/Raven.Studio.Html5/App/models/documentMetadata.ts
@@ -3,6 +3,7 @@
 class documentMetadata {
     ravenEntityName: string;
     ravenClrType: string;
+    ravenEntityLabel: string = "";
     nonAuthoritativeInfo: boolean;
     id: string;
     tempIndexScore: number;
@@ -18,6 +19,7 @@ class documentMetadata {
         if (dto) {
             this.ravenEntityName = dto['Raven-Entity-Name'];
             this.ravenClrType = dto['Raven-Clr-Type'];
+            this.ravenEntityLabel = dto['Raven-Entity-Label'];
             this.nonAuthoritativeInfo = dto['Non-Authoritative-Information'];
             this.id = dto['@id'];
             this.tempIndexScore = dto['Temp-Index-Score'];
@@ -39,6 +41,7 @@ class documentMetadata {
 
             for (var property in dto) {
                 if (property.toUpperCase() !== 'Raven-Entity-Name'.toUpperCase() &&
+                    property.toUpperCase() !== 'Raven-Entity-Label'.toUpperCase() &&
                     property.toUpperCase() !== 'Raven-Clr-Type'.toUpperCase() &&
                     property.toUpperCase() !== 'Non-Authoritative-Information'.toUpperCase() &&
                     property.toUpperCase() !== '@id'.toUpperCase() &&
@@ -54,13 +57,15 @@ class documentMetadata {
             }
         }
     }
-    prettyLabel(text: string) {
-        return text !== null ? text.replace(/__/g, '/') : text;
+
+    getLabel() {
+        return this.ravenEntityName !== null ? this.ravenEntityName.replace(/__/g, '/') : this.ravenEntityName;
     }
     toDto(): documentMetadataDto {
         var dto: any = {
             'Raven-Entity-Name': this.ravenEntityName,
             'Raven-Clr-Type': this.ravenClrType,
+            'Raven-Entity-Label': this.ravenEntityLabel,
             'Non-Authoritative-Information': this.nonAuthoritativeInfo,
             '@id': this.id,
             'Temp-Index-Score': this.tempIndexScore,

--- a/Raven.Studio.Html5/App/views/documents.html
+++ b/Raven.Studio.Html5/App/views/documents.html
@@ -14,7 +14,7 @@
                 <a href="javascript:void(0)">
                     <div class="collection-name">
                         <div class="collection-text pull-left collection-color-strip" data-bind="css: colorClass"></div>
-                        <span class="collection-text pull-left collection-name-part" data-bind=" text: prettyLabel(name), attr: {title: name}"></span>
+                        <span class="collection-text pull-left collection-name-part" data-bind="text: getLabel(), attr: {title: name}"></span>
                         <span class="collection-text pull-left text-muted" data-bind="visible: !isSystemDocuments && !isAllDocuments, css: { 'text-muted': $data !== $parent.selectedCollection() }, text:  '&nbsp;(' + documentsCountWithThousandsSeparator() + ')'"></span>
                     </div>
                 </a>

--- a/Raven.Studio.Html5/App/views/editDocument.html
+++ b/Raven.Studio.Html5/App/views/editDocument.html
@@ -11,7 +11,7 @@
         </li>
         <!-- ko ifnot: isCreatingNewDocument -->
         <li data-bind="with: metadata" style="display: inline-block">
-            <a style="display: inline-block" href="#" data-bind="text: $root.isInDocMode() === true?(ravenEntityName ===undefined)?'System Documents':prettyLabel(ravenEntityName):$root.queryIndex, 
+            <a style="display: inline-block" href="#" data-bind="text: $root.isInDocMode() === true?(ravenEntityName ===undefined)?'System Documents':getLabel():$root.queryIndex, 
             attr: {title:ravenEntityName, href: '#documents?collection=' + (ravenEntityName ===undefined)?'System Documents':ravenEntityName }, click: $root.navigateToCollection.bind($root,
             (ravenEntityName ===undefined)?'System Documents':ravenEntityName)"></a>
         </li>
@@ -71,7 +71,11 @@
 
                     <div class="row">
                         <label class="col-md-5">Raven-Entity-Name</label>
-                        <span class="col-md-7" data-bind="text: prettyLabel(ravenEntityName), attr: {title:ravenEntityName}"></span>
+                        <span class="col-md-7" data-bind="text: ravenEntityName, attr: {title:ravenEntityName}"></span>
+                    </div>
+                    <div class="row" data-bind="if: ravenEntityLabel">
+                        <label class="col-md-5">Raven-Entity-Label</label>
+                        <span class="col-md-7" data-bind="text: ravenEntityLabel, attr: {title:ravenEntityLabel}"></span>
                     </div>
                     <div class="row">
                         <label class="col-md-5">Etag</label>
@@ -84,7 +88,6 @@
                     <div class="row">
                         <label class="col-md-5">Size in KB</label>
                         <span class="col-md-7" data-bind="text: $root.documentSize() , attr: {title:$root.documentSize() }"></span>
-
                     </div>
                 </div>
                 <div class="col-md-12 query-metadata" data-bind="visible:topRecentDocuments().length > 0">

--- a/Raven.Studio.Html5/Raven.Studio.Html5.csproj
+++ b/Raven.Studio.Html5/Raven.Studio.Html5.csproj
@@ -33,6 +33,7 @@
     <TypeScriptCompile Include="App\commands\counter\saveCounterStorageReplicationCommand.ts" />
     <TypeScriptCompile Include="App\commands\createSampleDataClassCommand.ts" />
     <TypeScriptCompile Include="App\commands\forceLicenseUpdate.ts" />
+    <TypeScriptCompile Include="App\commands\getCollectionsLabelCommand.ts" />
     <TypeScriptCompile Include="App\commands\getStudioConfig.ts" />
     <TypeScriptCompile Include="App\commands\licenseCheckConnectivityCommand.ts" />
     <TypeScriptCompile Include="App\commands\deleteResourceCommand.ts" />


### PR DESCRIPTION
Added the functionality for a user to specify a "*Raven-Entity-Label*" metadata separate from entity name, which will be used in rendering collection labels to the screen in the HTML5 studio.

The label is retrieved by a simple transformer, *Raven/LabelsByCollectionName*. This transformer is created if it is not found when the collections view is rendered.

If an entity label is not found, the fallback default is to return to using Raven-Entity-Name, as expected.

This adds a new line to the editDocument.html view to display the Raven-Entity-Label if it is present.

http://issues.hibernatingrhinos.com/issue/RavenDB-4308