### PR TITLE
RavenDB-4510 Added configuration option to prevent from recovering in…

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -291,6 +291,7 @@ namespace Raven.Abstractions.Data
         {
             public const string DisableIndexingFreeSpaceThreshold = "Raven/Indexing/DisableIndexingFreeSpaceThreshold";
             public const string DisableMapReduceInMemoryTracking = "Raven/Indexing/DisableMapReduceInMemoryTracking";
+            public const string SkipRecoveryOnStartup = "Raven/Indexing/SkipRecoveryOnStartup";
         }
     }
 }

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -330,6 +330,7 @@ namespace Raven.Database.Config
             Indexing.MaxNumberOfItemsToProcessInTestIndexes = ravenSettings.Indexing.MaxNumberOfItemsToProcessInTestIndexes.Value;
             Indexing.DisableIndexingFreeSpaceThreshold = ravenSettings.Indexing.DisableIndexingFreeSpaceThreshold.Value;
             Indexing.DisableMapReduceInMemoryTracking = ravenSettings.Indexing.DisableMapReduceInMemoryTracking.Value;
+            Indexing.SkipRecoveryOnStartup = ravenSettings.Indexing.SkipRecoveryOnStartup.Value;
 
             TombstoneRetentionTime = ravenSettings.TombstoneRetentionTime.Value;
 
@@ -1535,6 +1536,8 @@ namespace Raven.Database.Config
             public int DisableIndexingFreeSpaceThreshold { get; set; }
 
             public bool DisableMapReduceInMemoryTracking { get; set; }
+
+            public bool SkipRecoveryOnStartup { get; set; }
         }
 
         public class WebSocketsConfiguration

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -271,6 +271,7 @@ namespace Raven.Database.Config
             Indexing.MaxNumberOfItemsToProcessInTestIndexes = new IntegerSetting(settings[Constants.MaxNumberOfItemsToProcessInTestIndexes], 512);
             Indexing.DisableIndexingFreeSpaceThreshold = new IntegerSetting(settings[Constants.Indexing.DisableIndexingFreeSpaceThreshold], 2048);
             Indexing.DisableMapReduceInMemoryTracking = new BooleanSetting(settings[Constants.Indexing.DisableMapReduceInMemoryTracking], false);
+            Indexing.SkipRecoveryOnStartup = new BooleanSetting(settings[Constants.Indexing.SkipRecoveryOnStartup], false);
 
             DefaultStorageTypeName = new StringSetting(settings["Raven/StorageTypeName"] ?? settings["Raven/StorageEngine"], string.Empty);
 
@@ -517,6 +518,7 @@ namespace Raven.Database.Config
 
             public IntegerSetting DisableIndexingFreeSpaceThreshold { get; set; }
             public BooleanSetting DisableMapReduceInMemoryTracking { get; set; }
+            public BooleanSetting SkipRecoveryOnStartup { get; set; }
         }
 
         public class PrefetcherConfiguration

--- a/Raven.Database/Indexing/IndexStorage.cs
+++ b/Raven.Database/Indexing/IndexStorage.cs
@@ -229,7 +229,7 @@ namespace Raven.Database.Indexing
                     if (resetTried)
                         throw new InvalidOperationException("Could not open / create index" + indexName + ", reset already tried", e);
 
-                    if (recoveryTried == false && luceneDirectory != null)
+                    if (recoveryTried == false && luceneDirectory != null && configuration.Indexing.SkipRecoveryOnStartup == false)
                     {
                         recoveryTried = true;
                         startupLog.WarnException("Could not open index " + indexName + ". Trying to recover index", e);


### PR DESCRIPTION
…dexes on startup so in case of large databases we will be able to load it fast, however all of the indexes will be reset (useful when we just want to retrieve the data and don't care for indexes)