### PR TITLE
added IDocumentSaveChangesListener to DocumentSession Listeners

### DIFF
--- a/Raven.Client.Lightweight/Document/DocumentSession.cs
+++ b/Raven.Client.Lightweight/Document/DocumentSession.cs
@@ -718,6 +718,11 @@ namespace Raven.Client.Document
 
         public void SaveChanges()
         {
+            foreach (var listener in theListeners.SaveChangesListeners)
+            {
+                listener.BeforeSaveChanges(this);
+            }
+           
             using (EntityToJson.EntitiesToJsonCachingScope())
             {
                 var data = PrepareForSaveChanges();
@@ -731,6 +736,11 @@ namespace Raven.Client.Document
                 if (batchResults == null)
                     throw new InvalidOperationException("Cannot call Save Changes after the document store was disposed.");
                 UpdateBatchResults(batchResults, data);
+            }
+
+            foreach (var listener in theListeners.SaveChangesListeners)
+            {
+                listener.AfterSaveChanges(this);
             }
         }
 

--- a/Raven.Client.Lightweight/Document/DocumentSessionListeners.cs
+++ b/Raven.Client.Lightweight/Document/DocumentSessionListeners.cs
@@ -17,6 +17,7 @@ namespace Raven.Client.Document
             ConversionListeners = new IDocumentConversionListener[0];
             QueryListeners = new IDocumentQueryListener[0];
             StoreListeners = new IDocumentStoreListener[0];
+            SaveChangesListeners = new IDocumentSaveChangesListener[0];
             DeleteListeners = new IDocumentDeleteListener[0];
             ConflictListeners = new IDocumentConflictListener[0];
         }
@@ -33,6 +34,10 @@ namespace Raven.Client.Document
         ///     The store listeners
         /// </summary>
         public IDocumentStoreListener[] StoreListeners { get; set; }
+        /// <summary>
+        ///     The SaveChanges listeners
+        /// </summary>
+        public IDocumentSaveChangesListener[] SaveChangesListeners { get; set; }
         /// <summary>
         ///     The delete listeners
         /// </summary>
@@ -59,6 +64,11 @@ namespace Raven.Client.Document
         public void RegisterListener(IDocumentStoreListener conversionListener)
         {
             StoreListeners = StoreListeners.Concat(new[] { conversionListener }).ToArray();
+        }
+
+        public void RegisterListener(IDocumentSaveChangesListener saveChangesListener)
+        {
+            SaveChangesListeners = SaveChangesListeners.Concat(new[] { saveChangesListener }).ToArray();
         }
 
 

--- a/Raven.Client.Lightweight/Listeners/IDocumentSaveChangesListener.cs
+++ b/Raven.Client.Lightweight/Listeners/IDocumentSaveChangesListener.cs
@@ -1,0 +1,20 @@
+//-----------------------------------------------------------------------
+// <copyright file="IDocumentStoreListener.cs" company="Hibernating Rhinos LTD">
+//     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+using Raven.Json.Linq;
+
+namespace Raven.Client.Listeners
+{
+    /// <summary>
+    /// Hook for users to provide additional logic on store operations
+    /// </summary>
+    /// 
+    public interface IDocumentSaveChangesListener
+    {
+        void BeforeSaveChanges(IDocumentSession session);
+
+        void AfterSaveChanges(IDocumentSession session);
+    }
+}

--- a/Raven.Client.Lightweight/Raven.Client.Lightweight.csproj
+++ b/Raven.Client.Lightweight/Raven.Client.Lightweight.csproj
@@ -178,6 +178,7 @@
     <Compile Include="FileSystem\Shard\IShardResolutionStrategy.cs" />
     <Compile Include="FileSystem\SynchronizationServerClient.cs" />
     <Compile Include="Helpers\EnvironmentHelper.cs" />
