### PR TITLE
RavenDB-4648 added commands for custom collections labels

### DIFF
--- a/Bundles/Raven.Client.Authorization/Raven.Client.Authorization.xproj
+++ b/Bundles/Raven.Client.Authorization/Raven.Client.Authorization.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>43ebd466-4a7b-4cf3-85cd-72fecee22986</ProjectGuid>
     <RootNamespace>Raven.Client.Authorization</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Bundles/Raven.Client.UniqueConstraints/Raven.Client.UniqueConstraints.xproj
+++ b/Bundles/Raven.Client.UniqueConstraints/Raven.Client.UniqueConstraints.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>674195ae-d3eb-47c2-a2d7-f0096414507d</ProjectGuid>
     <RootNamespace>Raven.Client.UniqueConstraints2</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Raven.Abstractions/Raven.Abstractions.xproj
+++ b/Raven.Abstractions/Raven.Abstractions.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>b47725e6-abb2-411f-9487-004d05ff3581</ProjectGuid>
     <RootNamespace>Raven.Abstractions</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Raven.Client.Lightweight/Raven.Client.Lightweight.xproj
+++ b/Raven.Client.Lightweight/Raven.Client.Lightweight.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>e4b2f12e-402a-424c-ab95-8cca10913337</ProjectGuid>
     <RootNamespace>Raven.Client</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Raven.Sparrow/Sparrow/Sparrow.xproj
+++ b/Raven.Sparrow/Sparrow/Sparrow.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>74281eb6-a5b8-4377-a20d-a845195328ed</ProjectGuid>
     <RootNamespace>Sparrow</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Raven.Studio.Html5/App/commands/database/documents/getCollectionLabelCommand.ts
+++ b/Raven.Studio.Html5/App/commands/database/documents/getCollectionLabelCommand.ts
@@ -1,0 +1,35 @@
+﻿import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+
+class getCollectionLabelCommand extends commandBase {
+
+    constructor(private db: database, private name: string, private pretty: boolean) {
+        super();
+    }
+    ravenEntityLabel: string;
+    ravenEntityLabelExists: boolean = false;
+    execute(): JQueryPromise<string> {
+        var url = "/docs/";
+        var args = {
+            docId: "Raven/Labels"
+        }
+        return this.query(url, args, this.db)
+            .done((result) => {
+                if (result[0] !== undefined) {
+                    if (result[0].Labels[this.name] !== undefined) {
+                        return this.ravenEntityLabel = result[0].Labels[this.name];
+                    }
+                }
+            })
+            .fail((response: JQueryXHR) => this.reportError("Failed to create class code", response.responseText, response.statusText));
+    }
+    getLabelText(): string {
+        return this.ravenEntityLabel !== undefined
+            ? this.ravenEntityLabel : this.pretty ? this.name.replace(/__/g, '/') : this.name;
+    }
+    checkLabel(): boolean {
+        return this.ravenEntityLabel !== undefined;
+    }
+}
+
+export = getCollectionLabelCommand;

