### PR TITLE
RavenDB-4484

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -901,13 +901,9 @@ namespace Voron.Impl.Journal
             // Copy the transaction header to the output buffer. 
             Memory.Copy(outputBuffer, txHeaderBase, sizeof(TransactionHeader));
             
-            byte* pageRef = outputBuffer;
             var pages = new IntPtr[compressedPages];
             for (int index = 0; index < compressedPages; index++)
-            {
-                pages[index] = new IntPtr(pageRef);
-                pageRef = pageRef + pageSize;
-            }            
+                pages[index] = new IntPtr(outputBuffer + (index * pageSize));
 
             return pages;
         }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -730,9 +730,11 @@ namespace Voron.Impl.Journal
 
                     lastReadTxHeader = *readTxHeader;
 
-                    var compressedPages = (readTxHeader->CompressedSize / _waj._env.Options.PageSize) + (readTxHeader->CompressedSize % _waj._env.Options.PageSize == 0 ? 0 : 1);
+                    int totalSize = readTxHeader->CompressedSize + sizeof(TransactionHeader);
+                    int compressedPages = (totalSize / _waj._env.Options.PageSize) + (totalSize % _waj._env.Options.PageSize == 0 ? 0 : 1);
 
-                    txPos += compressedPages + 1;
+                    // We skip to the next transaction header.
+                    txPos += compressedPages;
                 }
                 
                 Debug.Assert(_lastSyncedJournal != -1);
@@ -846,22 +848,28 @@ namespace Voron.Impl.Journal
         {
             // numberOfPages include the tx header page, which we don't compress
             var dataPagesCount = numberOfPages - 1;
-            var pageSize = tx.Environment.Options.PageSize;
-            var sizeInBytes = dataPagesCount * pageSize;
-            var outputBuffer = LZ4.MaximumOutputLength(sizeInBytes);
-            var outputBufferInPages = outputBuffer / pageSize +
-                                      (outputBuffer % pageSize == 0 ? 0 : 1);
-            var pagesRequired = (dataPagesCount + outputBufferInPages);
 
+            int pageSize = tx.Environment.Options.PageSize;
+            var sizeInBytes = dataPagesCount * pageSize;
+
+            // We want to include the Transaction Header straight into the compression buffer.
+            var outputBufferSize = LZ4.MaximumOutputLength(sizeInBytes) + sizeof(TransactionHeader);
+            var outputBufferInPages = outputBufferSize / pageSize +
+                                      (outputBufferSize % pageSize == 0 ? 0 : 1);
+
+            // The pages required includes the intermediate pages and the required output pages. 
+            var pagesRequired = (dataPagesCount + outputBufferInPages);
             var pagerState = compressionPager.EnsureContinuous(0, pagesRequired);
             tx.AddPagerState(pagerState);
-            var tempBuffer = compressionPager.AcquirePagePointer(0);
-            var compressionBuffer = compressionPager.AcquirePagePointer(dataPagesCount);
-
-            var write = tempBuffer;
+                        
+            // We get the pointer to the compression buffer, which will be the buffer that will hold the whole thing.
+            var outputBuffer = compressionPager.AcquirePagePointer(dataPagesCount);
+            
+            // Where we are going to store the input data continously to compress it afterwards.             
+            var tempBuffer = compressionPager.AcquirePagePointer(0);           
             var txPages = tx.GetTransactionPages();
-
-            foreach( var txPage in txPages )
+            var write = tempBuffer;
+            foreach ( var txPage in txPages )
             {
                 var scratchPage = tx.Environment.ScratchBufferPool.AcquirePagePointer(txPage.ScratchFileNumber, txPage.PositionInScratchBuffer);
                 var count = txPage.NumberOfPages * pageSize;
@@ -869,33 +877,37 @@ namespace Voron.Impl.Journal
                 write += count;
             }
 
-            var len = DoCompression(tempBuffer, compressionBuffer, sizeInBytes, outputBuffer);
-            var remainder = len % pageSize;
-            var compressedPages = (len / pageSize) + (remainder == 0 ? 0 : 1);
+            var compressionBuffer = outputBuffer + sizeof(TransactionHeader);
+            var len = DoCompression(tempBuffer, compressionBuffer, sizeInBytes, outputBufferSize);
 
+            int totalLength = len + sizeof(TransactionHeader);  // We need to account for the transaction header as part of the total length.
+            var remainder = totalLength % pageSize;
+            var compressedPages = (totalLength / pageSize) + (remainder == 0 ? 0 : 1);
+            
             if (remainder != 0)
             {
                 // zero the remainder of the page
-                UnmanagedMemory.Set(compressionBuffer + len, 0, pageSize - remainder);
-            }
-
-            var pages = new IntPtr[compressedPages + 1];
+                UnmanagedMemory.Set(outputBuffer + totalLength, 0, pageSize - remainder);
+            }     
 
             var txHeaderPage = tx.GetTransactionHeaderPage();
             var txHeaderBase = tx.Environment.ScratchBufferPool.AcquirePagePointer(txHeaderPage.ScratchFileNumber, txHeaderPage.PositionInScratchBuffer);
             var txHeader = (TransactionHeader*)txHeaderBase;
