### PR TITLE
limit new index precompute operation to maximum total size

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -23,6 +23,7 @@ namespace Raven.Abstractions.Data
 
 
         public const string LastModified = "Last-Modified";
+        public const string SerializedSizeOnDisk = "SerializedSizeOnDisk";
         public const string CreationDate = "Creation-Date";
         public const string RavenCreationDate = "Raven-Creation-Date";
         public const string RavenLastModified = "Raven-Last-Modified";

--- a/Raven.Abstractions/Exceptions/TotalDataSizeExceededException.cs
+++ b/Raven.Abstractions/Exceptions/TotalDataSizeExceededException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Raven.Abstractions.Exceptions
+{
+    public class TotalDataSizeExceededException : Exception
+    {
+    }
+}

--- a/Raven.Abstractions/Exceptions/TotalDataSizeExceededException.cs
+++ b/Raven.Abstractions/Exceptions/TotalDataSizeExceededException.cs
@@ -1,8 +1,50 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace Raven.Abstractions.Exceptions
 {
+    /// <summary>
+    /// Exception thrown when first time index population exceeds configured threshold
+    /// </summary>
+    [Serializable]
     public class TotalDataSizeExceededException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TotalDataSizeExceededException"/> class.
+        /// </summary>
+        public TotalDataSizeExceededException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TotalDataSizeExceededException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public TotalDataSizeExceededException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TotalDataSizeExceededException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner.</param>
+        public TotalDataSizeExceededException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+#if !DNXCORE50
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TotalDataSizeExceededException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is null. </exception>
+        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0). </exception>
+
+        protected TotalDataSizeExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+#endif
     }
 }

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -261,6 +261,7 @@
     <Compile Include="Exceptions\Subscriptions\SubscriptionDoesNotExistException.cs" />
     <Compile Include="Exceptions\Subscriptions\SubscriptionInUseException.cs" />
     <Compile Include="Exceptions\Subscriptions\SubscriptionException.cs" />
+    <Compile Include="Exceptions\TotalDataSizeExceededException.cs" />
     <Compile Include="Exceptions\TransformCompilationException.cs" />
     <Compile Include="Exceptions\IndexCompilationException.cs" />
     <Compile Include="Exceptions\IndexDisabledException.cs" />

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -252,9 +252,15 @@ namespace Raven.Client.Connection.Async
         }
 
         public Task<string> PutIndexAsync(string name, IndexDefinition indexDef, bool overwrite, CancellationToken token = default(CancellationToken))
-        {
+        {			
             return ExecuteWithReplication("PUT", operationMetadata => DirectPutIndexAsync(name, indexDef, overwrite, operationMetadata, token), token);
         }
+
+        public Task<Tuple<string,Operation>> PutIndexAsyncWithOperation(string name, IndexDefinition indexDef, bool overwrite, CancellationToken token = default(CancellationToken))
+        {
+            return ExecuteWithReplication("PUT", operationMetadata => DirectPutIndexAsyncWitOperation(name, indexDef, overwrite, operationMetadata, token), token);
+        }
+
 
         public Task<string[]> PutIndexesAsync(IndexToAdd[] indexesToAdd, CancellationToken token = default(CancellationToken))
         {
@@ -272,6 +278,11 @@ namespace Raven.Client.Connection.Async
         }
 
         public async Task<string> DirectPutIndexAsync(string name, IndexDefinition indexDef, bool overwrite, OperationMetadata operationMetadata, CancellationToken token = default(CancellationToken))
+        {
+            return (await DirectPutIndexAsyncWitOperation(name, indexDef, overwrite, operationMetadata, token).ConfigureAwait(false)).Item1;
+        }
+
+        public async Task<Tuple<string,Operation>> DirectPutIndexAsyncWitOperation(string name, IndexDefinition indexDef, bool overwrite, OperationMetadata operationMetadata, CancellationToken token = default(CancellationToken))
         {
             var requestUri = operationMetadata.Url + "/indexes/" + Uri.EscapeUriString(name) + "?definition=yes";
             using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUri, "GET", operationMetadata.Credentials, convention).AddOperationHeaders(OperationsHeaders)))
