### PR TITLE
[v3.5] RavenDB-4596 'key' parameter cannot start with 'Raven' because that i…

### DIFF
--- a/Raven.Abstractions/Smuggler/SmugglerDatabaseApiBase.cs
+++ b/Raven.Abstractions/Smuggler/SmugglerDatabaseApiBase.cs
@@ -1155,6 +1155,8 @@ namespace Raven.Abstractions.Smuggler
 
             while (identities.MoveNext())
             {
+                if (identities.Current.Key.StartsWith("Raven/"))
+                    continue;
                 itemsToInsert.Add(identities.Current);
                 count++;
 


### PR DESCRIPTION
…s a reserved system name
