### PR TITLE
RavenDB-4650 Fixing edge conditions related to recursive page splits …

### DIFF
--- a/src/Voron/Data/BTrees/ParentPageAction.cs
+++ b/src/Voron/Data/BTrees/ParentPageAction.cs
@@ -1,0 +1,102 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ParentPageAction.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+#if VALIDATE
+using System.Diagnostics;
+using System.Linq;
+#endif
+using System.Runtime.CompilerServices;
+using Voron.Impl;
+
+namespace Voron.Data.BTrees
+{
+    public unsafe class ParentPageAction
+    {
+        private readonly TreePage _currentPage;
+        private readonly TreePage _parentPage;
+        private readonly Tree _tree;
+        private readonly TreeCursor _cursor;
+        private readonly LowLevelTransaction _tx;
+
+        public ParentPageAction(TreePage parentPage, TreePage currentPage, Tree tree, TreeCursor cursor, LowLevelTransaction tx)
+        {
+            _parentPage = parentPage;
+            _currentPage = currentPage;
+            _tree = tree;
+            _cursor = cursor;
+            _tx = tx;
+        }
+
+        public TreePage ParentOfAddedPageRef { get; private set; }
+
+        public byte* AddSeparator(Slice separator, long pageRefNumber, int? nodePos = null)
+        {
+            var originalLastSearchPositionOfParent = _parentPage.LastSearchPosition;
+
+            if (nodePos == null)
+                nodePos = _parentPage.NodePositionFor(separator); // select the appropriate place for this
+
+            if (_parentPage.HasSpaceFor(_tx, TreeSizeOf.BranchEntry(separator) + Constants.NodeOffsetSize) == false)
+            {
+                var pageSplitter = new TreePageSplitter(_tx, _tree, separator, -1, pageRefNumber, TreeNodeFlags.PageRef, 0, _cursor);
+
+                var posToInsert = pageSplitter.Execute();
+
+                ParentOfAddedPageRef = _cursor.CurrentPage;
+
+                var adjustParentPageOnCursor = true;
+
+                for (int i = 0; i < _cursor.CurrentPage.NumberOfEntries; i++)
+                {
+                    if (_cursor.CurrentPage.GetNode(i)->PageNumber == _currentPage.PageNumber)
+                    {
+                        adjustParentPageOnCursor = false;
+                        _cursor.CurrentPage.LastSearchPosition = i;
+                        break;
+                    }
+                }
+
+                if (adjustParentPageOnCursor)
+                {
+                    // the above page split has modified the cursor that its first page points to the parent of the leaf where 'separatorKey' was inserted
+                    // and it doesn't have the reference to _page, we need to ensure that the actual parent is first at the cursor
+
+                    _cursor.Pop();
+                    _cursor.Push(_parentPage);
+
+                    EnsureValidLastSearchPosition(_parentPage, _currentPage.PageNumber, originalLastSearchPositionOfParent);
+                }
+#if VALIDATE
+                Debug.Assert(_cursor.CurrentPage.GetNode(_cursor.CurrentPage.LastSearchPosition)->PageNumber == _currentPage.PageNumber, 
+                            "The parent page is not referencing a page which is being split");
+
+                var parentToValidate = ParentOfAddedPageRef;
+                Debug.Assert(Enumerable.Range(0, parentToValidate.NumberOfEntries).Any(i => parentToValidate.GetNode(i)->PageNumber == pageRefNumber),
+                            "The parent page of a page reference isn't referencing it");
+#endif
+
+
+                return posToInsert;
+            }
+
+            ParentOfAddedPageRef = _parentPage;
+
+            var pos = _parentPage.AddPageRefNode(nodePos.Value, separator, pageRefNumber);
+
+            EnsureValidLastSearchPosition(_parentPage, _currentPage.PageNumber, originalLastSearchPositionOfParent);
+
+            return pos;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void EnsureValidLastSearchPosition(TreePage page, long referencedPageNumber, int originalLastSearchPosition)
+        {
+            if (page.NumberOfEntries <= originalLastSearchPosition || page.GetNode(originalLastSearchPosition)->PageNumber != referencedPageNumber)
+                page.LastSearchPosition = page.NodePositionReferencing(referencedPageNumber);
+            else
+                page.LastSearchPosition = originalLastSearchPosition;
+        }
+    }
+}

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -405,6 +405,23 @@ namespace Voron.Data.BTrees
             return LastSearchPosition;
         }
 
