### PR TITLE
RavenDB-4361 - Port a change from 2.5

### DIFF
--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -1296,12 +1296,6 @@ namespace Raven.Database.Prefetching
                 documentsToRemove.TryRemove(docToRemove.Key, out _);
             }
 
-            JsonDocument result;
-            while (prefetchingQueue.TryPeek(out result) && lastIndexedEtag.CompareTo(result.Etag) >= 0)
-            {
-                prefetchingQueue.TryDequeue(out result);
-            }
-
             HandleCleanupOfUnusedDocumentsInQueue();
         }
 


### PR DESCRIPTION
no need to remove the outdated documents by etag after a replication batch is complete,
since we already filtered them when fetching from the queue