@@ -300,7 +311,8 @@ namespace Raven.Client.Connection.Async
                 {
                     await request.WriteAsync(serializeObject).ConfigureAwait(false);
                     var result = await request.ReadResponseJsonAsync().ConfigureAwait(false);
-                    return result.Value<string>("Index");
+                    var operationId = result.Value<long>("OperationId");
+                    return Tuple.Create(result.Value<string>("Index"), operationId != -1 ? new Operation(this,operationId) : null);
                 }
                 catch (ErrorResponseException e)
                 {

--- a/Raven.Client.Lightweight/Connection/IDatabaseCommands.cs
+++ b/Raven.Client.Lightweight/Connection/IDatabaseCommands.cs
@@ -490,6 +490,14 @@ namespace Raven.Client.Connection
         string PutIndex(string name, IndexDefinition indexDef, bool overwrite);
 
         /// <summary>
+        ///     Creates an index with the specified name, based on an index definition
+        /// </summary>
+        /// <param name="name">name of an index</param>
+        /// <param name="indexDef">definition of an index</param>
+        /// <param name="precomputeBatchOperation">Operation of first time index population.</param>
+        string PutIndex(string name, IndexDefinition indexDef, out Operation precomputeBatchOperation);
+
+        /// <summary>
         ///     Creates an index with the specified name, based on an index definition that is created by the supplied
         ///     IndexDefinitionBuilder
         /// </summary>

--- a/Raven.Client.Lightweight/Connection/ServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/ServerClient.cs
@@ -228,6 +228,13 @@ namespace Raven.Client.Connection
             return AsyncHelpers.RunSync(() => asyncServerClient.PutIndexAsync(name, definition, false));
         }
 
+        public string PutIndex(string name, IndexDefinition definition, out Operation precomputeBatchOperation)
+        {
+            var result = AsyncHelpers.RunSync(() => asyncServerClient.PutIndexAsyncWithOperation(name, definition, false));
+            precomputeBatchOperation = result.Item2;
+            return result.Item1;
+        }
+
         public string[] PutIndexes(IndexToAdd[] indexesToAdd)
         {
             return AsyncHelpers.RunSync(() => asyncServerClient.PutIndexesAsync(indexesToAdd));

--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -228,14 +228,21 @@ namespace Raven.Database.Actions
         [MethodImpl(MethodImplOptions.Synchronized)]
         public string PutIndex(string name, IndexDefinition definition)
         {
-            return PutIndexInternal(name, definition);
+            long _;
+            return PutIndex(name, definition, out _);
         }
 
-        private string PutIndexInternal(string name, IndexDefinition definition, bool disableIndexBeforePut = false, bool isUpdateBySideSide = false, IndexCreationOptions? creationOptions = null)
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public string PutIndex(string name, IndexDefinition definition, out long opId)
+        {
+            return PutIndexInternal(name, definition, out opId);
+        }
+
+        private string PutIndexInternal(string name, IndexDefinition definition, out long opId,bool disableIndexBeforePut = false, bool isUpdateBySideSide = false, IndexCreationOptions? creationOptions = null)
         {
             if (name == null)
                 throw new ArgumentNullException("name");
-
+            opId = -1;
             name = name.Trim();
             IsIndexNameValid(name);
 
@@ -278,7 +285,7 @@ namespace Raven.Database.Actions
                     break;
             }
 
-            PutNewIndexIntoStorage(name, definition, disableIndexBeforePut);
+            opId = PutNewIndexIntoStorage(name, definition, disableIndexBeforePut);
 
             WorkContext.ClearErrorsFor(name);
 
@@ -300,7 +307,8 @@ namespace Raven.Database.Actions
             {
                 foreach (var indexToAdd in indexesToAdd)
                 {
-                    var nameToAdd = PutIndexInternal(indexToAdd.Name, indexToAdd.Definition, disableIndexBeforePut: true);
+                    long opId;
+                    var nameToAdd = PutIndexInternal(indexToAdd.Name, indexToAdd.Definition,out opId, disableIndexBeforePut: true);
                     if (nameToAdd == null)
                         continue;
 
@@ -367,7 +375,8 @@ namespace Raven.Database.Actions
                         }
                     }
 
-                    var nameToAdd = PutIndexInternal(indexName, indexToAdd.Definition, disableIndexBeforePut: true, isUpdateBySideSide: true, creationOptions: creationOptions);
+                    long _;
+                    var nameToAdd = PutIndexInternal(indexName, indexToAdd.Definition,out _, disableIndexBeforePut: true, isUpdateBySideSide: true, creationOptions: creationOptions);
                     if (nameToAdd == null)
                         continue;
 
@@ -423,7 +432,7 @@ namespace Raven.Database.Actions
             }
         }
 
