### PR TITLE
RavenDB-4538 Test studio

### DIFF
--- a/Raven.Studio.Html5/App/common/bindingHelpers/aceEditorBindingHandler.ts
+++ b/Raven.Studio.Html5/App/common/bindingHelpers/aceEditorBindingHandler.ts
@@ -261,6 +261,7 @@ class aceEditorBindingHandler {
         if (code !== editorCode) {
             aceEditor.getSession().setValue(code||"");
         }
+        aceEditor.setReadOnly(bindingValues.readOnly);
         if (this.allowResize) {
             this.alterHeight(element, aceEditor);
         }

--- a/Raven.Studio.Html5/App/viewmodels/database/patch/patch.ts
+++ b/Raven.Studio.Html5/App/viewmodels/database/patch/patch.ts
@@ -546,7 +546,7 @@ class patch extends viewModelBase {
         if (status.OperationProgress != null) {
             var progressValue = Math.round(100 * (status.OperationProgress.ProcessedEntries / status.OperationProgress.TotalEntries));
             this.patchingProgress(progressValue);
-            this.patchingProgressText(status.OperationProgress.ProcessedEntries + " / " + status.OperationProgress.TotalEntries + " (" + progressValue + "%)");
+            this.patchingProgressText(status.OperationProgress.ProcessedEntries.toLocaleString() + " / " + status.OperationProgress.TotalEntries.toLocaleString() + " (" + progressValue + "%)");
         }
 
         if (status.Completed) {

--- a/Raven.Studio.Html5/App/views/database/patch/patch.html
+++ b/Raven.Studio.Html5/App/views/database/patch/patch.html
@@ -3,7 +3,7 @@
     <div class="btn-toolbar" role="toolbar">
         <a target="_blank" data-bind="attr: { href: $root.currentHelpLink }, visible: $root.currentHelpLink" class="global_help_link"><i class="fa fa-question-circle fa-2x"></i></a>
         <div class="btn-group" data-bind="with: patchDocument">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-bind="disable: $root.isPatchingInProgress()">
                 <span data-bind="text: patchOnOption"></span>
                 <span class="caret"></span>
             </button>
@@ -14,7 +14,7 @@
             </ul>
         </div>
         <div class="btn-group">
-            <button data-bind="enable: savedPatches().length" class="btn btn-default dropdown-toggle" data-toggle="dropdown" title="Load a saved patch"><i class="fa fa-arrow-up"></i> Load <span class="caret"></span></button>
+            <button data-bind="enable: savedPatches().length && !$root.isPatchingInProgress()" class="btn btn-default dropdown-toggle" data-toggle="dropdown" title="Load a saved patch"><i class="fa fa-arrow-up"></i> Load <span class="caret"></span></button>
             <ul class="dropdown-menu" role="menu" data-bind="foreach: savedPatches">
                 <li>
                     <a href="#" data-bind="click: $root.usePatch.bind($root, $data)">
@@ -22,11 +22,11 @@
                     </a>
                 </li>
             </ul>
-            <button class="btn btn-default" title="Save the current patch" data-bind="click: savePatch, enable: (patchDocument().script())"><i class="fa fa-save"></i> Save</button>
+            <button class="btn btn-default" title="Save the current patch" data-bind="click: savePatch, enable: patchDocument().script() && !$root.isPatchingInProgress()"><i class="fa fa-save"></i> Save</button>
         </div>
 
         <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-bind="visible: recentPatches().length > 0">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-bind="visible: recentPatches().length > 0, disable: $root.isPatchingInProgress()">
                 Recent Patches <span class="caret"></span>
             </button>
             <ul class="dropdown-menu" role="menu" data-bind="foreach: recentPatches">
@@ -47,36 +47,46 @@
         </div>
 
         <div class="btn-group">
-            <button class="btn btn-default" title="Test the patch script on the selected document (Alt+T)" data-bind="click: testPatch, enable: isExecuteAllowed" accesskey="T"><i class="fa fa-question-circle"></i> Test</button>
+            <button class="btn btn-default" title="Test the patch script on the selected document (Alt+T)" data-bind="click: testPatch, enable: isExecuteAllowed() && !$root.isPatchingInProgress()" accesskey="T"><i class="fa fa-question-circle"></i> Test</button>
         </div>
 
-        <div class="btn-group" data-bind="visible: (!!patchDocument()) && patchDocument().isDocumentPatch()">
-            <button class="btn btn-primary" title="Execute Patch (Alt+P)" accesskey="P" data-bind="click: executePatchOnSingle, enable: isExecuteAllowed">
+        <div class="btn-group" data-bind="visible: patchDocument() && patchDocument().isDocumentPatch()">
+            <button class="btn btn-primary" title="Execute Patch (Alt+P)" accesskey="P" data-bind="click: executePatchOnSingle, enable: isExecuteAllowed() && !$root.isPatchingInProgress()">
                 <i class="fa fa-play"></i> Patch
             </button>
         </div>
         <div class="btn-group" data-bind="visible: (!!patchDocument()) && (patchDocument().isCollectionPatch() || patchDocument().isIndexPatch())">
-            <button class="btn btn-primary" title="Patch the selected documents (Alt+S)" accesskey="S" data-bind="click: executePatchOnSelected, enable: isExecuteAllowed">
+            <button class="btn btn-primary" title="Patch the selected documents (Alt+S)" accesskey="S" data-bind="click: executePatchOnSelected, enable: isExecuteAllowed() && !$root.isPatchingInProgress()">
                 <i class="fa fa-play"></i> Patch Selected
             </button>
-            <button class="btn btn-primary" title="Patch all matching documents (Alt+A)" data-bind="click: executePatchOnAll, enable: (patchDocument().script())" accesskey="A">
+            <button class="btn btn-primary" title="Patch all matching documents (Alt+A)" data-bind="click: executePatchOnAll, enable: patchDocument().script() && !$root.isPatchingInProgress()" accesskey="A">
                 <i class="fa fa-forward"></i> Patch All
             </button>
         </div>
     </div>
-    <br />
+    <br/>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="progress" data-bind="css: { active: isPatchingInProgress() }, visible: showPatchingProgress() && (!!patchDocument()) && (patchDocument().isDocumentPatch() == false)">
+                <div class="progress-bar progress-bar-striped" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-bind="style: {width: patchingProgressPercentage}, aria-valuenow: patchingProgress">
+                    <span data-bind="text: patchingProgressText" />
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div class="form-inline">
+
         <div class="form-group" data-bind="visible: (!!patchDocument()) && patchDocument().isDocumentPatch()">
             <label for="documentToPatch" class="padd-right-10">Document to Patch:</label>
             <span data-bind="with: patchDocument">
-                <input id="documentToPatch" accesskey="I" type="text" class="form-control" data-bind="value: selectedItem, valueUpdate: 'afterkeydown', event: { keyup: $root.loadDocumentToTest.bind($root, $element.value) }" />
+                <input id="documentToPatch" accesskey="I" type="text" class="form-control" data-bind="value: selectedItem, valueUpdate: 'afterkeydown', event: { keyup: $root.loadDocumentToTest.bind($root, $element.value) }, enable: !$root.isPatchingInProgress()" />
             </span>
         </div>
         <div class="form-group" data-bind="visible: (!!patchDocument()) && patchDocument().isCollectionPatch()">
             <label for="collectionToPatch" class="padd-right-10">Collection to Patch:</label>
             <div class="btn-group" data-bind="with: patchDocument">
-                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-bind="disable: $root.isPatchingInProgress()">
                     <span data-bind="text: selectedItem"></span>
                     <span class="caret" data-bind="visible: $root.collections().length > 1"></span>
                 </button>
@@ -90,7 +100,7 @@
         <div class="form-group" data-bind="visible: (!!patchDocument()) && patchDocument().isIndexPatch()">
             <label for="indexToPatch" class="padd-right-10">Index to Patch:</label>
             <div class="btn-group" data-bind="with: patchDocument">
-                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-bind="disable: $root.isPatchingInProgress()">
                     <span data-bind="text: selectedItem"></span>
                     <span class="caret" data-bind="visible: $root.indexNames().length > 1"></span>
                 </button>
@@ -103,15 +113,6 @@
         </div>
     </div>
     <div class="form-horizontal">
-        <div class="form-group">
-            <div class="col-md-12">
-                <div class="progress" data-bind="css: { active: isPatchingInProgress() }, visible: showPatchingProgress() && (!!patchDocument()) && (patchDocument().isDocumentPatch() == false)">
-                    <div class="progress-bar progress-bar-striped" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-bind="style: {width: patchingProgressPercentage}, aria-valuenow: patchingProgress">
-                        <span data-bind="text: patchingProgressText" />
-                    </div>
-                </div>
-            </div>
-        </div>
         <div class="form-group" data-bind="visible: (!!patchDocument()) && patchDocument().isIndexPatch()">
             <div class="col-md-9">
                 <div>
@@ -125,7 +126,7 @@
                 </div>
                 <div>
                     <div data-bind="with: patchDocument">
-                        <pre id="queryEditor" class="form-control editor" data-bind="aceEditor: { code: $root.queryText, typeName:'queryText', allowResize: true, minHeight: 160, maxHeight: 200, completer:$root.queryCompleter, lang:'ace/mode/lucene', completerHostObject:$root}, valueUpdate: 'afterkeydown'"></pre>
+                        <pre id="queryEditor" class="form-control editor" data-bind="aceEditor: { code: $root.queryText, readOnly: $root.isPatchingInProgress(), typeName:'queryText', allowResize: true, minHeight: 160, maxHeight: 200, completer:$root.queryCompleter, lang:'ace/mode/lucene', completerHostObject:$root}, valueUpdate: 'afterkeydown'"></pre>
                     </div>
                 </div>
             </div>
@@ -143,7 +144,7 @@
                 <div>
                     <div class="row">
                         <div class="col-md-12" data-bind="with: patchDocument">
-                            <pre class="form-control" data-bind="aceEditor: { code: script, lang:'ace/mode/javascript' }" style="height: 160px;"></pre>
+                            <pre class="form-control" data-bind="aceEditor: { code: script, lang:'ace/mode/javascript', readOnly: $root.isPatchingInProgress() }" style="height: 160px;"></pre>
                         </div>
                     </div>
                 </div>
@@ -164,20 +165,20 @@
                         <tbody data-bind="foreach: parameters">
                             <tr>
                                 <td>
-                                    <input id="parametersName" type="text" class="form-control" data-bind="value: key" />
+                                    <input id="parametersName" type="text" class="form-control" data-bind="value: key, disable: $root.isPatchingInProgress()" />
                                 </td>
                                 <td>
-                                    <input id="parametersValue" type="text" class="form-control" data-bind="value: value" />
+                                    <input id="parametersValue" type="text" class="form-control" data-bind="value: value, disable: $root.isPatchingInProgress()" />
                                 </td>
                                 <td>
-                                    <button type="button" class="close" data-bind="click: $parent.removeParameter.bind($parent, $data)" title="Remove this parameter">
+                                    <button type="button" class="close" data-bind="click: $parent.removeParameter.bind($parent, $data), disable: $root.isPatchingInProgress()" title="Remove this parameter">
                                         <i class="fa fa-times"></i>
                                     </button>
                                 </td>
                             </tr>
                         </tbody>
                     </table>
-                    <button type="button" class="btn btn-default" data-bind="click: createParameter" title="Add a parameter">
+                    <button type="button" class="btn btn-default" data-bind="click: createParameter, disable: $root.isPatchingInProgress()" title="Add a parameter">
                         <i class="fa fa-plus"></i> Add parameter
                     </button>
                 </div>


### PR DESCRIPTION
- patch - block UI when patch is in progress
- Patch page: after applying a patch: documents count should have a separator.
