### PR TITLE
Fix for RavenDB-4387

### DIFF
--- a/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
+++ b/Raven.Client.Lightweight/Document/Async/AsyncDocumentSession.cs
@@ -525,7 +525,10 @@ namespace Raven.Client.Document.Async
                 var document = SerializationHelper.RavenJObjectToJsonDocument(enumerator.Current);
                 Current = new StreamResult<T>
                 {
-                    Document = (T)parent.ConvertToEntity(typeof(T),document.Key, document.DataAsJson, document.Metadata),
+                    Document = (T)parent.ConvertToEntity(typeof(T),
+                        document.Key, 
+                        document.DataAsJson, 
+                        document.Metadata, true),
                     Etag = document.Etag,
                     Key = document.Key,
                     Metadata = document.Metadata

--- a/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/Document/InMemoryDocumentSessionOperations.cs
@@ -497,8 +497,13 @@ more responsive application.
         /// <param name="id">The id.</param>
         /// <param name="documentFound">The document found.</param>
         /// <param name="metadata">The metadata.</param>
+        /// <param name="isStreaming">Is the conversion is part of the streaming? If yes, no sense in registering missing properties</param>
         /// <returns></returns>
-        public object ConvertToEntity(Type entityType, string id, RavenJObject documentFound, RavenJObject metadata)
+        public object ConvertToEntity(Type entityType, 
+            string id, 
+            RavenJObject documentFound, 
+            RavenJObject metadata,
+            bool isStreaming = false)
         {
             try
             {
@@ -516,7 +521,9 @@ more responsive application.
 
                 IDisposable disposable = null;
                 var defaultRavenContractResolver = Conventions.JsonContractResolver as DefaultRavenContractResolver;
-                if (defaultRavenContractResolver != null && Conventions.PreserveDocumentPropertiesNotFoundOnModel)
+                if (!isStreaming && 
+                    defaultRavenContractResolver != null && 
+                    Conventions.PreserveDocumentPropertiesNotFoundOnModel)
                 {
                     disposable = defaultRavenContractResolver.RegisterForExtensionData(RegisterMissingProperties);
                 }


### PR DESCRIPTION
Make sure that during streaming missing properties won't be registered and saved (RavenDB-4387)
-> makes no sense to save the missing properties during streaming, since we can potentially go over ALOT of documents that are unlikely to be saved later

That should lessen memory usage during streaming
(https://groups.google.com/forum/#!topic/ravendb/TWxDlYkObP0)