### PR TITLE
RavenDB-4354 In Raft add meaningful error messages when unable to add…

### DIFF
--- a/Raven.Database/Raft/ClusterManagementHttpClient.cs
+++ b/Raven.Database/Raft/ClusterManagementHttpClient.cs
@@ -422,7 +422,11 @@ namespace Raven.Database.Raft
             {
                 var response = await request.ExecuteAsync().ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode)
+                {
+                    if (response.StatusCode == HttpStatusCode.Forbidden || response.StatusCode == HttpStatusCode.Unauthorized)
+                        throw new UnauthorizedAccessException($"unable to reach {nodeConnectionInfo.Uri} make sure you have admin privileges on the <system> database");
                     throw new InvalidOperationException("Unable to fetch database statictics for: " + nodeConnectionInfo.Uri);
+                }
 
                 using (var responseStream = await response.GetResponseStreamWithHttpDecompression().ConfigureAwait(false))
                 {


### PR DESCRIPTION
… node to cluster when using api-key

(the error state couldn't fetch stats while it should show the actual reason that is you're not authorized)
