### PR TITLE
RavenDB-4373 index performance: Uncaught TypeError: Cannot read prope…

### DIFF
--- a/Raven.Studio.Html5/App/viewmodels/database/status/indexing/indexPerformance.ts
+++ b/Raven.Studio.Html5/App/viewmodels/database/status/indexing/indexPerformance.ts
@@ -377,6 +377,11 @@ class metrics extends viewModelBase {
 
         incomingData.forEach(d => {
 
+            // we have to filter out future batches that are not completed
+            if (!d.Duration) {
+                return;
+            }
+
             this.computePrefetchCache(d);
             if (dateLookup.has(d.Timestamp)) {
                 var index = dateLookup.get(d.Timestamp);


### PR DESCRIPTION
…rty 'split' of null
