### PR TITLE
RavenDB-4344 Deprecate the use of AlwaysWaitForNonStaleResultsAsOfLas…

### DIFF
--- a/Raven.Client.Lightweight/Document/AbstractDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AbstractDocumentQuery.cs
@@ -339,7 +339,9 @@ namespace Raven.Client.Document
 		    }
 #endif
 
+#pragma warning disable 618
 			if(conventions.DefaultQueryingConsistency == ConsistencyOptions.AlwaysWaitForNonStaleResultsAsOfLastWrite)
+#pragma warning restore 618
 			{
 				WaitForNonStaleResultsAsOfLastWrite();
 			}

--- a/Raven.Client.Lightweight/Document/DocumentConvention.cs
+++ b/Raven.Client.Lightweight/Document/DocumentConvention.cs
@@ -824,19 +824,23 @@ namespace Raven.Client.Document
 		/// This is ensured by the server, and require no action from the client
 		/// </summary>
 		None,
-		/// <summary>
-		///  After updating a documents, will only accept queries which already indexed the updated value.
-		/// </summary>
-		AlwaysWaitForNonStaleResultsAsOfLastWrite,
-		/// <summary>
-		/// Use AlwaysWaitForNonStaleResultsAsOfLastWrite, instead
-		/// </summary>
-		[Obsolete("Use AlwaysWaitForNonStaleResultsAsOfLastWrite, instead")]
+        /// <summary>
+        ///  After updating a documents, will only accept queries which already indexed the updated value.
+        /// </summary>
+        [Obsolete("Beware of AlwaysWaitForNonStaleResultsAsOfLastWrite overuse. " +
+                  "See: http://ravendb.net/docs/article-page/2.5/Csharp/client-api/querying/stale-indexes#setting-cut-off-point")]
+        AlwaysWaitForNonStaleResultsAsOfLastWrite,
+        /// <summary>
+        /// Use AlwaysWaitForNonStaleResultsAsOfLastWrite, instead
+        /// </summary>
+#pragma warning disable 618
+        [Obsolete("Use AlwaysWaitForNonStaleResultsAsOfLastWrite, instead")]
 		QueryYourWrites = AlwaysWaitForNonStaleResultsAsOfLastWrite,
-		/// <summary>
-		/// Use None, instead
-		/// </summary>
-		[Obsolete("Use None, instead")]
+#pragma warning restore 618
+        /// <summary>
+        /// Use None, instead
+        /// </summary>
+        [Obsolete("Use None, instead")]
 		MonotonicRead = None
 	}
 }


### PR DESCRIPTION
…tWrite at the convention level.
