### PR TITLE
Fix breaking change in the client: we should use the /document?id={ke…

### DIFF
--- a/src/Raven.Client/Connection/Async/AsyncServerClient.cs
+++ b/src/Raven.Client/Connection/Async/AsyncServerClient.cs
@@ -614,7 +614,7 @@ namespace Raven.Client.Connection.Async
             if (key != null)
                 key = Uri.EscapeDataString(key);
 
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/docs?id=" + key, method, metadata, operationMetadata.Credentials, convention, GetRequestTimeMetric(operationMetadata.Url)).AddOperationHeaders(OperationsHeaders)))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/document?id=" + key, method, metadata, operationMetadata.Credentials, convention, GetRequestTimeMetric(operationMetadata.Url)).AddOperationHeaders(OperationsHeaders)))
             {
                 request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
 
@@ -780,7 +780,7 @@ namespace Raven.Client.Connection.Async
         private async Task<MultiLoadResult> DirectGetAsync(OperationMetadata operationMetadata, string[] keys, string[] includes, string transformer,
                                                            Dictionary<string, RavenJToken> transformerParameters, bool metadataOnly, CancellationToken token = default(CancellationToken))
         {
-            var path = operationMetadata.Url + "/docs?";
+            var path = operationMetadata.Url + "/document?";
             if (metadataOnly)
                 path += "&metadata-only=true";
             if (includes != null && includes.Length > 0)
@@ -2027,7 +2027,7 @@ namespace Raven.Client.Connection.Async
 
         public string UrlFor(string documentKey)
         {
-            return Url + "/docs/" + documentKey;
+            return Url + "/document?id=" + documentKey;
         }
 
         public ILowLevelBulkInsertOperation GetBulkInsertOperation(BulkInsertOptions options, IDatabaseChanges changes)
@@ -2041,7 +2041,7 @@ namespace Raven.Client.Connection.Async
         {
             var metadata = new RavenJObject();
 
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/docs/" + key, HttpMethod.Head, operationMetadata.Credentials, convention, GetRequestTimeMetric(operationMetadata.Url)).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/document?id=" + key, HttpMethod.Head, operationMetadata.Credentials, convention, GetRequestTimeMetric(operationMetadata.Url)).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
             {
                 try
                 {

--- a/src/Raven.Client/Connection/RavenUrlExtensions.cs
+++ b/src/Raven.Client/Connection/RavenUrlExtensions.cs
@@ -103,7 +103,7 @@ namespace Raven.Client.Connection
 
         public static string Doc(this string url, string key)
         {
-            return $"{url}/docs/{key}";
+            return $"{url}/document?id={key}";
         }
 
         public static string Docs(this string url, int start, int pageSize)

--- a/src/Raven.Client/Document/Batches/LazyLoadOperation.cs
+++ b/src/Raven.Client/Document/Batches/LazyLoadOperation.cs
@@ -25,7 +25,7 @@ namespace Raven.Client.Document.Batches
 
         public GetRequest CreateRequest()
         {
-            const string path = "/docs";
+            const string path = "/document";
             var query = "id=" + Uri.EscapeDataString(key);
             return new GetRequest
             {


### PR DESCRIPTION
…y:string} endpoint instead of /docs/{key:string}