### PR TITLE
RavenDB-4651 Fixing a few issues in FilesReplicationInformer:

### DIFF
--- a/Raven.Client.Lightweight/Connection/ReplicationInformer.cs
+++ b/Raven.Client.Lightweight/Connection/ReplicationInformer.cs
@@ -178,6 +178,7 @@ namespace Raven.Client.Connection
                 if (document == null)
                 {
                     LastReplicationUpdate = SystemTime.UtcNow; // checked and not found
+                    ReplicationDestinations.Clear(); // clear destinations that could be retrieved from local storage
                     return;
                 }
 

--- a/Raven.Client.Lightweight/Connection/ReplicationInformerBase.cs
+++ b/Raven.Client.Lightweight/Connection/ReplicationInformerBase.cs
@@ -222,14 +222,14 @@ namespace Raven.Client.Connection
             switch (Conventions.FailoverBehaviorWithoutFlags)
             {
                 case FailoverBehavior.AllowReadsFromSecondaries:
-                    if (method == "GET")
+                    if (method == "GET" || method == "HEAD")
                         return;
                     break;
                 case FailoverBehavior.AllowReadsFromSecondariesAndWritesToSecondaries:
                     return;
                 case FailoverBehavior.FailImmediately:
                     var allowReadFromAllServers = Conventions.FailoverBehavior.HasFlag(FailoverBehavior.ReadFromAllServers);
-                    if (allowReadFromAllServers && method == "GET")
+                    if (allowReadFromAllServers && (method == "GET" || method == "HEAD"))
                         return;
                     break;
             }


### PR DESCRIPTION
- using full fs URL to build a server hash
- taking into account Enabled setting
- clearing destinations retrieved from the local storage if Raven/Synchronization/Destinations config was removed on the server side
- considering HEAD request as a read operation
- using direct method to retrieve Raven/Synchronization/Destinations config