+        public int NodePositionReferencing(long pageNumber)
+        {
+            Debug.Assert(IsBranch);
+
+            int referencingNode = 0;
+
+            for (; referencingNode < NumberOfEntries; referencingNode++)
+            {
+                if (GetNode(referencingNode)->PageNumber == pageNumber)
+                    break;
+            }
+
+            Debug.Assert(GetNode(referencingNode)->PageNumber == pageNumber);
+
+            return referencingNode;
+        }
+
         public override string ToString()
         {
             return "#" + PageNumber + " (count: " + NumberOfEntries + ") " + TreeFlags;

--- a/src/Voron/Data/BTrees/TreePageSplitter.cs
+++ b/src/Voron/Data/BTrees/TreePageSplitter.cs
@@ -88,7 +88,7 @@ namespace Voron.Data.BTrees
                     // sequential inserts, at that point, we are going to keep the current page as is and create a new 
                     // page, this will allow us to do minimal amount of work to get the best density
 
-                    TreePage _;
+                    TreePage branchOfSeparator;
 
                     byte* pos;
                     if (_page.IsBranch)
@@ -104,19 +104,24 @@ namespace Voron.Data.BTrees
 
                             var separatorKey = _page.GetNodeKey(node);
 
-                            AddSeparatorToParentPage(rightPage.PageNumber, separatorKey, true, out _);
+                            AddSeparatorToParentPage(rightPage.PageNumber, separatorKey, out branchOfSeparator);
 
                             _page.RemoveNode(_page.NumberOfEntries - 1);
                         }
                         else
                         {
                             _tree.FreePage(rightPage); // return the unnecessary right page
-                            return AddSeparatorToParentPage(_pageNumber, _newKey, false, out _);
+                            pos = AddSeparatorToParentPage(_pageNumber, _newKey, out branchOfSeparator);
+
+                            if (_cursor.CurrentPage.PageNumber != branchOfSeparator.PageNumber)
+                                _cursor.Push(branchOfSeparator);
+
+                            return pos;
                         }
                     }
                     else
                     {
-                        AddSeparatorToParentPage(rightPage.PageNumber, _newKey, true, out _);
+                        AddSeparatorToParentPage(rightPage.PageNumber, _newKey, out branchOfSeparator);
                         pos = AddNodeToPage(rightPage, 0);
                     }
                     _cursor.Push(rightPage);
@@ -188,7 +193,9 @@ namespace Voron.Data.BTrees
             }
 
             TreePage parentOfRight;
-            AddSeparatorToParentPage(rightPage.PageNumber, seperatorKey, toRight, out parentOfRight);
+            AddSeparatorToParentPage(rightPage.PageNumber, seperatorKey, out parentOfRight);
+
+            var parentOfPage = _cursor.CurrentPage;
 
             Slice instance = _page.CreateNewEmptyKey();
 
@@ -225,6 +232,13 @@ namespace Voron.Data.BTrees
             {
                 try
                 {
+                    if (toRight && _cursor.CurrentPage.PageNumber != parentOfRight.PageNumber)
+                    {
+                        // modify the cursor if we are going to insert to the right page
+                        _cursor.Pop();
+                        _cursor.Push(parentOfRight);
+                    }
+
                     // actually insert the new key
                     pos = toRight ? InsertNewKey(rightPage) : InsertNewKey(_page);
                 }
@@ -248,7 +262,7 @@ namespace Voron.Data.BTrees
                 Debug.Assert(rightPage.NumberOfEntries > 0);
 
                 if (_page.NumberOfEntries == 1)
-                    RemoveBranchWithOneEntry(_page, _cursor.ParentPage);
+                    RemoveBranchWithOneEntry(_page, parentOfPage);
 
                 if (rightPage.NumberOfEntries == 1)
                     RemoveBranchWithOneEntry(rightPage, parentOfRight);
@@ -306,36 +320,15 @@ namespace Voron.Data.BTrees
             return dataPos;
         }
 
-        private byte* AddSeparatorToParentPage(long pageNumber, Slice separatorKey, bool toRight, out TreePage parent)
+        private byte* AddSeparatorToParentPage(long pageRefNumber, Slice separatorKey, out TreePage parentOfPageRef)
         {
-            var pos = _parentPage.NodePositionFor(separatorKey); // select the appropriate place for this
+            var parent = new ParentPageAction(_parentPage, _page, _tree, _cursor, _tx);
 
-            if (_parentPage.HasSpaceFor(_tx, TreeSizeOf.BranchEntry(separatorKey) + Constants.NodeOffsetSize) == false)
-            {
-                var pageSplitter = new TreePageSplitter(_tx, _tree, separatorKey, -1, pageNumber, TreeNodeFlags.PageRef,
-                    0, _cursor);
-                var posToInsert = pageSplitter.Execute();
+            var pos = parent.AddSeparator(separatorKey, pageRefNumber);
 
-                if (toRight == false && _cursor.CurrentPage.PageNumber != _parentPage.PageNumber)
-                {
-                    // _newKey being added to _page wasn't meant to be inserted to a newly created right page
-                    // however the above page split has modified the cursor that its first page is a parent page for the right page containing separator key
-                    // we need to ensure that the current _parentPage is first at the cursor 
+            parentOfPageRef = parent.ParentOfAddedPageRef;
 
-                    parent = _cursor.Pop();
-                    _cursor.Push(_parentPage);
-                }
-                else
-                {
-                    parent = _parentPage;
-                }
-
-                return posToInsert;
-            }
-
-            parent = _parentPage;
-
-            return _parentPage.AddPageRefNode(pos, separatorKey, pageNumber);
+            return pos;
         }
 
         private int AdjustSplitPosition(int currentIndex, int splitIndex, ref bool toRight)

--- a/test/SlowTests/Voron/LongKeys.cs
+++ b/test/SlowTests/Voron/LongKeys.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using SlowTests.Utils;
 using Xunit;
 
 namespace SlowTests.Voron
@@ -75,6 +76,12 @@ namespace SlowTests.Voron
         [InlineData(1)]
         [InlineData(3)]
         [InlineData(103)]
+        [InlineData(4001)]
+        [InlineData(4024)]
+        [InlineData(4031)]
+        [InlineData(4041)]
+        [InlineData(4234)]
+        [InlineDataWithRandomSeed()]
         public void ShouldHaveEnoughSpaceWhenSplittingPageInHalf(int seed)
         {
             using (var tx = Env.WriteTransaction())


### PR DESCRIPTION
…and tree rebalances. These changes are fixing the problems with an incorrect state of a cursor or invalid LastSearchPosition on a page modified during the split operation (for writes or deletions because the tree rebalancer can call the page splitter internally to add a separator to the parent page).