-        internal void PutNewIndexIntoStorage(string name, IndexDefinition definition, bool disableIndex = false)
+        internal long PutNewIndexIntoStorage(string name, IndexDefinition definition, bool disableIndex = false)
         {
             Debug.Assert(Database.IndexStorage != null);
             Debug.Assert(TransactionalStorage != null);
@@ -468,8 +477,8 @@ namespace Raven.Database.Actions
             });
 
             Debug.Assert(index != null);
-
-            Action precomputeTask = null;
+            
+            Func<long> precomputeTask = null;
             if (WorkContext.RunIndexing &&
                 name.Equals(Constants.DocumentsByEntityNameIndex, StringComparison.InvariantCultureIgnoreCase) == false &&
                 Database.IndexStorage.HasIndex(Constants.DocumentsByEntityNameIndex) && isPrecomputedBatchForNewIndexIsRunning == false)
@@ -490,16 +499,19 @@ namespace Raven.Database.Actions
             IndexDefinitionStorage.AddIndex(definition.IndexId, definition);
 
             // we start the precomuteTask _after_ we finished adding the index
+            long operationId = -1;
             if (precomputeTask != null)
             {
-                precomputeTask();
+                operationId = precomputeTask();
             }
 
             WorkContext.ShouldNotifyAboutWork(() => "PUT INDEX " + name);
             WorkContext.NotifyAboutWork();
+
+            return operationId;	        
         }
 
