### PR TITLE
RavenDB-4344 Deprecate the use of AlwaysWaitForNonStaleResultsAsOfLas…

### DIFF
--- a/Raven.Client.Lightweight/Document/DocumentConvention.cs
+++ b/Raven.Client.Lightweight/Document/DocumentConvention.cs
@@ -832,6 +832,8 @@ namespace Raven.Client.Document
         /// <summary>
         ///  After updating a documents, will only accept queries which already indexed the updated value.
         /// </summary>
+        [Obsolete("Beware of AlwaysWaitForNonStaleResultsAsOfLastWrite overuse. " +
+                  "See: http://ravendb.net/docs/article-page/3.0/csharp/client-api/configuration/conventions/querying#defaultqueryingconsistency")]
         AlwaysWaitForNonStaleResultsAsOfLastWrite,
         /// <summary>
         /// Use AlwaysWaitForNonStaleResultsAsOfLastWrite, instead


### PR DESCRIPTION
…tWrite at the convention level.