-
             txHeader->Compressed = true;
             txHeader->CompressedSize = len;
             txHeader->UncompressedSize = sizeInBytes;
+            txHeader->Hash = Hashing.XXHash64.Calculate(compressionBuffer, len);
 
-            pages[0] = new IntPtr(txHeaderBase);
+            // Copy the transaction header to the output buffer. 
+            Memory.Copy(outputBuffer, txHeaderBase, sizeof(TransactionHeader));
+            
+            byte* pageRef = outputBuffer;
+            var pages = new IntPtr[compressedPages];
             for (int index = 0; index < compressedPages; index++)
             {
-                pages[index + 1] = new IntPtr(compressionBuffer + (index * pageSize));
-            }
-
-            txHeader->Hash = Hashing.XXHash64.Calculate(compressionBuffer, compressedPages * pageSize);
+                pages[index] = new IntPtr(pageRef);
+                pageRef = pageRef + pageSize;
+            }            
 
             return pages;
         }

--- a/test/FastTests/Voron/Journal/EdgeCases.cs
+++ b/test/FastTests/Voron/Journal/EdgeCases.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Xunit;
 using Voron;
 using Voron.Impl;
+using Voron.Impl.Journal;
 
 namespace FastTests.Voron.Journal
 {
@@ -17,7 +18,7 @@ namespace FastTests.Voron.Journal
         protected override void Configure(StorageEnvironmentOptions options)
         {
             options.PageSize = 4 * Constants.Size.Kilobyte;
-            options.MaxLogFileSize = 10 * options.PageSize;
+            options.MaxLogFileSize = 5 * options.PageSize;
         }
 
         [Fact]

--- a/test/SlowTests/SlowTests.xproj
+++ b/test/SlowTests/SlowTests.xproj
@@ -14,6 +14,9 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/test/SlowTests/Voron/RecoveryMultipleJournals.cs
+++ b/test/SlowTests/Voron/RecoveryMultipleJournals.cs
@@ -5,163 +5,163 @@ using Xunit;
 
 namespace SlowTests.Voron
 {
-	public class RecoveryMultipleJournals : StorageTest
-	{
-		protected override void Configure(StorageEnvironmentOptions options)
-		{
-			options.MaxLogFileSize = 10 * options.PageSize;
-			options.OnRecoveryError += (sender, args) => { }; // just shut it up
-			options.ManualFlushing = true;
-			options.MaxScratchBufferSize = 1 * 1024 * 1024 * 1024;
-		}
+    public class RecoveryMultipleJournals : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.MaxLogFileSize = 10 * options.PageSize;
+            options.OnRecoveryError += (sender, args) => { }; // just shut it up
+            options.ManualFlushing = true;
+            options.MaxScratchBufferSize = 1 * 1024 * 1024 * 1024;
+        }
 
-		[Fact]
-		public void CanRecoverAfterRestartWithMultipleFilesInSingleTransaction()
-		{
+        [Fact]
+        public void CanRecoverAfterRestartWithMultipleFilesInSingleTransaction()
+        {
 
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("tree");
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree");
 
-				tx.Commit();
-			}
-			using (var tx = Env.WriteTransaction())
-			{
-				for (var i = 0; i < 1000; i++)
-				{
-					tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
-				}
-				tx.Commit();
-			}
+                tx.Commit();
+            }
+            using (var tx = Env.WriteTransaction())
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
+                }
+                tx.Commit();
+            }
 
 
-			RestartDatabase();
+            RestartDatabase();
 
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree( "tree");
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree( "tree");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.ReadTransaction())
-			{
-				for (var i = 0; i < 1000; i++)
-				{
-					var readResult = tx.CreateTree("tree").Read("a" + i);
-					Assert.NotNull(readResult);
-					{
-						Assert.Equal(100, readResult.Reader.Length);
-					}
-				}
-				tx.Commit();
-			}
-		}
+            using (var tx = Env.ReadTransaction())
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    var readResult = tx.CreateTree("tree").Read("a" + i);
+                    Assert.NotNull(readResult);
+                    {
+                        Assert.Equal(100, readResult.Reader.Length);
+                    }
+                }
+                tx.Commit();
+            }
+        }
 
