### PR TITLE
Committable

### DIFF
--- a/src/Voron/Impl/ICommittable.cs
+++ b/src/Voron/Impl/ICommittable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Voron.Impl
+{
+    public interface ICommittable
+    {
+        bool RequiresParticipation { get; }
+        void PrepareForCommit();
+    }
+}

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -20,6 +20,7 @@ namespace Voron.Impl
 
         private readonly Dictionary<string, PrefixTree> _prefixTrees = new Dictionary<string, PrefixTree>();
         private readonly Dictionary<string, Tree> _trees = new Dictionary<string, Tree>();
+        private readonly HashSet<ICommittable> _participants = new HashSet<ICommittable>();
 
         public Transaction(LowLevelTransaction lowLevelTransaction)
         {
@@ -55,11 +56,16 @@ namespace Voron.Impl
 
         public void Commit()
         {
-            CommitTrees();
+            PrepareForCommit();
             _lowLevelTransaction.Commit();
         }
 
-        internal void CommitTrees()
+        public void Register(ICommittable participant)
+        {
+            _participants.Add(participant);
+        }
+
+        internal void PrepareForCommit()
         {
             if (_multiValueTrees != null)
             {
@@ -69,8 +75,7 @@ namespace Voron.Impl
                     var key = multiValueTree.Key.Item2;
                     var childTree = multiValueTree.Value;
 
-                    var trh =
-                        (TreeRootHeader*)parentTree.DirectAdd(key, sizeof(TreeRootHeader), TreeNodeFlags.MultiValuePageRef);
+                    var trh = (TreeRootHeader*)parentTree.DirectAdd(key, sizeof(TreeRootHeader), TreeNodeFlags.MultiValuePageRef);
                     childTree.State.CopyTo(trh);
                 }
             }
@@ -79,6 +84,7 @@ namespace Voron.Impl
             {
                 if (tree == null)
                     continue;
+
                 tree.State.InWriteTransaction = false;
                 var treeState = tree.State;
                 if (treeState.IsModified)
@@ -88,18 +94,10 @@ namespace Voron.Impl
                 }
             }
 
-            foreach (var prefixTree in PrefixTrees)
+            foreach (var participant in _participants)
             {
-                // FEDERICO: This should never happen, why it happens on tree still eludes me. 
-                if (prefixTree == null)
-                    continue;
-
-                var treeState = prefixTree.State;
-                if (treeState.IsModified)
-                {
-                    var treePtr = (PrefixTreeRootHeader*)_lowLevelTransaction.RootObjects.DirectAdd((Slice)prefixTree.Name, sizeof(PrefixTreeRootHeader));
-                    treeState.CopyTo(treePtr);
-                }
+                if (participant.RequiresParticipation)
+                    participant.PrepareForCommit();
             }
         }
 
@@ -226,7 +224,7 @@ namespace Voron.Impl
             if (_prefixTrees.TryGetValue(treeName, out tree))
                 return tree;
 
-            if (PrefixTree.TryOpen(_lowLevelTransaction, _lowLevelTransaction.RootObjects, treeName, out tree))
+            if (PrefixTree.TryOpen(this, _lowLevelTransaction.RootObjects, treeName, out tree))
             {
                 _prefixTrees.Add(treeName, tree);
                 return tree;
@@ -246,7 +244,7 @@ namespace Voron.Impl
 
             Slice key = name;
 
-            tree = PrefixTree.Create(LowLevelTransaction, LowLevelTransaction.RootObjects, name, subtreeDepth);
+            tree = PrefixTree.Create(this, LowLevelTransaction.RootObjects, name, subtreeDepth);
             tree.Name = name;
 
             AddPrefixTree(name, tree);

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -172,7 +172,7 @@ namespace Voron
                 metadataTree.Add("db-id", DbId.ToByteArray());
                 metadataTree.Add("schema-version", EndianBitConverter.Little.GetBytes(Options.SchemaVersion));
 
-                treesTx.CommitTrees();
+                treesTx.PrepareForCommit();
 
                 tx.Commit();
             }


### PR DESCRIPTION
Give any object the ability to register itself to become part of the transaction preparation. It is important because as we grow the potential data structures the Transaction itself is starting to get very crowded, this allows us to have layered structures like Table that would hold their own tree and only require that tree to prepare in the transaction context to be committed.