### PR TITLE
RavenDB-4114 replacing JsonPropertyAttribute PropertyName only when n…

### DIFF
--- a/Raven.Abstractions/Extensions/CSharpIdentifierExtensions.cs
+++ b/Raven.Abstractions/Extensions/CSharpIdentifierExtensions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Raven.Abstractions.Extensions
+{
+    public static class CSharpIdentifierExtensions
+    {
+        public static bool IsValidIdentifier(this string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier))
+                return false;
+
+            if (keywordsTable == null)
+                FillKeywordTable();
+
+            if (keywordsTable.Contains(identifier))
+                return false;
+
+            if (!is_identifier_start_character(identifier[0]))
+                return false;
+
+            for (int i = 1; i < identifier.Length; i++)
+                if (!is_identifier_part_character(identifier[i]))
+                    return false;
+
+            return true;
+        }
+
+
+        internal static bool is_identifier_start_character(char c)
+        {
+            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '@' || char.IsLetter(c);
+        }
+
+        internal static bool is_identifier_part_character(char c)
+        {
+            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || (c >= '0' && c <= '9') || char.IsLetter(c);
+        }
+
+
+        private static System.Collections.Hashtable keywordsTable;
+        private static string[] keywords = new string[] {
+    "abstract","event","new","struct","as","explicit","null","switch","base","extern",
+    "this","false","operator","throw","break","finally","out","true",
+    "fixed","override","try","case","params","typeof","catch","for",
+    "private","foreach","protected","checked","goto","public",
+    "unchecked","class","if","readonly","unsafe","const","implicit","ref",
+    "continue","in","return","using","virtual","default",
+    "interface","sealed","volatile","delegate","internal","do","is",
+    "sizeof","while","lock","stackalloc","else","static","enum",
+    "namespace",
+    "object","bool","byte","float","uint","char","ulong","ushort",
+    "decimal","int","sbyte","short","double","long","string","void",
+    "partial", "yield", "where"
+};
+
+        internal static void FillKeywordTable()
+        {
+            lock (keywords)
+            {
+                if (keywordsTable == null)
+                {
+                    keywordsTable = new System.Collections.Hashtable();
+                    foreach (string keyword in keywords)
+                    {
+                        keywordsTable.Add(keyword, keyword);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -271,6 +271,7 @@
     <Compile Include="Extensions\AttachmentExtensions.cs" />
     <Compile Include="Extensions\CharExtensions.cs" />
     <Compile Include="Extensions\CryptoTransformExtensions.cs" />
+    <Compile Include="Extensions\CSharpIdentifierExtensions.cs" />
     <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Exceptions\ConcurrencyException.cs" />
     <Compile Include="Extensions\Buffers.cs" />

--- a/Raven.Client.Lightweight/Indexes/ExpressionStringBuilder.cs
+++ b/Raven.Client.Lightweight/Indexes/ExpressionStringBuilder.cs
@@ -225,7 +225,7 @@ namespace Raven.Client.Indexes
                 Visit(instance);
                 if (ShouldParantesisMemberExpression(instance))
                     Out(")");
-                Out(isJsonProperty?"[\"" + name +"\"]": "." + name);
+                Out(isJsonProperty && !name.IsValidIdentifier() ?"[\"" + name +"\"]": "." + name);                
             }
             else
             {

--- a/Raven.Tests.MailingList/IndexesIgnoreNewtonsoftJsonPropertyAttributes.cs
+++ b/Raven.Tests.MailingList/IndexesIgnoreNewtonsoftJsonPropertyAttributes.cs
@@ -34,6 +34,9 @@ namespace RavenTestConsole.RavenTests
         
             [Raven.Imports.Newtonsoft.Json.JsonProperty("ZipCode")]
             public string Postcode { get; set; }
+
+            [Raven.Imports.Newtonsoft.Json.JsonProperty("~i'm@Ivalid#")]
+            public string InvalidProperty { get; set; }
         }
 
         private class StudentDtos_ByEmailDomain : AbstractIndexCreationTask<StudentDto, StudentDtos_ByEmailDomain.Result>
@@ -42,6 +45,7 @@ namespace RavenTestConsole.RavenTests
             {
                 public string Email { get; set; }
                 public string Postcode { get; set; }
+                public string InvalidProperty { get; set; }
             }
 
             public StudentDtos_ByEmailDomain()
@@ -50,7 +54,8 @@ namespace RavenTestConsole.RavenTests
                                   select new Result
                                   {
                                       Email = studentDto.Email,
-                                      Postcode = studentDto.Postcode
+                                      Postcode = studentDto.Postcode,
+                                      InvalidProperty = studentDto.InvalidProperty
                                   };
             }
         }
@@ -74,12 +79,14 @@ namespace RavenTestConsole.RavenTests
 
                 Assert.Equal(@"docs.StudentDtos.Select(studentDto => new {
     Email = studentDto.Email,
-    Postcode = studentDto[""ZipCode""]
+    Postcode = studentDto.ZipCode,
+    InvalidProperty = studentDto[""~i'm@Ivalid#""]
 })", definition.Map);
 
                 Assert.NotEqual(@"docs.StudentDtos.Select(studentDto => new {
-    Email = studentDto[""EmailAddress""],
-    Postcode = studentDto[""ZipCode""]
+    Email = studentDto.EmailAddress,
+    Postcode = studentDto.ZipCode,
+    InvalidProperty = studentDto[""~i'm@Ivalid#""]
 })", definition.Map);
             }
         }


### PR DESCRIPTION
…ame is an invalid CSharp identifier