-		[Fact]
-		public void CanResetLogInfoAfterBigUncommitedTransaction()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("tree");
+        [Fact]
+        public void CanResetLogInfoAfterBigUncommitedTransaction()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			var currentJournalInfo = Env.Journal.GetCurrentJournalInfo();
+            var currentJournalInfo = Env.Journal.GetCurrentJournalInfo();
 
-			using (var tx = Env.WriteTransaction())
-			{
-				for (var i = 0; i < 1000; i++)
-				{
-					tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
-				}
-				//tx.Commit(); - not committing here
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
+                }
+                //tx.Commit(); - not committing here
+            }
 
-			Assert.Equal(currentJournalInfo.CurrentJournal, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
+            Assert.Equal(currentJournalInfo.CurrentJournal, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
 
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("tree").Add("a", new MemoryStream(new byte[100]));
-				tx.Commit();
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("a", new MemoryStream(new byte[100]));
+                tx.Commit();
+            }
 
-			Assert.Equal(currentJournalInfo.CurrentJournal, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
-		}
+            Assert.Equal(currentJournalInfo.CurrentJournal, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
+        }
 
-		[Fact]
-		public void CanResetLogInfoAfterBigUncommitedTransaction2()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree( "tree");
+        [Fact]
+        public void CanResetLogInfoAfterBigUncommitedTransaction2()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree( "tree");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				for (var i = 0; i < 1000; i++)
-				{
-					tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
-				}
-				tx.Commit(); 
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
+                }
+                tx.Commit(); 
+            }
 
-			var currentJournalInfo = Env.Journal.GetCurrentJournalInfo();
+            var currentJournalInfo = Env.Journal.GetCurrentJournalInfo();
 
-			var random = new Random();
-			var buffer = new byte[1000000];
-			random.NextBytes(buffer);
+            var random = new Random();
+            var buffer = new byte[1000000];
+            random.NextBytes(buffer);
 
-			using (var tx = Env.WriteTransaction())
-			{
-				for (var i = 0; i < 1000; i++)
-				{
-					tx.CreateTree("tree").Add("b" + i, new MemoryStream(buffer));
-				}
-				//tx.Commit(); - not committing here
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    tx.CreateTree("tree").Add("b" + i, new MemoryStream(buffer));
+                }
+                //tx.Commit(); - not committing here
+            }
 
