### PR TITLE
[3.0] RavenDB-4596 'key' parameter cannot start with 'Raven' because that i…

### DIFF
--- a/Raven.Abstractions/Smuggler/SmugglerDatabaseApiBase.cs
+++ b/Raven.Abstractions/Smuggler/SmugglerDatabaseApiBase.cs
@@ -1113,6 +1113,8 @@ namespace Raven.Abstractions.Smuggler
 
             while (identities.MoveNext())
             {
+                if (identities.Current.Key.StartsWith("Raven/"))
+                    continue;
                 itemsToInsert.Add(identities.Current);
                 count++;
 


### PR DESCRIPTION
…s a reserved system name