-        private Action TryCreateTaskForApplyingPrecomputedBatchForNewIndex(Index index, IndexDefinition definition)
+        private Func<long> TryCreateTaskForApplyingPrecomputedBatchForNewIndex(Index index, IndexDefinition definition)
         {
             if (Database.Configuration.MaxPrecomputedBatchSizeForNewIndex <= 0) //precaution -> should never be lower than 0
                 return null;
@@ -531,10 +543,19 @@ namespace Raven.Database.Actions
                 {
                     try
                     {
-                        ApplyPrecomputedBatchForNewIndex(index, generator, 
+                        ApplyPrecomputedBatchForNewIndex(index, generator,
                             index.IsTestIndex == false ?
-                            Database.Configuration.MaxPrecomputedBatchSizeForNewIndex :  
-                            Database.Configuration.Indexing.MaxNumberOfItemsToProcessInTestIndexes, cts);
+                                Database.Configuration.MaxPrecomputedBatchSizeForNewIndex :
+                                Database.Configuration.Indexing.MaxNumberOfItemsToProcessInTestIndexes, cts);
+                    }
+                    catch (TotalDataSizeExceededException e)
+                    {
+                        Log.Warn(string.Format(
+                            @"Aborting applying precomputed batch for index {0}, 
+                                because total data size gatherered exceeded 
+                                configured data size ({1} bytes)", 
+                            index, Database.Configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes) , e);
+                        throw;
                     }
                     catch (Exception e)
                     {
@@ -569,6 +590,7 @@ namespace Raven.Database.Actions
                                 },
                                 out id,
                                 cts);
+                        return id;
                     }
                     catch (Exception)
                     {
@@ -605,7 +627,7 @@ namespace Raven.Database.Actions
                     ShouldSkipDuplicateChecking = true
                 })
                 {
-                    op.Init();
+                    op.Init();					
 
                     if ((op.Header.TotalResults > Database.Configuration.MaxNumberOfItemsToProcessInSingleBatch))
                     {
@@ -628,6 +650,7 @@ namespace Raven.Database.Actions
 
                     Log.Debug("For new index {0}, using precomputed indexing batch optimization for {1} docs", index,
                               op.Header.TotalResults);
+                    int totalLoadedDocumentSize = 0;
                     op.Execute(document =>
                     {
                         var metadata = document.Value<RavenJObject>(Constants.Metadata);
@@ -635,16 +658,27 @@ namespace Raven.Database.Actions
                         var etag = Etag.Parse(metadata.Value<string>("@etag"));
                         var lastModified = DateTime.Parse(metadata.Value<string>(Constants.LastModified));
                         document.Remove(Constants.Metadata);
+                        var serializedSizeOnDisk = metadata.Value<int>(Constants.SerializedSizeOnDisk);
+                        metadata.Remove(Constants.SerializedSizeOnDisk);
 
                         var doc = new JsonDocument
                         {
                             DataAsJson = document,
                             Etag = etag,
                             Key = key,
+                            SerializedSizeOnDisk = serializedSizeOnDisk,
                             LastModified = lastModified,
                             SkipDeleteFromIndex = true,
                             Metadata = metadata
                         };
+
+                        totalLoadedDocumentSize += serializedSizeOnDisk;
+                        if (totalLoadedDocumentSize >= Database.Configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes)
+                        {
+                            //we are aborting operation, so don't keep the references
+                            docsToIndex.Clear(); 
+                            throw new TotalDataSizeExceededException();
+                        }
 
                         docsToIndex.Add(doc);
                     });

--- a/Raven.Database/Actions/QueryActions.cs
+++ b/Raven.Database/Actions/QueryActions.cs
@@ -280,7 +280,7 @@ namespace Raven.Database.Actions
                 using (new CurrentTransformationScope(database, docRetriever))
                 {
                     foreach (var result in results)
-                    {
+                    {						
                         cancellationToken.ThrowIfCancellationRequested();
                         database.WorkContext.UpdateFoundWork();
 
@@ -362,7 +362,7 @@ namespace Raven.Database.Actions
             }
 
             IndexingFunc transformFunc = null;
-
+            
             // Check an explicitly declared one first
             if (string.IsNullOrEmpty(query.ResultsTransformer) == false)
             {
@@ -383,6 +383,12 @@ namespace Raven.Database.Actions
                     {
                         ravenJObject[Constants.DocumentIdFieldName] = x.Key;
                     }
+                    var metadata = ravenJObject.Value<RavenJObject>(Constants.Metadata);
+                    if (metadata == null) //precaution, should not happen
+                        ravenJObject.Add(Constants.Metadata, RavenJToken.FromObject(new {x.SerializedSizeOnDisk}));
+                    else
+                        metadata[Constants.SerializedSizeOnDisk] = x.SerializedSizeOnDisk;
+
                     return ravenJObject;
                 });
                 return showTimings ? new TimedEnumerable<RavenJObject>(resultsWithoutTransformer, loadingDocumentsFinish) : resultsWithoutTransformer;

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -105,6 +105,8 @@ namespace Raven.Database.Config
 
             MaxPrecomputedBatchSizeForNewIndex = ravenSettings.MaxPrecomputedBatchSizeForNewIndex.Value;
 
+            MaxPrecomputedBatchTotalDocumentSizeInBytes = ravenSettings.MaxPrecomputedBatchTotalDocumentSizeInBytes.Value;
+
             MaxClauseCount = ravenSettings.MaxClauseCount.Value;
 
             AllowScriptsToAdjustNumberOfSteps = ravenSettings.AllowScriptsToAdjustNumberOfSteps.Value;
@@ -361,7 +363,9 @@ namespace Raven.Database.Config
             return FilePathTools.MakeSureEndsWithSlash(workingDirectory.ToFullPath());
         }
 
-        public int MaxPrecomputedBatchSizeForNewIndex { get; private set; }
+        public int MaxPrecomputedBatchSizeForNewIndex { get; set; }
+
+        public int MaxPrecomputedBatchTotalDocumentSizeInBytes { get; set; }
 
         public TimeSpan ConcurrentResourceLoadTimeout { get; private set; }
 

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -49,8 +49,11 @@ namespace Raven.Database.Config
 
         public void Setup(int defaultMaxNumberOfItemsToIndexInSingleBatch, int defaultInitialNumberOfItemsToIndexInSingleBatch)
         { 
-            const int maxPrecomputedBatchSize = 32 * 1024;
-            MaxPrecomputedBatchSizeForNewIndex = new IntegerSetting(settings["Raven/MaxPrecomputedBatchSizeForNewIndex"], maxPrecomputedBatchSize);
+            const int defaultPrecomputedBatchSize = 32 * 1024;
+            MaxPrecomputedBatchSizeForNewIndex = new IntegerSetting(settings["Raven/MaxPrecomputedBatchSizeForNewIndex"], defaultPrecomputedBatchSize);
+
+            const int defaultPrecomputedBatchTotalDocumentSizeInBytes = 1024*1024*250;  //250 mb
+            MaxPrecomputedBatchTotalDocumentSizeInBytes = new IntegerSetting(settings["Raven/MaxPrecomputedBatchTotalDocumentSizeInBytes"], defaultPrecomputedBatchTotalDocumentSizeInBytes);
 
             //1024 is Lucene.net default - so if the setting is not set it will be the same as not touching Lucene's settings at all
             MaxClauseCount = new IntegerSetting(settings[Constants.MaxClauseCount], 1024);
@@ -310,8 +313,10 @@ namespace Raven.Database.Config
             return val;
         }
 
+        public IntegerSetting MaxPrecomputedBatchTotalDocumentSizeInBytes { get; private set; }
+
         public IntegerSetting MaxPrecomputedBatchSizeForNewIndex { get; private set; }
-    
+
         public BooleanSetting CacheDocumentsInMemory { get; set; }
 
 

--- a/Raven.Database/Server/Controllers/IndexController.cs
+++ b/Raven.Database/Server/Controllers/IndexController.cs
@@ -267,8 +267,9 @@ namespace Raven.Database.Server.Controllers
 
             try
             {
-                Database.Indexes.PutIndex(index, data);
-                return GetMessageWithObject(new { Index = index }, HttpStatusCode.Created);
+                long opId;
+                Database.Indexes.PutIndex(index, data, out opId);
+                return GetMessageWithObject(new { Index = index, OperationId = opId }, HttpStatusCode.Created);
             }
             catch (Exception ex)
             {

--- a/Raven.Database/Server/Controllers/IndexController.cs
+++ b/Raven.Database/Server/Controllers/IndexController.cs
@@ -269,7 +269,16 @@ namespace Raven.Database.Server.Controllers
             {
                 long opId;
                 Database.Indexes.PutIndex(index, data, out opId);
-                return GetMessageWithObject(new { Index = index, OperationId = opId }, HttpStatusCode.Created);
+
+                //treat includePrecomputeOperation as a flag
+                var includePrecomputeOperation = GetQueryStringValue("includePrecomputeOperation");
+                if (!String.IsNullOrWhiteSpace(includePrecomputeOperation) &&
+                    includePrecomputeOperation.Equals("yes",StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetMessageWithObject(new { Index = index, OperationId = opId }, HttpStatusCode.Created);
+                }
+
+                return GetMessageWithObject(new { Index = index }, HttpStatusCode.Created);
             }
             catch (Exception ex)
             {

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -161,6 +161,7 @@ namespace Raven.Tests.Core.Configuration
             configurationComparer.Ignore(x => x.EnableResponseLoggingForEmbeddedDatabases);
             configurationComparer.Ignore(x => x.DynamicMemoryLimitForProcessing);
             configurationComparer.Assert(expected => expected.MaxPrecomputedBatchSizeForNewIndex.Value, actual => actual.MaxPrecomputedBatchSizeForNewIndex);
+            configurationComparer.Assert(expected => expected.MaxPrecomputedBatchTotalDocumentSizeInBytes.Value, actual => actual.MaxPrecomputedBatchTotalDocumentSizeInBytes);			
             configurationComparer.Assert(expected => expected.RejectClientsModeEnabled.Value, actual => actual.RejectClientsMode);
             configurationComparer.Assert(expected => expected.MaxSecondsForTaskToWaitForDatabaseToLoad.Value, actual => actual.MaxSecondsForTaskToWaitForDatabaseToLoad);
             configurationComparer.Assert(expected => expected.NewIndexInMemoryMaxTime.Value, actual => actual.NewIndexInMemoryMaxTime);

--- a/Raven.Tests.Issues/NewIndexOptimizationIssue.cs
+++ b/Raven.Tests.Issues/NewIndexOptimizationIssue.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Abstractions.Indexing;
+using Raven.Client.Connection;
+using Raven.Database.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class NewIndexOptimizationIssue : RavenTestBase
+    {
+        protected override void ModifyConfiguration(InMemoryRavenConfiguration configuration)
+        {
+            //limit precompute batch total size, so the operation fails in the test
+            configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes = 100;
+        }
+
+        [Fact]
+        public void PrecomputedBatchShouldFailIfTooMuchData()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Post
+                    {
+                        Title = "Querying document database"
+                    });
+
+                    session.Store(new Post
+                    {
+                        Title = "Introduction to RavenDB" 
+                    });
+
+                    session.Store(new Post
+                    {
+                        Title = "NOSQL databases" + new string(' ', 1024 * 1024)
+                    });
+
+                    session.Store(new Post
+                    {
+                        Title = "MSSQL 2012"
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                Operation precomputeBatchOperation;
+                store.DatabaseCommands.PutIndex("Posts/ByTitle", new IndexDefinition
+                {
+                    Map = "from post in docs.Posts select new { post.Title }",
+                    Indexes = { { "Title", FieldIndexing.Analyzed } }
+                },out precomputeBatchOperation);
+
+                //should fail because the threshold is set to 100 bytes, and 
+                //total size of existing documents is more than that
+                Assert.Throws<InvalidOperationException>(() => precomputeBatchOperation.WaitForCompletion());
+            }
+        }
+    }
+}

--- a/Raven.Tests.Issues/NewIndexOptimizationIssue.cs
+++ b/Raven.Tests.Issues/NewIndexOptimizationIssue.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Raven.Abstractions.Indexing;
 using Raven.Client.Connection;
 using Raven.Database.Config;
@@ -17,7 +15,7 @@ namespace Raven.Tests.Issues
         protected override void ModifyConfiguration(InMemoryRavenConfiguration configuration)
         {
             //limit precompute batch total size, so the operation fails in the test
-            configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes = 100;
+            configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes = 5;
         }
 
         [Fact]
@@ -62,6 +60,61 @@ namespace Raven.Tests.Issues
                 //should fail because the threshold is set to 100 bytes, and 
                 //total size of existing documents is more than that
                 Assert.Throws<InvalidOperationException>(() => precomputeBatchOperation.WaitForCompletion());
+            }
+        }
+
+        [Fact]
+        public void AllDocumentsShouldBeIndexedEvenIfPrecomputedBatchFails()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Post
+                    {
+                        Title = "Querying document database"
+                    });
+
+                    session.Store(new Post
+                    {
+                        Title = "Introduction to RavenDB"
+                    });
+
+                    session.Store(new Post
+                    {
+                        Title = "NOSQL databases"
+                    });
+
+                    session.Store(new Post
+                    {
+                        Title = "MSSQL 2012"
+                    });
+
+                    session.SaveChanges();
+                }
+
+                WaitForIndexing(store);
+
+                Operation precomputeBatchOperation;
+                store.DatabaseCommands.PutIndex("Posts/ByTitle", new IndexDefinition
+                {
+                    Map = "from post in docs.Posts select new { post.Title }",
+                    Indexes = { { "Title", FieldIndexing.Analyzed } }
+                }, out precomputeBatchOperation);
+
+                //should fail because the threshold is set to 100 bytes, and 
+                //total size of existing documents is more than that
+                Assert.Throws<InvalidOperationException>(() => precomputeBatchOperation.WaitForCompletion());
+                WaitForIndexing(store);
+
+                List<Post> fetchedPosts;
+                using (var session = store.OpenSession())
+                    fetchedPosts = session.Query<Post>("Posts/ByTitle").ToList();
+
+                var expectedTitles = new[] { "Querying document database" , "Introduction to RavenDB", "NOSQL databases", "MSSQL 2012" };
+                var fetchedTitles = fetchedPosts.Select(x => x.Title).ToList();
+                foreach(var title in expectedTitles)
+                    Assert.Contains(title,fetchedTitles,StringComparer.OrdinalIgnoreCase);
             }
         }
     }

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -138,6 +138,7 @@
     <Compile Include="1379\RavenDB_1379_Client_Lazy.cs" />
     <Compile Include="1379\RavenDB_1379_Client_Remote.cs" />
     <Compile Include="ActualValueInJsonReaderException.cs" />
+    <Compile Include="NewIndexOptimizationIssue.cs" />
     <Compile Include="RavenDB-4196.cs" />
     <Compile Include="RavenDB-4300.cs" />
     <Compile Include="RavenDB_3928.cs" />


### PR DESCRIPTION
* limit new index precompute operation to maximum size, if total accumulated document size exceeds the default, the operation is aborted
* relevant test