-			Assert.Equal(currentJournalInfo.CurrentJournal, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
+            Assert.Equal(currentJournalInfo.CurrentJournal, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
 
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("tree").Add("b", new MemoryStream(buffer));
-				tx.Commit();
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("b", new MemoryStream(buffer));
+                tx.Commit();
+            }
 
-			Assert.Equal(currentJournalInfo.CurrentJournal +1, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
-		}
+            Assert.Equal(currentJournalInfo.CurrentJournal +1, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
+        }
 
-		[Fact]
-		public void CanResetLogInfoAfterBigUncommitedTransactionWithRestart()
-		{
-		    RequireFileBasedPager();
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("tree").Add("exists", new MemoryStream(new byte[100]));
+        [Fact]
+        public void CanResetLogInfoAfterBigUncommitedTransactionWithRestart()
+        {
+            RequireFileBasedPager();
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("exists", new MemoryStream(new byte[100]));
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				for (var i = 0; i < 1000; i++)
-				{
-					tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
-				}
-				tx.Commit();
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
+                }
+                tx.Commit();
+            }
 
-			var lastJournal = Env.Journal.GetCurrentJournalInfo().CurrentJournal;
+            var lastJournal = Env.Journal.GetCurrentJournalInfo().CurrentJournal;
             
-			StopDatabase();
-			
+            StopDatabase();
+            
             CorruptPage(lastJournal, page: 4, pos: 3);
 
-			StartDatabase();
+            StartDatabase();
             using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.CreateTree("tree");
@@ -173,124 +173,129 @@ namespace SlowTests.Voron
                 
                 tx.Commit();
             }
-		}
+        }
 
-		[Fact]
-		public void CanResetLogInfoAfterBigUncommitedTransactionWithRestart2()
-		{
+        [Fact]
+        public void CanResetLogInfoAfterBigUncommitedTransactionWithRestart2()
+        {
             RequireFileBasedPager();
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree( "tree");
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree( "tree");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				for (var i = 0; i < 1000; i++)
-				{
-					tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
-				}
-				tx.Commit();
-			}
+            Random rnd = new Random();
 
-			var currentJournal = Env.Journal.GetCurrentJournalInfo().CurrentJournal;
+            var buffer = new byte[100];
+            rnd.NextBytes(buffer);
+            using (var tx = Env.WriteTransaction())
+            {
+                for (var i = 0; i < 1000; i++)
+                {                   
+                    tx.CreateTree("tree").Add("a" + i, new MemoryStream(buffer));
+                }
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				for (var i = 0; i < 1000; i++)
-				{
-					tx.CreateTree("tree").Add("b" + i, new MemoryStream(new byte[100]));
-				}
-				tx.Commit();
-			}
+            var currentJournal = Env.Journal.GetCurrentJournalInfo().CurrentJournal;
 
-			var lastJournal = Env.Journal.GetCurrentJournalInfo().CurrentJournal;
+            using (var tx = Env.WriteTransaction())
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    rnd.NextBytes(buffer);
+                    tx.CreateTree("tree").Add("b" + i, new MemoryStream(buffer));
+                }
+                tx.Commit();
+            }
 
-			StopDatabase();
+            var lastJournal = Env.Journal.GetCurrentJournalInfo().CurrentJournal;
 
-			CorruptPage(lastJournal - 1, page: 2, pos: 3);
+            StopDatabase();
 