--- a/Raven.Studio.Html5/App/commands/database/documents/getCollectionLabelCommand.ts
+++ b/Raven.Studio.Html5/App/commands/database/documents/getCollectionLabelCommand.ts
@@ -11,7 +11,7 @@ class getCollectionLabelCommand extends commandBase {
     execute(): JQueryPromise<string> {
         var url = "/docs/";
         var args = {
-            docId: "Raven/Labels"
+            docId: "Raven/StudioConfig"
         }
         return this.query(url, args, this.db)
             .done((result) => {

--- a/Raven.Studio.Html5/App/commands/database/documents/getCollectionsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/database/documents/getCollectionsCommand.ts
@@ -3,6 +3,7 @@ import database = require("models/resources/database");
 import collection = require("models/database/documents/collection");
 import getIndexTermsCommand = require("commands/database/index/getIndexTermsCommand");
 import getCollectionsCountCommand = require("commands/database/documents/getCollectionsCountCommand");
+import getCollectionsLabelsCommand = require("commands/database/documents/getCollectionsLabelsCommand");
 import getCachedCollectionsCount = require("commands/database/studio/getCachedCollectionsCount");
 
 class getCollectionsCommand extends commandBase {
@@ -55,7 +56,12 @@ class getCollectionsCommand extends commandBase {
                     var collections = terms.map(term => new collection(term, this.ownerDb, 0));
                     new getCollectionsCountCommand(collections, this.ownerDb)
                         .execute()
-                        .done(result => task.resolve(result))
+                        .done(r => {
+                            new getCollectionsLabelsCommand(collections, this.ownerDb)
+                                .execute()
+                                .done(result => task.resolve(result))
+                                .fail(result => task.reject(result));
+                        })
                         .fail(result => task.reject(result));
                 }
                 if (this.lastQueryDate != null) {

--- a/Raven.Studio.Html5/App/commands/database/documents/getCollectionsLabelsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/database/documents/getCollectionsLabelsCommand.ts
@@ -1,0 +1,58 @@
+﻿import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import collection = require("models/database/documents/collection");
+import queryUtil = require("common/queryUtil");
+
+class getCollectionsLabelsCommand extends commandBase {
+
+    /**
+    * @param ownerDb The database the collections will belong to.
+    */
+    constructor(private collections: collection[], private ownerDb: database) {
+        super();
+
+        if (!this.ownerDb) {
+            throw new Error("Must specify a database.");
+        }
+    }
+
+    execute(): JQueryPromise<collection[]> {
+        var task = $.Deferred();
+
+        var requests = this.collections.map(collection => {
+            return {
+                Url: "/queries/",
+                Headers: {},
+                Query: "?id=" + queryUtil.escapeTerm("Raven/Labels")
+            }
+        });
+        this.post("/multi_get?parallel=yes", JSON.stringify(requests), this.ownerDb, null, 0)
+            .done((result) => {
+                // if there are no results, then we simply need to leave and go back to normal collection display
+                if (!result[0].Result.Results[0])
+                    task.resolve(this.collections);
+                var arr = result[0].Result.Results[0].Labels;
+                for (var i = 0; i < this.collections.length; i++) {
+                    if (arr[this.collections[i].collectionName] !== undefined) {
+                        this.collections[i].collectionLabel =
+                            arr[this.collections[i].collectionName];
+                    } else {
+                        this.collections[i].collectionLabel = this.collections[i].collectionName;
+                    }
+                }
+                // sort the collections alphabetically
+                task.resolve(this.collections.sort((n, r) => {
+                    return (n.collectionLabel === r.collectionLabel) ? 0 : (n.collectionLabel > r.collectionLabel) ? 1 : -1;
+                }));
+            })
+            .fail((response: JQueryXHR) => {
+                this.reportError("Failed to fetch collection labels", response.responseText, response.statusText);
+                // collection labels are only cosmetic, we never want to stop the ui for them.
+                task.resolve(response);
+            });
+
+        return task;
+    }
+}
+
+export = getCollectionsLabelsCommand;

--- a/Raven.Studio.Html5/App/commands/database/documents/getCollectionsLabelsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/database/documents/getCollectionsLabelsCommand.ts
@@ -24,7 +24,7 @@ class getCollectionsLabelsCommand extends commandBase {
             return {
                 Url: "/queries/",
                 Headers: {},
-                Query: "?id=" + queryUtil.escapeTerm("Raven/Labels")
+                Query: "?id=" + queryUtil.escapeTerm("Raven/StudioConfig")
             }
         });
         this.post("/multi_get?parallel=yes", JSON.stringify(requests), this.ownerDb, null, 0)

--- a/Raven.Studio.Html5/App/commands/database/documents/getCollectionsLabelsCommand.ts
+++ b/Raven.Studio.Html5/App/commands/database/documents/getCollectionsLabelsCommand.ts
@@ -16,6 +16,7 @@ class getCollectionsLabelsCommand extends commandBase {
         }
     }
 
+
     execute(): JQueryPromise<collection[]> {
         var task = $.Deferred();
 

--- a/Raven.Studio.Html5/App/models/database/documents/collection.ts
+++ b/Raven.Studio.Html5/App/models/database/documents/collection.ts
@@ -13,7 +13,8 @@ class collection implements ICollectionBase {
     isSystemDocuments = false;
     bindings = ko.observable<string[]>();
 
-    public collectionName : string;
+    public collectionName: string;
+    public collectionLabel: string;
     private documentsList: pagedList;
     public static allDocsCollectionName = "All Documents";
     private static systemDocsCollectionName = "System Documents";
@@ -32,11 +33,9 @@ class collection implements ICollectionBase {
     activate() {
         ko.postbox.publish("ActivateCollection", this);
     }
-
-    prettyLabel(text: string) {
-        return text.replace(/__/g, '/');
+    getLabel() {
+        return this.collectionLabel || this.collectionName.replace(/__/g, '/');
     }
-
     getDocuments(): pagedList {
         if (!this.documentsList) {
             this.documentsList = this.createPagedList();

--- a/Raven.Studio.Html5/App/models/database/documents/document.ts
+++ b/Raven.Studio.Html5/App/models/database/documents/document.ts
@@ -35,7 +35,14 @@ class document implements documentBase {
 
         return propertyNames;
     }
-
+    getDocumentCollectionLabel(queryResult: any): string {
+        var name = this.getEntityName();
+        if (queryResult[0] !== undefined) {
+            if (queryResult[0].Labels[name] !== undefined) {
+                return queryResult[0].Labels[name];
+            }
+        }
+    }
     toDto(includeMeta: boolean = false): documentDto {
         var dto = { '@metadata': undefined };
         var properties = this.getDocumentPropertyNames();

--- a/Raven.Studio.Html5/App/views/database/documents/documents.html
+++ b/Raven.Studio.Html5/App/views/database/documents/documents.html
@@ -15,7 +15,7 @@
                 <a href="javascript:void(0)">
                     <div class="collection-name">
                         <div class="collection-text pull-left collection-color-strip" data-bind="css: colorClass"></div>
-                        <span class="collection-text pull-left collection-name-part" data-bind="text: prettyLabel(name), attr: {title: name}"></span>
+                        <span class="collection-text pull-left collection-name-part" data-bind="text: getLabel(), attr: {title: name}"></span>
                     </div>
                 </a>
             </li>
@@ -25,7 +25,7 @@
                 <a href="javascript:void(0)">
                     <div class="collection-name">
                         <div class="collection-text pull-left collection-color-strip" data-bind="css: colorClass"></div>
-                        <span class="collection-text pull-left collection-name-part" data-bind="text: prettyLabel(name), attr: {title: name}"></span>
+                        <span class="collection-text pull-left collection-name-part" data-bind="text: getLabel(), attr: {title: name}"></span>
                         <span class="collection-text pull-left text-muted" data-bind="visible: !isSystemDocuments && !isAllDocuments, css: { 'text-muted': $data !== $parent.selectedCollection() }, text:  '&nbsp;(' + documentsCountWithThousandsSeparator() + ')', updateHighlighting: documentCount()"></span>
                     </div>
                 </a>

--- a/Raven.Studio.Html5/App/views/database/documents/editDocument.html
+++ b/Raven.Studio.Html5/App/views/database/documents/editDocument.html
@@ -90,6 +90,10 @@
                         <label class="col-md-5">Raven-Entity-Name</label>
                         <span class="col-md-7" data-bind="text: $root.prettyLabel(ravenEntityName), attr: {title:ravenEntityName}"></span>
                     </div>
+                    <div class="row" data-bind="if: $root.hasLabel()">
+                        <label class="col-md-5">Label</label>
+                        <span class="col-md-7" data-bind="text: $root.documentLabel, attr: {title:ravenEntityName}"></span>
+                    </div>
                     <div class="row">
                         <label class="col-md-5">Etag</label>
                         <span class="col-md-7" data-bind="text: etag, attr: {title:etag}"></span>

--- a/Raven.Studio.Html5/Raven.Studio.Html5.csproj
+++ b/Raven.Studio.Html5/Raven.Studio.Html5.csproj
@@ -36,6 +36,8 @@
     <TypeScriptCompile Include="App\commands\database\cluster\initializeNewClusterCommand.ts" />
     <TypeScriptCompile Include="App\commands\database\debug\getFilteredOutIndexStatsCommand.ts" />
     <TypeScriptCompile Include="App\commands\database\documents\generateClassCommand.ts" />
+    <TypeScriptCompile Include="App\commands\database\documents\getCollectionLabelCommand.ts" />
+    <TypeScriptCompile Include="App\commands\database\documents\getCollectionsLabelsCommand.ts" />
     <TypeScriptCompile Include="App\commands\database\documents\getDocumentsPreviewCommand.ts" />
     <TypeScriptCompile Include="App\commands\database\index\forceIndexReplace.ts" />
     <TypeScriptCompile Include="App\commands\database\index\startReducingCommand.ts" />

--- a/Raven.Tests.Core/Raven.Tests.Core.xproj
+++ b/Raven.Tests.Core/Raven.Tests.Core.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>d0139cd0-2720-4b4e-a76c-a83eb1ba954b</ProjectGuid>
     <RootNamespace>Raven.Tests.Core</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AssemblyName>Raven.Tests.Core</AssemblyName>

--- a/Raven.Tryouts/Raven.Tryouts.xproj
+++ b/Raven.Tryouts/Raven.Tryouts.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>8fb9f3e5-9041-4708-adf5-63684927e57a</ProjectGuid>
     <RootNamespace>Raven.Tryouts</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-4648

The last time I submitted my patch to add custom labels with metadata, it was rejected because of the claim that it was overhead to manage the metadata, and would have to be tracked.

To that end, I went back to the drawing board and devised a new method - using a simple settings document in the database that will be captured and used to style labels if the user desires. It does not need to be tracked in any metadata - and not having it will cause no change to the behaviors.

This adds two new commands; 

`getCollectionLabelCommand`\- used to retrieve label information from a document for a single collection.
`getCollectionsLabelsCommand`\- used to retrieve label information from a document for all non-system collections.

Using these, it is easy to store label information in a settings document called "Raven/Labels" that simply contains the names to replace Raven-Entity-Labels with aesthetically only. It does not interfere with runtime or any other behavior, and it does not require metadata.

Collection labels will always gracefully fall back to the default Raven-Entity-Label if there is an error or the settings document does not exist, or is malformed. 

The collections view will be sorted alphabetically with respect to both custom and default labels correctly.

The are relatively agnostic and contain all the logic necessary to get a label provided the collection name and an active database connection are given. They can be easily re-used in the other places where it may be desirable to "skin" the entity name. For this pull request, I only modified the collections view, and the editDocuments view. If it goes through and it is desired, I will go through and work on patching it into other places too.

The settings document merely needs a property called `Labels`, and each property is just the name of the collection you wish to customize. At this moment, it must be called `Raven/Labels`.
![creating the settings document](http://issues.hibernatingrhinos.com/_persistent/pr03_ss_001.jpg?file=74-1106&v=0&c=true&rw=635&rh=501&u=1464293015828)

The collections view will be styled to use the replacements in this document - sorting alphabetically with respect to **both** the customized and non-customized labels together.
![customized collections view](http://issues.hibernatingrhinos.com/_persistent/pr03_ss_002.jpg?file=74-1107&v=0&c=true&rw=697&rh=536&u=1464293015828)

Nothing else is affected.
![document identities and other behaviors are not touched](http://issues.hibernatingrhinos.com/_persistent/pr03_ss_003.jpg?file=74-1108&v=0&w=743&h=537&c=false&u=1464293015828)

On documents belonging to a collection with a customized label, information on it will show up in the edit view.
![information on labels is visible in the edit view](http://issues.hibernatingrhinos.com/_persistent/pr03_ss_004.jpg?file=74-1109&v=0&c=true&rw=1613&rh=557&u=1464293015828)

And of course, documents in collections that are not involved will simply have no knowledge that it exists.
![collections without a custom label are not affected](http://issues.hibernatingrhinos.com/_persistent/pr03_ss_005.jpg?file=74-1110&v=0&c=true&rw=1557&rh=554&u=1464293015828)
