### PR TITLE
flag to control initial precomputed batch size

### DIFF
--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -501,6 +501,9 @@ namespace Raven.Database.Actions
 
         private Action TryCreateTaskForApplyingPrecomputedBatchForNewIndex(Index index, IndexDefinition definition)
         {
+            if (Database.Configuration.MaxPrecomputedBatchSizeForNewIndex <= 0) //precaution -> should never be lower than 0
+                return null;
+
             var generator = IndexDefinitionStorage.GetViewGenerator(definition.IndexId);
             if (generator.ForEntityNames.Count == 0 && index.IsTestIndex == false)
             {
@@ -528,7 +531,10 @@ namespace Raven.Database.Actions
                 {
                     try
                     {
-                        ApplyPrecomputedBatchForNewIndex(index, generator, index.IsTestIndex == false ? Database.Configuration.MaxNumberOfItemsToProcessInSingleBatch : Database.Configuration.Indexing.MaxNumberOfItemsToProcessInTestIndexes, cts);
+                        ApplyPrecomputedBatchForNewIndex(index, generator, 
+                            index.IsTestIndex == false ?
+                            Database.Configuration.MaxPrecomputedBatchSizeForNewIndex :  
+                            Database.Configuration.Indexing.MaxNumberOfItemsToProcessInTestIndexes, cts);
                     }
                     catch (Exception e)
                     {

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -103,6 +103,8 @@ namespace Raven.Database.Config
             WorkingDirectory = CalculateWorkingDirectory(ravenSettings.WorkingDir.Value);
             FileSystem.InitializeFrom(this);
 
+            MaxPrecomputedBatchSizeForNewIndex = ravenSettings.MaxPrecomputedBatchSizeForNewIndex.Value;
+
             MaxClauseCount = ravenSettings.MaxClauseCount.Value;
 
             AllowScriptsToAdjustNumberOfSteps = ravenSettings.AllowScriptsToAdjustNumberOfSteps.Value;
@@ -358,6 +360,8 @@ namespace Raven.Database.Config
 
             return FilePathTools.MakeSureEndsWithSlash(workingDirectory.ToFullPath());
         }
+
+        public int MaxPrecomputedBatchSizeForNewIndex { get; private set; }
 
         public TimeSpan ConcurrentResourceLoadTimeout { get; private set; }
 

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -48,7 +48,10 @@ namespace Raven.Database.Config
         }
 
         public void Setup(int defaultMaxNumberOfItemsToIndexInSingleBatch, int defaultInitialNumberOfItemsToIndexInSingleBatch)
-        {
+        { 
+            const int maxPrecomputedBatchSize = 32 * 1024;
+            MaxPrecomputedBatchSizeForNewIndex = new IntegerSetting(settings["Raven/MaxPrecomputedBatchSizeForNewIndex"], maxPrecomputedBatchSize);
+
             //1024 is Lucene.net default - so if the setting is not set it will be the same as not touching Lucene's settings at all
             MaxClauseCount = new IntegerSetting(settings[Constants.MaxClauseCount], 1024);
 
@@ -307,6 +310,8 @@ namespace Raven.Database.Config
             return val;
         }
 
+        public IntegerSetting MaxPrecomputedBatchSizeForNewIndex { get; private set; }
+    
         public BooleanSetting CacheDocumentsInMemory { get; set; }
 
 


### PR DESCRIPTION
numeric flag to control amount of documents loaded in initial precomputed batch for new index