### PR TITLE
RavenDB-4548 Fixing creation of signatures when a file name contains …

### DIFF
--- a/Raven.Database/FileSystem/Synchronization/Rdc/Wrapper/StorageSignatureRepository.cs
+++ b/Raven.Database/FileSystem/Synchronization/Rdc/Wrapper/StorageSignatureRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Raven.Abstractions.Logging;
+using Raven.Database.Extensions;
 using Raven.Database.FileSystem.Infrastructure;
 using Raven.Database.FileSystem.Storage;
 
@@ -47,6 +48,11 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
         public Stream CreateContent(string sigName)
         {
             var sigFileName = NameToPath(sigName);
+
+            var signatureDirectory = Path.GetDirectoryName(sigFileName);
+
+            IOExtensions.CreateDirectoryIfNotExists(signatureDirectory);
+
             var result = File.Create(sigFileName, 64 * 1024);
             log.Info("File {0} created", sigFileName);
             _createdFiles.Add(sigFileName, result);
@@ -119,8 +125,8 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
 
         public void Dispose()
         {
-            CloseCreatedStreams();
-            Directory.Delete(_tempDirectory, true);
+           CloseCreatedStreams();
+           IOExtensions.DeleteDirectory(_tempDirectory);
         }
 
         public SignatureInfo GetByName(string sigName)
@@ -166,7 +172,7 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
         {
             foreach (var item in _createdFiles)
             {
-                item.Value.Close();
+                item.Value.Dispose();
             }
         }
     }

--- a/Raven.Tests.FileSystem/Bugs/SynchronizationOfFileInsideDirectory.cs
+++ b/Raven.Tests.FileSystem/Bugs/SynchronizationOfFileInsideDirectory.cs
@@ -1,0 +1,51 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SynchronizationOfFileInsideDirectory.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Abstractions.FileSystem;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Raven.Tests.FileSystem.Bugs
+{
+    public class SynchronizationOfFileInsideDirectory : RavenFilesTestWithLogs
+    {
+        [Theory]
+        [InlineData("m s.bin")]
+        [InlineData("/content/ms.bin")]
+        [InlineData("/content/m s.bin")]
+        public async Task SignaturesShouldWorkIfFileNameContainsFolders(string fileName)
+        {
+            var source = NewAsyncClient(0);
+            var destination = NewAsyncClient(1);
+
+            var r = new Random();
+
+            var bytes = new byte[2*1024*1024];
+
+            r.NextBytes(bytes);
+
+            await source.UploadAsync(fileName, new MemoryStream(bytes));
+
+            var syncResult = await source.Synchronization.StartAsync(fileName, destination);
+
+            Assert.Null(syncResult.Exception);
+            Assert.Equal(SynchronizationType.ContentUpdate, syncResult.Type);
+
+            bytes = new byte[3 * 1024 * 1024];
+
+            r.NextBytes(bytes);
+
+            await source.UploadAsync(fileName, new MemoryStream(bytes));
+
+            syncResult = await source.Synchronization.StartAsync(fileName, destination);
+
+            Assert.Null(syncResult.Exception);
+            Assert.Equal(SynchronizationType.ContentUpdate, syncResult.Type);
+        }
+    }
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Bugs\Queries.cs" />
     <Compile Include="Bugs\SearchingCollections.cs" />
     <Compile Include="Bugs\SynchronizationAfterSetUpDestinations.cs" />
+    <Compile Include="Bugs\SynchronizationOfFileInsideDirectory.cs" />
     <Compile Include="Bugs\UpdatingMetadata.cs" />
     <Compile Include="Bugs\UploadFilesWithTheSameContentConcurrently.cs" />
     <Compile Include="Bugs\UploadDownload.cs" />

--- a/Raven.Tests.FileSystem/Storage/StorageSignatureRepositoryTests.cs
+++ b/Raven.Tests.FileSystem/Storage/StorageSignatureRepositoryTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using Raven.Database.FileSystem.Synchronization.Rdc.Wrapper;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Raven.Tests.FileSystem
 {
@@ -44,18 +45,20 @@ namespace Raven.Tests.FileSystem
             Assert.Equal(1, result.Length);
         }
 
-        [Fact]
-        public void Should_assign_signature_to_proper_file()
+        [Theory]
+        [InlineData("test.bin")]
+        [InlineData("/directory/test.bin")]
+        public void Should_assign_signature_to_proper_file(string fileName)
         {
-            var tested = new StorageSignatureRepository(transactionalStorage, "test.bin");
-            using(var sigContent = tested.CreateContent("test.bin.0.sig"))
+            var tested = new StorageSignatureRepository(transactionalStorage, fileName);
+            using(var sigContent = tested.CreateContent(fileName + ".0.sig"))
             {
                 sigContent.WriteByte(3);
             }
-            tested.Flush(new[] { SignatureInfo.Parse("test.bin.0.sig") } );
+            tested.Flush(new[] { SignatureInfo.Parse(fileName + ".0.sig") } );
 
-            var result = tested.GetByName("test.bin.0.sig");
-            Assert.Equal("test.bin.0.sig", result.Name);
+            var result = tested.GetByName(fileName + ".0.sig");
+            Assert.Equal(fileName + ".0.sig", result.Name);
             Assert.Equal(1, result.Length);
         }
 

--- a/Raven.Tests.FileSystem/Synchronization/SigGeneratorTest.cs
+++ b/Raven.Tests.FileSystem/Synchronization/SigGeneratorTest.cs
@@ -112,23 +112,26 @@ namespace Raven.Tests.FileSystem.Synchronization
             randomStream.Read(buffer, 0, size);
             var stream = new MemoryStream(buffer);
 
-            using (var signatureRepository = new VolatileSignatureRepository("test"))
-            using (var rested = new SigGenerator())
+            foreach (var fileName in new [] { "test", "content/test", "/content/test"})
             {
-                var signatures = signatureRepository.GetByFileName();
-                Assert.Equal(0, signatures.Count());
+                using (var signatureRepository = new VolatileSignatureRepository(fileName))
+                using (var rested = new SigGenerator())
+                {
+                    var signatures = signatureRepository.GetByFileName();
+                    Assert.Equal(0, signatures.Count());
 
-                stream.Position = 0;
-                var result = rested.GenerateSignatures(stream, "test", signatureRepository);
+                    stream.Position = 0;
+                    var result = rested.GenerateSignatures(stream, fileName, signatureRepository);
 
-                signatures = signatureRepository.GetByFileName();
-                Assert.Equal(2, signatures.Count());
+                    signatures = signatureRepository.GetByFileName();
+                    Assert.Equal(2, signatures.Count());
 
-                stream.Position = 0;
-                result = rested.GenerateSignatures(stream, "test", signatureRepository);
+                    stream.Position = 0;
+                    result = rested.GenerateSignatures(stream, fileName, signatureRepository);
 
-                signatures = signatureRepository.GetByFileName();
-                Assert.Equal(2, signatures.Count());
+                    signatures = signatureRepository.GetByFileName();
+                    Assert.Equal(2, signatures.Count());
+                }
             }
         }
     }


### PR DESCRIPTION
…directories e.g. /content/file.txt
