### PR TITLE
RavenDB-3660 Verify that we have enough space when importing a database

### DIFF
--- a/Raven.Database/FileSystem/Controllers/FsStudioTasksController.cs
+++ b/Raven.Database/FileSystem/Controllers/FsStudioTasksController.cs
@@ -34,7 +34,6 @@ namespace Raven.Database.FileSystem.Controllers
     {
 
         [HttpGet]
-        [RavenRoute("studio-tasks/check-sufficient-diskspace")]
         [RavenRoute("fs/{fileSystemName}/studio-tasks/check-sufficient-diskspace")]
         public async Task<HttpResponseMessage> CheckSufficientDiskspaceBeforeImport(long fileSize)
         {


### PR DESCRIPTION
RavenDB-4592 No sufficient diskspace for import, consider using Raven.Smuggler.exe directly.