-			StartDatabase();
-			Assert.Equal(currentJournal, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
+            CorruptPage(lastJournal - 1, page: 2, pos: 3);
 
-		}
+            StartDatabase();
+            Assert.Equal(currentJournal, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
+
+        }
 
 
-		[Fact]
-		public void CorruptingOneTransactionWillKillAllFutureTransactions()
-		{
+        [Fact]
+        public void CorruptingOneTransactionWillKillAllFutureTransactions()
+        {
             RequireFileBasedPager();
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree( "tree");
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree( "tree");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			for (int i = 0; i < 1000; i++)
-			{
-				using (var tx = Env.WriteTransaction())
-				{
-					tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
-					tx.Commit();
-				}
-			}
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    tx.CreateTree("tree").Add("a" + i, new MemoryStream(new byte[100]));
+                    tx.Commit();
+                }
+            }
 
-			var lastJournal = Env.Journal.GetCurrentJournalInfo().CurrentJournal;
-			var lastJournalPosition = Env.Journal.CurrentFile.WritePagePosition;
+            var lastJournal = Env.Journal.GetCurrentJournalInfo().CurrentJournal;
+            var lastJournalPosition = Env.Journal.CurrentFile.WritePagePosition;
 
-			StopDatabase();
+            StopDatabase();
 
-			CorruptPage(lastJournal - 3, lastJournalPosition + 1, 5);
+            CorruptPage(lastJournal - 3, lastJournalPosition + 1, 5);
 
-			StartDatabase();
+            StartDatabase();
 
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("tree");
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.ReadTransaction())
-			{
-				Assert.Null(tx.CreateTree("tree").Read("a999"));
-			}
+            using (var tx = Env.ReadTransaction())
+            {
+                Assert.Null(tx.CreateTree("tree").Read("a999"));
+            }
 
-		}
+        }
 
-		private void CorruptPage(long journal, long page, int pos)
-		{
-			_options.Dispose();
-			_options = StorageEnvironmentOptions.ForPath(DataDir);
-			Configure(_options);
-			using (var fileStream = new FileStream(
-				Path.Combine(DataDir, StorageEnvironmentOptions.JournalName(journal)), 
-				FileMode.Open,
-				FileAccess.ReadWrite, 
-				FileShare.ReadWrite | FileShare.Delete))
-		    {
-		        fileStream.Position = page*_options.PageSize;
+        private void CorruptPage(long journal, long page, int pos)
+        {
+            _options.Dispose();
+            _options = StorageEnvironmentOptions.ForPath(DataDir);
+            Configure(_options);
+            using (var fileStream = new FileStream(
+                Path.Combine(DataDir, StorageEnvironmentOptions.JournalName(journal)), 
+                FileMode.Open,
+                FileAccess.ReadWrite, 
+                FileShare.ReadWrite | FileShare.Delete))
+            {
+                fileStream.Position = page*_options.PageSize;
 
-				var buffer = new byte[_options.PageSize];
+                var buffer = new byte[_options.PageSize];
 
-		        var remaining = buffer.Length;
-		        var start = 0;
-		        while (remaining > 0)
-		        {
-		            var read = fileStream.Read(buffer, start, remaining);
-		            if (read == 0)
-		                break;
-		            start += read;
-		            remaining -= read;
-		        }
+                var remaining = buffer.Length;
+                var start = 0;
+                while (remaining > 0)
+                {
+                    var read = fileStream.Read(buffer, start, remaining);
+                    if (read == 0)
+                        break;
+                    start += read;
+                    remaining -= read;
+                }
 
-		        buffer[pos] = 42;
-				fileStream.Position = page * _options.PageSize;
-		        fileStream.Write(buffer, 0, buffer.Length);
-		    }
-		}
-	}
+                buffer[pos] = 42;
+                fileStream.Position = page * _options.PageSize;
+                fileStream.Write(buffer, 0, buffer.Length);
+            }
+        }
+    }
 }


### PR DESCRIPTION
No difference in OPs per second for my very limited tests on v4.0 (do not have the correct infrastructure to do proper testing of such cases yet); but the saving is significant. 

100000 transactions of 10 insert operations each. 

With single page header: 20 journals
Without single page header: 25 journals

Saving: 5 journals = 64Mb * 5 = 320MB of IO
