### PR TITLE
RavenDB-4586

### DIFF
--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -15,363 +15,359 @@ using Sparrow.Binary;
 
 namespace Voron.Data.BTrees
 {
-	/* Multi tree behavior
-	 * -------------------
-	 * A multi tree is a tree that is used only with MultiRead, MultiAdd, MultiDelete
-	 * The common use case is a secondary index that allows duplicates. 
-	 * 
-	 * The API exposed goes like this:
-	 * 
-	 * MultiAdd("key", "val1"), MultiAdd("key", "val2"), MultiAdd("key", "val3") 
-	 * 
-	 * And then you can read it back with MultiRead("key") : IIterator
-	 * 
-	 * When deleting, you delete one value at a time: MultiDelete("key", "val1")
-	 * 
-	 * The actual values are stored as keys in a separate tree per key. In order to optimize
-	 * space usage, multi trees work in the following fashion.
-	 * 
-	 * If the totale size of the values per key is less than NodeMaxSize, we store them as an embedded
-	 * page inside the owning tree. If then are more than the node max size, we create a separate tree
-	 * for them and then only store the tree root infromation.
-	 */
-	public unsafe partial class Tree
-	{
-		public bool IsMultiValueTree { get; set; }
+    /* Multi tree behavior
+     * -------------------
+     * A multi tree is a tree that is used only with MultiRead, MultiAdd, MultiDelete
+     * The common use case is a secondary index that allows duplicates. 
+     * 
+     * The API exposed goes like this:
+     * 
+     * MultiAdd("key", "val1"), MultiAdd("key", "val2"), MultiAdd("key", "val3") 
+     * 
+     * And then you can read it back with MultiRead("key") : IIterator
+     * 
+     * When deleting, you delete one value at a time: MultiDelete("key", "val1")
+     * 
+     * The actual values are stored as keys in a separate tree per key. In order to optimize
+     * space usage, multi trees work in the following fashion.
+     * 
+     * If the totale size of the values per key is less than NodeMaxSize, we store them as an embedded
+     * page inside the owning tree. If then are more than the node max size, we create a separate tree
+     * for them and then only store the tree root infromation.
+     */
+    public unsafe partial class Tree
+    {
+        public bool IsMultiValueTree { get; set; }
 
-		public void MultiAdd(Slice key, Slice value, ushort? version = null)
-		{
-			if (value == null) throw new ArgumentNullException(nameof(value));
-			int maxNodeSize = Llt.DataPager.NodeMaxSize;
-			if (value.Size > maxNodeSize)
-				throw new ArgumentException("Cannot add a value to child tree that is over " + maxNodeSize + " bytes in size", nameof(value));
-			if (value.Size == 0)
-				throw new ArgumentException("Cannot add empty value to child tree");
+        public void MultiAdd(Slice key, Slice value, ushort? version = null)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            int maxNodeSize = Llt.DataPager.NodeMaxSize;
+            if (value.Size > maxNodeSize)
+                throw new ArgumentException("Cannot add a value to child tree that is over " + maxNodeSize + " bytes in size", nameof(value));
+            if (value.Size == 0)
+                throw new ArgumentException("Cannot add empty value to child tree");
 
-			State.IsModified = true;
-			State.Flags |= TreeFlags.MultiValueTrees;
+            State.IsModified = true;
+            State.Flags |= TreeFlags.MultiValueTrees;
 
-			Lazy<TreeCursor> lazy;
-			TreeNodeHeader* node;
-			var page = FindPageFor(key, out node, out lazy);
-			if ((page == null || page.LastMatch != 0))
-			{
-				MultiAddOnNewValue(key, value, version, maxNodeSize);
-				return;
-			}
+            TreeNodeHeader* node;
+            var page = FindPageFor(key, out node);
+            if ((page == null || page.LastMatch != 0))
+            {
+                MultiAddOnNewValue(key, value, version, maxNodeSize);
+                return;
+            }
 
-			page = ModifyPage(page);
-			var item = page.GetNode(page.LastSearchPosition);
+            page = ModifyPage(page);
+            var item = page.GetNode(page.LastSearchPosition);
 
-			// already was turned into a multi tree, not much to do here
-			if (item->Flags == TreeNodeFlags.MultiValuePageRef)
-			{
-				var existingTree = OpenMultiValueTree(key, item);
-				existingTree.DirectAdd(value, 0, version: version);
-				return;
-			}
+            // already was turned into a multi tree, not much to do here
+            if (item->Flags == TreeNodeFlags.MultiValuePageRef)
+            {
+                var existingTree = OpenMultiValueTree(key, item);
+                existingTree.DirectAdd(value, 0, version: version);
+                return;
+            }
 
-			byte* nestedPagePtr;
-			if (item->Flags == TreeNodeFlags.PageRef)
-			{
-				var overFlowPage = ModifyPage(item->PageNumber);
-				nestedPagePtr = overFlowPage.Base + Constants.TreePageHeaderSize;
-			}
-			else
-			{
-				nestedPagePtr = TreeNodeHeader.DirectAccess(_llt, item);
-			}
+            byte* nestedPagePtr;
+            if (item->Flags == TreeNodeFlags.PageRef)
+            {
+                var overFlowPage = ModifyPage(item->PageNumber);
+                nestedPagePtr = overFlowPage.Base + Constants.TreePageHeaderSize;
+            }
+            else
+            {
+                nestedPagePtr = TreeNodeHeader.DirectAccess(_llt, item);
+            }
 
-			var nestedPage = new TreePage(nestedPagePtr, "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, item));
+            var nestedPage = new TreePage(nestedPagePtr, "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, item));
 
-			var existingItem = nestedPage.Search(value);
-			if (nestedPage.LastMatch != 0)
-				existingItem = null;// not an actual match, just greater than
+            var existingItem = nestedPage.Search(value);
+            if (nestedPage.LastMatch != 0)
+                existingItem = null;// not an actual match, just greater than
 
-			ushort previousNodeRevision = existingItem != null ?  existingItem->Version : (ushort)0;
-			CheckConcurrency(key, value, version, previousNodeRevision, TreeActionType.Add);
-			
-			if (existingItem != null)
-			{
-				// maybe same value added twice?
-				var tmpKey = page.GetNodeKey(item);
-				if (tmpKey.Compare(value) == 0)
-					return; // already there, turning into a no-op
-				nestedPage.RemoveNode(nestedPage.LastSearchPosition);
-			}
+            ushort previousNodeRevision = existingItem != null ?  existingItem->Version : (ushort)0;
+            CheckConcurrency(key, value, version, previousNodeRevision, TreeActionType.Add);
+            
+            if (existingItem != null)
+            {
+                // maybe same value added twice?
+                var tmpKey = page.GetNodeKey(item);
+                if (tmpKey.Compare(value) == 0)
+                    return; // already there, turning into a no-op
+                nestedPage.RemoveNode(nestedPage.LastSearchPosition);
+            }
 
             var valueToInsert = value;
 
-			if (nestedPage.HasSpaceFor(_llt, valueToInsert, 0))
-			{
-				// we are now working on top of the modified root page, we can just modify the memory directly
-				nestedPage.AddDataNode(nestedPage.LastSearchPosition, valueToInsert, 0, previousNodeRevision);
-				return;
-			}
+            if (nestedPage.HasSpaceFor(_llt, valueToInsert, 0))
+            {
+                // we are now working on top of the modified root page, we can just modify the memory directly
+                nestedPage.AddDataNode(nestedPage.LastSearchPosition, valueToInsert, 0, previousNodeRevision);
+                return;
+            }
 
-			int pageSize = nestedPage.CalcSizeUsed() + Constants.TreePageHeaderSize;
-			var newRequiredSize = pageSize + nestedPage.GetRequiredSpace(valueToInsert, 0);
-			if (newRequiredSize <= maxNodeSize)
-			{
-				// we can just expand the current value... no need to create a nested tree yet
+            int pageSize = nestedPage.CalcSizeUsed() + Constants.TreePageHeaderSize;
+            var newRequiredSize = pageSize + nestedPage.GetRequiredSpace(valueToInsert, 0);
+            if (newRequiredSize <= maxNodeSize)
+            {
+                // we can just expand the current value... no need to create a nested tree yet
                 var actualPageSize = (ushort) Math.Min(Bits.NextPowerOf2(newRequiredSize), maxNodeSize);
 
                 var currentDataSize = TreeNodeHeader.GetDataSize(_llt, item);
                 ExpandMultiTreeNestedPageSize(key, value, nestedPagePtr, actualPageSize, currentDataSize);
 
-				return;
-			}
-			// we now have to convert this into a tree instance, instead of just a nested page
-			var tree = Create(_llt, _tx, TreeFlags.MultiValue);
-			for (int i = 0; i < nestedPage.NumberOfEntries; i++)
-			{
-				var existingValue = nestedPage.GetNodeKey(i);
-				tree.DirectAdd(existingValue, 0);
-			}
-			tree.DirectAdd(value, 0, version: version);
-			_tx.AddMultiValueTree(this, key, tree);
-			// we need to record that we switched to tree mode here, so the next call wouldn't also try to create the tree again
-			DirectAdd(key, sizeof (TreeRootHeader), TreeNodeFlags.MultiValuePageRef);
-		}
+                return;
+            }
+            // we now have to convert this into a tree instance, instead of just a nested page
+            var tree = Create(_llt, _tx, TreeFlags.MultiValue);
+            for (int i = 0; i < nestedPage.NumberOfEntries; i++)
+            {
+                var existingValue = nestedPage.GetNodeKey(i);
+                tree.DirectAdd(existingValue, 0);
+            }
+            tree.DirectAdd(value, 0, version: version);
+            _tx.AddMultiValueTree(this, key, tree);
+            // we need to record that we switched to tree mode here, so the next call wouldn't also try to create the tree again
+            DirectAdd(key, sizeof (TreeRootHeader), TreeNodeFlags.MultiValuePageRef);
+        }
 
-		private void ExpandMultiTreeNestedPageSize(Slice key, Slice value, byte* nestedPagePtr, ushort newSize, int currentSize)
-		{
-			Debug.Assert(newSize > currentSize);
-			TemporaryPage tmp;
-			using (_llt.Environment.GetTemporaryPage(_llt, out tmp))
-			{
-				var tempPagePointer = tmp.TempPagePointer;
+        private void ExpandMultiTreeNestedPageSize(Slice key, Slice value, byte* nestedPagePtr, ushort newSize, int currentSize)
+        {
+            Debug.Assert(newSize > currentSize);
+            TemporaryPage tmp;
+            using (_llt.Environment.GetTemporaryPage(_llt, out tmp))
+            {
+                var tempPagePointer = tmp.TempPagePointer;
                 Memory.Copy(tempPagePointer, nestedPagePtr, currentSize);
-				Delete(key); // release our current page
-				TreePage nestedPage = new TreePage(tempPagePointer, "multi tree", (ushort)currentSize);
+                Delete(key); // release our current page
+                TreePage nestedPage = new TreePage(tempPagePointer, "multi tree", (ushort)currentSize);
 
-				var ptr = DirectAdd(key, newSize);
+                var ptr = DirectAdd(key, newSize);
 
-				var newNestedPage = new TreePage(ptr, "multi tree", newSize)
-				{
-					Lower = (ushort)Constants.TreePageHeaderSize,
-					Upper = newSize,
-					TreeFlags = TreePageFlags.Leaf,
-					PageNumber = -1L // mark as invalid page number
-				};
-			
-				Slice nodeKey = nestedPage.CreateNewEmptyKey();
-				for (int i = 0; i < nestedPage.NumberOfEntries; i++)
-				{
-					var nodeHeader = nestedPage.GetNode(i);
-					nestedPage.SetNodeKey(nodeHeader, ref nodeKey);
-					newNestedPage.AddDataNode(i, nodeKey, 0, (ushort)(nodeHeader->Version - 1)); // we dec by one because AdddataNode will inc by one, and we don't want to change those values
-				}
+                var newNestedPage = new TreePage(ptr, "multi tree", newSize)
+                {
+                    Lower = (ushort)Constants.TreePageHeaderSize,
+                    Upper = newSize,
+                    TreeFlags = TreePageFlags.Leaf,
+                    PageNumber = -1L // mark as invalid page number
+                };
+            
+                Slice nodeKey = nestedPage.CreateNewEmptyKey();
+                for (int i = 0; i < nestedPage.NumberOfEntries; i++)
+                {
+                    var nodeHeader = nestedPage.GetNode(i);
+                    nestedPage.SetNodeKey(nodeHeader, ref nodeKey);
+                    newNestedPage.AddDataNode(i, nodeKey, 0, (ushort)(nodeHeader->Version - 1)); // we dec by one because AdddataNode will inc by one, and we don't want to change those values
+                }
 
-				newNestedPage.Search(value);
-				newNestedPage.AddDataNode(newNestedPage.LastSearchPosition, value, 0, 0);
-			}
-		}
+                newNestedPage.Search(value);
+                newNestedPage.AddDataNode(newNestedPage.LastSearchPosition, value, 0, 0);
+            }
+        }
 
-		private void MultiAddOnNewValue(Slice key, Slice value, ushort? version, int maxNodeSize)
-		{
-			Slice valueToInsert = value;
+        private void MultiAddOnNewValue(Slice key, Slice value, ushort? version, int maxNodeSize)
+        {
+            Slice valueToInsert = value;
 
-			var requiredPageSize = Constants.TreePageHeaderSize + TreeSizeOf.LeafEntry(-1, valueToInsert, 0) + Constants.NodeOffsetSize;
-			if (requiredPageSize > maxNodeSize)
-			{
-				// no choice, very big value, we might as well just put it in its own tree from the get go...
-				// otherwise, we would have to put this in overflow page, and that won't save us any space anyway
+            var requiredPageSize = Constants.TreePageHeaderSize + TreeSizeOf.LeafEntry(-1, valueToInsert, 0) + Constants.NodeOffsetSize;
+            if (requiredPageSize > maxNodeSize)
+            {
+                // no choice, very big value, we might as well just put it in its own tree from the get go...
+                // otherwise, we would have to put this in overflow page, and that won't save us any space anyway
 
-				var tree = Create(_llt, _tx, TreeFlags.MultiValue);
-				tree.DirectAdd(value, 0);
-				_tx.AddMultiValueTree(this, key, tree);
+                var tree = Create(_llt, _tx, TreeFlags.MultiValue);
+                tree.DirectAdd(value, 0);
+                _tx.AddMultiValueTree(this, key, tree);
 
-				DirectAdd(key, sizeof (TreeRootHeader), TreeNodeFlags.MultiValuePageRef);
-				return;
-			}
+                DirectAdd(key, sizeof (TreeRootHeader), TreeNodeFlags.MultiValuePageRef);
+                return;
+            }
 
-			var actualPageSize = (ushort) Math.Min(Bits.NextPowerOf2(requiredPageSize), maxNodeSize);
+            var actualPageSize = (ushort) Math.Min(Bits.NextPowerOf2(requiredPageSize), maxNodeSize);
 
-			var ptr = DirectAdd(key, actualPageSize);
+            var ptr = DirectAdd(key, actualPageSize);
 
-			var nestedPage = new TreePage(ptr, "multi tree", actualPageSize)
-			{
-				PageNumber = -1L,// hint that this is an inner page
-				Lower = (ushort) Constants.TreePageHeaderSize,
-				Upper = actualPageSize,
-				TreeFlags = TreePageFlags.Leaf,
-			};
+            var nestedPage = new TreePage(ptr, "multi tree", actualPageSize)
+            {
+                PageNumber = -1L,// hint that this is an inner page
+                Lower = (ushort) Constants.TreePageHeaderSize,
+                Upper = actualPageSize,
+                TreeFlags = TreePageFlags.Leaf,
+            };
 
-			CheckConcurrency(key, value, version, 0, TreeActionType.Add);
+            CheckConcurrency(key, value, version, 0, TreeActionType.Add);
 
-			nestedPage.AddDataNode(0, valueToInsert, 0, 0);
-		}
+            nestedPage.AddDataNode(0, valueToInsert, 0, 0);
+        }
 
-		public void MultiDelete(Slice key, Slice value, ushort? version = null)
-		{
-			State.IsModified = true;
-			Lazy<TreeCursor> lazy;
-			TreeNodeHeader* node;
-			var page = FindPageFor(key, out node, out lazy);
-			if (page == null || page.LastMatch != 0)
-			{
-				return; //nothing to delete - key not found
-			}
+        public void MultiDelete(Slice key, Slice value, ushort? version = null)
+        {
+            State.IsModified = true;
+            TreeNodeHeader* node;
+            var page = FindPageFor(key, out node);
+            if (page == null || page.LastMatch != 0)
+            {
+                return; //nothing to delete - key not found
+            }
 
-			page = ModifyPage(page);
+            page = ModifyPage(page);
 
-			var item = page.GetNode(page.LastSearchPosition);
+            var item = page.GetNode(page.LastSearchPosition);
 
-			if (item->Flags == TreeNodeFlags.MultiValuePageRef) //multi-value tree exists
-			{
-				var tree = OpenMultiValueTree(key, item);
+            if (item->Flags == TreeNodeFlags.MultiValuePageRef) //multi-value tree exists
+            {
+                var tree = OpenMultiValueTree(key, item);
 
-				tree.Delete(value, version);
+                tree.Delete(value, version);
 
-				// previously, we would convert back to a simple model if we dropped to a single entry
-				// however, it doesn't really make sense, once you got enough values to go to an actual nested 
-				// tree, you are probably going to remain that way, or be removed completely.
-				if (tree.State.NumberOfEntries != 0) 
-					return;
-				_tx.TryRemoveMultiValueTree(this, key);
-				_llt.FreePage(tree.State.RootPageNumber);
+                // previously, we would convert back to a simple model if we dropped to a single entry
+                // however, it doesn't really make sense, once you got enough values to go to an actual nested 
+                // tree, you are probably going to remain that way, or be removed completely.
+                if (tree.State.NumberOfEntries != 0) 
+                    return;
+                _tx.TryRemoveMultiValueTree(this, key);
+                _llt.FreePage(tree.State.RootPageNumber);
 
-				Delete(key);
-			}
-			else // we use a nested page here
-			{
-				var nestedPage = new TreePage(TreeNodeHeader.DirectAccess(_llt, item), "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, item));
-				var nestedItem = nestedPage.Search(value);
-				if (nestedPage.LastMatch != 0) // value not found
-					return;
+                Delete(key);
+            }
+            else // we use a nested page here
+            {
+                var nestedPage = new TreePage(TreeNodeHeader.DirectAccess(_llt, item), "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, item));
+                var nestedItem = nestedPage.Search(value);
+                if (nestedPage.LastMatch != 0) // value not found
+                    return;
 
-				byte* nestedPagePtr;
-				if (item->Flags == TreeNodeFlags.PageRef)
-				{
-					var overFlowPage = ModifyPage(item->PageNumber);
-					nestedPagePtr = overFlowPage.Base + Constants.TreePageHeaderSize;
-				}
-				else
-				{
-					nestedPagePtr = TreeNodeHeader.DirectAccess(_llt, item);
-				}
+                byte* nestedPagePtr;
+                if (item->Flags == TreeNodeFlags.PageRef)
+                {
+                    var overFlowPage = ModifyPage(item->PageNumber);
+                    nestedPagePtr = overFlowPage.Base + Constants.TreePageHeaderSize;
+                }
+                else
+                {
+                    nestedPagePtr = TreeNodeHeader.DirectAccess(_llt, item);
+                }
 
-				nestedPage = new TreePage(nestedPagePtr, "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, item))
-				{
-					LastSearchPosition = nestedPage.LastSearchPosition
-				};
+                nestedPage = new TreePage(nestedPagePtr, "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, item))
+                {
+                    LastSearchPosition = nestedPage.LastSearchPosition
+                };
 
-				CheckConcurrency(key, value, version, nestedItem->Version, TreeActionType.Delete);
-				nestedPage.RemoveNode(nestedPage.LastSearchPosition);
-				if (nestedPage.NumberOfEntries == 0)
-					Delete(key);
-			}
-		}
+                CheckConcurrency(key, value, version, nestedItem->Version, TreeActionType.Delete);
+                nestedPage.RemoveNode(nestedPage.LastSearchPosition);
+                if (nestedPage.NumberOfEntries == 0)
+                    Delete(key);
+            }
+        }
 
-		//TODO: write a test for this
-		public long MultiCount(Slice key)
-		{
-			Lazy<TreeCursor> lazy;
-			TreeNodeHeader* node;
-			var page = FindPageFor(key, out node, out lazy);
-			if (page == null || page.LastMatch != 0)
-				return 0;
+        //TODO: write a test for this
+        public long MultiCount(Slice key)
+        {
+            TreeNodeHeader* node;
+            var page = FindPageFor(key, out node);
+            if (page == null || page.LastMatch != 0)
+                return 0;
 
-			Debug.Assert(node != null);
+            Debug.Assert(node != null);
 
-			var fetchedNodeKey = page.GetNodeKey(node);
-			if (fetchedNodeKey.Compare(key) != 0)
-			{
-				throw new InvalidDataException("Was unable to retrieve the correct node. Data corruption possible");
-			}
+            var fetchedNodeKey = page.GetNodeKey(node);
+            if (fetchedNodeKey.Compare(key) != 0)
+            {
+                throw new InvalidDataException("Was unable to retrieve the correct node. Data corruption possible");
+            }
 
-			if (node->Flags == TreeNodeFlags.MultiValuePageRef)
-			{
-				var tree = OpenMultiValueTree(key, node);
+            if (node->Flags == TreeNodeFlags.MultiValuePageRef)
+            {
+                var tree = OpenMultiValueTree(key, node);
 
-				return tree.State.NumberOfEntries;
-			}
+                return tree.State.NumberOfEntries;
+            }
 
-			var nestedPage = new TreePage(TreeNodeHeader.DirectAccess(_llt, node), "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, node));
+            var nestedPage = new TreePage(TreeNodeHeader.DirectAccess(_llt, node), "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, node));
 
-			return nestedPage.NumberOfEntries;
-		}
+            return nestedPage.NumberOfEntries;
+        }
 
-		public IIterator MultiRead(Slice key)
-		{
-			Lazy<TreeCursor> lazy;
-			TreeNodeHeader* node;
-			var page = FindPageFor(key, out node, out lazy);
-			if (page == null || page.LastMatch != 0)
-				return new EmptyIterator();
+        public IIterator MultiRead(Slice key)
+        {
+            TreeNodeHeader* node;
+            var page = FindPageFor(key, out node);
+            if (page == null || page.LastMatch != 0)
+                return new EmptyIterator();
 
-			Debug.Assert(node != null);
+            Debug.Assert(node != null);
 
-			var fetchedNodeKey = page.GetNodeKey(node);
-			if (fetchedNodeKey.Compare(key) != 0)
-			{
-				throw new InvalidDataException("Was unable to retrieve the correct node. Data corruption possible");
-			}
+            var fetchedNodeKey = page.GetNodeKey(node);
+            if (fetchedNodeKey.Compare(key) != 0)
+            {
+                throw new InvalidDataException("Was unable to retrieve the correct node. Data corruption possible");
+            }
 
-			if (node->Flags == TreeNodeFlags.MultiValuePageRef)
-			{
-				var tree = OpenMultiValueTree(key, node);
+            if (node->Flags == TreeNodeFlags.MultiValuePageRef)
+            {
+                var tree = OpenMultiValueTree(key, node);
 
-				return tree.Iterate();
-			}
+                return tree.Iterate();
+            }
 
-			var nestedPage = new TreePage(TreeNodeHeader.DirectAccess(_llt, node), "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, node));
-				
-			return new TreePageIterator(nestedPage);
-		}
+            var nestedPage = new TreePage(TreeNodeHeader.DirectAccess(_llt, node), "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, node));
+                
+            return new TreePageIterator(nestedPage);
+        }
 
-		private Tree OpenMultiValueTree(Slice key, TreeNodeHeader* item)
-		{
-			Tree tree;
-			if (_tx.TryGetMultiValueTree(this, key, out tree))
-				return tree;
+        private Tree OpenMultiValueTree(Slice key, TreeNodeHeader* item)
+        {
+            Tree tree;
+            if (_tx.TryGetMultiValueTree(this, key, out tree))
+                return tree;
 
-			var childTreeHeader =
-				(TreeRootHeader*)((byte*)item + item->KeySize + Constants.NodeHeaderSize);
+            var childTreeHeader =
+                (TreeRootHeader*)((byte*)item + item->KeySize + Constants.NodeHeaderSize);
 
-			Debug.Assert(childTreeHeader->RootPageNumber < _llt.State.NextPageNumber);
-			Debug.Assert(childTreeHeader->Flags == TreeFlags.MultiValue);
-			
-			tree = Open(_llt, _tx,childTreeHeader);
+            Debug.Assert(childTreeHeader->RootPageNumber < _llt.State.NextPageNumber);
+            Debug.Assert(childTreeHeader->Flags == TreeFlags.MultiValue);
+            
+            tree = Open(_llt, _tx,childTreeHeader);
 
-			_tx.AddMultiValueTree(this, key, tree);
-			return tree;
-		}
+            _tx.AddMultiValueTree(this, key, tree);
+            return tree;
+        }
 
-		private bool TryOverwriteDataOrMultiValuePageRefNode(TreeNodeHeader* updatedNode, Slice key, int len,
-														     TreeNodeFlags requestedNodeType, ushort? version, out byte* pos)
-		{
-			switch (requestedNodeType)
-			{
-				case TreeNodeFlags.Data:
-				case TreeNodeFlags.MultiValuePageRef:
-					{
-						if (updatedNode->DataSize == len &&
-							(updatedNode->Flags == TreeNodeFlags.Data || updatedNode->Flags == TreeNodeFlags.MultiValuePageRef))
-						{
-							CheckConcurrency(key, version, updatedNode->Version, TreeActionType.Add);
+        private bool TryOverwriteDataOrMultiValuePageRefNode(TreeNodeHeader* updatedNode, Slice key, int len,
+                                                             TreeNodeFlags requestedNodeType, ushort? version, out byte* pos)
+        {
+            switch (requestedNodeType)
+            {
+                case TreeNodeFlags.Data:
+                case TreeNodeFlags.MultiValuePageRef:
+                    {
+                        if (updatedNode->DataSize == len &&
+                            (updatedNode->Flags == TreeNodeFlags.Data || updatedNode->Flags == TreeNodeFlags.MultiValuePageRef))
+                        {
+                            CheckConcurrency(key, version, updatedNode->Version, TreeActionType.Add);
 
-							if (updatedNode->Version == ushort.MaxValue)
-								updatedNode->Version = 0;
-							updatedNode->Version++;
+                            if (updatedNode->Version == ushort.MaxValue)
+                                updatedNode->Version = 0;
+                            updatedNode->Version++;
 
-							updatedNode->Flags = requestedNodeType;
+                            updatedNode->Flags = requestedNodeType;
 
-							{
-								pos = (byte*)updatedNode + Constants.NodeHeaderSize + updatedNode->KeySize;
-								return true;
-							}
-						}
-						break;
-					}
-				case TreeNodeFlags.PageRef:
-					throw new InvalidOperationException("We never add PageRef explicitly");
-				default:
-					throw new ArgumentOutOfRangeException();
-			}
-			pos = null;
-			return false;
-		}
-	}
+                            {
+                                pos = (byte*)updatedNode + Constants.NodeHeaderSize + updatedNode->KeySize;
+                                return true;
+                            }
+                        }
+                        break;
+                    }
+                case TreeNodeFlags.PageRef:
+                    throw new InvalidOperationException("We never add PageRef explicitly");
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            pos = null;
+            return false;
+        }
+    }
 }

--- a/src/Voron/Data/BTrees/TreeIterator.cs
+++ b/src/Voron/Data/BTrees/TreeIterator.cs
@@ -4,244 +4,241 @@ using Voron.Impl;
 
 namespace Voron.Data.BTrees
 {
-	public unsafe class TreeIterator : IIterator
-	{
-		private readonly Tree _tree;
+    public unsafe class TreeIterator : IIterator
+    {
+        private readonly Tree _tree;
         private readonly LowLevelTransaction _tx;
-		private TreeCursor _cursor;
-		private TreePage _currentPage;
-		private Slice _currentKey = new Slice(SliceOptions.Key);
-		private Slice _currentInternalKey;
-	    private bool _disposed;
+        private TreeCursor _cursor;
+        private TreePage _currentPage;
+        private Slice _currentKey = new Slice(SliceOptions.Key);
+        private Slice _currentInternalKey;
+        private bool _disposed;
 
-        public event Action<IIterator> OnDispoal;
+        public event Action<IIterator> OnDisposal;
 
         public TreeIterator(Tree tree, LowLevelTransaction tx)
-		{
-			_tree = tree;
-			_tx = tx;
+        {
+            _tree = tree;
+            _tx = tx;
 
             _currentInternalKey = new Slice(SliceOptions.Key); 				
-		}
+        }
 
-		public int GetCurrentDataSize()
-		{
+        public int GetCurrentDataSize()
+        {
             if(_disposed)
                 throw new ObjectDisposedException("TreeIterator " + _tree.Name);
-			return TreeNodeHeader.GetDataSize(_tx, Current);
-		}
+            return TreeNodeHeader.GetDataSize(_tx, Current);
+        }
 
-		public bool Seek(Slice key)
-		{
+        public bool Seek(Slice key)
+        {
             if (_disposed)
                 throw new ObjectDisposedException("TreeIterator " + _tree.Name);
 
-			Lazy<TreeCursor> lazy;
-			TreeNodeHeader* node;
-			_currentPage = _tree.FindPageFor(key, out node, out lazy);
-			_cursor = lazy.Value;
-			_cursor.Pop();
+            TreeNodeHeader* node;
+            Func<TreeCursor> cursorConstructor;
+            _currentPage = _tree.FindPageFor(key, out node, out cursorConstructor);
+            _cursor = cursorConstructor();
+            _cursor.Pop();
 
-		    if (node != null)
-		    {
-			    _currentPage.SetNodeKey(node, ref _currentInternalKey);
-				_currentKey = _currentInternalKey.ToSlice();
-				return this.ValidateCurrentKey(Current, _currentPage);
-		    }
-		    
-            // The key is not found in the db, but we are Seek()ing for equals or starts with.
-		    // We know that the exact value isn't there, but it is possible that the next page has values 
-		    // that is actually greater than the key, so we need to check it as well.
-
-		    _currentPage.LastSearchPosition = _currentPage.NumberOfEntries; // force next MoveNext to move to the next _page_.
-		    return MoveNext();
-		}
-
-		public Slice CurrentKey
-		{
-			get
-			{
-                if (_disposed)
-                    throw new ObjectDisposedException("TreeIterator " + _tree.Name);
-
-				if (_currentPage == null)
-					throw new InvalidOperationException("No current page was set");
-
-				if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
-					throw new InvalidOperationException(string.Format("Current page is invalid. Search position ({0}) exceeds number of entries ({1}). Page: {2}.", _currentPage.LastSearchPosition, _currentPage.NumberOfEntries, _currentPage));
-					
-				return _currentKey;
-			}
-		}
-
-		/// <summary>
-		/// Deletes the current key/value pair and returns true if there is 
-		/// another key after it
-		/// </summary>
-		public bool DeleteCurrentAndMoveNext()
-		{
-			var currentKey = CurrentKey;
-			_tree.Delete(currentKey);
-			return Seek(currentKey);
-		}
-
-		public TreeNodeHeader* Current
-		{
-			get
-			{
-                if (_disposed)
-                    throw new ObjectDisposedException("TreeIterator " + _tree.Name);
-
-				if (_currentPage == null)
-					throw new InvalidOperationException("No current page was set");
-
-				if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
-					throw new InvalidOperationException(string.Format("Current page is invalid. Search position ({0}) exceeds number of entries ({1}). Page: {2}.", _currentPage.LastSearchPosition, _currentPage.NumberOfEntries, _currentPage));
-					
-				return _currentPage.GetNode(_currentPage.LastSearchPosition);
-			}
-		}
-
-		public bool MovePrev()
-		{
-            if (_disposed)
-                throw new ObjectDisposedException("TreeIterator " + _tree.Name);
-			while (true)
-			{
-				_currentPage.LastSearchPosition--;
-				if (_currentPage.LastSearchPosition >= 0)
-				{
-					// run out of entries, need to select the next page...
-					while (_currentPage.IsBranch)
-					{
-						_cursor.Push(_currentPage);
-						var node = _currentPage.GetNode(_currentPage.LastSearchPosition);
-						_currentPage = _tx.GetReadOnlyTreePage(node->PageNumber);
-						_currentPage.LastSearchPosition = _currentPage.NumberOfEntries - 1;
-					}
-					var current = _currentPage.GetNode(_currentPage.LastSearchPosition);
-					if (this.ValidateCurrentKey(current, _currentPage) == false)
-						return false;
-
-					_currentPage.SetNodeKey(current, ref _currentInternalKey);
-					_currentKey = _currentInternalKey.ToSlice();
-					return true;// there is another entry in this page
-				}
-				if (_cursor.PageCount == 0)
-					break;
-				_currentPage = _cursor.Pop();
-			}
-			_currentPage = null;
-			return false;
-		}
-
-		public bool MoveNext()
-		{
-            if (_disposed)
-                throw new ObjectDisposedException("TreeIterator " + _tree.Name);
-
-			while (_currentPage != null)
-			{
-				_currentPage.LastSearchPosition++;
-				if (_currentPage.LastSearchPosition < _currentPage.NumberOfEntries)
-				{
-					// run out of entries, need to select the next page...
-					while (_currentPage.IsBranch)
-					{
-						_cursor.Push(_currentPage);
-						var node = _currentPage.GetNode(_currentPage.LastSearchPosition);
-						_currentPage = _tx.GetReadOnlyTreePage(node->PageNumber);
-
-						_currentPage.LastSearchPosition = 0;
-					}
-					var current = _currentPage.GetNode(_currentPage.LastSearchPosition);
-					if (this.ValidateCurrentKey(current, _currentPage) == false)
-						return false;
-
-					_currentPage.SetNodeKey(current, ref _currentInternalKey);
-					_currentKey = _currentInternalKey.ToSlice();
-					return true;// there is another entry in this page
-				}
-				if (_cursor.PageCount == 0)
-					break;
-				_currentPage = _cursor.Pop();
-			}
-			_currentPage = null;
-			
-			return false;
-		}
-
-		public bool Skip(int count)
-		{
-			if (count != 0)
-			{
-				var moveMethod = (count > 0) ? (Func<bool>)MoveNext : MovePrev;
-
-				for (int i = 0; i < Math.Abs(count); i++)
-				{
-					if (!moveMethod()) break;
-				}
-			}
-
-			return _currentPage != null && this.ValidateCurrentKey(Current, _currentPage);
-		}
-
-		public ValueReader CreateReaderForCurrent()
-		{
-			return TreeNodeHeader.Reader(_tx, Current);
-		}
-
-		public void Dispose()
-		{
-		    if (_disposed)
-		        return;
-		    _disposed = true;
-            _cursor.Dispose();
-            var action = OnDispoal;
-            if (action != null)
+            if (node != null)
             {
-                action(this);
+                _currentPage.SetNodeKey(node, ref _currentInternalKey);
+                _currentKey = _currentInternalKey.ToSlice();
+                return this.ValidateCurrentKey(Current, _currentPage);
+            }
+            
+            // The key is not found in the db, but we are Seek()ing for equals or starts with.
+            // We know that the exact value isn't there, but it is possible that the next page has values 
+            // that is actually greater than the key, so we need to check it as well.
+
+            _currentPage.LastSearchPosition = _currentPage.NumberOfEntries; // force next MoveNext to move to the next _page_.
+            return MoveNext();
+        }
+
+        public Slice CurrentKey
+        {
+            get
+            {
+                if (_disposed)
+                    throw new ObjectDisposedException("TreeIterator " + _tree.Name);
+
+                if (_currentPage == null)
+                    throw new InvalidOperationException("No current page was set");
+
+                if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
+                    throw new InvalidOperationException(string.Format("Current page is invalid. Search position ({0}) exceeds number of entries ({1}). Page: {2}.", _currentPage.LastSearchPosition, _currentPage.NumberOfEntries, _currentPage));
+                    
+                return _currentKey;
             }
         }
 
-	    public Slice RequiredPrefix { get; set; }
+        /// <summary>
+        /// Deletes the current key/value pair and returns true if there is 
+        /// another key after it
+        /// </summary>
+        public bool DeleteCurrentAndMoveNext()
+        {
+            var currentKey = CurrentKey;
+            _tree.Delete(currentKey);
+            return Seek(currentKey);
+        }
 
-		public Slice MaxKey { get; set; }
+        public TreeNodeHeader* Current
+        {
+            get
+            {
+                if (_disposed)
+                    throw new ObjectDisposedException("TreeIterator " + _tree.Name);
 
-	    public long TreeRootPage
-	    {
+                if (_currentPage == null)
+                    throw new InvalidOperationException("No current page was set");
+
+                if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
+                    throw new InvalidOperationException(string.Format("Current page is invalid. Search position ({0}) exceeds number of entries ({1}). Page: {2}.", _currentPage.LastSearchPosition, _currentPage.NumberOfEntries, _currentPage));
+                    
+                return _currentPage.GetNode(_currentPage.LastSearchPosition);
+            }
+        }
+
+        public bool MovePrev()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException("TreeIterator " + _tree.Name);
+            while (true)
+            {
+                _currentPage.LastSearchPosition--;
+                if (_currentPage.LastSearchPosition >= 0)
+                {
+                    // run out of entries, need to select the next page...
+                    while (_currentPage.IsBranch)
+                    {
+                        _cursor.Push(_currentPage);
+                        var node = _currentPage.GetNode(_currentPage.LastSearchPosition);
+                        _currentPage = _tx.GetReadOnlyTreePage(node->PageNumber);
+                        _currentPage.LastSearchPosition = _currentPage.NumberOfEntries - 1;
+                    }
+                    var current = _currentPage.GetNode(_currentPage.LastSearchPosition);
+                    if (this.ValidateCurrentKey(current, _currentPage) == false)
+                        return false;
+
+                    _currentPage.SetNodeKey(current, ref _currentInternalKey);
+                    _currentKey = _currentInternalKey.ToSlice();
+                    return true;// there is another entry in this page
+                }
+                if (_cursor.PageCount == 0)
+                    break;
+                _currentPage = _cursor.Pop();
+            }
+            _currentPage = null;
+            return false;
+        }
+
+        public bool MoveNext()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException("TreeIterator " + _tree.Name);
+
+            while (_currentPage != null)
+            {
+                _currentPage.LastSearchPosition++;
+                if (_currentPage.LastSearchPosition < _currentPage.NumberOfEntries)
+                {
+                    // run out of entries, need to select the next page...
+                    while (_currentPage.IsBranch)
+                    {
+                        _cursor.Push(_currentPage);
+                        var node = _currentPage.GetNode(_currentPage.LastSearchPosition);
+                        _currentPage = _tx.GetReadOnlyTreePage(node->PageNumber);
+
+                        _currentPage.LastSearchPosition = 0;
+                    }
+                    var current = _currentPage.GetNode(_currentPage.LastSearchPosition);
+                    if (this.ValidateCurrentKey(current, _currentPage) == false)
+                        return false;
+
+                    _currentPage.SetNodeKey(current, ref _currentInternalKey);
+                    _currentKey = _currentInternalKey.ToSlice();
+                    return true;// there is another entry in this page
+                }
+                if (_cursor.PageCount == 0)
+                    break;
+                _currentPage = _cursor.Pop();
+            }
+            _currentPage = null;
+            
+            return false;
+        }
+
+        public bool Skip(int count)
+        {
+            if (count != 0)
+            {
+                var moveMethod = (count > 0) ? (Func<bool>)MoveNext : MovePrev;
+
+                for (int i = 0; i < Math.Abs(count); i++)
+                {
+                    if (!moveMethod()) break;
+                }
+            }
+
+            return _currentPage != null && this.ValidateCurrentKey(Current, _currentPage);
+        }
+
+        public ValueReader CreateReaderForCurrent()
+        {
+            return TreeNodeHeader.Reader(_tx, Current);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            _cursor.Dispose();
+            OnDisposal?.Invoke(this);
+        }
+
+        public Slice RequiredPrefix { get; set; }
+
+        public Slice MaxKey { get; set; }
+
+        public long TreeRootPage
+        {
             get { return  this._tree.State.RootPageNumber; }
-	    }
-	}
+        }
+    }
 
-	public static class IteratorExtensions
-	{
-		public static IEnumerable<string> DumpValues(this IIterator self)
-		{
-			if (self.Seek(Slice.BeforeAllKeys) == false)
-				yield break;
+    public static class IteratorExtensions
+    {
+        public static IEnumerable<string> DumpValues(this IIterator self)
+        {
+            if (self.Seek(Slice.BeforeAllKeys) == false)
+                yield break;
 
-			do
-			{
-				yield return self.CurrentKey.ToString();
-			} while (self.MoveNext());
-		}
+            do
+            {
+                yield return self.CurrentKey.ToString();
+            } while (self.MoveNext());
+        }
 
-		public unsafe static bool ValidateCurrentKey(this IIterator self, TreeNodeHeader* node, TreePage page)
-		{
-			if (self.RequiredPrefix != null)
-			{
-				var currentKey = page.GetNodeKey(node);
-				if (currentKey.StartsWith(self.RequiredPrefix) == false)
-					return false;
-			}
-			if (self.MaxKey != null)
-			{
-				var currentKey = page.GetNodeKey(node);
-				if (currentKey.Compare(self.MaxKey) >= 0)
-					return false;
-			}
-			return true;
-		}
-	}
+        public unsafe static bool ValidateCurrentKey(this IIterator self, TreeNodeHeader* node, TreePage page)
+        {
+            if (self.RequiredPrefix != null)
+            {
+                var currentKey = page.GetNodeKey(node);
+                if (currentKey.StartsWith(self.RequiredPrefix) == false)
+                    return false;
+            }
+            if (self.MaxKey != null)
+            {
+                var currentKey = page.GetNodeKey(node);
+                if (currentKey.Compare(self.MaxKey) >= 0)
+                    return false;
+            }
+            return true;
+        }
+    }
 }

--- a/src/Voron/Data/BTrees/TreePageIterator.cs
+++ b/src/Voron/Data/BTrees/TreePageIterator.cs
@@ -19,9 +19,8 @@ namespace Voron.Data.BTrees
         public void Dispose()
         {
             _disposed = true;
-            var action = OnDispoal;
-            if (action != null)
-                action(this);
+
+            OnDisposal?.Invoke(this);
         }
 
         public bool Seek(Slice key)
@@ -120,6 +119,6 @@ namespace Voron.Data.BTrees
             return new ValueReader((byte*)node + node->KeySize + Constants.NodeHeaderSize, node->DataSize);
         }
 
-        public event Action<IIterator> OnDispoal;
+        public event Action<IIterator> OnDisposal;
     }
 }

--- a/src/Voron/Data/EmptyIterator.cs
+++ b/src/Voron/Data/EmptyIterator.cs
@@ -32,7 +32,7 @@ namespace Voron.Data
         }
 
 
-        public event Action<IIterator> OnDispoal;
+        public event Action<IIterator> OnDisposal;
 
         public IEnumerable<string> DumpValues()
         {
@@ -67,9 +67,7 @@ namespace Voron.Data
 
         public void Dispose()
         {
-            var action = OnDispoal;
-            if (action != null)
-                action(this);
+            OnDisposal?.Invoke(this);
         }
     }
 }

--- a/src/Voron/Data/IIterator.cs
+++ b/src/Voron/Data/IIterator.cs
@@ -14,6 +14,6 @@ namespace Voron.Data
         bool Skip(int count);
         ValueReader CreateReaderForCurrent();
 
-        event Action<IIterator> OnDispoal;
+        event Action<IIterator> OnDisposal;
     }
 }

--- a/test/FastTests/Voron/StorageTest.cs
+++ b/test/FastTests/Voron/StorageTest.cs
@@ -162,9 +162,8 @@ namespace FastTests.Voron
 
         protected unsafe Tuple<Slice, Slice> ReadKey(Transaction txh, Tree tree, Slice key)
         {
-            Lazy<TreeCursor> lazy;
             TreeNodeHeader* node;
-            var p = tree.FindPageFor(key, out node, out lazy);
+            var p = tree.FindPageFor(key, out node);
 
 
             if (node == null)


### PR DESCRIPTION
Avoid creating the lazy and all cursor objects when it is not needed.

In the cases where the cursor will be used, we now only allocate the lambda, we avoid allocating a Lazy on top of the lambda itself. The benchmarks show there are a few improvements in Tables.

```
Before:

fill rnd                   :      8.005 ms    124.906 ops / sec
fill rnd separate tx       :     28.719 ms     34.819 ops / sec
insert rnd separate tx     :      4.420 ms     22.622 ops / sec

After:

fill rnd                   :      5.909 ms    169.232 ops / sec
fill rnd separate tx       :     27.967 ms     35.755 ops / sec
insert rnd separate tx     :      4.055 ms     24.660 ops / sec
```
