### PR TITLE
RavenDB-4510 Added configuration option to prevent from recovering in…

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -501,6 +501,7 @@ namespace Raven.Abstractions.Data
         {
             public const string DisableIndexingFreeSpaceThreshold = "Raven/Indexing/DisableIndexingFreeSpaceThreshold";
             public const string DisableMapReduceInMemoryTracking = "Raven/Indexing/DisableMapReduceInMemoryTracking";
+            public const string SkipRecoveryOnStartup = "Raven/Indexing/SkipRecoveryOnStartup";
         }
         public const string RequestFailedExceptionMarker = "ExceptionRequestFailed";
 

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -360,6 +360,7 @@ namespace Raven.Database.Config
             Indexing.UseLuceneASTParser = ravenSettings.Indexing.UseLuceneASTParser.Value;
             Indexing.DisableIndexingFreeSpaceThreshold = ravenSettings.Indexing.DisableIndexingFreeSpaceThreshold.Value;
             Indexing.DisableMapReduceInMemoryTracking = ravenSettings.Indexing.DisableMapReduceInMemoryTracking.Value;
+            Indexing.SkipRecoveryOnStartup = ravenSettings.Indexing.SkipRecoveryOnStartup.Value;
 
             Cluster.ElectionTimeout = ravenSettings.Cluster.ElectionTimeout.Value;
             Cluster.HeartbeatTimeout = ravenSettings.Cluster.HeartbeatTimeout.Value;
@@ -1688,9 +1689,11 @@ namespace Raven.Database.Config
                     if (value == useLuceneASTParser)
                         return;
                     QueryBuilder.UseLuceneASTParser = useLuceneASTParser = value;
-        }
+                }
             }
             private bool useLuceneASTParser = true;
+
+            public bool SkipRecoveryOnStartup { get; set; }
         }
 
         public class ClusterConfiguration

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -299,6 +299,7 @@ namespace Raven.Database.Config
             Indexing.DisableMapReduceInMemoryTracking = new BooleanSetting(settings[Constants.Indexing.DisableMapReduceInMemoryTracking], false);
             Indexing.MaxNumberOfStoredIndexingBatchInfoElements = new IntegerSetting(settings[Constants.MaxNumberOfStoredIndexingBatchInfoElements], 512);
             Indexing.UseLuceneASTParser = new BooleanSetting(settings[Constants.UseLuceneASTParser], true);
+            Indexing.SkipRecoveryOnStartup = new BooleanSetting(settings[Constants.Indexing.SkipRecoveryOnStartup], false);
 
             Cluster.ElectionTimeout = new IntegerSetting(settings["Raven/Cluster/ElectionTimeout"], RaftEngineOptions.DefaultElectionTimeout * 10);		// 12000ms
             Cluster.HeartbeatTimeout = new IntegerSetting(settings["Raven/Cluster/HeartbeatTimeout"], RaftEngineOptions.DefaultHeartbeatTimeout * 5);	// 1500ms
@@ -564,6 +565,7 @@ namespace Raven.Database.Config
             public BooleanSetting DisableMapReduceInMemoryTracking { get; set; }
             public IntegerSetting MaxNumberOfStoredIndexingBatchInfoElements { get; set; }
             public BooleanSetting UseLuceneASTParser { get; set; }
+            public BooleanSetting SkipRecoveryOnStartup { get; set; }
         }
 
         public class ClusterConfiguration

--- a/Raven.Database/Indexing/IndexStorage.cs
+++ b/Raven.Database/Indexing/IndexStorage.cs
@@ -252,7 +252,7 @@ namespace Raven.Database.Indexing
                     if (indexImplementation != null)
                         indexImplementation.Dispose();
 
-                    if (recoveryTried == false && luceneDirectory != null)
+                    if (recoveryTried == false && luceneDirectory != null && configuration.Indexing.SkipRecoveryOnStartup == false)
                     {
                         recoveryTried = true;
                         startupLog.WarnException("Could not open index " + indexName + ". Trying to recover index", e);


### PR DESCRIPTION
…dexes on startup so in case of large databases we will be able to load it fast, however all of the indexes will be reset (useful when we just want to retrieve the data and don't care for indexes)