### PR TITLE
RavenDB-4349

### DIFF
--- a/Raven.Tests.FileSystem/Smuggler/SmugglerExecutionTests.cs
+++ b/Raven.Tests.FileSystem/Smuggler/SmugglerExecutionTests.cs
@@ -214,7 +214,7 @@ namespace Raven.Tests.FileSystem.Smuggler
                 {
                     ReseedRandom(100); // Force a random distribution.
 
-                    await InitializeWithRandomFiles(store, 50, 30);
+                    await InitializeWithRandomFiles(store, 48, 30);
 
                     // now perform full backup
                     var dumper = new SmugglerFilesApi { Options = { Incremental = true } };
@@ -263,7 +263,7 @@ namespace Raven.Tests.FileSystem.Smuggler
                         using (var session = s.OpenAsyncSession())
                         {
                             var files = s.AsyncFilesCommands.BrowseAsync().Result;
-                            Assert.Equal(50, files.Count());
+                            Assert.Equal(48, files.Count());
                         }
 
                     });

--- a/Raven.Tests.Issues/RavenDB_3484.cs
+++ b/Raven.Tests.Issues/RavenDB_3484.cs
@@ -209,16 +209,19 @@ namespace Raven.Tests.Issues
 
                     User user;
 
-                    Assert.True(items[i].TryTake(out user, waitForDocTimeout));
-                    Assert.True(items[i].TryTake(out user, waitForDocTimeout));
+                    Assert.True(items[i].TryTake(out user, waitForDocTimeout),$"Waited for {waitForDocTimeout.TotalSeconds} seconds to get notified about a user, giving up... ");
+                    Assert.True(items[i].TryTake(out user, waitForDocTimeout), $"Waited for {waitForDocTimeout.TotalSeconds} seconds to get notified about a user, giving up... ");
 
                     SpinWait.SpinUntil(() => batchAcknowledged, TimeSpan.FromSeconds(5)); // let it acknowledge the processed batch before we open another subscription
-
+                    Assert.True(batchAcknowledged,"Wait for 5 seconds for batch to be acknoeledged, giving up...");
                     if (i > 0)
                     {
-                        Assert.False(items[i - 1].TryTake(out user, TimeSpan.FromSeconds(2)));
-                        Assert.True(SpinWait.SpinUntil(() => subscriptions[i - 1].IsConnectionClosed, TimeSpan.FromSeconds(5)));
-                        Assert.True(subscriptions[i - 1].SubscriptionConnectionException is SubscriptionInUseException);
+                        Assert.False(items[i - 1].TryTake(out user, TimeSpan.FromSeconds(2)),
+                            "Was able to take a connection to subscription even though a new connection was opened with ForceAndKeep strategy.");
+                        Assert.True(SpinWait.SpinUntil(() => subscriptions[i - 1].IsConnectionClosed, TimeSpan.FromSeconds(5)),
+                            "Previous connection to subscription was not closed even though a new connection was opened with ForceAndKeep strategy.");
+                        Assert.True(subscriptions[i - 1].SubscriptionConnectionException is SubscriptionInUseException,
+                            "SubscriptionConnectionException is not set to expected type, SubscriptionInUseException.");
                     }
                 }
             }


### PR DESCRIPTION
* Fixed an issue where 52 requests are sent to FS while it is been loaded when we allow only 50 concurrent requests.
* Adding some meaningful messages for issue #3484 (that i can't reproduce) so if it fails on TeamCity we could have more information than Assert.True failed.