### PR TITLE
RavenDB-4402 removing failing test that would check for string sort-h…

### DIFF
--- a/Raven.Tests.Issues/RavenDB_3442.cs
+++ b/Raven.Tests.Issues/RavenDB_3442.cs
@@ -35,25 +35,5 @@ namespace Raven.Tests.Issues
                 Assert.Equal(SortOptions.Int, index.SortOptions["Age"]);
             }
         }
-
-        [Fact]
-        public void WhereEqualsShouldSendSortHintsAndDynamicIndexesShouldSetAppropriateSortOptionsThen2()
-        {
-            using (var store = NewDocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Query<User>()
-                        .Where(x => x.Name == "John")
-                        .ToList();
-                }
-
-                var indexes = store.DatabaseCommands.GetIndexes(0, 10);
-                var index = indexes.Single(x => x.Name.StartsWith("Auto/"));
-
-                Assert.Equal(1, index.SortOptions.Count);
-                Assert.Equal(SortOptions.String, index.SortOptions["Name"]);
-            }
-        }
     }
 }


### PR DESCRIPTION
…int i have removed string sort-hints from where equals because that is the default sorting