### PR TITLE
RavenDB-4651 Fixing a few issues in FilesReplicationInformer:

### DIFF
--- a/Raven.Client.Lightweight/Connection/ReplicationInformer.cs
+++ b/Raven.Client.Lightweight/Connection/ReplicationInformer.cs
@@ -190,6 +190,7 @@ namespace Raven.Client.Connection
                 if (document == null)
                 {
                     lastReplicationUpdate = SystemTime.UtcNow; // checked and not found
+                    ReplicationDestinations.Clear(); // clear destinations that could be retrieved from local storage
                     return;
                 }
 

--- a/Raven.Client.Lightweight/Connection/ReplicationInformerBase.cs
+++ b/Raven.Client.Lightweight/Connection/ReplicationInformerBase.cs
@@ -194,14 +194,14 @@ namespace Raven.Client.Connection
             {
                 case FailoverBehavior.AllowReadsFromSecondaries:
                 case FailoverBehavior.AllowReadFromSecondariesWhenRequestTimeSlaThresholdIsReached:
-                    if (method == HttpMethods.Get)
+                    if (method == HttpMethods.Get || method == HttpMethods.Head)
                         return;
                     break;
                 case FailoverBehavior.AllowReadsFromSecondariesAndWritesToSecondaries:
                     return;
                 case FailoverBehavior.FailImmediately:
                     var allowReadFromAllServers = Conventions.FailoverBehavior.HasFlag(FailoverBehavior.ReadFromAllServers);
-                    if (allowReadFromAllServers && method == HttpMethods.Get)
+                    if (allowReadFromAllServers && (method == HttpMethods.Get || method == HttpMethods.Head))
                         return;
                     break;
             }

--- a/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
+++ b/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
@@ -1101,46 +1101,48 @@ namespace Raven.Client.FileSystem
                 this.client = client;
             }
 
-            public Task<SynchronizationDestination[]> GetDestinationsAsync()
+            public async Task<SynchronizationDestination[]> GetDestinationsAsync()
             {
-                return client.ExecuteWithReplication(HttpMethods.Get, async (operation, requestTimeMetric) =>
+                var requestUriString = BaseUrl + "/config?name=" + Uri.EscapeDataString(SynchronizationConstants.RavenSynchronizationDestinations);
+
+                using (var request = RequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUriString, HttpMethods.Get, Credentials, convention)).AddOperationHeaders(OperationsHeaders))
                 {
-                    var requestUriString = operation.Url + "/config?name=" + Uri.EscapeDataString(SynchronizationConstants.RavenSynchronizationDestinations);
-                    using (var request = RequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUriString, HttpMethod.Get, operation.Credentials, convention)).AddOperationHeaders(OperationsHeaders))
+                    try
                     {
-                        try
-                        {
-                            var response = (RavenJObject)await request.ReadResponseJsonAsync().ConfigureAwait(false);
-                            var rawDestinations = (RavenJArray)response["Destinations"];
-                            return rawDestinations.JsonDeserialization<SynchronizationDestination>();
-                        }
-                        catch (Exception e)
-                        {
-                            throw e.SimplifyException();
-                        }
+                        var response = (RavenJObject)await request.ReadResponseJsonAsync().ConfigureAwait(false);
+                        var rawDestinations = (RavenJArray)response["Destinations"];
+                        return rawDestinations.JsonDeserialization<SynchronizationDestination>();
                     }
-                });
+                    catch (Exception e)
+                    {
+                        var responseException = e as ErrorResponseException;
+                        if (responseException == null)
+                            throw e.SimplifyException();
+
+                        if (responseException.StatusCode == HttpStatusCode.NotFound)
+                            return null;
+
+                        throw responseException;
+                    }
+                }
             }
 
             public Task SetDestinationsAsync(params SynchronizationDestination[] destinations)
             {
-                return client.ExecuteWithReplication(HttpMethods.Put, async (operation, requestTimeMetric) =>
+                var requestUriString = BaseUrl + "/config?name=" + Uri.EscapeDataString(SynchronizationConstants.RavenSynchronizationDestinations);
+                using (var request = RequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUriString, HttpMethods.Put, Credentials, convention)).AddOperationHeaders(OperationsHeaders))
                 {
-                    var requestUriString = operation.Url + "/config?name=" + Uri.EscapeDataString(SynchronizationConstants.RavenSynchronizationDestinations);
-                    using (var request = RequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUriString, HttpMethod.Put, operation.Credentials, convention)).AddOperationHeaders(OperationsHeaders))
-                    {
-                        var data = new { Destinations = destinations };
+                    var data = new { Destinations = destinations };
 
-                        try
-                        {
-                            await request.WriteWithObjectAsync(data).ConfigureAwait(false);
-                        }
-                        catch (Exception e)
-                        {
-                            throw e.SimplifyException();
-                        }
+                    try
+                    {
+                        return request.WriteWithObjectAsync(data);
                     }
-                });
+                    catch (Exception e)
+                    {
+                        throw e.SimplifyException();
+                    }
+                }
             }
 
             public async Task<ItemsPage<ConflictItem>> GetConflictsAsync(int start = 0, int pageSize = 25)


### PR DESCRIPTION
- using full fs URL to build a server hash
- taking into account Enabled setting
- clearing destinations retrieved from the local storage if Raven/Synchronization/Destinations config was removed on the server side
- considering HEAD request as a read operation
- using direct method to retrieve Raven/Synchronization/Destinations config