+    <Compile Include="Listeners\IDocumentSaveChangesListener.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Util\Auth\SingleAuthTokenRetriever.cs" />
     <Compile Include="Indexes\AbstractScriptedIndexCreationTask.cs" />

--- a/Raven.Database/Client/EmbeddableDocumentStore.cs
+++ b/Raven.Database/Client/EmbeddableDocumentStore.cs
@@ -449,6 +449,12 @@ namespace Raven.Client.Embedded
             return this;
         }
 
+        public IDocumentStore RegisterListener(IDocumentSaveChangesListener listener)
+        {
+            Listeners.RegisterListener(listener);
+            return this;
+        }
+
         public void InitializeProfiling()
         {
             _inner.InitializeProfiling();

--- a/Raven.Tests.MailingList/Raven.Tests.MailingList.csproj
+++ b/Raven.Tests.MailingList/Raven.Tests.MailingList.csproj
@@ -479,6 +479,7 @@
     <Compile Include="UrlInIdsRepro.cs" />
     <Compile Include="UsingLoadStartsWithAndDashSepartor.cs" />
     <Compile Include="VacancyCampaignsTests.cs" />
+    <Compile Include="ValerioBorioni2.cs" />
     <Compile Include="ValerioBorioni.cs" />
     <Compile Include="Vicente.cs" />
     <Compile Include="Victor.cs" />

--- a/Raven.Tests.MailingList/ValerioBorioni2.cs
+++ b/Raven.Tests.MailingList/ValerioBorioni2.cs
@@ -1,0 +1,108 @@
+// -----------------------------------------------------------------------
+//  <copyright file="AaronSt.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Document;
+using Raven.Tests.Common;
+
+using Xunit;
+using System.Net;
+using System.IO;
+using Raven.Abstractions.Data;
+using Raven.Client.Listeners;
+using Raven.Client;
+
+namespace Raven.Tests.MailingList
+{
+    public class ValerioBorioni2 : RavenTest
+    {
+        [Fact]
+        public void saveChanges_listener_can_fail_before_saving()
+        {
+            string entityId = "myEntity/1";
+
+            var failingBeforeListener = new FailingBeforeSaveChangesListener();
+
+            using (var store = NewDocumentStore())
+            {
+                store.RegisterListener(failingBeforeListener);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new MyEntity { Id = entityId });
+                    Assert.Throws<NotImplementedException>(() => session.SaveChanges());
+                }
+            };
+        }
+
+        [Fact]
+        public void saveChanges_listener_can_fail_after_saving()
+        {
+            string entityId = "myEntity/1";
+
+            var failingAfterListener = new FailingAfterSaveChangesListener();
+
+            using (var store = NewDocumentStore())
+            {
+                store.RegisterListener(failingAfterListener);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new MyEntity { Id = entityId });
+                    Assert.Throws<NotImplementedException>(() => session.SaveChanges());
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var entity = session.Query<MyEntity>().Customize(r => r.WaitForNonStaleResults()).Single();
+                    Assert.Equal(entityId, entity.Id);
+                }
+            };
+
+        }
+
+        public class MyEntity
+        {
+            public string Id { get; set; }
+            public string Body { get; set; }
+
+            public MyEntity()
+            {
+                Body = "";
+            }
+        }
+
+        public class FailingBeforeSaveChangesListener : IDocumentSaveChangesListener
+        {
+            public void BeforeSaveChanges(IDocumentSession session)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void AfterSaveChanges(IDocumentSession session)
+            {
+               
+            }
+
+        }
+        public class FailingAfterSaveChangesListener : IDocumentSaveChangesListener
+        {
+            public void BeforeSaveChanges(IDocumentSession session)
+            {
+
+            }
+
+            public void AfterSaveChanges(IDocumentSession session)
+            {
+                throw new NotImplementedException();
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
I have always wanted to be able to do things like publishing client push notifications, or publishing domain events.
This listener allows this scenario without implementing the whole IDocumentSession interface just to put some code around SaveChanges method.