### PR TITLE
RavenDB-4548 Fixing creation of signatures when a file name contains …

### DIFF
--- a/Raven.Database/FileSystem/Synchronization/Rdc/Wrapper/StorageSignatureRepository.cs
+++ b/Raven.Database/FileSystem/Synchronization/Rdc/Wrapper/StorageSignatureRepository.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Raven.Abstractions.Logging;
 using Raven.Database.Config;
+using Raven.Database.Extensions;
 using Raven.Database.FileSystem.Infrastructure;
 using Raven.Database.FileSystem.Storage;
 
@@ -48,6 +49,11 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
         public Stream CreateContent(string sigName)
         {
             var sigFileName = NameToPath(sigName);
+
+            var signatureDirectory = Path.GetDirectoryName(sigFileName);
+
+            IOExtensions.CreateDirectoryIfNotExists(signatureDirectory);
+
             var result = File.Create(sigFileName, 64 * 1024);
             log.Info("File {0} created", sigFileName);
             _createdFiles.Add(sigFileName, result);
@@ -120,8 +126,8 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
 
         public void Dispose()
         {
-            CloseCreatedStreams();
-            Directory.Delete(_tempDirectory, true);
+           CloseCreatedStreams();
+           IOExtensions.DeleteDirectory(_tempDirectory);
         }
 
         public SignatureInfo GetByName(string sigName)
@@ -167,7 +173,7 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
         {
             foreach (var item in _createdFiles)
             {
-                item.Value.Close();
+                item.Value.Dispose();
             }
         }
     }

--- a/Raven.Database/FileSystem/Synchronization/Rdc/Wrapper/VolatileSignatureRepository.cs
+++ b/Raven.Database/FileSystem/Synchronization/Rdc/Wrapper/VolatileSignatureRepository.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Raven.Abstractions.Logging;
 using Raven.Database.Config;
+using Raven.Database.Extensions;
 using Raven.Database.FileSystem.Infrastructure;
 
 namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
