### PR TITLE
RavenDB-4310 (failing tests - issues is already closed but i need an …

### DIFF
--- a/Raven.Database/FileSystem/Storage/Esent/TransactionalStorage.cs
+++ b/Raven.Database/FileSystem/Storage/Esent/TransactionalStorage.cs
@@ -153,8 +153,7 @@ namespace Raven.Database.FileSystem.Storage.Esent
                     Monitor.TryEnter(locker, 30 * 1000, ref lockTaken);
                     if (lockTaken == false)
                     {
-                        throw new TimeoutException("Could not take Esent Compact Lock. Because of a probable bug in Esent, we only allow a single database to be compacted at a given time.\r\n" +
-                                                   "However, we waited for 30 seconds for the compact lock to be released, and gave up. The database wasn't compacted, please try again later, when the other compaction process is over.");
+                        throw new TimeoutException("Couldn't take FS lock for initializing a new FS (Esent bug requires us to lock the storage), we have waited for 30 seconds, aborting.");
                     }
                     Api.JetInit(ref instance);
 
@@ -329,7 +328,6 @@ namespace Raven.Database.FileSystem.Storage.Esent
                 }
                 if (e.Error != JET_err.FileNotFound)
                 {
-                    Debugger.Break();
                     throw;
                 }
             }

--- a/Raven.Tryouts/Program.cs
+++ b/Raven.Tryouts/Program.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using Raven.SlowTests.RavenThreadPool;
 #if !DNXCORE50
 
 using Raven.Tests.Core;
@@ -15,26 +17,23 @@ namespace Raven.Tryouts
         public static void Main(string[] args)
         {
 #if !DNXCORE50
-            for (int i = 0; i < 10; i++)
+
+            try
             {
-                Console.WriteLine("i = " + i);
-                using (var testServerFixture = new TestServerFixture())
+                for (int i = 0; i < 1000; i++)
                 {
-                    for (int j = 0; j < 10; j++)
+                    if(i%50==0)
+                        Console.WriteLine("i = " + i);
+                    using (var test = new ParallelCalculation())
                     {
-                        Console.WriteLine("j = " + j);
-                        using (var querying = new Querying())
-                        {
-                            querying.SetFixture(testServerFixture);
-                            querying.CanStreamQueryResult();
-                        }
-                        using (var querying = new Querying())
-                        {
-                            querying.SetFixture(testServerFixture);
-                            querying.CanGetFacets();
-                        }
+                        test.ThrottlingTest();
                     }
                 }
+            }
+            catch (Exception e)
+            {
+
+                Debugger.Break();
             }
 #endif
         }


### PR DESCRIPTION
…issue#)

Adding a locker to FS Esent TransactionalStorage Initialize because of Esent bug.
It seems locking the Compact alone doesn't resolve the problem i had to lock the
JetInit with the EnsureDatabaseIsCreatedAndAttachToDatabase removing any of them would result in errors.