@@ -31,6 +32,11 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
         public Stream CreateContent(string sigName)
         {
             var sigFileName = NameToPath(sigName);
+
+            var signatureDirectory = Path.GetDirectoryName(sigFileName);
+
+            IOExtensions.CreateDirectoryIfNotExists(signatureDirectory);
+
             var result = File.Create(sigFileName, 64 * 1024);
             log.Info("File {0} created", sigFileName);
             _createdFiles.Add(sigFileName, result);
@@ -50,10 +56,10 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
 
         public DateTime? GetLastUpdate()
         {
-            var preResult = from item in GetSigFileNamesByFileName()
+            var preResult = (from item in GetSigFileNamesByFileName()
                             let lastWriteTime = new FileInfo(item).LastWriteTime
                             orderby lastWriteTime descending
-                            select lastWriteTime;
+                            select lastWriteTime).ToList();
             if (preResult.Any())
                 return preResult.First();
 
@@ -63,12 +69,20 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
         public void Dispose()
         {
             CloseCreatedStreams();
-            Directory.Delete(_tempDirectory, true);
+            IOExtensions.DeleteDirectory(_tempDirectory);
         }
 
         private IEnumerable<string> GetSigFileNamesByFileName()
         {
-            return Directory.GetFiles(_tempDirectory, _fileName + "*.sig");
+            var fullPath = NameToPath(_fileName);
+            var directory = Path.GetDirectoryName(fullPath);
+
+            if (Directory.Exists(directory) == false)
+                return Enumerable.Empty<string>();
+
+            var fileName = Path.GetFileName(fullPath);
+
+            return Directory.GetFiles(directory, fileName + "*.sig");
         }
 
         private string NameToPath(string name)
@@ -86,7 +100,7 @@ namespace Raven.Database.FileSystem.Synchronization.Rdc.Wrapper
         {
             foreach (var item in _createdFiles)
             {
-                item.Value.Close();
+                item.Value.Dispose();
             }
 
             _createdFiles.Clear();

--- a/Raven.Tests.FileSystem/Bugs/SynchronizationOfFileInsideDirectory.cs
+++ b/Raven.Tests.FileSystem/Bugs/SynchronizationOfFileInsideDirectory.cs
@@ -1,0 +1,51 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SynchronizationOfFileInsideDirectory.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Abstractions.FileSystem;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Raven.Tests.FileSystem.Bugs
+{
+    public class SynchronizationOfFileInsideDirectory : RavenFilesTestWithLogs
+    {
+        [Theory]
+        [InlineData("m s.bin")]
+        [InlineData("/content/ms.bin")]
+        [InlineData("/content/m s.bin")]
+        public async Task SignaturesShouldWorkIfFileNameContainsFolders(string fileName)
+        {
+            var source = NewAsyncClient(0);
+            var destination = NewAsyncClient(1);
+
+            var r = new Random();
+
+            var bytes = new byte[2*1024*1024];
+
+            r.NextBytes(bytes);
+
+            await source.UploadAsync(fileName, new MemoryStream(bytes));
+
+            var syncResult = await source.Synchronization.StartAsync(fileName, destination);
+
+            Assert.Null(syncResult.Exception);
+            Assert.Equal(SynchronizationType.ContentUpdate, syncResult.Type);
+
+            bytes = new byte[3 * 1024 * 1024];
+
+            r.NextBytes(bytes);
+
+            await source.UploadAsync(fileName, new MemoryStream(bytes));
+
+            syncResult = await source.Synchronization.StartAsync(fileName, destination);
+
+            Assert.Null(syncResult.Exception);
+            Assert.Equal(SynchronizationType.ContentUpdate, syncResult.Type);
+        }
+    }
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Bugs\Queries.cs" />
     <Compile Include="Bugs\SearchingCollections.cs" />
     <Compile Include="Bugs\SynchronizationAfterSetUpDestinations.cs" />
+    <Compile Include="Bugs\SynchronizationOfFileInsideDirectory.cs" />
     <Compile Include="Bugs\UpdatingMetadata.cs" />
     <Compile Include="Bugs\UploadFilesWithTheSameContentConcurrently.cs" />
     <Compile Include="Bugs\UploadDownload.cs" />

--- a/Raven.Tests.FileSystem/Storage/StorageSignatureRepositoryTests.cs
+++ b/Raven.Tests.FileSystem/Storage/StorageSignatureRepositoryTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Raven.Database.Config;
 using Raven.Database.FileSystem.Synchronization.Rdc.Wrapper;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Raven.Tests.FileSystem
 {
@@ -54,18 +55,20 @@ namespace Raven.Tests.FileSystem
             Assert.Equal(1, result.Length);
         }
 
-        [Fact]
-        public void Should_assign_signature_to_proper_file()
+        [Theory]
+        [InlineData("test.bin")]
+        [InlineData("/directory/test.bin")]
+        public void Should_assign_signature_to_proper_file(string fileName)
         {
-            var tested = new StorageSignatureRepository(transactionalStorage, "test.bin", configuration);
-            using(var sigContent = tested.CreateContent("test.bin.0.sig"))
+            var tested = new StorageSignatureRepository(transactionalStorage, fileName, configuration);
+            using(var sigContent = tested.CreateContent(fileName + ".0.sig"))
             {
                 sigContent.WriteByte(3);
             }
-            tested.Flush(new[] { SignatureInfo.Parse("test.bin.0.sig") } );
+            tested.Flush(new[] { SignatureInfo.Parse(fileName + ".0.sig") } );
 
-            var result = tested.GetByName("test.bin.0.sig");
-            Assert.Equal("test.bin.0.sig", result.Name);
+            var result = tested.GetByName(fileName + ".0.sig");
+            Assert.Equal(fileName + ".0.sig", result.Name);
             Assert.Equal(1, result.Length);
         }
 

--- a/Raven.Tests.FileSystem/Synchronization/SigGeneratorTest.cs
+++ b/Raven.Tests.FileSystem/Synchronization/SigGeneratorTest.cs
@@ -119,23 +119,26 @@ namespace Raven.Tests.FileSystem.Synchronization
             randomStream.Read(buffer, 0, size);
             var stream = new MemoryStream(buffer);
 
-            using (var signatureRepository = new VolatileSignatureRepository("test", configuration))
-            using (var rested = new SigGenerator())
+            foreach (var fileName in new [] { "test", "content/test", "/content/test"})
             {
-                var signatures = signatureRepository.GetByFileName();
-                Assert.Equal(0, signatures.Count());
+                using (var signatureRepository = new VolatileSignatureRepository(fileName, configuration))
+                using (var rested = new SigGenerator())
+                {
+                    var signatures = signatureRepository.GetByFileName();
+                    Assert.Equal(0, signatures.Count());
 
-                stream.Position = 0;
-                var result = rested.GenerateSignatures(stream, "test", signatureRepository);
+                    stream.Position = 0;
+                    var result = rested.GenerateSignatures(stream, fileName, signatureRepository);
 
-                signatures = signatureRepository.GetByFileName();
-                Assert.Equal(2, signatures.Count());
+                    signatures = signatureRepository.GetByFileName();
+                    Assert.Equal(2, signatures.Count());
 
-                stream.Position = 0;
-                result = rested.GenerateSignatures(stream, "test", signatureRepository);
+                    stream.Position = 0;
+                    result = rested.GenerateSignatures(stream, fileName, signatureRepository);
 
-                signatures = signatureRepository.GetByFileName();
-                Assert.Equal(2, signatures.Count());
+                    signatures = signatureRepository.GetByFileName();
+                    Assert.Equal(2, signatures.Count());
+                }
             }
         }
     }


### PR DESCRIPTION
…directories e.g. /content/file.txt
