### PR TITLE
ByteString [DO NOT MERGE UNTIL CODE FREEZE]

### DIFF
--- a/bench/Voron.Benchmark/BTreeBench.cs
+++ b/bench/Voron.Benchmark/BTreeBench.cs
@@ -274,7 +274,7 @@ namespace Voron.Benchmark
                             var tree = tx.ReadTree("test");
                             using (var it = tree.Iterate())
                             {
-                                if (it.Seek(Slice.BeforeAllKeys))
+                                if (it.Seek(Slices.BeforeAllKeys))
                                 {
                                     do
                                     {

--- a/bench/Voron.Benchmark/TableBench.cs
+++ b/bench/Voron.Benchmark/TableBench.cs
@@ -63,15 +63,10 @@ namespace Voron.Benchmark
                     continue;
                 }
 
-                var slice = o as Slice;
-                if (slice != null)
+                if (o is Slice)
                 {
-                    if (slice.Array == null)
-                        throw new NotSupportedException();
-
-                    gcHandle = GCHandle.Alloc(slice.Array, GCHandleType.Pinned);
-                    builder.Add((byte*)gcHandle.AddrOfPinnedObject(), slice.Array.Length);
-                    handles1.Add(gcHandle);
+                    var slice = (Slice)o;
+                    builder.Add(slice.Content.Ptr, slice.Content.Length);
 
                     continue;
                 }
@@ -349,7 +344,7 @@ namespace Voron.Benchmark
                             {
                                 var current = j * currentBase;
                                 var key = current.ToString("0000000000000000");
-                                var tableReader = docs.ReadByKey(key);
+                                var tableReader = docs.ReadByKey(Slice.From(tx.Allocator, key));
 
                                 int size;
                                 byte* buffer = tableReader.Read(1, out size);
@@ -397,7 +392,7 @@ namespace Voron.Benchmark
                         {
                             var docs = new Table(docsSchema, "docs", tx);
 
-                            foreach (var reader in docs.SeekByPrimaryKey(Slice.BeforeAllKeys) )
+                            foreach (var reader in docs.SeekByPrimaryKey(Slices.BeforeAllKeys) )
                             {
                                 int size;
                                 reader.Read(0, out size);
@@ -431,7 +426,7 @@ namespace Voron.Benchmark
                     for (int i = 0; i < Configuration.Transactions * Configuration.ItemsPerTransaction; i++)
                     {
                         var key = i.ToString("0000000000000000");
-                        var tableReader = docs.ReadByKey(key);
+                        var tableReader = docs.ReadByKey(Slice.From(tx.Allocator, key));
 
                         int size;
                         byte* buffer = tableReader.Read(1, out size);

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -114,14 +114,14 @@ namespace Raven.Server.Documents.Expiration
                         var tree = tx.InnerTransaction.CreateTree(DocumentsByExpiration);
                         using (var it = tree.Iterate())
                         {
-                            if (it.Seek(Slice.BeforeAllKeys) == false)
+                            if (it.Seek(Slices.BeforeAllKeys) == false)
                                 return;
 
                             while (it.CurrentKey.CreateReader().ReadBigEndianInt64() < currentTicks)
                             {
                                 using (var multiIt = tree.MultiRead(it.CurrentKey, allowWrites: true))
                                 {
-                                    if (multiIt.Seek(Slice.BeforeAllKeys))
+                                    if (multiIt.Seek(Slices.BeforeAllKeys))
                                     {
                                         do
                                         {
@@ -205,7 +205,7 @@ namespace Raven.Server.Documents.Expiration
             var ticksBigEndian = IPAddress.HostToNetworkOrder(date.Ticks);
 
             var tree = context.Transaction.InnerTransaction.CreateTree(DocumentsByExpiration);
-            tree.MultiAdd(new Slice((byte*)&ticksBigEndian, sizeof(long)), loweredKey);
+            tree.MultiAdd(Slice.From(context.Allocator, (byte*)&ticksBigEndian, sizeof(long)), loweredKey);
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBase.cs
@@ -13,6 +13,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
 using Voron;
+using Sparrow;
 
 namespace Raven.Server.Documents.Indexes
 {
@@ -20,7 +21,7 @@ namespace Raven.Server.Documents.Indexes
     {
         protected const string MetadataFileName = "metadata";
 
-        protected static readonly Slice DefinitionSlice = "Definition";
+        protected static readonly Slice DefinitionSlice = Slice.From(StorageEnvironment.LabelsContext, "Definition", ByteStringType.Immutable); 
 
         private int? _cachedHashCode;
 
@@ -61,7 +62,7 @@ namespace Raven.Server.Documents.Indexes
                 writer.Flush();
 
                 stream.Position = 0;
-                tree.Add(DefinitionSlice, stream.ToArray());
+                tree.Add(DefinitionSlice, Slice.From(context.Allocator, stream.ToArray()));
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -11,7 +11,9 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Voron;
+using Voron.Data;
 using Voron.Data.Tables;
+using Sparrow;
 
 namespace Raven.Server.Documents.Indexes
 {
@@ -60,12 +62,12 @@ namespace Raven.Server.Documents.Indexes
                 var typeInt = (int)_index.Type;
 
                 var statsTree = tx.InnerTransaction.CreateTree(Schema.StatsTree);
-                statsTree.Add(Schema.TypeSlice, new Slice((byte*)&typeInt, sizeof(int)));
+                statsTree.Add(Schema.TypeSlice, Slice.External(context.Allocator, (byte*)&typeInt, sizeof(int)));
 
                 if (statsTree.ReadVersion(Schema.CreatedTimestampSlice) == 0)
                 {
                     var binaryDate = SystemTime.UtcNow.ToBinary();
-                    statsTree.Add(Schema.CreatedTimestampSlice, new Slice((byte*)&binaryDate, sizeof(long)));
+                    statsTree.Add(Schema.CreatedTimestampSlice, Slice.External(context.Allocator, (byte*)&binaryDate, sizeof(long)));
                 }
 
                 tx.InnerTransaction.CreateTree(Schema.EtagsTree);
@@ -85,7 +87,7 @@ namespace Raven.Server.Documents.Indexes
             {
                 var statsTree = tx.InnerTransaction.ReadTree(Schema.StatsTree);
                 var priorityInt = (int)priority;
-                statsTree.Add(Schema.PrioritySlice, new Slice((byte*)&priorityInt, sizeof(int)));
+                statsTree.Add(Schema.PrioritySlice, Slice.External(context.Allocator, (byte*)&priorityInt, sizeof(int)));
 
                 tx.Commit();
             }
@@ -133,7 +135,7 @@ namespace Raven.Server.Documents.Indexes
             {
                 var table = new Table(_errorsSchema, "Errors", tx.InnerTransaction);
 
-                foreach (var sr in table.SeekForwardFrom(_errorsSchema.Indexes["ErrorTimestamps"], Slice.BeforeAllKeys))
+                foreach (var sr in table.SeekForwardFrom(_errorsSchema.Indexes["ErrorTimestamps"], Slices.BeforeAllKeys))
                 {
                     foreach (var tvr in sr.Results)
                     {
@@ -195,34 +197,34 @@ namespace Raven.Server.Documents.Indexes
 
         public long ReadLastProcessedTombstoneEtag(RavenTransaction tx, string collection)
         {
-            return ReadLastEtag(tx, Schema.EtagsTombstoneTree, collection);
+            return ReadLastEtag(tx, Schema.EtagsTombstoneTree, Slice.From(tx.InnerTransaction.Allocator, collection));
         }
 
         public long ReadLastIndexedEtag(RavenTransaction tx, string collection)
         {
-            return ReadLastEtag(tx, Schema.EtagsTree, collection);
+            return ReadLastEtag(tx, Schema.EtagsTree, Slice.From(tx.InnerTransaction.Allocator, collection));
         }
 
         public void WriteLastTombstoneEtag(RavenTransaction tx, string collection, long etag)
         {
-            WriteLastEtag(tx, Schema.EtagsTombstoneTree, collection, etag);
+            WriteLastEtag(tx, Schema.EtagsTombstoneTree, Slice.From(tx.InnerTransaction.Allocator, collection), etag);
         }
 
         public void WriteLastIndexedEtag(RavenTransaction tx, string collection, long etag)
         {
-            WriteLastEtag(tx, Schema.EtagsTree, collection, etag);
+            WriteLastEtag(tx, Schema.EtagsTree, Slice.From(tx.InnerTransaction.Allocator, collection), etag);
         }
 
-        private unsafe void WriteLastEtag(RavenTransaction tx, string tree, string collection, long etag)
+        private unsafe void WriteLastEtag(RavenTransaction tx, string tree, Slice collection, long etag)
         {
             if (Log.IsDebugEnabled)
                 Log.Debug($"Writing last etag for '{_index.Name} ({_index.IndexId})'. Tree: {tree}. Collection: {collection}. Etag: {etag}.");
 
             var statsTree = tx.InnerTransaction.CreateTree(tree);
-            statsTree.Add(collection, new Slice((byte*)&etag, sizeof(long)));
+            statsTree.Add(collection, Slice.External( tx.InnerTransaction.Allocator, (byte*)&etag, sizeof(long)));
         }
 
-        private static long ReadLastEtag(RavenTransaction tx, string tree, string collection)
+        private static long ReadLastEtag(RavenTransaction tx, string tree, Slice collection)
         {
             var statsTree = tx.InnerTransaction.CreateTree(tree);
             var readResult = statsTree.Read(collection);
@@ -258,7 +260,7 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 var binaryDate = indexingTime.ToBinary();
-                statsTree.Add(Schema.LastIndexingTimeSlice, new Slice((byte*)&binaryDate, sizeof(long)));
+                statsTree.Add(Schema.LastIndexingTimeSlice, Slice.External(context.Allocator, (byte*)&binaryDate, sizeof(long)));
 
                 if (stats.Errors != null)
                 {
@@ -293,7 +295,7 @@ namespace Raven.Server.Documents.Indexes
                 return;
 
             var numberOfEntriesToDelete = table.NumberOfEntries - MaxNumberOfKeptErrors;
-            table.DeleteForwardFrom(_errorsSchema.Indexes["ErrorTimestamps"], Slice.BeforeAllKeys, numberOfEntriesToDelete);
+            table.DeleteForwardFrom(_errorsSchema.Indexes["ErrorTimestamps"], Slices.BeforeAllKeys, numberOfEntriesToDelete);
         }
 
         public static IndexType ReadIndexType(int indexId, StorageEnvironment environment)
@@ -320,25 +322,25 @@ namespace Raven.Server.Documents.Indexes
 
             public static readonly string EtagsTombstoneTree = "Etags.Tombstone";
 
-            public static readonly Slice TypeSlice = "Type";
+            public static readonly Slice TypeSlice = Slice.From(StorageEnvironment.LabelsContext, "Type", ByteStringType.Immutable);
 
-            public static readonly Slice CreatedTimestampSlice = "CreatedTimestamp";
+            public static readonly Slice CreatedTimestampSlice = Slice.From(StorageEnvironment.LabelsContext, "CreatedTimestamp", ByteStringType.Immutable);
 
-            public static readonly Slice MapAttemptsSlice = "MapAttempts";
+            public static readonly Slice MapAttemptsSlice = Slice.From(StorageEnvironment.LabelsContext, "MapAttempts", ByteStringType.Immutable);
 
-            public static readonly Slice MapSuccessesSlice = "MapSuccesses";
+            public static readonly Slice MapSuccessesSlice = Slice.From(StorageEnvironment.LabelsContext, "MapSuccesses", ByteStringType.Immutable);
 
-            public static readonly Slice MapErrorsSlice = "MapErrors";
+            public static readonly Slice MapErrorsSlice = Slice.From(StorageEnvironment.LabelsContext, "MapErrors", ByteStringType.Immutable);
 
-            public static readonly Slice ReduceAttemptsSlice = "ReduceAttempts";
+            public static readonly Slice ReduceAttemptsSlice = Slice.From(StorageEnvironment.LabelsContext, "ReduceAttempts", ByteStringType.Immutable);
 
-            public static readonly Slice ReduceSuccessesSlice = "ReduceSuccesses";
+            public static readonly Slice ReduceSuccessesSlice = Slice.From(StorageEnvironment.LabelsContext, "ReduceSuccesses", ByteStringType.Immutable);
 
-            public static readonly Slice ReduceErrorsSlice = "ReduceErrors";
+            public static readonly Slice ReduceErrorsSlice = Slice.From(StorageEnvironment.LabelsContext, "ReduceErrors", ByteStringType.Immutable);
 
-            public static readonly Slice LastIndexingTimeSlice = "LastIndexingTime";
+            public static readonly Slice LastIndexingTimeSlice = Slice.From(StorageEnvironment.LabelsContext, "LastIndexingTime", ByteStringType.Immutable);
 
-            public static readonly Slice PrioritySlice = "Priority";
+            public static readonly Slice PrioritySlice = Slice.From(StorageEnvironment.LabelsContext, "Priority", ByteStringType.Immutable);
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/AutoMapReduceIndex.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 var state = GetReduceKeyState(mapEntry.ReduceKeyHash, indexContext, create: false);
                 
                 fixed (long* ptr = &mapEntry.Id)
-                    state.Tree.Delete(new Slice((byte*)ptr, sizeof(long)));
+                    state.Tree.Delete(Slice.External(indexContext.Allocator, (byte*)ptr, sizeof(long)));
 
                 _mapReduceWorkContext.EntryDeleted(mapEntry);
             }
@@ -230,7 +230,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         var previousState = GetReduceKeyState(mapEntry.ReduceKeyHash, indexContext, create: false);
 
                         fixed (long* ptr = &mapEntry.Id)
-                            previousState.Tree.Delete(new Slice((byte*)ptr, sizeof(long)));
+                            previousState.Tree.Delete(Slice.External(indexContext.Allocator, (byte*)ptr, sizeof(long)));
 
                         documentMapEntries.Delete(mapEntry.Id);
 
@@ -242,10 +242,10 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             if (id == -1)
             {
                 id = _mapReduceWorkContext.GetNextIdentifier();
-                documentMapEntries.Add(id, new Slice((byte*)&reduceKeyHash, sizeof(ulong)));
+                documentMapEntries.Add(id, Slice.External(indexContext.Allocator, (byte*)&reduceKeyHash, sizeof(ulong)));
             }
 
-            var pos = state.Tree.DirectAdd(new Slice((byte*)&id, sizeof(long)), mappedResult.Size);
+            var pos = state.Tree.DirectAdd(Slice.External(indexContext.Allocator, (byte*)&id, sizeof(long)), mappedResult.Size);
 
             mappedResult.CopyTo(pos);
         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResults.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResults.cs
@@ -91,7 +91,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         writer.DeleteReduceResult(reduceKeyHash, stats);
 
                         var emptyPageNumber = page.PageNumber;
-                        table.DeleteByKey(new Slice((byte*)&emptyPageNumber, sizeof(long)));
+                        table.DeleteByKey(Slice.External(indexContext.Allocator, (byte*)&emptyPageNumber, sizeof(long)));
 
                         continue;
                     }
@@ -140,7 +140,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 }
 
                 long tmp = 0;
-                Slice pageNumberSlice = new Slice((byte*)&tmp, sizeof(long));
+                var pageNumberSlice = Slice.External(indexContext.Allocator, (byte*)&tmp, sizeof(long));
                 foreach (var freedPage in modifiedState.FreedPages)
                 {
                     tmp = freedPage;
@@ -240,7 +240,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             for (int i = 0; i < page.NumberOfEntries; i++)
             {
                 var childPageNumber = IPAddress.HostToNetworkOrder(page.GetNode(i)->PageNumber);
-                var tvr = table.ReadByKey(new Slice((byte*)&childPageNumber, sizeof(long)));
+                var tvr = table.ReadByKey(Slice.External(indexContext.Allocator, (byte*)&childPageNumber, sizeof(long)));
                 if (tvr == null)
                 {
                     throw new InvalidOperationException("Couldn't find pre-computed results for existing page " + childPageNumber);

--- a/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
+++ b/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
@@ -223,6 +223,8 @@ namespace Raven.Server.Documents.Versioning
 
         public static Slice GetSliceFromKey(DocumentsOperationContext context, string key)
         {
+            // REVIEW: Is this needed? Could we just use the ByteString?
+
             var byteCount = Encoding.UTF8.GetMaxByteCount(key.Length);
             if (byteCount > 255)
                 throw new ArgumentException(
@@ -248,7 +250,7 @@ namespace Raven.Server.Documents.Versioning
                 var keyBytes = buffer + sizeof(char) + key.Length * sizeof(char);
 
                 size = Encoding.UTF8.GetBytes(destChars, key.Length + 1, keyBytes, byteCount + 1);
-                return new Slice(keyBytes, (ushort)size);
+                return Slice.External(context.Allocator, keyBytes, (ushort)size);
             }
         }
 

--- a/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
@@ -5,7 +5,9 @@ using System.Threading;
 using Lucene.Net.Store;
 using Raven.Abstractions.Extensions;
 using Voron;
+using Voron.Data;
 using Voron.Impl;
+using Sparrow;
 
 namespace Raven.Server.Indexing
 {
@@ -38,7 +40,7 @@ namespace Raven.Server.Indexing
             var filesTree = _currentTransaction.Value.ReadTree("Files");
             using (var it = filesTree.Iterate())
             {
-                if (it.Seek(Slice.BeforeAllKeys))
+                if (it.Seek(Slices.BeforeAllKeys))
                 {
                     do
                     {
@@ -55,24 +57,24 @@ namespace Raven.Server.Indexing
             var readResult = filesTree.Read(name);
             if (readResult == null)
                 throw new FileNotFoundException("Could not find file", name);
+
             return readResult.Version;
         }
 
         public override unsafe void TouchFile(string name)
         {
             var filesTree = _currentTransaction.Value.ReadTree("Files");
-            Slice key = name;
-            var readResult = filesTree.Read(key);
+            var readResult = filesTree.Read(name);
             if (readResult == null)
                 throw new FileNotFoundException("Could not find file", name);
-            filesTree.DirectAdd(key, readResult.Reader.Length);
+
+            filesTree.DirectAdd(name, readResult.Reader.Length);
         }
 
         public override long FileLength(string name)
         {
             var filesTree = _currentTransaction.Value.ReadTree("Files");
-            Slice key = name;
-            var readResult = filesTree.Read(key);
+            var readResult = filesTree.Read(name);
             if (readResult == null)
                 throw new FileNotFoundException("Could not find file", name);
 
@@ -83,11 +85,11 @@ namespace Raven.Server.Indexing
         public override void DeleteFile(string name)
         {
             var filesTree = _currentTransaction.Value.ReadTree("Files");
-            Slice key = name;
-            var readResult = filesTree.Read(key);
+            var readResult = filesTree.Read(name);
             if (readResult == null)
                 throw new FileNotFoundException("Could not find file", name);
-            filesTree.Delete(key);
+
+            filesTree.Delete(name);
         }
 
         public override IndexInput OpenInput(string name)

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -27,11 +27,11 @@ namespace Raven.Server.Indexing
 
         private int _size;
 
-        public VoronIndexInput(ThreadLocal<Transaction> transaction, Slice name)
+        public VoronIndexInput(ThreadLocal<Transaction> transaction, string name)
         {
+            _name = Slice.From(transaction.Value.Allocator, name, ByteStringType.Immutable); 
             _originalTransactionId = transaction.Value.LowLevelTransaction.Id;
             _currentTransaction = transaction;
-            _name = name;
 
             OpenInternal(this);
         }

--- a/src/Raven.Server/Indexing/VoronIndexOutput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexOutput.cs
@@ -2,18 +2,20 @@
 using System.IO;
 using Lucene.Net.Store;
 using Voron.Impl;
+using Voron;
+using Sparrow;
 
 namespace Raven.Server.Indexing
 {
     public class VoronIndexOutput : BufferedIndexOutput
     {
-        private readonly string _name;
+        private readonly Slice _name;
         private readonly Transaction _tx;
         private readonly FileStream _file;
 
         public VoronIndexOutput(string tempPath, string name, Transaction tx)
         {
-            _name = name;
+            _name = Slice.From(tx.Allocator, name, ByteStringType.Immutable);
             _tx = tx;
             var fileTempPath = Path.Combine(tempPath, name + "_" + Guid.NewGuid());
             //TODO: Pass this flag

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -1,4 +1,5 @@
 ﻿using Raven.Server.Documents;
+using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Server.ServerWide.Context
@@ -13,14 +14,14 @@ namespace Raven.Server.ServerWide.Context
             _documentDatabase = documentDatabase;
         }
 
-        protected override DocumentsTransaction CreateReadTransaction()
+        protected override DocumentsTransaction CreateReadTransaction(ByteStringContext context)
         {
-            return new DocumentsTransaction(this, _documentDatabase.DocumentsStorage.Environment.ReadTransaction(), _documentDatabase.Notifications);
+            return new DocumentsTransaction(this, _documentDatabase.DocumentsStorage.Environment.ReadTransaction(context), _documentDatabase.Notifications);
         }
 
-        protected override DocumentsTransaction CreateWriteTransaction()
+        protected override DocumentsTransaction CreateWriteTransaction(ByteStringContext context)
         {
-            return new DocumentsTransaction(this, _documentDatabase.DocumentsStorage.Environment.WriteTransaction(), _documentDatabase.Notifications);
+            return new DocumentsTransaction(this, _documentDatabase.DocumentsStorage.Environment.WriteTransaction(context), _documentDatabase.Notifications);
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -13,6 +13,7 @@ using Raven.Server.Utils.Metrics;
 using Sparrow.Json;
 using Voron;
 using Voron.Data;
+using Sparrow;
 
 namespace Raven.Server.ServerWide
 {
@@ -119,7 +120,7 @@ namespace Raven.Server.ServerWide
             var dbs = ctx.Transaction.InnerTransaction.ReadTree("items");
             using (var it = dbs.Iterate())
             {
-                it.RequiredPrefix = prefix;
+                it.RequiredPrefix = Slice.From(ctx.Allocator, prefix, ByteStringType.Immutable);
                 if (it.Seek(it.RequiredPrefix) == false)
                     yield break;
 

--- a/src/Sparrow/ByteString.cs
+++ b/src/Sparrow/ByteString.cs
@@ -1,0 +1,939 @@
+﻿//#define VALIDATE
+
+using Sparrow.Binary;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sparrow
+{
+    [Flags]
+    public enum ByteStringType : byte
+    {
+        Immutable = 0x00, // This is a shorthand for an internal-immutable string. 
+        Mutable = 0x01,
+        External = 0x02,
+        Reserved1 = 0x04, // This bit is reserved for future uses.
+        Reserved2 = 0x08, // This bit is reserved for future uses.
+
+        // These flags are unused and can be used by users to store custom information on the instance.
+        UserDefined1 = 0x10,
+        UserDefined2 = 0x20,
+        UserDefined3 = 0x40,
+        UserDefined4 = 0x80,
+
+        /// <summary>
+        /// Use this value to mask out the user defined bits using the & (Bitwise AND) operator.
+        /// </summary>
+        ByteStringMask = 0x0F,
+
+        /// <summary>
+        /// Use this value to mask out the ByteStringType bits using the & (Bitwise AND) operator.
+        /// </summary>
+        UserDefinedMask = 0xF0
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    unsafe struct ByteStringStorage
+    {
+        /// <summary>
+        /// The actual type for the byte string
+        /// </summary>
+        public ByteStringType Flags;
+
+        /// <summary>
+        /// The actual length of the byte string
+        /// </summary>
+        public int Length;
+
+        /// <summary>
+        /// This is the pointer to the start of the byte stream. 
+        /// </summary>
+        public byte* Ptr;
+
+        /// <summary>
+        /// This is the total storage size for this byte string. Length will always be smaller than Size - 1.
+        /// </summary>
+        public int Size;
+
+#if VALIDATE
+        public const ulong NullKey = unchecked((ulong)-1);
+
+        /// <summary>
+        /// The validation key for the storage value.
+        /// </summary>
+        [FieldOffset(20)]
+        public ulong Key;
+#endif
+    }
+
+    public unsafe struct ByteString : IEquatable<ByteString>
+    {
+        internal ByteStringStorage* _pointer;
+
+#if VALIDATE
+        internal ByteString(ByteStringStorage* ptr)
+        {
+            this._pointer = ptr;
+            this.Key = ptr->Key; // We store the storage key
+        }
+
+        internal readonly ulong Key;
+#else
+        internal ByteString(ByteStringStorage* ptr)
+        {
+            this._pointer = ptr;
+        }
+#endif
+        public ByteStringType Flags
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Debug.Assert(HasValue);
+                EnsureIsNotBadPointer();
+
+                return _pointer->Flags;
+            }
+        }
+
+        public byte* Ptr
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Debug.Assert(HasValue);
+                EnsureIsNotBadPointer();
+
+                return _pointer->Ptr;
+            }            
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetUserDefinedFlags( ByteStringType flags)
+        {
+            if ((flags & ByteStringType.ByteStringMask) != 0)
+                throw new ArgumentException("The flags passed contains reserved bits.");
+
+            _pointer->Flags |= flags;
+        }
+
+        public bool IsMutable
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Debug.Assert(HasValue);
+                EnsureIsNotBadPointer();
+
+                return (_pointer->Flags & ByteStringType.Mutable) != 0;
+            }
+        }
+
+        public bool IsExternal
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Debug.Assert(HasValue);
+                EnsureIsNotBadPointer();
+
+                return (_pointer->Flags & ByteStringType.External) != 0;
+            }
+        }
+
+        public int Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (_pointer == null)
+                    return 0;
+
+                EnsureIsNotBadPointer();
+
+                return _pointer->Length;
+            }
+        }
+
+        public bool HasValue
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _pointer != null; }
+        }
+
+        public byte this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Debug.Assert(HasValue);
+                EnsureIsNotBadPointer();
+
+                return *(_pointer->Ptr + (sizeof(byte) * index));
+            }
+        }
+
+        public void CopyTo(int from, byte* dest, int offset, int count)
+        {
+            Debug.Assert(HasValue);
+
+            if (from + count > _pointer->Length)
+                throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the slice");
+
+            EnsureIsNotBadPointer();
+            Memory.CopyInline(dest + offset, _pointer->Ptr + from, count);
+        }
+
+        public void CopyTo(byte* dest)
+        {
+            Debug.Assert(HasValue);
+
+            EnsureIsNotBadPointer();
+            Memory.CopyInline(dest, _pointer->Ptr, _pointer->Length);
+        }
+
+        public void CopyTo(byte[] dest)
+        { 
+            Debug.Assert(HasValue);
+
+            EnsureIsNotBadPointer();
+            fixed (byte* p = dest)
+            {
+                Memory.CopyInline(p, _pointer->Ptr, _pointer->Length);
+            }
+        }
+
+#if VALIDATE
+
+        [Conditional("VALIDATE")]
+        internal void EnsureIsNotBadPointer()
+        {
+            if (_pointer->Ptr == null)
+                throw new InvalidOperationException("The inner storage pointer is not initialized. This is a defect on the implementation of the ByteStringContext class");
+
+            if (_pointer->Key == ByteStringStorage.NullKey)
+                throw new InvalidOperationException("The memory referenced has already being released. This is a dangling pointer. Check your .Release() statements and aliases in the calling code.");
+
+            if ( this.Key != _pointer->Key)
+            {
+                if (this.Key >> 16 != _pointer->Key >> 16)
+                    throw new InvalidOperationException("The owner context for the ByteString and the unmanaged storage are different. This is a defect on the implementation of the ByteStringContext class");
+
+                Debug.Assert((this.Key & 0x0000000FFFFFFFF) != (_pointer->Key & 0x0000000FFFFFFFF));
+                throw new InvalidOperationException("The key for the ByteString and the unmanaged storage are different. This is a dangling pointer. Check your .Release() statements and aliases in the calling code.");                                    
+            }
+        }
+
+#else
+        [Conditional("VALIDATE")]
+        internal void EnsureIsNotBadPointer() { }
+#endif
+
+        public void CopyTo(int from, byte[] dest, int offset, int count)
+        {
+            Debug.Assert(HasValue);
+
+            if (from + count > _pointer->Length)
+                throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the slice");
+            if (offset + count > dest.Length)
+                throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the buffer");
+
+            EnsureIsNotBadPointer();
+            fixed (byte* p = dest)
+            {
+                Memory.CopyInline(p + offset, _pointer->Ptr + from, count);
+            }
+        }
+
+        public override string ToString()
+        {
+            if (!HasValue)
+                return string.Empty;
+
+            EnsureIsNotBadPointer();
+
+            return new string((char*)_pointer->Ptr, 0, _pointer->Length);
+        }
+
+        public string ToString(Encoding encoding)
+        {
+            if (!HasValue)
+                return string.Empty;
+
+            EnsureIsNotBadPointer();
+
+            return encoding.GetString(_pointer->Ptr, _pointer->Length);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ByteString && this == (ByteString)obj;
+        }
+
+        public override int GetHashCode()
+        {
+            // Given how the size of slices can vary it is better to lose a bit (10%) on smaller slices 
+            // (less than 20 bytes) and to win big on the bigger ones. 
+            //
+            // After 24 bytes the gain is 10%
+            // After 64 bytes the gain is 2x
+            // After 128 bytes the gain is 4x.
+            //
+            // We should control the distribution of this over time.
+
+            if (_pointer == null)
+                return 0;
+
+            // JIT will remove the corresponding line based on the target architecture using dead code removal.
+            if (IntPtr.Size == 4)  
+                return (int)Hashing.XXHash32.CalculateInline(_pointer->Ptr, _pointer->Length);
+            else
+                return (int)Hashing.XXHash64.CalculateInline(_pointer->Ptr, _pointer->Length);
+        }
+
+        public static bool operator ==(ByteString x, ByteString y)
+        {
+            return x._pointer == y._pointer;
+        }
+        public static bool operator !=(ByteString x, ByteString y)
+        {
+            return !(x == y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Equals(ByteString other)
+        {
+            return this == other;
+        }
+    }
+
+
+    public unsafe class ByteStringContext : IDisposable
+    {
+        class SegmentInformation
+        {
+            public bool CanDispose; 
+
+            public byte* Start;
+            public byte* Current;
+            public byte* End;
+
+            public int Size
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get { return (int)(End - Start); }
+            }
+
+            public int SizeLeft
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get { return (int)(End - Current); }
+            }
+        }
+
+        public const int MinBlockSizeInBytes = 64 * 1024; // If this is changed, we need to change also LogMinBlockSize.
+        private const int LogMinBlockSize = 16;
+
+        public const int DefaultAllocationBlockSizeInBytes = 2 * MinBlockSizeInBytes;
+        public const int MinReusableBlockSizeInBytes = 8;
+        
+        /// <summary>
+        /// This list keeps all the segments already instantiated in order to release them after context finalization. 
+        /// </summary>
+        private readonly List<SegmentInformation> _wholeSegments;
+        private readonly int _allocationBlockSize;
+
+        /// <summary>
+        /// This list keeps the hot segments released for use. It is important to note that we will never put into this list
+        /// a segment with less space than the MinBlockSize value.
+        /// </summary>
+        private readonly List<SegmentInformation> _internalReadyToUseMemorySegments;
+        private readonly int[] _internalReusableStringPoolCount;
+        private readonly Stack<IntPtr>[] _internalReusableStringPool;
+        private SegmentInformation _internalCurrent;        
+        
+
+        private const int ExternalFastPoolSize = 16;
+        private int _externalAlignedSize = 0;
+        private int _externalCurrentLeft = 0;
+        private int _externalFastPoolCount = 0;
+        private readonly IntPtr[] _externalFastPool = new IntPtr[ExternalFastPoolSize];
+        private readonly Stack<IntPtr> _externalStringPool;
+        private SegmentInformation _externalCurrent;
+
+        public ByteStringContext(int allocationBlockSize = DefaultAllocationBlockSizeInBytes)
+        {
+            if (allocationBlockSize < MinBlockSizeInBytes)
+                throw new ArgumentException($"It is not a good idea to allocate chunks of less than the {nameof(MinBlockSizeInBytes)} value of {MinBlockSizeInBytes}");
+
+            this._allocationBlockSize = allocationBlockSize;
+
+            this._wholeSegments = new List<SegmentInformation>();
+            this._internalReadyToUseMemorySegments = new List<SegmentInformation>();            
+
+            this._internalReusableStringPool = new Stack<IntPtr>[LogMinBlockSize];
+            this._internalReusableStringPoolCount = new int[LogMinBlockSize];
+
+            this._internalCurrent = AllocateSegment(allocationBlockSize);
+            this._externalCurrent = AllocateSegment(allocationBlockSize);
+
+            this._externalStringPool = new Stack<IntPtr>(64);
+
+            PrepareForValidation();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ByteString Allocate(int length)
+        {
+            return AllocateInternal(length, ByteStringType.Mutable);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetPoolIndexForReuse(int size)
+        {
+            return Bits.CeilLog2(size) - 1; // x^0 = 1 therefore we start counting at 1 instead.
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetPoolIndexForReservation(int size)
+        {
+            return Bits.MostSignificantBit(size) - 1; // x^0 = 1 therefore we start counting at 1 instead.
+        }
+
+        private ByteString AllocateExternal(byte* valuePtr, int size, ByteStringType type)
+        {
+            Debug.Assert((type & ByteStringType.External) != 0, "This allocation routine is only for use with external storage byte strings.");
+
+            int allocationSize = sizeof(ByteStringStorage);
+
+            ByteStringStorage* storagePtr;
+            if (_externalFastPoolCount > 0)
+            {
+                storagePtr = (ByteStringStorage*)_externalFastPool[--_externalFastPoolCount].ToPointer();
+            }
+            else if (_externalStringPool.Count != 0)
+            {
+                storagePtr = (ByteStringStorage*)_externalStringPool.Pop().ToPointer();
+            }
+            else
+            {
+                if (_externalCurrentLeft == 0)
+                    AllocateExternalSegment(_allocationBlockSize);
+
+                storagePtr = (ByteStringStorage*)_externalCurrent.Current;
+                _externalCurrent.Current += _externalAlignedSize;
+                _externalCurrentLeft--;
+            }     
+
+            storagePtr->Flags = type;
+            storagePtr->Length = size;
+            storagePtr->Ptr = valuePtr;
+
+            return new ByteString(storagePtr);
+        }
+
+        private ByteString AllocateInternal(int length, ByteStringType type)
+        {
+            Debug.Assert((type & ByteStringType.External) == 0, "This allocation routine is only for use with internal storage byte strings.");
+            type &= ~ByteStringType.External; // We are allocating internal, so we will force it (even if we are checking for it in debug).
+
+            int allocationSize = length + sizeof(ByteStringStorage);
+
+            // This is even bigger than the configured allocation block size. There is no reason why we shouldn't
+            // allocate it directly. When released (if released) this will be reused as a segment, ensuring that the context
+            // could handle that.
+            if (allocationSize > _allocationBlockSize)
+                return AllocateWholeSegment(length, type); // We will pass the length because this is a whole allocated segment able to hold a length size ByteString.
+
+            int reusablePoolIndex = GetPoolIndexForReuse(allocationSize); 
+            int allocationUnit = Bits.NextPowerOf2(allocationSize);
+
+            // The allocation unit is bigger than MinBlockSize (therefore it wont be 2^n aligned).
+            // Then we will 64bits align the allocation.
+            if (allocationUnit > MinBlockSizeInBytes)
+                allocationUnit += sizeof(long) - allocationUnit % sizeof(long);
+
+            // All allocation units are 32 bits aligned. If not we will have a performance issue.
+            Debug.Assert(allocationUnit % sizeof(int) == 0);    
+
+            // If we can reuse... we retrieve those.
+            if (allocationSize <= MinBlockSizeInBytes && _internalReusableStringPoolCount[reusablePoolIndex] != 0)
+            {                
+                // This is a stack because hotter memory will be on top. 
+                Stack<IntPtr> pool = _internalReusableStringPool[reusablePoolIndex];
+
+                _internalReusableStringPoolCount[reusablePoolIndex]--;
+                void* ptr = pool.Pop().ToPointer();
+
+                return Create(ptr, length, allocationUnit, type);
+            }
+            else
+            {
+                int currentSizeLeft = _internalCurrent.SizeLeft;
+                if (allocationUnit > currentSizeLeft) // This shouldn't happen that much, if it does you should increase your default allocation block. 
+                {                   
+                    SegmentInformation segment = null;
+                    
+                    // We will try to find a hot segment with enough space if available.
+                    // Older (colder) segments are at the front of the list. That's why we would start scanning backwards.
+                    for ( int i = _internalReadyToUseMemorySegments.Count - 1; i >= 0; i--)
+                    {
+                        var segmentValue = _internalReadyToUseMemorySegments[i];
+                        if (segmentValue.SizeLeft >= allocationUnit)
+                        {
+                            // Put the last where this one is (if it is the same, this is a no-op) and remove it from the list.
+                            _internalReadyToUseMemorySegments[i] = _internalReadyToUseMemorySegments[_internalReadyToUseMemorySegments.Count - 1];
+                            _internalReadyToUseMemorySegments.RemoveAt(_internalReadyToUseMemorySegments.Count - 1);
+
+                            segment = segmentValue;
+                            break;
+                        }                            
+                    }
+
+                    // If the size left is bigger than MinBlockSize, we release current as a reusable segment
+                    if (currentSizeLeft > MinBlockSizeInBytes)
+                    {
+                        byte* start = _internalCurrent.Current;
+                        byte* end = start + currentSizeLeft;
+
+                        _internalReadyToUseMemorySegments.Add(new SegmentInformation{ Start = start, Current = start, End = end, CanDispose = false });
+                    }
+                    else if ( currentSizeLeft > sizeof(ByteStringType) + MinReusableBlockSizeInBytes)
+                    {
+                        // The memory chunk left is big enough to make sense to reuse it.
+                        reusablePoolIndex = GetPoolIndexForReservation(currentSizeLeft);
+
+                        Stack<IntPtr> pool = this._internalReusableStringPool[reusablePoolIndex];
+                        if (pool == null)
+                        {
+                            pool = new Stack<IntPtr>();
+                            this._internalReusableStringPool[reusablePoolIndex] = pool;
+                        }
+
+                        pool.Push(new IntPtr(_internalCurrent.Current));
+                        this._internalReusableStringPoolCount[reusablePoolIndex]++;
+                    }
+
+                    // Use the segment and if there is no segment available that matches the request, just get a new one.
+                    this._internalCurrent = segment ?? AllocateSegment(_allocationBlockSize);
+                }                    
+
+                var byteString = Create(_internalCurrent.Current, length, allocationUnit, type);                
+                _internalCurrent.Current += byteString._pointer->Size;                
+
+                return byteString;
+            }
+        }
+
+
+        private ByteString Create(void* ptr, int length, int size, ByteStringType type = ByteStringType.Immutable)
+        {
+            Debug.Assert(length <= size - sizeof(ByteStringStorage));
+
+            var basePtr = (ByteStringStorage*)ptr;
+            basePtr->Flags = type;
+            basePtr->Length = length;
+            basePtr->Ptr = (byte*)ptr + sizeof(ByteStringStorage);                        
+            basePtr->Size = size;
+
+            return new ByteString(basePtr);
+        }
+
+        private ByteString AllocateWholeSegment(int length, ByteStringType type)
+        {
+            // The allocation is big, therefore we will just allocate the segment and move on.                
+            var segment = AllocateSegment(length + sizeof(ByteStringStorage));
+
+            var byteString = Create(segment.Current, length, segment.Size, type);
+            segment.Current += byteString._pointer->Size;
+            _wholeSegments.Add(segment);
+
+            return byteString;
+        }
+
+        /// <summary>
+        /// This method is intended to be used to release read-only properties in disposing patterns implementations.
+        /// WARNING: Other uses are discouraged because the resulting ByteString will be a dangling pointer that will fail
+        /// when compiled in VALIDATE mode and have an undefined behavior on normal mode of operation. 
+        /// </summary>
+        /// <param name="value"></param>
+        public void ReleaseReadonly(ByteString value)
+        {
+            Release(ref value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleaseExternal(ref ByteString value)
+        {
+            Debug.Assert(value._pointer != null, "Pointer cannot be null. You have a defect in your code.");
+            if (value._pointer == null)
+                return;
+
+            // We are releasing, therefore we should validate among other things if an immutable string changed and if we are the owners.
+            Validate(value);
+
+            // We release the pointer in the appropriate reuse pool.
+            if (this._externalFastPoolCount < ExternalFastPoolSize)
+            {
+                // Release in the fast pool. 
+                this._externalFastPool[this._externalFastPoolCount++] = new IntPtr(value._pointer);
+            }
+            else
+            {
+                this._externalStringPool.Push(new IntPtr(value._pointer));
+            }
+
+#if VALIDATE
+            // Setting the null key ensures that in between we can validate that no further deallocation
+            // happens on this memory segment.
+            value._pointer->Key = ByteStringStorage.NullKey;
+#endif
+
+            // WE WANT it to happen, no matter what. 
+            value._pointer = null;
+        }
+
+        public void Release(ref ByteString value)
+        {
+            Debug.Assert(value._pointer != null, "Pointer cannot be null. You have a defect in your code.");
+            if (value._pointer == null)
+                return;
+
+            // We are releasing, therefore we should validate among other things if an immutable string changed and if we are the owners.
+            Validate(value);
+
+            if ( value.IsExternal )
+            {
+                // We release the pointer in the appropriate reuse pool.
+                if (this._externalFastPoolCount < ExternalFastPoolSize)
+                {
+                    // Release in the fast pool. 
+                    this._externalFastPool[this._externalFastPoolCount++] = new IntPtr(value._pointer);
+                }
+                else
+                {
+                    this._externalStringPool.Push(new IntPtr(value._pointer));
+                }
+            }
+            else
+            {
+                int reusablePoolIndex = GetPoolIndexForReuse(value._pointer->Size);
+
+                if (value._pointer->Size <= MinBlockSizeInBytes)
+                {
+                    Stack<IntPtr> pool = this._internalReusableStringPool[reusablePoolIndex];
+                    if (pool == null)
+                    {
+                        pool = new Stack<IntPtr>();
+                        this._internalReusableStringPool[reusablePoolIndex] = pool;
+                    }
+
+                    pool.Push(new IntPtr(value._pointer));
+                    this._internalReusableStringPoolCount[reusablePoolIndex]++;
+                }
+                else  // The released memory is big enough, we will just release it as a new segment. 
+                {
+                    byte* start = (byte*)value._pointer;
+                    byte* end = start + value._pointer->Size;
+
+                    var segment = new SegmentInformation { Start = start, Current = start, End = end, CanDispose = false };
+                    _internalReadyToUseMemorySegments.Add(segment);
+                }
+            }
+
+#if VALIDATE
+            // Setting the null key ensures that in between we can validate that no further deallocation
+            // happens on this memory segment.
+            value._pointer->Key = ByteStringStorage.NullKey;
+#endif
+
+            // WE WANT it to happen, no matter what. 
+            value._pointer = null;
+        }
+
+        private SegmentInformation AllocateSegment(int size)
+        {
+            byte* start = (byte*)Marshal.AllocHGlobal(size).ToPointer();
+            byte* end = start + size;
+
+            var segment = new SegmentInformation { Start = start, Current = start, End = end, CanDispose = true };
+            _wholeSegments.Add(segment);
+
+            return segment;
+        }
+
+
+        private void AllocateExternalSegment(int size)
+        {
+            byte* start = (byte*)Marshal.AllocHGlobal(size).ToPointer();
+            byte* end = start + size;
+
+            _externalCurrent = new SegmentInformation { Start = start, Current = start, End = end, CanDispose = true };
+            _externalAlignedSize = (sizeof(ByteStringStorage) + (sizeof(long) - sizeof(ByteStringStorage) % sizeof(long)));
+            _externalCurrentLeft = (int)(_externalCurrent.End - _externalCurrent.Start) / _externalAlignedSize;
+
+            _wholeSegments.Add(_externalCurrent);
+        }
+
+        public ByteString Skip(ByteString value, int bytesToSkip, ByteStringType type = ByteStringType.Mutable)
+        {
+            Debug.Assert(value._pointer != null, "ByteString cant be null.");
+
+            if (bytesToSkip < 0)
+                throw new ArgumentException($"'{nameof(bytesToSkip)}' cannot be smaller than 0.");
+
+            if (bytesToSkip > value.Length)
+                throw new ArgumentException($"'{nameof(bytesToSkip)}' cannot be bigger than '{nameof(value)}.Length' 0.");
+
+            // TODO: If origin and destination are immutable, we can create external references.
+
+            int size = value.Length - bytesToSkip;
+            var result = AllocateInternal(size, type);
+            Memory.CopyInline(result._pointer->Ptr, value._pointer->Ptr + bytesToSkip, size);
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString Clone(ByteString value, ByteStringType type = ByteStringType.Mutable)
+        {
+            Debug.Assert(value._pointer != null, $"{nameof(value)} cant be null.");
+
+            // TODO: If origin and destination are immutable, we can create external references.
+
+            var result = AllocateInternal(value.Length, type);
+            Memory.CopyInline(result._pointer->Ptr, value._pointer->Ptr, value._pointer->Length);
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(string value, ByteStringType type = ByteStringType.Mutable)
+        {
+            Debug.Assert(value != null, $"{nameof(value)} cant be null.");
+
+            byte[] utf8 = Encoding.UTF8.GetBytes(value);
+
+            var result = AllocateInternal(utf8.Length, type);
+            fixed (byte* ptr = utf8)
+            {
+                Memory.Copy(result._pointer->Ptr, ptr, utf8.Length);
+            }
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(string value, Encoding encoding, ByteStringType type = ByteStringType.Mutable)
+        {
+            Debug.Assert(value != null, $"{nameof(value)} cant be null.");
+
+            byte[] encodedBytes = encoding.GetBytes(value);
+
+            var result = AllocateInternal(encodedBytes.Length, type);
+            fixed (byte* ptr = encodedBytes)
+            {
+                Memory.Copy(result._pointer->Ptr, ptr, encodedBytes.Length);
+            }
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(byte[] value, ByteStringType type = ByteStringType.Mutable)
+        {
+            Debug.Assert(value != null, $"{nameof(value)} cant be null.");
+
+            var result = AllocateInternal(value.Length, type);
+            fixed (byte* ptr = value)
+            {
+                Memory.Copy(result._pointer->Ptr, ptr, value.Length);
+            }
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(byte[] value, int size, ByteStringType type = ByteStringType.Mutable)
+        {
+            Debug.Assert(value != null, $"{nameof(value)} cant be null.");
+
+            var result = AllocateInternal(size, type);
+            fixed (byte* ptr = value)
+            {
+                Memory.Copy(result._pointer->Ptr, ptr, size);
+            }
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(int value, ByteStringType type = ByteStringType.Mutable)
+        {
+            var result = AllocateInternal(sizeof(int), type);
+            ((int*)result._pointer->Ptr)[0] = value;
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(long value, ByteStringType type = ByteStringType.Mutable)
+        {
+            var result = AllocateInternal(sizeof(long), type);
+            ((long*)result._pointer->Ptr)[0] = value;
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(short value, ByteStringType type = ByteStringType.Mutable)
+        {
+            var result = AllocateInternal(sizeof(short), type);
+            ((short*)result._pointer->Ptr)[0] = value;
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(byte value, ByteStringType type = ByteStringType.Mutable)
+        {
+            var result = AllocateInternal(1, type);
+            result._pointer->Ptr[0] = value;
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString From(byte* valuePtr, int size, ByteStringType type = ByteStringType.Mutable)
+        {
+            Debug.Assert(valuePtr != null, $"{nameof(valuePtr)} cant be null.");
+            Debug.Assert((type & ByteStringType.External) == 0, $"{nameof(From)} is not expected to be called with the '{nameof(ByteStringType.External)}' requested type, use {nameof(FromPtr)} instead.");
+
+            var result = AllocateInternal(size, type);
+            Memory.Copy(result._pointer->Ptr, valuePtr, size);
+
+            RegisterForValidation(result);
+            return result;
+        }
+
+        public ByteString FromPtr(byte* valuePtr, int size, ByteStringType type = ByteStringType.Mutable | ByteStringType.External)
+        {
+            Debug.Assert(valuePtr != null, $"{nameof(valuePtr)} cant be null.");
+            Debug.Assert(size >= 0, $"{nameof(size)} cannot be negative.");
+
+            var result = AllocateExternal(valuePtr, size, type | ByteStringType.External); // We are allocating external, so we will force it (even if we are checking for it in debug).
+
+            RegisterForValidation(result);
+
+            return result;
+        }
+
+#if VALIDATE
+
+        private static int globalContextId;
+        private int _allocationCount;
+
+        protected int ContextId;
+
+        private void PrepareForValidation()
+        {
+            this.ContextId = Interlocked.Increment(ref globalContextId);
+        }
+
+        private void RegisterForValidation(void* storage)
+        {
+            // There shouldn't be reuse for the storage, unless we have a different allocation on reused memory.
+            // Therefore, monotonically increasing the key we ensure that we can check when we have dangling pointers in our code.
+            // We use interlocked in order to avoid validation bugs when validating (we are playing it safe).
+            ((ByteStringStorage*)storage)->Key = (ulong)(((long)this.ContextId << 32) + Interlocked.Increment(ref _allocationCount)); ;
+        }
+
+        private void RegisterForValidation(ByteString value)
+        {
+            value.EnsureIsNotBadPointer();
+
+            if (!value.IsMutable)
+                throw new NotImplementedException("Validation still not implemented for immutable Byte Strings");
+        }
+
+        private void Validate(ByteString value)
+        {
+            value.EnsureIsNotBadPointer();
+
+            if (value._pointer->Key == ByteStringStorage.NullKey)
+                throw new InvalidOperationException("Trying to release an alias of an already removed object. You have a dangling pointer in hand.");
+
+            if (value._pointer->Key >> 32 != (ulong)this.ContextId)
+                throw new InvalidOperationException("The owner of the ByteString is a different context. You are mixing contexts, which has undefined behavior.");
+
+            if (!value.IsMutable)
+                throw new NotImplementedException("Validation still not implemented for immutable Byte Strings");
+
+        }
+
+#else
+        [Conditional("VALIDATE")]
+        private void PrepareForValidation() { }
+
+        [Conditional("VALIDATE")]
+        private void RegisterForValidation(void* _) { }
+
+        [Conditional("VALIDATE")]
+        private void RegisterForValidation(ByteString _) { }
+
+        [Conditional("VALIDATE")]
+        private void Validate(ByteString _) { }
+
+#endif
+
+        #region IDisposable
+
+        private bool isDisposed = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                }
+
+                foreach (var segment in _wholeSegments)
+                {
+                    if ( segment.CanDispose)
+                        Marshal.FreeHGlobal(new IntPtr(segment.Start));
+                }
+
+                _wholeSegments.Clear();
+                _internalReadyToUseMemorySegments.Clear();
+
+                isDisposed = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+         ~ByteStringContext()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -129,7 +129,7 @@ namespace Sparrow.Json
             return new UnmanagedWriteBuffer(this, GetMemory(_lastStreamSize));
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (_disposed)
                 return;

--- a/src/Voron/Data/BTrees/ParentPageAction.cs
+++ b/src/Voron/Data/BTrees/ParentPageAction.cs
@@ -36,7 +36,7 @@ namespace Voron.Data.BTrees
             var originalLastSearchPositionOfParent = _parentPage.LastSearchPosition;
 
             if (nodePos == null)
-                nodePos = _parentPage.NodePositionFor(separator); // select the appropriate place for this
+                nodePos = _parentPage.NodePositionFor(_tx, separator); // select the appropriate place for this
 
             if (_parentPage.HasSpaceFor(_tx, TreeSizeOf.BranchEntry(separator) + Constants.NodeOffsetSize) == false)
             {

--- a/src/Voron/Data/BTrees/RecentlyFoundTreePages.cs
+++ b/src/Voron/Data/BTrees/RecentlyFoundTreePages.cs
@@ -13,10 +13,11 @@ namespace Voron.Data.BTrees
         public class FoundTreePage
         {
             public readonly long Number;
-            public TreePage Page;
             public readonly Slice FirstKey;
             public readonly Slice LastKey;
             public readonly long[] CursorPath;
+
+            public TreePage Page;
 
             public FoundTreePage(long number, TreePage page, Slice firstKey, Slice lastKey, long[] cursorPath)
             {
@@ -84,9 +85,9 @@ namespace Voron.Data.BTrees
                 switch (key.Options)
                 {
                     case SliceOptions.Key:
-                        if ((first.Options != SliceOptions.BeforeAllKeys && key.Compare(first) < 0))
+                        if ((first.Options != SliceOptions.BeforeAllKeys && SliceComparer.Compare(key, first) < 0))
                             break;
-                        if (last.Options != SliceOptions.AfterAllKeys && key.Compare(last) > 0)
+                        if (last.Options != SliceOptions.AfterAllKeys && SliceComparer.Compare(key, last) > 0)
                             break;
                         return page;
                     case SliceOptions.BeforeAllKeys:

--- a/src/Voron/Data/BTrees/Tree.Extensions.cs
+++ b/src/Voron/Data/BTrees/Tree.Extensions.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Voron.Data.BTrees
+{
+    partial class Tree
+    {
+        public long Increment(string key, long delta)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            return Increment(keySlice, delta);
+        }
+
+        public long Increment( string key, long delta, ushort version)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            return Increment(keySlice, delta, version);
+        }
+
+        public void Add(string key, Stream value, ushort version)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            Add(keySlice, value, version);
+        }
+
+        public void Add(string key, Stream value)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            Add(keySlice, value);
+        }
+
+        public void Add(string key, MemoryStream value, ushort? version = null)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            Add(keySlice, value, version);
+        }
+
+        public void Add( string key, byte[] value, ushort version)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            var valueSlice = Slice.From(_llt.Allocator, value, Sparrow.ByteStringType.Immutable);
+
+            Add(keySlice, valueSlice, version);
+        }
+
+        public void Add(string key, byte[] value)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+
+            Add(keySlice, value);
+        }
+
+        public void Add(string key, string value, ushort? version = null)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            var valueSlice = Slice.From(_llt.Allocator, value, Sparrow.ByteStringType.Immutable);
+
+            Add(keySlice, valueSlice, version);
+        }
+
+        public unsafe byte* DirectAdd(string key, int len, TreeNodeFlags nodeType = TreeNodeFlags.Data, ushort? version = null)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            return DirectAdd(keySlice, len, nodeType, version);
+        }
+
+        public void Delete(string key)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            Delete(keySlice);
+        }
+
+        public void Delete(string key, ushort version)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            Delete(keySlice, version);
+        }
+
+        public ReadResult Read(string key)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            return Read(keySlice);
+        }
+
+        public ushort ReadVersion(string key)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            return ReadVersion(keySlice);
+        }
+
+
+        public void MultiAdd(string key, string value, ushort? version = null)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            var valueSlice = Slice.From(_llt.Allocator, value, Sparrow.ByteStringType.Immutable);
+            MultiAdd(keySlice, valueSlice, version);
+        }
+
+        public void MultiAdd(string key, Slice value, ushort? version = null)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            MultiAdd(keySlice, value, version);
+        }
+
+        public void MultiAdd(Slice key, string value, ushort? version = null)
+        {
+            var valueSlice = Slice.From(_llt.Allocator, value, Sparrow.ByteStringType.Immutable);
+            MultiAdd(key, valueSlice, version);
+        }
+
+        public void MultiDelete(string key, string value, ushort? version = null)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            var valueSlice = Slice.From(_llt.Allocator, value, Sparrow.ByteStringType.Immutable);
+            MultiDelete(keySlice, valueSlice, version);
+        }
+
+        public void MultiDelete(string key, Slice value, ushort? version = null)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            MultiDelete(keySlice, value, version);
+        }
+
+        public IIterator MultiRead(string key)
+        {
+            var keySlice = Slice.From(_llt.Allocator, key, Sparrow.ByteStringType.Immutable);
+            return MultiRead(keySlice);
+        }
+    }
+}

--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -29,9 +29,9 @@ namespace Voron.Data.BTrees
      * The actual values are stored as keys in a separate tree per key. In order to optimize
      * space usage, multi trees work in the following fashion.
      * 
-     * If the totale size of the values per key is less than NodeMaxSize, we store them as an embedded
+     * If the total size of the values per key is less than NodeMaxSize, we store them as an embedded
      * page inside the owning tree. If then are more than the node max size, we create a separate tree
-     * for them and then only store the tree root infromation.
+     * for them and then only store the tree root information.
      */
     public unsafe partial class Tree
     {

--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -39,7 +39,9 @@ namespace Voron.Data.BTrees
 
         public void MultiAdd(Slice key, Slice value, ushort? version = null)
         {
-            if (value == null) throw new ArgumentNullException(nameof(value));
+            if (!value.HasValue)
+                throw new ArgumentNullException(nameof(value));
+
             int maxNodeSize = Llt.DataPager.NodeMaxSize;
             if (value.Size > maxNodeSize)
                 throw new ArgumentException("Cannot add a value to child tree that is over " + maxNodeSize + " bytes in size", nameof(value));
@@ -75,7 +77,7 @@ namespace Voron.Data.BTrees
 
             var nestedPage = new TreePage(nestedPagePtr, "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, item));
 
-            var existingItem = nestedPage.Search(value);
+            var existingItem = nestedPage.Search(_llt, value);
             if (nestedPage.LastMatch != 0)
                 existingItem = null;// not an actual match, just greater than
 
@@ -85,9 +87,10 @@ namespace Voron.Data.BTrees
             if (existingItem != null)
             {
                 // maybe same value added twice?
-                var tmpKey = page.GetNodeKey(item);
-                if (tmpKey.Compare(value) == 0)
+                var tmpKey = TreeNodeHeader.ToSlicePtr(_llt.Allocator, item);
+                if (SliceComparer.Equals( tmpKey, value))
                     return; // already there, turning into a no-op
+
                 nestedPage.RemoveNode(nestedPage.LastSearchPosition);
             }
 
@@ -125,7 +128,7 @@ namespace Voron.Data.BTrees
             var tree = Create(_llt, _tx, TreeFlags.MultiValue);
             for (int i = 0; i < nestedPage.NumberOfEntries; i++)
             {
-                var existingValue = nestedPage.GetNodeKey(i);
+                var existingValue = nestedPage.GetNodeKey(_llt, i);
                 tree.DirectAdd(existingValue, 0);
             }
             tree.DirectAdd(value, 0, version: version);
@@ -155,16 +158,18 @@ namespace Voron.Data.BTrees
                     TreeFlags = TreePageFlags.Leaf,
                     PageNumber = -1L // mark as invalid page number
                 };
-            
-                Slice nodeKey = nestedPage.CreateNewEmptyKey();
+
+                var nodeKey = new Slice();
                 for (int i = 0; i < nestedPage.NumberOfEntries; i++)
                 {
                     var nodeHeader = nestedPage.GetNode(i);
-                    nestedPage.SetNodeKey(nodeHeader, ref nodeKey);
+
+                    nodeKey = TreeNodeHeader.ToSlicePtr(_tx.Allocator, nodeHeader, ByteStringType.Mutable);
+
                     newNestedPage.AddDataNode(i, nodeKey, 0, (ushort)(nodeHeader->Version - 1)); // we dec by one because AdddataNode will inc by one, and we don't want to change those values
                 }
 
-                newNestedPage.Search(value);
+                newNestedPage.Search(_llt, value);
                 newNestedPage.AddDataNode(newNestedPage.LastSearchPosition, value, 0, 0);
             }
         }
@@ -238,7 +243,7 @@ namespace Voron.Data.BTrees
             else // we use a nested page here
             {
                 var nestedPage = new TreePage(TreeNodeHeader.DirectAccess(_llt, item), "multi tree", (ushort)TreeNodeHeader.GetDataSize(_llt, item));
-                var nestedItem = nestedPage.Search(value);
+                var nestedItem = nestedPage.Search(_llt, value);
                 if (nestedPage.LastMatch != 0) // value not found
                     return;
 
@@ -269,11 +274,9 @@ namespace Voron.Data.BTrees
 
             Debug.Assert(node != null);
 
-            var fetchedNodeKey = page.GetNodeKey(node);
-            if (fetchedNodeKey.Compare(key) != 0)
-            {
+            var fetchedNodeKey = TreeNodeHeader.ToSlicePtr(_llt.Allocator, node);
+            if (!SliceComparer.EqualsInline(fetchedNodeKey,key))
                 throw new InvalidDataException("Was unable to retrieve the correct node. Data corruption possible");
-            }
 
             if (node->Flags == TreeNodeFlags.MultiValuePageRef)
             {
@@ -296,11 +299,9 @@ namespace Voron.Data.BTrees
 
             Debug.Assert(node != null);
 
-            var fetchedNodeKey = page.GetNodeKey(node);
-            if (fetchedNodeKey.Compare(key) != 0)
-            {
+            var fetchedNodeKey = TreeNodeHeader.ToSlicePtr(_llt.Allocator, node);
+            if (!SliceComparer.EqualsInline(fetchedNodeKey,key))
                 throw new InvalidDataException("Was unable to retrieve the correct node. Data corruption possible");
-            }
 
             if (node->Flags == TreeNodeFlags.MultiValuePageRef)
             {
@@ -314,11 +315,11 @@ namespace Voron.Data.BTrees
             if (allowWrites)
             {
                 ptr = DirectAdd(key, dataSize);//make sure that the memory we pass is writable
-                key = key.Clone(); // ensure that we won't have a key that is going to be modified
+                key = key.Clone(_tx.Allocator, ByteStringType.Immutable); // ensure that we won't have a key that is going to be modified
             }
             var nestedPage = new TreePage(ptr, "multi tree", dataSize);
                 
-            return new TreePageIterator(key ,this, nestedPage, allowWrites);
+            return new TreePageIterator(_tx.LowLevelTransaction, key ,this, nestedPage, allowWrites);
         }
 
         private Tree OpenMultiValueTree(Slice key, TreeNodeHeader* item)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -19,11 +19,7 @@ namespace Voron.Data.BTrees
         public event Action<long> PageModified;
         public event Action<long> PageFreed;
 
-        private RecentlyFoundTreePages _recentlyFoundPages;
-        public RecentlyFoundTreePages RecentlyFoundPages
-        {
-            get { return _recentlyFoundPages ?? (_recentlyFoundPages = new RecentlyFoundTreePages(_llt.Flags == TransactionFlags.Read ? 8 : 2)); }
-        }
+        private readonly RecentlyFoundTreePages _recentlyFoundPages;
 
         public string Name { get; set; }
 
@@ -44,6 +40,7 @@ namespace Voron.Data.BTrees
         {
             _llt = llt;
             _tx = tx;
+            _recentlyFoundPages = new RecentlyFoundTreePages(llt.Flags == TransactionFlags.Read ? 8 : 2);
             _state = new TreeMutableState(llt)
             {
                 RootPageNumber = root
@@ -54,6 +51,7 @@ namespace Voron.Data.BTrees
         {
             _llt = llt;
             _tx = tx;
+            _recentlyFoundPages = new RecentlyFoundTreePages(llt.Flags == TransactionFlags.Read ? 8 : 2);
             _state = new TreeMutableState(llt);
             _state = state;
         }
@@ -93,18 +91,6 @@ namespace Voron.Data.BTrees
             return tree;
         }
 
-        public void Add(Slice key, Stream value, ushort? version = null)
-        {
-            if (value == null) throw new ArgumentNullException(nameof(value));
-            if (value.Length > int.MaxValue)
-                throw new ArgumentException("Cannot add a value that is over 2GB in size", nameof(value));
-
-            State.IsModified = true;
-            var pos = DirectAdd(key, (int)value.Length, version: version);
-
-            CopyStreamToPointer(_llt, value, pos);
-        }
-
         /// <summary>
         /// This is using little endian
         /// </summary>
@@ -125,6 +111,18 @@ namespace Voron.Data.BTrees
             return value;
         }
 
+        public void Add(Slice key, Stream value, ushort? version = null)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            if (value.Length > int.MaxValue)
+                throw new ArgumentException("Cannot add a value that is over 2GB in size", nameof(value));
+
+            State.IsModified = true;
+            var pos = DirectAdd(key, (int)value.Length, version: version);
+
+            CopyStreamToPointer(_llt, value, pos);
+        }
+
         public void Add(Slice key, byte[] value, ushort? version = null)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));
@@ -140,7 +138,8 @@ namespace Voron.Data.BTrees
 
         public void Add(Slice key, Slice value, ushort? version = null)
         {
-            if (value == null) throw new ArgumentNullException(nameof(value));
+            if (!value.HasValue)
+                throw new ArgumentNullException(nameof(value));
 
             State.IsModified = true;
             var pos = DirectAdd(key, value.Size, version: version);
@@ -181,7 +180,7 @@ namespace Voron.Data.BTrees
                 throw new ArgumentException("Cannot add a value in a read only transaction");
 
             if (AbstractPager.IsKeySizeValid(key.Size) == false)
-                throw new ArgumentException($"Key size is too big, must be at most {AbstractPager.GetMaxKeySize()} bytes, but was {(key.Size + AbstractPager.RequiredSpaceForNewNode)}", nameof(key));
+                throw new ArgumentException($"Key size is too big, must be at most {AbstractPager.MaxKeySize} bytes, but was {(key.Size + AbstractPager.RequiredSpaceForNewNode)}", nameof(key));
 
             Func<TreeCursor> cursorConstructor;
             TreeNodeHeader* node;
@@ -193,9 +192,9 @@ namespace Voron.Data.BTrees
             bool? shouldGoToOverflowPage = null;
             if (page.LastMatch == 0) // this is an update operation
             {
-                node = page.GetNode(page.LastSearchPosition);
+                node = page.GetNode(page.LastSearchPosition);                
 
-                Debug.Assert(page.GetNodeKey(node).Equals(key));
+                Debug.Assert(SliceComparer.EqualsInline(TreeNodeHeader.ToSlicePtr(_llt.Allocator, node), key));
 
                 shouldGoToOverflowPage = ShouldGoToOverflowPage(len);
 
@@ -282,14 +281,11 @@ namespace Voron.Data.BTrees
 
         public TreePage ModifyPage(long pageNumber)
         {
-
             var newPage = _llt.ModifyPage(pageNumber).ToTreePage();
             newPage.Dirty = true;
-            RecentlyFoundPages.Reset(pageNumber);
+            _recentlyFoundPages.Reset(pageNumber);
 
-            var onPageModified = PageModified;
-            if (onPageModified != null)
-                onPageModified(pageNumber);
+            PageModified?.Invoke(pageNumber);
 
             return newPage;
         }
@@ -309,10 +305,7 @@ namespace Voron.Data.BTrees
 
             State.RecordNewPage(overflowPageStart, numberOfPages);
 
-
-            var onPageModified = PageModified;
-            if (onPageModified != null)
-                onPageModified(overflowPageStart.PageNumber);
+            PageModified?.Invoke(overflowPageStart.PageNumber);
 
             return overflowPageStart.PageNumber;
         }
@@ -393,7 +386,7 @@ namespace Voron.Data.BTrees
             return SearchForPage(key, out cursor, out node);
         }
 
-        private TreePage SearchForPage(Slice key, out TreeNodeHeader* node)
+        private TreePage SearchForPage(Slice key, out TreeNodeHeader* node) 
         {
             var p = _llt.GetReadOnlyTreePage(State.RootPageNumber);
 
@@ -406,19 +399,10 @@ namespace Voron.Data.BTrees
             while ((p.TreeFlags & TreePageFlags.Branch) == TreePageFlags.Branch)
             {
                 int nodePos;
-                if (key.Options == SliceOptions.BeforeAllKeys)
+
+                if ( key.Options == SliceOptions.Key)
                 {
-                    p.LastSearchPosition = nodePos = 0;
-                    rightmostPage = false;
-                }
-                else if (key.Options == SliceOptions.AfterAllKeys)
-                {
-                    p.LastSearchPosition = nodePos = (ushort)(p.NumberOfEntries - 1);
-                    leftmostPage = false;
-                }
-                else
-                {
-                    if (p.Search(key) != null)
+                    if (p.Search(_llt, key) != null)
                     {
                         nodePos = p.LastSearchPosition;
                         if (p.LastMatch != 0)
@@ -439,6 +423,16 @@ namespace Voron.Data.BTrees
                         leftmostPage = false;
                     }
                 }
+                else if (key.Options == SliceOptions.BeforeAllKeys)
+                {
+                    p.LastSearchPosition = nodePos = 0;
+                    rightmostPage = false;
+                }
+                else // if (key.Options == SliceOptions.AfterAllKeys)
+                {
+                    p.LastSearchPosition = nodePos = (ushort)(p.NumberOfEntries - 1);
+                    leftmostPage = false;
+                }
 
                 var pageNode = p.GetNode(nodePos);
                 p = _llt.GetReadOnlyTreePage(pageNode->PageNumber);
@@ -451,7 +445,7 @@ namespace Voron.Data.BTrees
             if (p.IsLeaf == false)
                 throw new InvalidDataException("Index points to a non leaf page");
 
-            node = p.Search(key); // will set the LastSearchPosition
+            node = p.Search(_llt, key); // will set the LastSearchPosition
 
             AddToRecentlyFoundPages(cursorPath, p, leftmostPage, rightmostPage);
 
@@ -483,7 +477,7 @@ namespace Voron.Data.BTrees
                 }
                 else
                 {
-                    if (p.Search(key) != null)
+                    if (p.Search(_llt, key) != null)
                     {
                         nodePos = p.LastSearchPosition;
                         if (p.LastMatch != 0)
@@ -518,7 +512,7 @@ namespace Voron.Data.BTrees
             if (p.IsLeaf == false)
                 throw new InvalidDataException("Index points to a non leaf page");
 
-            node = p.Search(key); // will set the LastSearchPosition
+            node = p.Search(_llt, key); // will set the LastSearchPosition
 
             AddToRecentlyFoundPages(cursor, p, leftmostPage, rightmostPage);
 
@@ -526,30 +520,32 @@ namespace Voron.Data.BTrees
         }
 
         private void AddToRecentlyFoundPages(List<long> c, TreePage p, bool leftmostPage, bool rightmostPage)
-        {
+        {            
             Slice firstKey;
             if (leftmostPage == true)
             {
-                firstKey = Slice.BeforeAllKeys;
+                firstKey = Slices.BeforeAllKeys;
             }
             else
             {
-                firstKey = p.GetNodeKey(0);
+                // We are going to store the slice, therefore we copy.
+                firstKey = p.GetNodeKey(_llt, 0, ByteStringType.Immutable);
             }
 
             Slice lastKey;
             if (rightmostPage == true)
             {
-                lastKey = Slice.AfterAllKeys;
+                lastKey = Slices.AfterAllKeys;
             }
             else
             {
-                lastKey = p.GetNodeKey(p.NumberOfEntries - 1);
+                // We are going to store the slice, therefore we copy.
+                lastKey = p.GetNodeKey(_llt, p.NumberOfEntries - 1, ByteStringType.Immutable);
             }
 
             var foundPage = new RecentlyFoundTreePages.FoundTreePage(p.PageNumber, p, firstKey, lastKey, c.ToArray());
 
-            RecentlyFoundPages.Add(foundPage);
+            _recentlyFoundPages.Add(foundPage);
         }
 
         private void AddToRecentlyFoundPages(TreeCursor c, TreePage p, bool leftmostPage, bool rightmostPage)
@@ -557,21 +553,23 @@ namespace Voron.Data.BTrees
             Slice firstKey;
             if (leftmostPage == true)
             {
-                firstKey = Slice.BeforeAllKeys;
+                firstKey = Slices.BeforeAllKeys;
             }
             else
             {
-                firstKey = p.GetNodeKey(0);
+                // We are going to store the slice, therefore we copy.
+                firstKey = p.GetNodeKey(_llt, 0, ByteStringType.Immutable);
             }
 
             Slice lastKey;
             if (rightmostPage == true)
             {
-                lastKey = Slice.AfterAllKeys;
+                lastKey = Slices.AfterAllKeys;
             }
             else
             {
-                lastKey = p.GetNodeKey(p.NumberOfEntries - 1);
+                // We are going to store the slice, therefore we copy.
+                lastKey = p.GetNodeKey(_llt, p.NumberOfEntries - 1, ByteStringType.Immutable);
             }
 
             var cursorPath = new long[c.Pages.Count];
@@ -586,7 +584,7 @@ namespace Voron.Data.BTrees
 
             var foundPage = new RecentlyFoundTreePages.FoundTreePage(p.PageNumber, p, firstKey, lastKey, cursorPath);
 
-            RecentlyFoundPages.Add(foundPage);
+            _recentlyFoundPages.Add(foundPage);
         }
 
         private bool TryUseRecentTransactionPage(Slice key, out TreePage page, out TreeNodeHeader* node)
@@ -594,7 +592,7 @@ namespace Voron.Data.BTrees
             node = null;
             page = null;
 
-            var recentPages = RecentlyFoundPages;
+            var recentPages = _recentlyFoundPages;
             if (recentPages == null)
                 return false;
 
@@ -616,7 +614,7 @@ namespace Voron.Data.BTrees
             if (page.IsLeaf == false)
                 throw new InvalidDataException("Index points to a non leaf page");
 
-            node = page.Search(key); // will set the LastSearchPosition
+            node = page.Search(_llt, key); // will set the LastSearchPosition
 
             return true;
         }
@@ -627,7 +625,7 @@ namespace Voron.Data.BTrees
             page = null;
             cursor = null;
 
-            var recentPages = RecentlyFoundPages;
+            var recentPages = _recentlyFoundPages;
             if (recentPages == null)
                 return false;
 
@@ -650,8 +648,8 @@ namespace Voron.Data.BTrees
 
             if (page.IsLeaf == false)
                 throw new InvalidDataException("Index points to a non leaf page");
-
-            node = page.Search(key); // will set the LastSearchPosition
+            
+            node = page.Search(_llt, key); // will set the LastSearchPosition
 
             var cursorPath = foundPage.CursorPath;
             var pageCopy = page;
@@ -668,7 +666,12 @@ namespace Voron.Data.BTrees
                     else
                     {
                         var cursorPage = _llt.GetReadOnlyTreePage(p);
-                        if (key.Options == SliceOptions.BeforeAllKeys)
+                        if (key.Options == SliceOptions.Key)
+                        {
+                            if (cursorPage.Search(_llt, key) != null && cursorPage.LastMatch != 0)
+                                cursorPage.LastSearchPosition--;
+                        }
+                        else if (key.Options == SliceOptions.BeforeAllKeys)
                         {
                             cursorPage.LastSearchPosition = 0;
                         }
@@ -676,13 +679,7 @@ namespace Voron.Data.BTrees
                         {
                             cursorPage.LastSearchPosition = (ushort)(cursorPage.NumberOfEntries - 1);
                         }
-                        else if (cursorPage.Search(key) != null)
-                        {
-                            if (cursorPage.LastMatch != 0)
-                            {
-                                cursorPage.LastSearchPosition--;
-                            }
-                        }
+                        else throw new ArgumentException();
 
                         c.Push(cursorPage);
                     }
@@ -698,9 +695,7 @@ namespace Voron.Data.BTrees
             var page = AllocateNewPage(_llt, flags, num);
             State.RecordNewPage(page, num);
 
-            var onPageModified = PageModified;
-            if (onPageModified != null)
-                onPageModified(page.PageNumber);
+            PageModified?.Invoke(page.PageNumber);
 
             return page;
         }
@@ -719,9 +714,8 @@ namespace Voron.Data.BTrees
 
         internal void FreePage(TreePage p)
         {
-            var onPageFreed = PageFreed;
-            if (onPageFreed != null)
-                onPageFreed(p.PageNumber);
+            PageFreed?.Invoke(p.PageNumber);
+
             if (p.IsOverflow)
             {
                 var numberOfPages = _llt.DataPager.GetNumberOfOverflowPages(p.OverflowSize);
@@ -778,7 +772,7 @@ namespace Voron.Data.BTrees
             return new TreeIterator(this, _llt);
         }
 
-        public ReadResult Read(Slice key)
+        public ReadResult Read(Slice key)       
         {
             TreeNodeHeader* node;
             var p = FindPageFor(key, out node);
@@ -790,13 +784,13 @@ namespace Voron.Data.BTrees
         }
 
         public int GetDataSize(Slice key)
-        {
+        {            
             TreeNodeHeader* node;
             var p = FindPageFor(key, out node);
             if (p == null || p.LastMatch != 0)
                 return -1;
 
-            if (node == null || p.GetNodeKey(node).Compare(key) != 0)
+            if (node == null || !SliceComparer.EqualsInline(TreeNodeHeader.ToSlicePtr(_llt.Allocator, node), key))
                 return -1;
 
             return TreeNodeHeader.GetDataSize(_llt, node);
@@ -806,7 +800,7 @@ namespace Voron.Data.BTrees
         {
             Func<TreeCursor> cursorConstructor;
             TreeNodeHeader* node;
-            var p = FindPageFor(page.IsLeaf ? page.GetNodeKey(0) : page.GetNodeKey(1), out node, out cursorConstructor);
+            var p = FindPageFor(page.IsLeaf ? page.GetNodeKey(_llt, 0) : page.GetNodeKey(_llt, 1), out node, out cursorConstructor);
             if (p == null || p.LastMatch != 0)
                 return -1;
 
@@ -835,7 +829,7 @@ namespace Voron.Data.BTrees
             if (p == null || p.LastMatch != 0)
                 return 0;
 
-            if (node == null || p.GetNodeKey(node).Compare(key) != 0)
+            if (node == null || !SliceComparer.EqualsInline(TreeNodeHeader.ToSlicePtr(_llt.Allocator, node),key))
                 return 0;
 
             return node->Version;
@@ -866,13 +860,12 @@ namespace Voron.Data.BTrees
             var root = _llt.GetReadOnlyTreePage(State.RootPageNumber);
             stack.Push(root);
 
+            Slice key = default(Slice);
             while (stack.Count > 0)
             {
                 var p = stack.Pop();
                 results.Add(p.PageNumber);
-
-                var key = p.CreateNewEmptyKey();
-
+                
                 for (int i = 0; i < p.NumberOfEntries; i++)
                 {
                     var node = p.GetNode(i);
@@ -891,8 +884,7 @@ namespace Voron.Data.BTrees
                     }
                     else if (node->Flags == TreeNodeFlags.MultiValuePageRef)
                     {
-                        // this is a multi value
-                        p.SetNodeKey(node, ref key);
+                        key = TreeNodeHeader.ToSlicePtr(_tx.Allocator, node, ByteStringType.Mutable);
                         var tree = OpenMultiValueTree(key, node);
                         results.AddRange(tree.AllPages());
                     }
@@ -903,9 +895,9 @@ namespace Voron.Data.BTrees
                             var valueReader = TreeNodeHeader.Reader(_llt, node);
                             var valueSize = ((FixedSizeTreeHeader.Embedded*)valueReader.Base)->ValueSize;
 
-                            var fixedSizeTreeName = p.GetNodeKey(i);
+                            var fixedSizeTreeName = p.GetNodeKey(_llt, i);
 
-                            var fixedSizeTree = new FixedSizeTree(_llt, this, (Slice)fixedSizeTreeName, valueSize);
+                            var fixedSizeTree = new FixedSizeTree(_llt, this, fixedSizeTreeName, valueSize);
 
                             var pages = fixedSizeTree.AllPages();
                             results.AddRange(pages);
@@ -982,9 +974,7 @@ namespace Voron.Data.BTrees
                     writtableOverflowPage.OverflowSize = len;
                     pos = writtableOverflowPage.Base + Constants.TreePageHeaderSize;
 
-                    var onPageModified = PageModified;
-                    if (onPageModified != null)
-                        onPageModified(writtableOverflowPage.PageNumber);
+                    PageModified?.Invoke(writtableOverflowPage.PageNumber);
 
                     return true;
                 }
@@ -997,9 +987,10 @@ namespace Voron.Data.BTrees
         {
             using (var it = Iterate())
             {
-                if (it.Seek(Slice.AfterAllKeys) == false)
-                    return null;
-                return it.CurrentKey.Clone();
+                if (it.Seek(Slices.AfterAllKeys) == false)
+                    return new Slice();
+
+                return it.CurrentKey.Clone(_tx.Allocator);
             }
         }
 
@@ -1007,9 +998,10 @@ namespace Voron.Data.BTrees
         {
             using (var it = Iterate())
             {
-                if (it.Seek(Slice.BeforeAllKeys) == false)
-                    return null;
-                return it.CurrentKey.Clone();
+                if (it.Seek(Slices.BeforeAllKeys) == false)
+                    return new Slice();
+
+                return it.CurrentKey.Clone(_tx.Allocator);
             }
         }
 
@@ -1027,7 +1019,8 @@ namespace Voron.Data.BTrees
             FixedSizeTree fixedTree;
             if (_fixedSizeTrees.TryGetValue(key, out fixedTree) == false)
             {
-                _fixedSizeTrees[key] = fixedTree = new FixedSizeTree(_llt, this, key, valSize);
+                var keySlice = Slice.From(_llt.Allocator, key, ByteStringType.Immutable);
+                _fixedSizeTrees[key] = fixedTree = new FixedSizeTree(_llt, this, keySlice, valSize);
             }
 
             State.Flags |= TreeFlags.FixedSizeTrees;

--- a/src/Voron/Data/BTrees/TreeIterator.cs
+++ b/src/Voron/Data/BTrees/TreeIterator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Sparrow;
+using System;
 using System.Collections.Generic;
 using Voron.Impl;
 
@@ -8,20 +9,20 @@ namespace Voron.Data.BTrees
     {
         private readonly Tree _tree;
         private readonly LowLevelTransaction _tx;
+
         private TreeCursor _cursor;
         private TreePage _currentPage;
-        private Slice _currentKey = new Slice(SliceOptions.Key);
-        private Slice _currentInternalKey;
         private bool _disposed;
 
         public event Action<IIterator> OnDisposal;
+
+        private Slice _currentKey = default(Slice);
+        private Slice _currentInternalKey = new Slice();
 
         public TreeIterator(Tree tree, LowLevelTransaction tx)
         {
             _tree = tree;
             _tx = tx;
-
-            _currentInternalKey = new Slice(SliceOptions.Key); 				
         }
 
         public int GetCurrentDataSize()
@@ -37,16 +38,17 @@ namespace Voron.Data.BTrees
                 throw new ObjectDisposedException("TreeIterator " + _tree.Name);
 
             TreeNodeHeader* node;
-            Func<TreeCursor> cursorConstructor;
-            _currentPage = _tree.FindPageFor(key, out node, out cursorConstructor);
-            _cursor = cursorConstructor();
+            Func<TreeCursor> constructor;
+            _currentPage = _tree.FindPageFor(key, out node, out constructor);
+            _cursor = constructor();
             _cursor.Pop();
 
             if (node != null)
             {
-                _currentPage.SetNodeKey(node, ref _currentInternalKey);
-                _currentKey = _currentInternalKey.ToSlice();
-                return this.ValidateCurrentKey(Current, _currentPage);
+                _currentInternalKey = TreeNodeHeader.ToSlicePtr(_tx.Allocator, node, ByteStringType.Mutable);
+                _currentKey = _currentInternalKey; // TODO: Check here if aliasing via pointer is the intended use.
+
+                return this.ValidateCurrentKey(_tx, Current);
             }
             
             // The key is not found in the db, but we are Seek()ing for equals or starts with.
@@ -120,11 +122,11 @@ namespace Voron.Data.BTrees
                         _currentPage.LastSearchPosition = _currentPage.NumberOfEntries - 1;
                     }
                     var current = _currentPage.GetNode(_currentPage.LastSearchPosition);
-                    if (this.ValidateCurrentKey(current, _currentPage) == false)
+                    if (this.ValidateCurrentKey(_tx, current) == false)
                         return false;
 
-                    _currentPage.SetNodeKey(current, ref _currentInternalKey);
-                    _currentKey = _currentInternalKey.ToSlice();
+                    _currentInternalKey = TreeNodeHeader.ToSlicePtr(_tx.Allocator, current, ByteStringType.Mutable);
+                    _currentKey = _currentInternalKey;
                     return true;// there is another entry in this page
                 }
                 if (_cursor.PageCount == 0)
@@ -155,11 +157,11 @@ namespace Voron.Data.BTrees
                         _currentPage.LastSearchPosition = 0;
                     }
                     var current = _currentPage.GetNode(_currentPage.LastSearchPosition);
-                    if (this.ValidateCurrentKey(current, _currentPage) == false)
+                    if (this.ValidateCurrentKey(_tx, current) == false)
                         return false;
 
-                    _currentPage.SetNodeKey(current, ref _currentInternalKey);
-                    _currentKey = _currentInternalKey.ToSlice();
+                    _currentInternalKey = TreeNodeHeader.ToSlicePtr(_tx.Allocator, current, ByteStringType.Mutable);
+                    _currentKey = _currentInternalKey;
                     return true;// there is another entry in this page
                 }
                 if (_cursor.PageCount == 0)
@@ -183,7 +185,7 @@ namespace Voron.Data.BTrees
                 }
             }
 
-            return _currentPage != null && this.ValidateCurrentKey(Current, _currentPage);
+            return _currentPage != null && this.ValidateCurrentKey(_tx, Current);
         }
 
         public ValueReader CreateReaderForCurrent()
@@ -214,28 +216,29 @@ namespace Voron.Data.BTrees
     public static class IteratorExtensions
     {
         public static IEnumerable<string> DumpValues(this IIterator self)
-        {
-            if (self.Seek(Slice.BeforeAllKeys) == false)
+        {                      
+            if (self.Seek(Slices.BeforeAllKeys) == false)
                 yield break;
 
             do
             {
                 yield return self.CurrentKey.ToString();
-            } while (self.MoveNext());
+            }
+            while (self.MoveNext());
         }
-
-        public unsafe static bool ValidateCurrentKey(this IIterator self, TreeNodeHeader* node, TreePage page)
+        
+        public unsafe static bool ValidateCurrentKey(this IIterator self, LowLevelTransaction tx, TreeNodeHeader* node)
         {
-            if (self.RequiredPrefix != null)
+            if (self.RequiredPrefix.HasValue)
             {
-                var currentKey = page.GetNodeKey(node);
-                if (currentKey.StartsWith(self.RequiredPrefix) == false)
+                var currentKey = TreeNodeHeader.ToSlicePtr(tx.Allocator, node);
+                if (SliceComparer.StartWith(currentKey, self.RequiredPrefix) == false)
                     return false;
             }
-            if (self.MaxKey != null)
+            if (self.MaxKey.HasValue)
             {
-                var currentKey = page.GetNodeKey(node);
-                if (currentKey.Compare(self.MaxKey) >= 0)
+                var currentKey = TreeNodeHeader.ToSlicePtr(tx.Allocator, node);
+                if (SliceComparer.CompareInline(currentKey, self.MaxKey) >= 0)
                     return false;
             }
             return true;

--- a/src/Voron/Data/BTrees/TreeNodeHeader.cs
+++ b/src/Voron/Data/BTrees/TreeNodeHeader.cs
@@ -36,13 +36,13 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Slice ToSlice(ByteStringContext context, TreeNodeHeader* node, ByteStringType type = ByteStringType.Mutable)
         {
-            return new Slice(SliceOptions.Key, context.From((byte*)node + Constants.NodeHeaderSize, node->KeySize, type));
+            return new Slice(context.From((byte*)node + Constants.NodeHeaderSize, node->KeySize, type | (ByteStringType)SliceOptions.Key));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Slice ToSlicePtr(ByteStringContext context, TreeNodeHeader* node, ByteStringType type = ByteStringType.Mutable)
         {
-            return new Slice(SliceOptions.Key, context.FromPtr((byte*)node + Constants.NodeHeaderSize, node->KeySize, type));
+            return new Slice(context.FromPtr((byte*)node + Constants.NodeHeaderSize, node->KeySize, type | (ByteStringType)SliceOptions.Key));
         }
 
         public static byte* DirectAccess(LowLevelTransaction tx, TreeNodeHeader* node)

--- a/src/Voron/Data/BTrees/TreeNodeHeader.cs
+++ b/src/Voron/Data/BTrees/TreeNodeHeader.cs
@@ -7,65 +7,79 @@ using Voron.Impl;
 
 namespace Voron.Data.BTrees
 {
-	[StructLayout(LayoutKind.Explicit, Pack = 1)]
-	public unsafe struct  TreeNodeHeader
-	{
-		[FieldOffset(0)]
-		public int DataSize;
+    [StructLayout(LayoutKind.Explicit, Pack = 1)]
+    public unsafe struct TreeNodeHeader
+    {
+        static readonly int _nodeTypeSize = Constants.NodeHeaderSize + Constants.NodeOffsetSize;
 
-		[FieldOffset(0)]
-		public long PageNumber;
+        [FieldOffset(0)]
+        public int DataSize;
 
-		[FieldOffset(8)]
-		public TreeNodeFlags Flags;
+        [FieldOffset(0)]
+        public long PageNumber;
 
-		[FieldOffset(9)]
-		public ushort KeySize;
+        [FieldOffset(8)]
+        public TreeNodeFlags Flags;
 
-		[FieldOffset(11)]
-		public ushort Version;
+        [FieldOffset(9)]
+        public ushort KeySize;
+
+        [FieldOffset(11)]
+        public ushort Version;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public int GetNodeSize()
-		{
-			return Constants.NodeHeaderSize + KeySize + Constants.NodeOffsetSize + (Flags == (TreeNodeFlags.PageRef) ? 0 : DataSize);
-		}
+        public int GetNodeSize()
+        {
+            return _nodeTypeSize + KeySize  + (Flags == (TreeNodeFlags.PageRef) ? 0 : DataSize);
+        }
 
-		public static byte* DirectAccess(LowLevelTransaction tx, TreeNodeHeader* node)
-		{
-			if (node->Flags == (TreeNodeFlags.PageRef))
-			{
-				var overFlowPage = tx.GetReadOnlyTreePage(node->PageNumber);
-				return overFlowPage.Base + Constants.TreePageHeaderSize;
-			}
-			return (byte*) node + node->KeySize + Constants.NodeHeaderSize;
-		}
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Slice ToSlice(ByteStringContext context, TreeNodeHeader* node, ByteStringType type = ByteStringType.Mutable)
+        {
+            return new Slice(SliceOptions.Key, context.From((byte*)node + Constants.NodeHeaderSize, node->KeySize, type));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Slice ToSlicePtr(ByteStringContext context, TreeNodeHeader* node, ByteStringType type = ByteStringType.Mutable)
+        {
+            return new Slice(SliceOptions.Key, context.FromPtr((byte*)node + Constants.NodeHeaderSize, node->KeySize, type));
+        }
+
+        public static byte* DirectAccess(LowLevelTransaction tx, TreeNodeHeader* node)
+        {
+            if (node->Flags == (TreeNodeFlags.PageRef))
+            {
+                var overFlowPage = tx.GetReadOnlyTreePage(node->PageNumber);
+                return overFlowPage.Base + Constants.TreePageHeaderSize;
+            }
+            return (byte*) node + node->KeySize + Constants.NodeHeaderSize;
+        }
 
         public static ValueReader Reader(LowLevelTransaction tx, TreeNodeHeader* node)
-		{
-			if (node->Flags == (TreeNodeFlags.PageRef))
-			{
-				var overFlowPage = tx.GetPage(node->PageNumber);
+        {
+            if (node->Flags == (TreeNodeFlags.PageRef))
+            {
+                var overFlowPage = tx.GetPage(node->PageNumber);
 
-				Debug.Assert(overFlowPage.IsOverflow, "Requested oveflow page but got " + overFlowPage.Flags);
-				Debug.Assert(overFlowPage.OverflowSize > 0, "Overflow page cannot be size equal 0 bytes");
+                Debug.Assert(overFlowPage.IsOverflow, "Requested overflow page but got " + overFlowPage.Flags);
+                Debug.Assert(overFlowPage.OverflowSize > 0, "Overflow page cannot be size equal 0 bytes");
 
                 return new ValueReader(overFlowPage.Pointer + Constants.TreePageHeaderSize, overFlowPage.OverflowSize);
-			}
+            }
             return new ValueReader((byte*)node + node->KeySize + Constants.NodeHeaderSize, node->DataSize);
-		}
+        }
 
-	    public static Slice GetData(LowLevelTransaction tx, TreeNodeHeader* node)
-	    {
+        public static Slice GetData(LowLevelTransaction tx, TreeNodeHeader* node)
+        {
             if (node->Flags == (TreeNodeFlags.PageRef))
             {
                 var overFlowPage = tx.GetPage(node->PageNumber);
                 if (overFlowPage.OverflowSize > ushort.MaxValue)
                     throw new InvalidOperationException("Cannot convert big data to a slice, too big");
-                return new Slice(overFlowPage.Pointer + Constants.TreePageHeaderSize, (ushort)overFlowPage.OverflowSize);
+                return Slice.External(tx.Allocator, overFlowPage.Pointer + Constants.TreePageHeaderSize, (ushort)overFlowPage.OverflowSize, ByteStringType.Immutable);
             }
-            return new Slice((byte*)node + node->KeySize + Constants.NodeHeaderSize, (ushort) node->DataSize);
-	    }
+            return Slice.External(tx.Allocator, (byte*)node + node->KeySize + Constants.NodeHeaderSize, (ushort) node->DataSize);
+        }
 
 
         public static void CopyTo(LowLevelTransaction tx, TreeNodeHeader* node, byte* dest)
@@ -78,14 +92,14 @@ namespace Voron.Data.BTrees
             Memory.Copy(dest, (byte*)node + node->KeySize + Constants.NodeHeaderSize, node->DataSize);
         }
 
-		public static int GetDataSize(LowLevelTransaction tx, TreeNodeHeader* node)
-		{
-			if (node->Flags == (TreeNodeFlags.PageRef))
-			{
-				var overFlowPage = tx.GetPage(node->PageNumber);
-				return overFlowPage.OverflowSize;
-			}
-			return node->DataSize;
-		}
-	}
+        public static int GetDataSize(LowLevelTransaction tx, TreeNodeHeader* node)
+        {
+            if (node->Flags == (TreeNodeFlags.PageRef))
+            {
+                var overFlowPage = tx.GetPage(node->PageNumber);
+                return overFlowPage.OverflowSize;
+            }
+            return node->DataSize;
+        }
+    }
 }

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -124,7 +124,8 @@ namespace Voron.Data.BTrees
 
                             LastMatch = SliceComparer.CompareInline(key, pageKey);
 
-                            pageKey.ReleaseExternal(allocator); // Ensure we will reuse the external reference.
+                            // Ensure we will reuse the external reference improving memory locality.
+                            pageKey.ReleaseExternal(allocator); 
 
                             if (LastMatch == 0)
                                 break;

--- a/src/Voron/Data/BTrees/TreePageIterator.cs
+++ b/src/Voron/Data/BTrees/TreePageIterator.cs
@@ -9,17 +9,19 @@ namespace Voron.Data.BTrees
         private readonly Tree _parent;
         private readonly TreePage _page;
         private readonly bool _allowWritable;
-        private Slice _currentKey = new Slice(SliceOptions.Key);
-        private Slice _currentInternalKey;
+        private readonly LowLevelTransaction _tx;
+
+        private Slice _currentInternalKey = default(Slice);    
+        private Slice _currentKey = default(Slice);
         private bool _disposed;
 
-        public TreePageIterator(Slice treeKey, Tree parent, TreePage page, bool allowWritable)
+        public TreePageIterator(LowLevelTransaction tx, Slice treeKey, Tree parent, TreePage page, bool allowWritable)
         {
+            _tx = tx;
             _treeKey = treeKey;
             _parent = parent;
             _page = page;
-            _allowWritable = allowWritable;
-            _currentInternalKey = page.CreateNewEmptyKey();
+            _allowWritable = allowWritable;          
         }
 
         public void Dispose()
@@ -33,14 +35,15 @@ namespace Voron.Data.BTrees
         {
             if(_disposed)
                 throw new ObjectDisposedException("PageIterator");
-            var current = _page.Search(key);
+
+            var current = _page.Search(_tx, key);
             if (current == null)
                 return false;
 
-            _page.SetNodeKey(current, ref _currentInternalKey);
-            _currentKey = _currentInternalKey.ToSlice();
+            _currentInternalKey = TreeNodeHeader.ToSlicePtr(_tx.Allocator, current);
+            _currentKey = _currentInternalKey;
 
-            return this.ValidateCurrentKey(current, _page);
+            return this.ValidateCurrentKey(_tx, current);
         }
 
         public TreeNodeHeader* Current
@@ -110,12 +113,13 @@ namespace Voron.Data.BTrees
                 return false;
 
             var current = _page.GetNode(_page.LastSearchPosition);
-            if (this.ValidateCurrentKey(current, _page) == false)
+            if (this.ValidateCurrentKey(_tx, current) == false)
             {
                 return false;
             }
-            _page.SetNodeKey(current, ref _currentInternalKey);
-            _currentKey = _currentInternalKey.ToSlice();
+
+            _currentInternalKey = TreeNodeHeader.ToSlicePtr(_tx.Allocator, current);
+            _currentKey = _currentInternalKey;
             return true;
         }
 

--- a/src/Voron/Data/BTrees/TreePageSplitter.cs
+++ b/src/Voron/Data/BTrees/TreePageSplitter.cs
@@ -64,7 +64,7 @@ namespace Voron.Data.BTrees
                     _tree.State.Depth++;
 
                     // now add implicit left page
-                    newRootPage.AddPageRefNode(0, Slice.BeforeAllKeys, _page.PageNumber);
+                    newRootPage.AddPageRefNode(0, Slices.BeforeAllKeys, _page.PageNumber);
                     _parentPage = newRootPage;
                     _parentPage.LastSearchPosition++;
                 }
@@ -99,10 +99,10 @@ namespace Voron.Data.BTrees
 
                             TreeNodeHeader* node = _page.GetNode(_page.NumberOfEntries - 1);
                             Debug.Assert(node->Flags == TreeNodeFlags.PageRef);
-                            rightPage.AddPageRefNode(0, Slice.BeforeAllKeys, node->PageNumber);
+                            rightPage.AddPageRefNode(0, Slices.BeforeAllKeys, node->PageNumber);
                             pos = AddNodeToPage(rightPage, 1);
 
-                            var separatorKey = _page.GetNodeKey(node);
+                            var separatorKey = TreeNodeHeader.ToSlicePtr(_tx.Allocator, node);
 
                             AddSeparatorToParentPage(rightPage.PageNumber, separatorKey, out branchOfSeparator);
 
@@ -132,9 +132,9 @@ namespace Voron.Data.BTrees
             }
         }
 
-        private byte* AddNodeToPage(TreePage page, int index, Slice alreadyPreparedNewKey = null)
+        private byte* AddNodeToPage(TreePage page, int index, Slice alreadyPreparedNewKey = default(Slice))
         {
-            var newKeyToInsert = alreadyPreparedNewKey ?? _newKey;
+            var newKeyToInsert = alreadyPreparedNewKey.HasValue ? alreadyPreparedNewKey : _newKey;
 
             switch (_nodeType)
             {
@@ -180,12 +180,12 @@ namespace Voron.Data.BTrees
                 splitIndex = AdjustSplitPosition(currentIndex, splitIndex, ref toRight);
             }
 
-            var currentKey = _page.GetNodeKey(splitIndex);
-            Slice seperatorKey;
+            var currentKey = _page.GetNodeKey(_tx, splitIndex);
 
+            Slice seperatorKey;
             if (toRight && splitIndex == currentIndex)
             {
-                seperatorKey = currentKey.Compare(_newKey) < 0 ? currentKey : _newKey;
+                seperatorKey = SliceComparer.Compare(currentKey, _newKey) < 0 ? currentKey : _newKey;
             }
             else
             {
@@ -197,29 +197,27 @@ namespace Voron.Data.BTrees
 
             var parentOfPage = _cursor.CurrentPage;
 
-            Slice instance = _page.CreateNewEmptyKey();
-
             bool addedAsImplicitRef = false;
-
-            if (_page.IsBranch && toRight && seperatorKey.Equals(_newKey))
+            if (_page.IsBranch && toRight && SliceComparer.EqualsInline(seperatorKey, _newKey))
             {
                 // _newKey needs to be inserted as first key (BeforeAllKeys) to the right page, so we need to add it before we move entries from the current page
-                AddNodeToPage(rightPage, 0, Slice.BeforeAllKeys);
+                AddNodeToPage(rightPage, 0, Slices.BeforeAllKeys);
                 addedAsImplicitRef = true;
             }
 
             // move the actual entries from page to right page
+            var instance = new Slice();
             ushort nKeys = _page.NumberOfEntries;
             for (int i = splitIndex; i < nKeys; i++)
             {
                 TreeNodeHeader* node = _page.GetNode(i);
                 if (_page.IsBranch && rightPage.NumberOfEntries == 0)
                 {
-                    rightPage.CopyNodeDataToEndOfPage(node, Slice.BeforeAllKeys);
+                    rightPage.CopyNodeDataToEndOfPage(node, Slices.BeforeAllKeys);
                 }
                 else
                 {
-                    _page.SetNodeKey(node, ref instance);
+                    instance = TreeNodeHeader.ToSlicePtr(_tx.Allocator, node);
                     rightPage.CopyNodeDataToEndOfPage(node, instance);
                 }
             }
@@ -302,7 +300,7 @@ namespace Voron.Data.BTrees
 
         private byte* InsertNewKey(TreePage p)
         {
-            int pos = p.NodePositionFor(_newKey);
+            int pos = p.NodePositionFor(_tx, _newKey);
 
             var newKeyToInsert = _newKey;
 
@@ -384,7 +382,7 @@ namespace Voron.Data.BTrees
 
             debugInfo.AppendFormat("\r\n_tree.Name: {0}\r\n", _tree.Name);
             debugInfo.AppendFormat("_newKey: {0}, _len: {1}, needed space: {2}\r\n", _newKey, _len, _page.GetRequiredSpace(_newKey, _len));
-            debugInfo.AppendFormat("key at LastSearchPosition: {0}, current key: {1}, seperatorKey: {2}\r\n", _page.GetNodeKey(_page.LastSearchPosition), currentKey, seperatorKey);
+            debugInfo.AppendFormat("key at LastSearchPosition: {0}, current key: {1}, seperatorKey: {2}\r\n", _page.GetNodeKey(_tx, _page.LastSearchPosition), currentKey, seperatorKey);
             debugInfo.AppendFormat("currentIndex: {0}\r\n", currentIndex);
             debugInfo.AppendFormat("splitIndex: {0}\r\n", splitIndex);
             debugInfo.AppendFormat("toRight: {0}\r\n", toRight);
@@ -394,7 +392,7 @@ namespace Voron.Data.BTrees
             for (int i = 0; i < _page.NumberOfEntries; i++)
             {
                 var node = _page.GetNode(i);
-                var key = _page.GetNodeKey(node);
+                var key = TreeNodeHeader.ToSlicePtr(_tx.Allocator, node);
                 debugInfo.AppendFormat("{0} - {2} {1}\r\n", key,
                     node->DataSize, node->Flags == TreeNodeFlags.Data ? "Size" : "Page");
             }
@@ -404,7 +402,7 @@ namespace Voron.Data.BTrees
             for (int i = 0; i < rightPage.NumberOfEntries; i++)
             {
                 var node = rightPage.GetNode(i);
-                var key = rightPage.GetNodeKey(node);
+                var key = TreeNodeHeader.ToSlicePtr(_tx.Allocator, node);
                 debugInfo.AppendFormat("{0} - {2} {1}\r\n", key,
                     node->DataSize, node->Flags == TreeNodeFlags.Data ? "Size" : "Page");
             }

--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -73,8 +73,7 @@ namespace Voron.Data.BTrees
                 }
 
                 var minKeys = page.IsBranch ? 2 : 1;
-                if ((page.UseMoreSizeThan(_tx.DataPager.PageMinSpace)) &&
-                    page.NumberOfEntries >= minKeys)
+                if ((page.UseMoreSizeThan(_tx.DataPager.PageMinSpace)) && page.NumberOfEntries >= minKeys)
                     return null; // above space/keys thresholds
 
                 Debug.Assert(parentPage.NumberOfEntries >= 2); // if we have less than 2 entries in the parent, the tree is invalid
@@ -279,7 +278,7 @@ namespace Voron.Data.BTrees
 
                 if (implicitLeftNode == actualKeyNode)
                 {
-                    implicitLeftKeyToInsert = new Slice(actualKeyNode);
+                    implicitLeftKeyToInsert = TreeNodeHeader.ToSlicePtr(_tx.Allocator, actualKeyNode);
                 }
                 else
                 {
@@ -332,13 +331,13 @@ namespace Voron.Data.BTrees
         private Slice GetActualKey(TreePage page, int pos, out TreeNodeHeader* node)
         {
             node = page.GetNode(pos);
-            var key = page.GetNodeKey(node);
-            while (key.KeyLength == 0)
+            var key = TreeNodeHeader.ToSlicePtr(_tx.Allocator, node);
+            while (key.Size == 0)
             {
                 Debug.Assert(page.IsBranch);
                 page = _tx.GetReadOnlyTreePage(node->PageNumber);
                 node = page.GetNode(0);
-                key = page.GetNodeKey(node);
+                key = TreeNodeHeader.ToSlicePtr(_tx.Allocator, node);
             }
 
             return key;

--- a/src/Voron/Data/BTrees/TreeSizeOf.cs
+++ b/src/Voron/Data/BTrees/TreeSizeOf.cs
@@ -69,7 +69,7 @@ namespace Voron.Impl
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int NodeEntryWithAnotherKey(TreeNodeHeader* other, Slice key)
         {
-            var keySize = key == null ? other->KeySize : key.Size;
+            var keySize = key.HasValue ? key.Size : other->KeySize;
             var sz = keySize + Constants.NodeHeaderSize;
             if (other->Flags == TreeNodeFlags.Data || other->Flags == TreeNodeFlags.MultiValuePageRef)
                 sz += other->DataSize;

--- a/src/Voron/Data/EmptyIterator.cs
+++ b/src/Voron/Data/EmptyIterator.cs
@@ -72,7 +72,9 @@ namespace Voron.Data
 
         public void Dispose()
         {
-            OnDisposal?.Invoke(this);
+            var action = OnDisposal;
+            if (action != null)
+                action(this);
         }
     }
 }

--- a/src/Voron/Data/IIterator.cs
+++ b/src/Voron/Data/IIterator.cs
@@ -4,16 +4,18 @@ namespace Voron.Data
 {
     public interface IIterator : IDisposable
     {
-        bool Seek(Slice key);
         Slice CurrentKey { get; }
-        int GetCurrentDataSize();
         Slice RequiredPrefix { get; set; }
         Slice MaxKey { get; set; }
+
+        bool Seek(Slice key);
         bool MoveNext();
         bool MovePrev();
         bool DeleteCurrentAndMoveNext();
         bool Skip(int count);
+
         ValueReader CreateReaderForCurrent();
+        int GetCurrentDataSize();
 
         event Action<IIterator> OnDisposal;
     }

--- a/src/Voron/Data/RawData/RawDataSection.cs
+++ b/src/Voron/Data/RawData/RawDataSection.cs
@@ -178,8 +178,9 @@ namespace Voron.Data.RawData
 
         public static byte* DirectRead(LowLevelTransaction tx, long id, out int size)
         {
-            var posInPage = (int)(id % tx.DataPager.PageSize);
-            var pageNumberInSection = (id - posInPage) / tx.DataPager.PageSize;
+            int pageSize = tx.DataPager.PageSize;
+            var posInPage = (int)(id % pageSize);
+            var pageNumberInSection = (id - posInPage) / pageSize;
             var pageHeader = PageHeaderFor(tx, pageNumberInSection);
 
             if (posInPage >= pageHeader->NextAllocation)

--- a/src/Voron/Data/RawData/RawDataSection.cs
+++ b/src/Voron/Data/RawData/RawDataSection.cs
@@ -11,11 +11,15 @@ namespace Voron.Data.RawData
     public unsafe class RawDataSection
     {
         protected const ushort ReservedHeaderSpace = 96;
+
         private readonly HashSet<long> _dirtyPages = new HashSet<long>();
-        protected readonly int _pageSize;
+
         protected readonly LowLevelTransaction _tx;
+        protected readonly int _pageSize;
+
         public readonly int MaxItemSize;
-        protected RawDataSmallSectionPageHeader* _sectionHeader;
+                
+        protected RawDataSmallSectionPageHeader* _sectionHeader;        
 
         [StructLayout(LayoutKind.Sequential)]
         public struct RawDataEntrySizes
@@ -27,7 +31,7 @@ namespace Voron.Data.RawData
         public RawDataSection(LowLevelTransaction tx, long pageNumber)
         {
             PageNumber = pageNumber;
-            _tx = tx;
+            _tx = tx;         
             _pageSize = _tx.DataPager.PageSize;
 
             MaxItemSize = (_pageSize - sizeof(RawDataSmallPageHeader)) / 2;
@@ -178,9 +182,8 @@ namespace Voron.Data.RawData
 
         public static byte* DirectRead(LowLevelTransaction tx, long id, out int size)
         {
-            int pageSize = tx.DataPager.PageSize;
-            var posInPage = (int)(id % pageSize);
-            var pageNumberInSection = (id - posInPage) / pageSize;
+            var posInPage = (int)(id % tx.PageSize);
+            var pageNumberInSection = (id - posInPage) / tx.PageSize;
             var pageHeader = PageHeaderFor(tx, pageNumberInSection);
 
             if (posInPage >= pageHeader->NextAllocation)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -25,7 +25,7 @@ namespace Voron.Data.Tables
         private readonly int _pageSize;      
 
         private Dictionary<Slice, Tree> _treesBySliceCache;
-        private readonly Dictionary<Slice, Dictionary<Slice, FixedSizeTree>> _fixedSizeTreeCache = new Dictionary<Slice, Dictionary<Slice, FixedSizeTree>>();
+        private readonly Dictionary<Slice, Dictionary<Slice, FixedSizeTree>> _fixedSizeTreeCache = new Dictionary<Slice, Dictionary<Slice, FixedSizeTree>>(SliceComparer.Instance);
 
         public readonly string Name;
 
@@ -47,7 +47,7 @@ namespace Voron.Data.Tables
             get
             {
                 if (_inactiveSections == null)
-                    _inactiveSections = GetFixedSizeTree(_tableTree, TableSchema.InactiveSectionSlice, 0);
+                    _inactiveSections = GetFixedSizeTree(_tableTree, TableSchema.InactiveSection, 0);
 
                 return _inactiveSections;
             }
@@ -71,7 +71,7 @@ namespace Voron.Data.Tables
             {
                 if (_activeDataSmallSection == null)
                 {
-                    var readResult = _tableTree.Read(TableSchema.ActiveSectionSlice);
+                    var readResult = _tableTree.Read(TableSchema.ActiveSection);
                     if (readResult == null)
                         throw new InvalidDataException($"Could not find active sections for {Name}");
 
@@ -102,7 +102,7 @@ namespace Voron.Data.Tables
             if (_tableTree == null)
                 throw new InvalidDataException($"Cannot find collection name {name}");
 
-            var stats = (TableSchemaStats*)_tableTree.DirectRead(TableSchema.StatsSlice);
+            var stats = (TableSchemaStats*)_tableTree.DirectRead(TableSchema.Stats);
             if (stats == null)
                 throw new InvalidDataException($"Cannot find stats value for table {name}");
 
@@ -121,7 +121,6 @@ namespace Voron.Data.Tables
             _tx = tx;
             _pageSize = _tx.LowLevelTransaction.DataPager.PageSize;
         }
-
 
         public TableValueReader ReadByKey(Slice key)
         {
@@ -226,7 +225,7 @@ namespace Voron.Data.Tables
             if (ptr == null)
                 return;
 
-            var stats = (TableSchemaStats*)_tableTree.DirectAdd(TableSchema.StatsSlice, sizeof(TableSchemaStats));
+            var stats = (TableSchemaStats*)_tableTree.DirectAdd(TableSchema.Stats, sizeof(TableSchemaStats));
             NumberOfEntries--;
             stats->NumberOfEntries = NumberOfEntries;
 
@@ -287,7 +286,7 @@ namespace Voron.Data.Tables
             //TODO: Avoid all those allocations by using a single buffer
             if (_schema.Key != null)
             {
-                var keySlice = _schema.Key.GetSlice(value);
+                var keySlice = _schema.Key.GetSlice(_tx.Allocator, value);
 
                 var pkTree = GetTree(_schema.Key);
                 pkTree.Delete(keySlice);
@@ -297,8 +296,8 @@ namespace Voron.Data.Tables
             {
                 // For now we wont create secondary indexes on Compact trees.
                 var indexTree = GetTree(indexDef);
-                var val = indexDef.GetSlice(value);
-                var fst = GetFixedSizeTree(indexTree, val, 0);
+                var val = indexDef.GetSlice(_tx.Allocator, value);
+                var fst = GetFixedSizeTree(indexTree, val.Clone(_tx.Allocator), 0);
                 fst.Delete(id);
             }
 
@@ -312,7 +311,7 @@ namespace Voron.Data.Tables
 
         public long Insert(TableValueBuilder builder)
         {
-            var stats = (TableSchemaStats*)_tableTree.DirectAdd(TableSchema.StatsSlice, sizeof(TableSchemaStats));
+            var stats = (TableSchemaStats*)_tableTree.DirectAdd(TableSchema.Stats, sizeof(TableSchemaStats));
             NumberOfEntries++;
             stats->NumberOfEntries = NumberOfEntries;
 
@@ -351,22 +350,23 @@ namespace Voron.Data.Tables
         }
 
         private void InsertIndexValuesFor(long id, TableValueReader value)
-        {          
-            if (_schema.Key != null)
+        {
+            var pk = _schema.Key;
+            if (pk != null)
             {
-                var pkval = _schema.Key.GetSlice(value);
+                var pkval = pk.GetSlice(_tx.Allocator, value);
 
-                var pk = _schema.Key;
-                var pkIndex = GetTree(_schema.Key);
-                pkIndex.Add(pkval, new Slice((byte*)&id, sizeof(long)));                      
+                var pkIndex = GetTree(pk);
+
+                pkIndex.Add(pkval, Slice.External(_tx.Allocator, (byte*)&id, sizeof(long), ByteStringType.Immutable));                      
             }
 
             foreach (var indexDef in _schema.Indexes.Values)
             {
                 // For now we wont create secondary indexes on Compact trees.
-                var val = indexDef.GetSlice(value);
+                var val = indexDef.GetSlice(_tx.Allocator, value);
                 var indexTree = GetTree(indexDef);
-                var index = GetFixedSizeTree(indexTree, val, 0);
+                var index = GetFixedSizeTree(indexTree, val.Clone(_tx.Allocator), 0);
                 index.Add(id);
             }
 
@@ -374,7 +374,7 @@ namespace Voron.Data.Tables
             {
                 var index = GetFixedSizeTree(indexDef);
                 long key = indexDef.GetValue(value);
-                index.Add(key, new Slice((byte*)&id, sizeof(long)));
+                index.Add(key, Slice.External(_tx.Allocator, (byte*)&id, sizeof(long)));
             }
         }
 
@@ -390,16 +390,17 @@ namespace Voron.Data.Tables
         private FixedSizeTree GetFixedSizeTree(Tree parent, Slice name, ushort valSize)
         {
             Dictionary<Slice, FixedSizeTree> cache;
-            var parentName = parent.Name ?? Constants.RootTreeName;
+
+            var parentName = Slice.From( _tx.Allocator, parent.Name ?? Constants.RootTreeName, ByteStringType.Immutable);            
             if (_fixedSizeTreeCache.TryGetValue(parentName, out cache) == false)
             {
-                _fixedSizeTreeCache[parentName] = cache = new Dictionary<Slice, FixedSizeTree>();
+                _fixedSizeTreeCache[parentName] = cache = new Dictionary<Slice, FixedSizeTree>(SliceComparer.Instance);
             }
             
             FixedSizeTree tree;
             if (cache.TryGetValue(name, out tree) == false)
             {
-                Slice treeName = name.Clone();
+                var treeName = name.Clone(_tx.Allocator);
                 var fixedSizeTree = new FixedSizeTree(_tx.LowLevelTransaction, parent, treeName, valSize);
                 return cache[fixedSizeTree.Name] = fixedSizeTree;
             }
@@ -434,7 +435,9 @@ namespace Voron.Data.Tables
                 }
 
                 _activeDataSmallSection = ActiveRawDataSmallSection.Create(_tx.LowLevelTransaction, Name);
-                _tableTree.Add(TableSchema.ActiveSectionSlice, EndianBitConverter.Little.GetBytes(_activeDataSmallSection.PageNumber));
+
+                var pageNumber = Slice.From(_tx.Allocator, EndianBitConverter.Little.GetBytes(_activeDataSmallSection.PageNumber), ByteStringType.Immutable);
+                _tableTree.Add(TableSchema.ActiveSection, pageNumber);
 
                 var allocationResult = _activeDataSmallSection.TryAllocate(size, out id);
 
@@ -446,7 +449,7 @@ namespace Voron.Data.Tables
         internal Tree GetTree(Slice name)
         {
             if (_treesBySliceCache == null)
-                _treesBySliceCache = new Dictionary<Slice, Tree>();
+                _treesBySliceCache = new Dictionary<Slice, Tree>(SliceComparer.Instance);
 
             Tree tree;
             if (_treesBySliceCache.TryGetValue(name, out tree))
@@ -468,7 +471,7 @@ namespace Voron.Data.Tables
             return GetTree(idx.NameAsSlice);
         }
 
-        public void DeleteByKey(Slice key)
+         public void DeleteByKey(Slice key)
         {
             var pk = _schema.Key;
             var pkTree = GetTree(_schema.Key);
@@ -516,13 +519,18 @@ namespace Voron.Data.Tables
             public IEnumerable<TableValueReader> Results;
         }
 
+        public IEnumerable<SeekResult> SeekForwardFrom(TableSchema.SchemaIndexDef index, string value, bool startsWith = false)
+        {            
+            return SeekForwardFrom(index, Slice.From(_tx.Allocator, value, ByteStringType.Immutable), startsWith);
+        }
+
         public IEnumerable<SeekResult> SeekForwardFrom(TableSchema.SchemaIndexDef index, Slice value, bool startsWith = false)
         {
             var tree = GetTree(index);
             using (var it = tree.Iterate())
             {
                 if (startsWith)
-                    it.RequiredPrefix = value;
+                    it.RequiredPrefix = value.Clone(_tx.Allocator);
 
                 if (it.Seek(value) == false)
                     yield break;
@@ -532,7 +540,7 @@ namespace Voron.Data.Tables
                     yield return new SeekResult
                     {
                         Key = it.CurrentKey,
-                        Results = GetSecondaryIndexForValue(tree, it.CurrentKey)
+                        Results = GetSecondaryIndexForValue(tree, it.CurrentKey.Clone(_tx.Allocator))
                     };
                 } while (it.MoveNext());
             }
@@ -561,7 +569,7 @@ namespace Voron.Data.Tables
             var tree = GetTree(pk);
             using (var it = tree.Iterate())
             {
-                if (it.Seek(Slice.AfterAllKeys) == false)
+                if (it.Seek(Slices.AfterAllKeys) == false)
                     return null;
 
                 return GetTableValueReader(it);
@@ -627,7 +635,7 @@ namespace Voron.Data.Tables
             var read = builder.Read(_schema.Key.StartIndex, out size);
 
             long id;
-            if (TryFindIdFromPrimaryKey(new Slice(read, (ushort)size), out id))
+            if (TryFindIdFromPrimaryKey(Slice.External(_tx.Allocator, read, (ushort)size, ByteStringType.Immutable), out id))
             {
                 id = Update(id, builder);
                 return id;
@@ -679,7 +687,7 @@ namespace Voron.Data.Tables
 
                 do
                 {
-                    var fst = GetFixedSizeTree(tree, it.CurrentKey, 0);
+                    var fst = GetFixedSizeTree(tree, it.CurrentKey.Clone(_tx.Allocator), 0);
                     using (var fstIt = fst.Iterate())
                     {
                         if (fstIt.Seek(long.MinValue) == false)

--- a/src/Voron/Data/Tables/TableSchema.cs
+++ b/src/Voron/Data/Tables/TableSchema.cs
@@ -1,3 +1,4 @@
+using Sparrow;
 using System;
 using System.Collections.Generic;
 using Voron.Data.BTrees;
@@ -14,12 +15,12 @@ namespace Voron.Data.Tables
         BTree = 0x01,
     }
 
-    public unsafe class TableSchema
+    public unsafe class TableSchema : IDisposable
     {
-        public static readonly Slice ActiveSectionSlice = "Active-Section";
-        public static readonly Slice InactiveSectionSlice = "Inactive-Section";
-        public static readonly Slice ActiveCandidateSection = "Active-Candidate-Section";
-        public static readonly Slice StatsSlice = "Stats";
+        public static readonly Slice ActiveSection = Slice.From(StorageEnvironment.LabelsContext, "Active-Section", ByteStringType.Immutable);
+        public static readonly Slice InactiveSection = Slice.From(StorageEnvironment.LabelsContext, "Inactive-Section", ByteStringType.Immutable);
+        public static readonly Slice ActiveCandidateSection = Slice.From(StorageEnvironment.LabelsContext, "Active-Candidate-Section", ByteStringType.Immutable);
+        public static readonly Slice Stats = Slice.From(StorageEnvironment.LabelsContext, "Stats", ByteStringType.Immutable);
 
         public SchemaIndexDef Key => _pk;
 
@@ -42,7 +43,7 @@ namespace Voron.Data.Tables
 
             public bool IsGlobal;                        
 
-            public Slice GetSlice(TableValueReader value)
+            public Slice GetSlice(ByteStringContext context, TableValueReader value)
             {
                 int totalSize;
                 var ptr = value.Read(StartIndex, out totalSize);
@@ -66,7 +67,7 @@ namespace Voron.Data.Tables
                 if (totalSize > ushort.MaxValue)
                     throw new ArgumentOutOfRangeException(nameof(totalSize), "Reading a slice that too big to be a slice");
 #endif
-                return new Slice(ptr, (ushort)totalSize);
+                return Slice.External(context, ptr, (ushort)totalSize);
             }
         }
 
@@ -93,7 +94,7 @@ namespace Voron.Data.Tables
 
         public TableSchema DefineIndex(string name, SchemaIndexDef index)
         {
-            index.NameAsSlice = name;
+            index.NameAsSlice = Slice.From(StorageEnvironment.LabelsContext, name, ByteStringType.Immutable);
             _indexes[name] = index;
 
             return this;
@@ -102,7 +103,7 @@ namespace Voron.Data.Tables
 
         public TableSchema DefineFixedSizeIndex(string name, FixedSizeSchemaIndexDef index)
         {
-            index.NameAsSlice = name;
+            index.NameAsSlice = Slice.From(StorageEnvironment.LabelsContext, name, ByteStringType.Immutable); ;
             _fixedSizeIndexes[name] = index;
 
             return this;
@@ -116,7 +117,7 @@ namespace Voron.Data.Tables
 
             if (string.IsNullOrWhiteSpace(_pk.Name))
                 _pk.Name = "PK";
-            _pk.NameAsSlice = _pk.Name;
+            _pk.NameAsSlice = Slice.From(StorageEnvironment.LabelsContext, _pk.Name, ByteStringType.Immutable);
 
             if (_pk.Count > 1)
                 throw new InvalidOperationException("Primary key must be a single field");
@@ -147,8 +148,11 @@ namespace Voron.Data.Tables
                 return; // this was already created
 
             var rawDataActiveSection = ActiveRawDataSmallSection.Create(tx.LowLevelTransaction, name);
-            tableTree.Add(ActiveSectionSlice, EndianBitConverter.Little.GetBytes(rawDataActiveSection.PageNumber));
-            var stats = (TableSchemaStats*)tableTree.DirectAdd(StatsSlice, sizeof(TableSchemaStats));
+
+            Slice pageNumber = Slice.From(tx.Allocator, EndianBitConverter.Little.GetBytes(rawDataActiveSection.PageNumber), ByteStringType.Immutable);
+            tableTree.Add(ActiveSection, pageNumber);
+            
+            var stats = (TableSchemaStats*)tableTree.DirectAdd(Stats, sizeof(TableSchemaStats));
             stats->NumberOfEntries = 0;
 
             if (_pk != null)
@@ -179,5 +183,35 @@ namespace Voron.Data.Tables
                 }
             }
         }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // We will release all the labels allocated for indexes.
+                    foreach ( var item in _indexes )
+                        item.Value.NameAsSlice.Release(StorageEnvironment.LabelsContext);
+
+                    // We will release all the labels allocated for fixed size indexes.
+                    foreach (var item in _fixedSizeIndexes)
+                        item.Value.NameAsSlice.Release(StorageEnvironment.LabelsContext);
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+        #endregion
     }
 }

--- a/src/Voron/Debugging/DebugStuff.cs
+++ b/src/Voron/Debugging/DebugStuff.cs
@@ -284,15 +284,14 @@ namespace Voron.Debugging
             for (int i = 0; i < page.NumberOfEntries; i++)
             {
                 var nodeHeader = page.GetNode(i);
+                var key = TreeNodeHeader.ToSlicePtr(tx.Allocator, nodeHeader).ToString();
+
                 if (page.IsLeaf)
-                {
-                    var key = new Slice(nodeHeader).ToString();
+                {               
                     sw.Write("<li>{0} {1} - size: {2:#,#}</li>", key, nodeHeader->Flags, TreeNodeHeader.GetDataSize(tx, nodeHeader));
                 }
                 else
                 {
-                    var key = new Slice(nodeHeader).ToString();
-
                     var pageNum = nodeHeader->PageNumber;
 
                     if (i == 0)

--- a/src/Voron/Impl/Constants.cs
+++ b/src/Voron/Impl/Constants.cs
@@ -37,11 +37,11 @@ namespace Voron.Impl
 
         public static readonly int NodeHeaderSize = sizeof(TreeNodeHeader);
 
-        public static int PageNumberSize = sizeof(long);
+        public const int PageNumberSize = sizeof(long);
 
-        public static int NodeOffsetSize = sizeof(ushort);
+        public const int NodeOffsetSize = sizeof(ushort);
 
-        public static ushort SizeOfUInt = sizeof(uint);
+        public const ushort SizeOfUInt = sizeof(uint);
 
         public const int CurrentVersion = 5;
 

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -80,16 +80,16 @@ namespace Voron.Impl.FreeSpace
             }
             return -1;
         }
-
+        
 
         // Code taken from http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogDeBruijn
-
         private static readonly int[] MultiplyDeBruijnBitPosition = 
             {
                 0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30,
                 8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31
             };
 
+        // TODO: Remove and use the version that is in Sparrow.
         private static int HighestBitSet(int v)
         {
 
@@ -180,9 +180,9 @@ namespace Voron.Impl.FreeSpace
             return tmpBuffer;
         }
 
-        public Slice ToSlice()
+        public Slice ToSlice(ByteStringContext context, ByteStringType type = ByteStringType.Mutable)
         {
-            return new Slice(ToBuffer());
+            return new Slice(context.From(ToBuffer(), type));
         }
     }
 }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -76,6 +76,8 @@ namespace Voron.Impl
             get { return _id; }
         }
 
+        public readonly int PageSize;
+
         public bool Committed { get; private set; }
 
         public bool RolledBack { get; private set; }
@@ -97,7 +99,7 @@ namespace Voron.Impl
 
         public LowLevelTransaction(StorageEnvironment env, long id, TransactionFlags flags, IFreeSpaceHandling freeSpaceHandling, ByteStringContext context = null )
         {
-            _dataPager = env.Options.DataPager;
+            _dataPager = env.Options.DataPager;            
             _pageSize = this.DataPager.PageSize;
             _env = env;
             _journal = env.Journal;
@@ -106,6 +108,7 @@ namespace Voron.Impl
             _allocator = context ?? new ByteStringContext();
 
             Flags = flags;
+            PageSize = _dataPager.PageSize;
 
             var scratchPagerStates = env.ScratchBufferPool.GetPagerStatesOfAllScratches();
             foreach (var scratchPagerState in scratchPagerStates.Values)

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -20,6 +20,7 @@ namespace Voron.Impl
     {
         private const int PagesTakenByHeader = 1;
         private readonly IVirtualPager _dataPager;
+        private readonly long _pageSize;
         private readonly StorageEnvironment _env;
         private readonly long _id;
         private readonly ByteStringContext _allocator;
@@ -30,10 +31,13 @@ namespace Voron.Impl
         public Tree RootObjects => _root;
 
         private readonly WriteAheadJournal _journal;
+
         private readonly HashSet<long> _dirtyPages = new HashSet<long>(NumericEqualityComparer.Instance);
         private readonly Dictionary<long, long> _dirtyOverflowPages = new Dictionary<long, long>(NumericEqualityComparer.Instance);
         private readonly HashSet<PagerState> _pagerStates = new HashSet<PagerState>();
+
         readonly Stack<long> _pagesToFreeOnCommit = new Stack<long>();
+
         private readonly IFreeSpaceHandling _freeSpaceHandling;
 
         private int _allocatedPagesInTransaction;
@@ -94,6 +98,7 @@ namespace Voron.Impl
         public LowLevelTransaction(StorageEnvironment env, long id, TransactionFlags flags, IFreeSpaceHandling freeSpaceHandling, ByteStringContext context = null )
         {
             _dataPager = env.Options.DataPager;
+            _pageSize = this.DataPager.PageSize;
             _env = env;
             _journal = env.Journal;
             _id = id;
@@ -242,8 +247,8 @@ namespace Voron.Impl
         {	        
             if (_disposed)
                 throw new ObjectDisposedException("Transaction");
-            Page p;
 
+            Page p;
             PageFromScratchBuffer value;
             if (_scratchPagesTable.TryGetValue(pageNumber, out value))
             {
@@ -290,14 +295,13 @@ namespace Voron.Impl
 
         private Page AllocateOverflowPage(long headerSize, long dataSize, long? pageNumber = null)
         {
-            long pageSize = this.DataPager.PageSize;
             long overflowSize = headerSize + dataSize;
             if (overflowSize > int.MaxValue - 1)
                 throw new InvalidOperationException($"Cannot allocate chunks bigger than { int.MaxValue / 1024 * 1024 } Mb.");
 
             Debug.Assert(overflowSize >= 0);
 
-            long numberOfPages = (overflowSize / pageSize) + (overflowSize % pageSize == 0 ? 0 : 1);
+            long numberOfPages = (overflowSize / _pageSize) + (overflowSize % _pageSize == 0 ? 0 : 1);
 
             var overflowPage = AllocatePage((int)numberOfPages, pageNumber);
             overflowPage.Flags = PageFlags.Overflow;
@@ -570,14 +574,18 @@ namespace Voron.Impl
             return this;
         }
 
+        private PagerState _lastState;
 
         internal void EnsurePagerStateReference(PagerState state)
         {
-            if (state == null)
+            if (state == _lastState || state == null)
                 return;
 
             if (_pagerStates.Add(state))
+            {
                 state.AddRef();
+                _lastState = state;
+            }
         }
     }
 }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -22,6 +22,7 @@ namespace Voron.Impl
         private readonly IVirtualPager _dataPager;
         private readonly StorageEnvironment _env;
         private readonly long _id;
+        private readonly ByteStringContext _allocator;
         private Tree _root;
 
         public bool FlushedToJournal { get; private set; }
@@ -80,21 +81,28 @@ namespace Voron.Impl
             get { return _state; }
         }
 
+        public ByteStringContext Allocator
+        {
+            get { return _allocator; }
+        }
+
         public ulong Hash
         {
             get { return _txHeader->Hash; }
         }
 
-        public LowLevelTransaction(StorageEnvironment env, long id, TransactionFlags flags, IFreeSpaceHandling freeSpaceHandling)
+        public LowLevelTransaction(StorageEnvironment env, long id, TransactionFlags flags, IFreeSpaceHandling freeSpaceHandling, ByteStringContext context = null )
         {
             _dataPager = env.Options.DataPager;
             _env = env;
             _journal = env.Journal;
             _id = id;
             _freeSpaceHandling = freeSpaceHandling;
-            Flags = flags;
-            var scratchPagerStates = env.ScratchBufferPool.GetPagerStatesOfAllScratches();
+            _allocator = context ?? new ByteStringContext();
 
+            Flags = flags;
+
+            var scratchPagerStates = env.ScratchBufferPool.GetPagerStatesOfAllScratches();
             foreach (var scratchPagerState in scratchPagerStates.Values)
             {
                 scratchPagerState.AddRef();

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -245,20 +245,15 @@ namespace Voron.Impl.Paging
                 GetSourceName());
         }
 
-        public abstract void ReleaseAllocationInfo(byte* baseAddress, long size);
+        public abstract void ReleaseAllocationInfo(byte* baseAddress, long size);        
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetMaxKeySize()
-        {
-            // NodeMaxSize - RequiredSpaceForNewNode for 4Kb page is 2038, so we drop this by a bit
-            return 2038;
-        }
+        // NodeMaxSize - RequiredSpaceForNewNode for 4Kb page is 2038, so we drop this by a bit
+        public static readonly int MaxKeySize = 2038 - RequiredSpaceForNewNode;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsKeySizeValid(int keySize)
-        {
-           
-            if (keySize + RequiredSpaceForNewNode > GetMaxKeySize())
+        {           
+            if (keySize > MaxKeySize)
                 return false;
 
             return true;

--- a/src/Voron/Impl/Paging/FragmentedPureMemoryPager.cs
+++ b/src/Voron/Impl/Paging/FragmentedPureMemoryPager.cs
@@ -29,7 +29,7 @@ namespace Voron.Impl.Paging
             foreach (var buffer in _buffers)
             {
                 if (page + buffer.SizeInPages > pageNumber)
-                    return buffer.Pointer + ((pageNumber - page)*PageSize);
+                    return buffer.Pointer + ((pageNumber - page)* _pageSize);
 
                 page += buffer.SizeInPages;
             }

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -24,13 +24,14 @@ namespace Voron.Impl.Scratch
         }
 
         private readonly IVirtualPager _scratchPager;
+        private readonly int _pageSize;
         private readonly int _scratchNumber;
 
         private readonly SortedList<long, long> _freePagesByTransaction = new SortedList<long, long>(NumericDescendingComparer.Instance);
-        private readonly Dictionary<long, LinkedList<PendingPage>> _freePagesBySize = new Dictionary<long, LinkedList<PendingPage>>();
-        private readonly Dictionary<long, LinkedList<long>> _freePagesBySizeAvailableImmediately = new Dictionary<long, LinkedList<long>>();
-        private readonly Dictionary<long, PageFromScratchBuffer> _allocatedPages = new Dictionary<long, PageFromScratchBuffer>();
-        
+        private readonly Dictionary<long, LinkedList<PendingPage>> _freePagesBySize = new Dictionary<long, LinkedList<PendingPage>>(NumericEqualityComparer.Instance);
+        private readonly Dictionary<long, LinkedList<long>> _freePagesBySizeAvailableImmediately = new Dictionary<long, LinkedList<long>>(NumericEqualityComparer.Instance);
+        private readonly Dictionary<long, PageFromScratchBuffer> _allocatedPages = new Dictionary<long, PageFromScratchBuffer>(NumericEqualityComparer.Instance);
+
 
         private long _allocatedPagesUsedSize;
         private long _lastUsedPage;
@@ -40,6 +41,7 @@ namespace Voron.Impl.Scratch
             _scratchPager = scratchPager;
             _scratchNumber = scratchNumber;
             _allocatedPagesUsedSize = 0;
+            _pageSize = scratchPager.PageSize;
         }
 
         public PagerState PagerState => _scratchPager.PagerState;
@@ -48,11 +50,11 @@ namespace Voron.Impl.Scratch
 
         public int NumberOfAllocations => _allocatedPages.Count;
 
-        public long Size => _scratchPager.NumberOfAllocatedPages * _scratchPager.PageSize;
+        public long Size => _scratchPager.NumberOfAllocatedPages * _pageSize;
 
         public long SizeAfterAllocation(long sizeToAllocate)
         {
-            return (_lastUsedPage + sizeToAllocate) * _scratchPager.PageSize;
+            return (_lastUsedPage + sizeToAllocate) * _pageSize;
         }
 
         public PageFromScratchBuffer Allocate(LowLevelTransaction tx, int numberOfPages, int sizeToAllocate)
@@ -223,7 +225,7 @@ namespace Voron.Impl.Scratch
                 result += values[i];
             }
 
-            return result * _scratchPager.PageSize;
+            return result * _pageSize;
         }
 
         internal Dictionary<long, long> GetMostAvailableFreePagesBySize()

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Sparrow;
+using System;
 using System.Collections.Generic;
 
 using Voron.Data;
@@ -25,13 +26,20 @@ namespace Voron.Impl
             _lowLevelTransaction = lowLevelTransaction;
         }
 
+        public ByteStringContext Allocator
+        {
+            get { return _lowLevelTransaction.Allocator; }
+        }
+
         public Tree ReadTree(string treeName)
         {
             Tree tree;
             if (_trees.TryGetValue(treeName, out tree))
                 return tree;
 
-            var header = (TreeRootHeader*)_lowLevelTransaction.RootObjects.DirectRead((Slice)treeName);
+            Slice treeNameSlice = Slice.From(this.Allocator, treeName, ByteStringType.Immutable);
+
+            var header = (TreeRootHeader*)_lowLevelTransaction.RootObjects.DirectRead(treeNameSlice);
             if (header != null)
             {
                 if (header->RootObjectType != RootObjectType.VariableSizeTree)
@@ -90,7 +98,7 @@ namespace Voron.Impl
                 var treeState = tree.State;
                 if (treeState.IsModified)
                 {
-                    var treePtr = (TreeRootHeader*)_lowLevelTransaction.RootObjects.DirectAdd((Slice)tree.Name, sizeof(TreeRootHeader));
+                    var treePtr = (TreeRootHeader*)_lowLevelTransaction.RootObjects.DirectAdd(tree.Name, sizeof(TreeRootHeader));
                     treeState.CopyTo(treePtr);
                 }
             }
@@ -107,7 +115,7 @@ namespace Voron.Impl
             if (_multiValueTrees == null)
                 _multiValueTrees = new Dictionary<Tuple<Tree, Slice>, Tree>(new TreeAndSliceComparer());
             mvTree.IsMultiValueTree = true;
-            _multiValueTrees.Add(Tuple.Create(tree, key.Clone()), mvTree);
+            _multiValueTrees.Add(Tuple.Create(tree, key.Clone(_lowLevelTransaction.Allocator, ByteStringType.Immutable)), mvTree);
         }
 
         internal bool TryGetMultiValueTree(Tree tree, Slice key, out Tree mvTree)
@@ -154,7 +162,7 @@ namespace Voron.Impl
                 _lowLevelTransaction.FreePage(page);
             }
 
-            _lowLevelTransaction.RootObjects.Delete((Slice)name);
+            _lowLevelTransaction.RootObjects.Delete(name);
 
             _trees.Remove(name);
         }
@@ -174,9 +182,9 @@ namespace Voron.Impl
             if (fromTree == null)
                 throw new ArgumentException("Tree " + fromName + " does not exists");
 
-            Slice key = (Slice)toName;
+            Slice key = Slice.From(this.Allocator, toName, ByteStringType.Immutable);
 
-            _lowLevelTransaction.RootObjects.Delete((Slice)fromName);
+            _lowLevelTransaction.RootObjects.Delete(fromName);
             var ptr = _lowLevelTransaction.RootObjects.DirectAdd(key, sizeof(TreeRootHeader));
             fromTree.State.CopyTo((TreeRootHeader*)ptr);
             fromTree.Name = toName;
@@ -197,7 +205,7 @@ namespace Voron.Impl
             if (_lowLevelTransaction.Flags == (TransactionFlags.ReadWrite) == false)
                 throw new InvalidOperationException("No such tree: '" + name + "' and cannot create trees in read transactions");
 
-            Slice key = name;
+            Slice key = Slice.From(this.Allocator, name, ByteStringType.Immutable);
 
             tree = Tree.Create(_lowLevelTransaction, this);
             tree.Name = name;
@@ -218,17 +226,14 @@ namespace Voron.Impl
 
         public FixedSizeTree FixedTreeFor(Slice treeName)
         {
-            var valueSize = FixedSizeTree.GetValueSize(LowLevelTransaction, LowLevelTransaction.RootObjects,
-                treeName);
+            var valueSize = FixedSizeTree.GetValueSize(LowLevelTransaction, LowLevelTransaction.RootObjects, treeName);
             return FixedTreeFor(treeName, valueSize);
         }
-
 
         public FixedSizeTree FixedTreeFor(Slice treeName, ushort valSize)
         {
             return new FixedSizeTree(LowLevelTransaction, LowLevelTransaction.RootObjects, treeName, valSize);
         }
-
 
         public RootObjectType GetRootObjectType(Slice name)
         {

--- a/src/Voron/Impl/TreeAndSliceComparer.cs
+++ b/src/Voron/Impl/TreeAndSliceComparer.cs
@@ -16,7 +16,7 @@ namespace Voron.Impl
             if (x.Item1 != y.Item1)
                 return false;
 
-            return x.Item2.Compare(y.Item2) == 0;
+            return SliceComparer.Equals(x.Item2, y.Item2);
         }
 
         public int GetHashCode(Tuple<Tree, Slice> obj)

--- a/src/Voron/Platform/Posix/PosixMemoryMapPager.cs
+++ b/src/Voron/Platform/Posix/PosixMemoryMapPager.cs
@@ -56,7 +56,7 @@ namespace Voron.Platform.Posix
                 PosixHelper.ThrowLastError(err);
             }
 
-            NumberOfAllocatedPages = _totalAllocationSize / PageSize;
+            NumberOfAllocatedPages = _totalAllocationSize / _pageSize;
             PagerState.Release();
             PagerState = CreatePagerState();
         }
@@ -123,7 +123,7 @@ namespace Voron.Platform.Posix
             tmp.Release(); //replacing the pager state --> so one less reference for it
 
             _totalAllocationSize += allocationSize;
-            NumberOfAllocatedPages = _totalAllocationSize/PageSize;
+            NumberOfAllocatedPages = _totalAllocationSize/ _pageSize;
 
             return newPagerState;
         }

--- a/src/Voron/Platform/Posix/PosixTempMemoryMapPager.cs
+++ b/src/Voron/Platform/Posix/PosixTempMemoryMapPager.cs
@@ -51,7 +51,7 @@ namespace Voron.Platform.Posix
             _totalAllocationSize = NearestSizeToPageSize(initialFileSize ?? _totalAllocationSize);
             PosixHelper.AllocateFileSpace(_fd, (ulong)_totalAllocationSize);
 
-            NumberOfAllocatedPages = _totalAllocationSize / PageSize;
+            NumberOfAllocatedPages = _totalAllocationSize / _pageSize;
             PagerState.Release();
             PagerState = CreatePagerState();
         }
@@ -105,7 +105,7 @@ namespace Voron.Platform.Posix
             PagerState = newPagerState;
             tmp.Release(); //replacing the pager state --> so one less reference for it
 
-            NumberOfAllocatedPages = _totalAllocationSize / PageSize;
+            NumberOfAllocatedPages = _totalAllocationSize / _pageSize;
 
             return newPagerState;
         }

--- a/src/Voron/Platform/Win32/Win32MemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/Win32MemoryMapPager.cs
@@ -91,7 +91,7 @@ namespace Voron.Platform.Win32
                 _totalAllocationSize = fileLength;
             }
 
-            NumberOfAllocatedPages = _totalAllocationSize / PageSize;
+            NumberOfAllocatedPages = _totalAllocationSize / _pageSize;
             PagerState.Release();
             PagerState = CreatePagerState();
         }
@@ -131,7 +131,7 @@ namespace Voron.Platform.Win32
             }
 
             _totalAllocationSize += allocationSize;
-            NumberOfAllocatedPages = _totalAllocationSize / PageSize;
+            NumberOfAllocatedPages = _totalAllocationSize / _pageSize;
 
             return newPagerState;
         }

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -4,171 +4,27 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using Voron.Data.BTrees;
-using Voron.Impl;
-using Voron.Util.Conversion;
 
 namespace Voron
 {
-    public sealed unsafe class Slice 
-    {        
-        public static Slice AfterAllKeys = new Slice(SliceOptions.AfterAllKeys);
-        public static Slice BeforeAllKeys = new Slice(SliceOptions.BeforeAllKeys);
-        public static Slice Empty = new Slice(new byte[0]);
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct Slice
+    {
+        public ByteString Content;
 
-        internal byte[] Array;
-        internal byte* Pointer;
-
-        public ushort Size;
-        public ushort KeyLength;
-        public SliceOptions Options;
-
-        private Slice()
-        { }
-
-        public Slice(SliceOptions options)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Slice(SliceOptions options, ByteString content)
         {
-            this.Options = options;
+            this.Content = content;
+            Content.SetUserDefinedFlags((ByteStringType)options);               
         }
 
-        private Slice(SliceOptions options, ushort size)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Slice(ByteString content)
         {
-            this.Options = options;
-            this.Size = size;
-            this.KeyLength = size;
+            this.Content = content;
         }
 
-        private Slice(SliceOptions options, ushort size, ushort keyLength)
-        {
-            this.Options = options;
-            this.Size = size;
-            this.KeyLength = keyLength;
-        }
-
-        public bool Equals(Slice other)
-        {
-            return Compare(other) == 0;
-        }
-
-        public Slice(byte* key, ushort size) 
-            : this( SliceOptions.Key, size, size )
-        {
-            this.Pointer = key;
-        }
-
-        public Slice(byte[] key)
-            : this(SliceOptions.Key, (ushort)key.Length)
-        {
-            this.Array = key;
-        }
-
-        public Slice(Slice other, ushort size) 
-            : this(other.Options, size, size )
-        {
-            Array = other.Array;
-            Pointer = other.Pointer;
-        }
-
-        public Slice(byte[] key, ushort size) 
-            : this(SliceOptions.Key, size, size )
-        {
-            Debug.Assert(key != null);
-            Array = key;
-        }
-
-        public Slice(TreeNodeHeader* node)
-        {
-            Options = SliceOptions.Key;
-            SetInline(this, node);
-        }
-
-        public Slice(string key) //todo: fix allocation
-            : this(Encoding.UTF8.GetBytes(key))
-        { }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((Slice)obj);
-        }
-
-        public override int GetHashCode()
-        {
-            // Given how the size of slices can vary it is better to lose a bit (10%) on smaller slices 
-            // (less than 20 bytes) and to win big on the bigger ones. 
-            //
-            // After 24 bytes the gain is 10%
-            // After 64 bytes the gain is 2x
-            // After 128 bytes the gain is 4x.
-            //
-            // We should control the distribution of this over time. 
-            if (Array != null)
-            {
-                fixed (byte* arrayPtr = Array)
-                {
-                    return (int)Hashing.XXHash32.CalculateInline(arrayPtr, Size);
-                }
-            }
-            return (int)Hashing.XXHash32.CalculateInline(Pointer, Size);
-        }
-
-        public byte this[int index]
-        {
-            get
-            {
-                if (Array != null)
-                    return Array[index];
-
-                if(Pointer == null) //precaution
-                    throw new InvalidOperationException("Uninitialized slice!");
-
-                if(index < 0 || index > Size)
-                    throw new ArgumentOutOfRangeException(nameof(index));
-
-                return *(Pointer + (sizeof (byte)*index));
-            }
-        }
-
-        public override string ToString()
-        {
-            // this is used for debug purposes only
-            if (Options != SliceOptions.Key)
-                return Options.ToString();
-
-            if (Size == sizeof (long) && Debugger.IsAttached)
-            {
-                if (Array != null)
-                {
-                    if (Array[0] == 0)
-                        return "I64 = " + EndianBitConverter.Big.ToInt64(Array, 0);
-                }
-                else if (*Pointer == 0)
-                {
-                    var bytes = new byte[sizeof (long)];
-                    CopyTo(bytes);
-                    return "I64 = " + EndianBitConverter.Big.ToInt64(bytes, 0);
-                }
-            }
-
-            if (Array != null)
-            {
-                if (Array.Length > 0 && Array[0] == 0)
-                {
-                    return ByteArrayToHexViaLookup32(Array);
-                }
-                return Encoding.UTF8.GetString(Array, 0, Size);
-            }
-            if (Size > 0 && Pointer[0] == 0)
-            {
-                return BytePointerToHexViaLookup32(Pointer, Size);
-            }
-            var temp = new byte[Size];
-            CopyTo(temp);
-            return Encoding.UTF8.GetString(temp, 0, Size);
-
-        }
 
         private static readonly uint[] _lookup32 = CreateLookup32();
 
@@ -183,215 +39,138 @@ namespace Voron
             return result;
         }
 
-        private static string ByteArrayToHexViaLookup32(byte[] bytes)
+        public bool HasValue
         {
-            var lookup32 = _lookup32;
-            var result = new char[bytes.Length * 2];
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                var val = lookup32[bytes[i]];
-                result[2 * i] = (char)val;
-                result[2 * i + 1] = (char)(val >> 16);
-            }
-            return new string(result);
+            get { return Content.HasValue; }
         }
 
-
-        private static string BytePointerToHexViaLookup32(byte* bytes, int count)
+        public int Size
         {
-            var lookup32 = _lookup32;
-            var result = new char[count * 2];
-            for (int i = 0; i < count; i++)
+            get
             {
-                var val = lookup32[bytes[i]];
-                result[2 * i] = (char)val;
-                result[2 * i + 1] = (char)(val >> 16);
-            }
-            return new string(result);
-        }
-
-        private int CompareData(Slice other, ushort size)
-        {
-            if (Array != null)
-            {
-                fixed (byte* a = Array)
-                {
-                    if (other.Array != null)
-                    {
-                        fixed (byte* b = other.Array)
-                        {
-                            return Memory.CompareInline(a, b, size);
-                        }
-                    }
-                    else return Memory.CompareInline(a, other.Pointer, size);
-                }
-            }
-
-            if (other.Array != null)
-            {
-                fixed (byte* b = other.Array)
-                {
-                    return Memory.CompareInline(Pointer, b, size);
-                }
-            }
-            else return Memory.CompareInline(Pointer, other.Pointer, size);
-        }      
-
-
-        public static implicit operator Slice(string s)
-        {
-            // TODO: Fix allocation
-            return new Slice(Encoding.UTF8.GetBytes(s));
-        }
-
-        public void CopyTo(byte* dest)
-        {
-            if (Array == null)
-            {
-                Memory.Copy(dest, Pointer, Size);
-                return;
-            }
-            fixed (byte* a = Array)
-            {
-                Memory.Copy(dest, a, Size);
+                Debug.Assert(Content.Length >= 0);
+                return Content.Length;
             }
         }
 
-        public Slice ToSlice()
+        public SliceOptions Options
         {
-            return new Slice(this, Size);
+            get
+            {
+                return (SliceOptions) (Content.Flags & ByteStringType.UserDefinedMask);
+            }
         }
 
-        public void CopyTo(byte[] dest)
+        public byte this[int index]
         {
-            if (Array == null)
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
             {
-                fixed (byte* p = dest)
-                    Memory.Copy(p, Pointer, Size);
-                return;
+                Debug.Assert(Content.Ptr != null, "Uninitialized slice!");
+
+                if (!Content.HasValue)
+                    throw new InvalidOperationException("Uninitialized slice!");
+
+                return *(Content.Ptr + (sizeof(byte) * index));
             }
-            Buffer.BlockCopy(Array, 0, dest, 0, Size);
         }
 
-        public void CopyTo(int from, byte[] dest, int offset, int count)
+        public Slice Clone(ByteStringContext context, ByteStringType type = ByteStringType.Mutable)
         {
-            if (from + count > Size)
-                throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the slice");
-            if(offset + count > dest.Length)
-                throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the buffer" +
-                                                              "");
-            if (Array == null)
-            {
-                fixed (byte* p = dest)
-                    Memory.Copy(p + offset, Pointer + from, count);
-                return;
-            }
-            Buffer.BlockCopy(Array, from, dest, offset, count);
+            return new Slice(context.Clone(this.Content, type));
+        }
+
+        public Slice Skip(ByteStringContext context, int bytesToSkip, ByteStringType type = ByteStringType.Mutable)
+        {
+            return new Slice(context.Skip(this.Content, bytesToSkip, type));       
         }
 
         public void CopyTo(int from, byte* dest, int offset, int count)
         {
-            if (from + count > Size)
-                throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the slice");
-
-            if (Array == null)
-            {
-                Memory.Copy(dest + offset, Pointer + from, count);
-                return;
-            }
-
-            fixed (byte* p = Array)
-                Memory.Copy(dest + offset, p + from, count);
+            this.Content.CopyTo(from, dest, offset, count);
         }
 
-        public Slice Clone()
+        public void CopyTo(byte* dest)
         {
-            var buffer = new byte[Size];
-            if (Array == null)
-            {
-                fixed (byte* dest = buffer)
-                {
-                    Memory.Copy(dest, Pointer, Size);
-                }
-            }
-            else
-            {
-                Buffer.BlockCopy(Array, 0, buffer, 0, Size);
-            }
-
-            return new Slice(buffer);
+            this.Content.CopyTo(dest);
+        }   
+         
+        public void CopyTo(byte[] dest)
+        {
+            this.Content.CopyTo(dest);
         }
 
+        public void CopyTo(int from, byte[] dest, int offset, int count)
+        {
+            this.Content.CopyTo(from, dest, offset, count);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Slice From(ByteStringContext context, string value, ByteStringType type = ByteStringType.Mutable)
+        {
+            return new Slice(context.From(value, type));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Slice From(ByteStringContext context, byte[] value, ByteStringType type = ByteStringType.Mutable)
+        {
+            return new Slice(context.From(value, type));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Slice From(ByteStringContext context, byte* value, int size, ByteStringType type = ByteStringType.Mutable)
+        {
+            return new Slice(context.From(value, size, type));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Slice External(ByteStringContext context, byte* value, int size, ByteStringType type = ByteStringType.Mutable | ByteStringType.External)
+        {
+            return new Slice(context.FromPtr(value, size, type | ByteStringType.External));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleaseExternal(ByteStringContext context)
+        {
+            context.ReleaseExternal(ref Content);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Release(ByteStringContext context)
+        {
+            context.Release(ref Content);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueReader CreateReader()
         {
-            if(Array != null)
-                throw new InvalidOperationException("Cannot create value reader from byte[]");
-
-            return new ValueReader(Pointer, Size);
+            return new ValueReader(Content.Ptr, Size);
         }
 
-        public Slice Skip(ushort bytesToSkip)
+        public override int GetHashCode()
         {
-            if (bytesToSkip == 0)
-                return new Slice(this, Size);
-
-            if (Pointer != null)
-                return new Slice(Pointer + bytesToSkip, (ushort)(Size - bytesToSkip));
-
-            var toAllocate = Size - bytesToSkip;
-            var array = new byte[toAllocate];
-
-            Buffer.BlockCopy(Array, bytesToSkip, array, 0, toAllocate);
-
-            return new Slice(array);
+            return this.Content.GetHashCode();
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Set(byte* p, ushort size)
+        public override string ToString()
         {
-            Pointer = p;
-            Size = size;
-            KeyLength = size;
-            Array = null;
+            return this.Content.ToString(Encoding.UTF8);
         }
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SetInline(Slice slice, TreeNodeHeader* node)
+    public static class Slices
+    {
+        private static readonly ByteStringContext _sharedSliceContent = new ByteStringContext();
+
+        public static readonly Slice AfterAllKeys;
+        public static readonly Slice BeforeAllKeys;
+        public static readonly Slice Empty;
+
+        static Slices()
         {
-            slice.Pointer = (byte*)node + Constants.NodeHeaderSize;
-            slice.Size = node->KeySize;
-            slice.KeyLength = node->KeySize;
-            slice.Array = null;
+            Empty = new Slice(SliceOptions.Key, _sharedSliceContent.From(string.Empty));
+            BeforeAllKeys = new Slice(SliceOptions.BeforeAllKeys, _sharedSliceContent.From(string.Empty));
+            AfterAllKeys = new Slice(SliceOptions.AfterAllKeys, _sharedSliceContent.From(string.Empty));
         }
-        
-        public void Set(TreeNodeHeader* node)
-        {
-            SetInline(this, node);
-        }
-
-        public int Compare(Slice other)
-        {
-            Debug.Assert(Options == SliceOptions.Key);
-            Debug.Assert(other.Options == SliceOptions.Key);
-
-            var srcKey = this.KeyLength;
-            var otherKey = other.KeyLength;
-            var length = srcKey <= otherKey ? srcKey : otherKey;
-
-            var r = CompareData(other, length);
-            if (r != 0)
-                return r;
-
-            return srcKey - otherKey;
-        }
-
-        public bool StartsWith(Slice other)
-        {
-            if (KeyLength < other.KeyLength)
-                return false;
-
-            return CompareData(other, other.KeyLength) == 0;
-        }
-
     }
 }

--- a/src/Voron/SliceComparer.cs
+++ b/src/Voron/SliceComparer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,8 +14,14 @@ namespace Voron
     public sealed class SliceComparer : IEqualityComparer<Slice>, IComparer<Slice>
     {
         public static readonly SliceComparer Instance = new SliceComparer();
-       
-        public int Compare(Slice x, Slice y)
+
+        int IComparer<Slice>.Compare(Slice x, Slice y)
+        {
+            return CompareInline(x, y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Compare( Slice x, Slice y)
         {
             return CompareInline(x, y);
         }
@@ -25,71 +32,75 @@ namespace Voron
             Debug.Assert(x.Options == SliceOptions.Key);
             Debug.Assert(y.Options == SliceOptions.Key);
 
-            var srcKey = x.KeyLength;
-            var otherKey = y.KeyLength;
-            var size = srcKey <= otherKey ? srcKey : otherKey;
+            var x1 = x.Content;
+            var y1 = y.Content;
+            if (x1 == y1) // Reference equality (specially useful on searching on collections)
+                return 0;
 
-            int r = 0;
-
+            int r, keyDiff;
             unsafe
             {
-                if (x.Array != null)
-                {
-                    fixed (byte* a = x.Array)
-                    {
-                        if (y.Array != null)
-                        {
-                            fixed (byte* b = y.Array)
-                            {
-                                r = Memory.CompareInline(a, b, size);
-                            }
-                        }
-                        else
-                        {
-                            r = Memory.CompareInline(a, y.Pointer, size);
-                        }
-                    }
-                }
-                else
-                {
-                    if (y.Array != null)
-                    {
-                        fixed (byte* b = y.Array)
-                        {
-                            r = Memory.CompareInline(x.Pointer, b, size);
-                        }
-                    }
-                    else
-                    {
-                        r = Memory.CompareInline(x.Pointer, y.Pointer, size);
-                    }
-                }
+                var size = Math.Min(x1.Length, y1.Length);
+                keyDiff = x1.Length - y1.Length;
+
+                r = Memory.CompareInline(x1.Ptr, y1.Ptr, size);
             }
-            
+
             if (r != 0)
                 return r;
 
-            return srcKey - otherKey;
+            return keyDiff;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(Slice x, Slice y)
+        bool IEqualityComparer<Slice>.Equals(Slice x, Slice y)
         {
             Debug.Assert(x.Options == SliceOptions.Key);
             Debug.Assert(y.Options == SliceOptions.Key);
 
-            var srcKey = x.KeyLength;
-            var otherKey = y.KeyLength;
+            var srcKey = x.Content.Length;
+            var otherKey = y.Content.Length;
             if (srcKey != otherKey)
                 return false;
 
-            return CompareInline( x, y ) == 0;
+            return CompareInline(x, y) == 0;
+        }
+
+        public static bool Equals(Slice x, Slice y)
+        {
+            return EqualsInline(x, y);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetHashCode(Slice obj)
+        public static bool EqualsInline(Slice x, Slice y)
+        {
+            Debug.Assert(x.Options == SliceOptions.Key);
+            Debug.Assert(y.Options == SliceOptions.Key);
+
+            var srcKey = x.Content.Length;
+            var otherKey = y.Content.Length;
+            if (srcKey != otherKey)
+                return false;
+
+            return CompareInline(x, y) == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        int IEqualityComparer<Slice>.GetHashCode(Slice obj)
         {
             return obj.GetHashCode();
         }
+
+        public unsafe static bool StartWith(Slice value, Slice prefix)
+        {
+            int prefixSize = prefix.Content.Length;
+            if (!value.Content.HasValue || prefixSize > value.Content.Length)
+                return false;
+
+            byte* prefixPtr = prefix.Content.Ptr;
+            byte* valuePtr = value.Content.Ptr;
+
+            return Memory.CompareInline(prefixPtr, valuePtr, prefix.Size) == 0;
+        }  
     }
 }

--- a/src/Voron/SliceOptions.cs
+++ b/src/Voron/SliceOptions.cs
@@ -1,9 +1,11 @@
+using Sparrow;
+
 namespace Voron
 {
     public enum SliceOptions : byte
     {
         Key = 0,
-        BeforeAllKeys = 1,
-        AfterAllKeys = 2,
+        BeforeAllKeys = ByteStringType.UserDefined1,
+        AfterAllKeys = ByteStringType.UserDefined2,
     }
 }

--- a/src/Voron/SliceWriter.cs
+++ b/src/Voron/SliceWriter.cs
@@ -1,3 +1,4 @@
+using Sparrow;
 using System;
 using System.Text;
 using Voron.Util.Conversion;
@@ -45,9 +46,10 @@ namespace Voron
             _pos += sizeof(short);
         }
 
-        public Slice CreateSlice()
+        public Slice CreateSlice(ByteStringContext context, ByteStringType type = ByteStringType.Mutable)
         {
-            return new Slice(_buffer);
+            var content = context.From(_buffer, type);
+            return new Slice(content);
         }
 
         public void Write(bool b)
@@ -90,9 +92,10 @@ namespace Voron
             _pos = 0;
         }
 
-        public Slice CreateSlice(int size)
+        public Slice CreateSlice(ByteStringContext context, int size, ByteStringType type = ByteStringType.Mutable)
         {
-            return new Slice(_buffer, (ushort)size);
+            var content = context.From(_buffer, size, type);
+            return new Slice(content);
         }
     }
 }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1,4 +1,5 @@
-﻿using Sparrow.Collections;
+﻿using Sparrow;
+using Sparrow.Collections;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -25,6 +26,12 @@ namespace Voron
 {
     public class StorageEnvironment : IDisposable
     {
+        /// <summary>
+        /// This is the shared storage where we are going to store all the static constants for names. 
+        /// WARNING: This context will never be released, so only static constants should be added here.
+        /// </summary>
+        public static readonly ByteStringContext LabelsContext = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes);
+
         private readonly StorageEnvironmentOptions _options;
 
         private readonly ConcurrentSet<LowLevelTransaction> _activeTransactions = new ConcurrentSet<LowLevelTransaction>();
@@ -289,17 +296,17 @@ namespace Voron
             }
         }
 
-        public Transaction ReadTransaction()
+        public Transaction ReadTransaction(ByteStringContext context = null)
         {
-            return new Transaction(NewLowLevelTransaction(TransactionFlags.Read));
+            return new Transaction(NewLowLevelTransaction(TransactionFlags.Read, context));
         }
 
-        public Transaction WriteTransaction()
+        public Transaction WriteTransaction(ByteStringContext context = null)
         {
-            return new Transaction(NewLowLevelTransaction(TransactionFlags.ReadWrite, null));
+            return new Transaction(NewLowLevelTransaction(TransactionFlags.ReadWrite, context, null));
         }
 
-        internal LowLevelTransaction NewLowLevelTransaction(TransactionFlags flags, TimeSpan? timeout = null)
+        internal LowLevelTransaction NewLowLevelTransaction(TransactionFlags flags, ByteStringContext context = null, TimeSpan? timeout = null)
         {
             bool txLockTaken = false;
             try
@@ -333,7 +340,7 @@ namespace Voron
                 try
                 {
                     long txId = flags == TransactionFlags.ReadWrite ? _transactionsCounter + 1 : _transactionsCounter;
-                    tx = new LowLevelTransaction(this, txId, flags, _freeSpaceHandling);
+                    tx = new LowLevelTransaction(this, txId, flags, _freeSpaceHandling, context);
                 }
                 finally
                 {
@@ -415,25 +422,27 @@ namespace Voron
             var fixedSizeTrees = new List<FixedSizeTree>();
             using (var rootIterator = tx.LowLevelTransaction.RootObjects.Iterate())
             {
-                if (rootIterator.Seek(Slice.BeforeAllKeys))
+                if (rootIterator.Seek(Slices.BeforeAllKeys))
                 {
                     do
                     {
-                        switch (tx.GetRootObjectType(rootIterator.CurrentKey))
+                        var curretKey = rootIterator.CurrentKey.Clone(tx.Allocator);
+                        switch (tx.GetRootObjectType(curretKey))
                         {
                             case RootObjectType.VariableSizeTree:
-                                var tree = tx.ReadTree(rootIterator.CurrentKey.ToString());
+                                var tree = tx.ReadTree(curretKey.ToString());
                                 trees.Add(tree);
                                 break;
                             case RootObjectType.EmbeddedFixedSizeTree:
                                 break;
                             case RootObjectType.FixedSizeTree:
-                                fixedSizeTrees.Add(tx.FixedTreeFor(rootIterator.CurrentKey, 0));
+                                fixedSizeTrees.Add(tx.FixedTreeFor(curretKey, 0));
                                 break;
                             default:
                                 throw new ArgumentOutOfRangeException();
                         }
-                    } while (rootIterator.MoveNext());
+                    }
+                    while (rootIterator.MoveNext());
                 }
             }
 

--- a/src/Voron/Util/SliceExtensions.cs
+++ b/src/Voron/Util/SliceExtensions.cs
@@ -1,3 +1,4 @@
+using Sparrow;
 using System.Diagnostics;
 using System.Text;
 
@@ -5,7 +6,7 @@ namespace Voron
 {
     public static class SliceExtensions
     {
-        public static Slice ToSlice(this string str)
+        public static Slice ToSlice(this string str, ByteStringContext context, ByteStringType type = ByteStringType.Mutable)
         {
             var size = Encoding.UTF8.GetByteCount(str);
             Debug.Assert(size <= ushort.MaxValue);
@@ -13,15 +14,15 @@ namespace Voron
             var sliceWriter = new SliceWriter(size);
             sliceWriter.Write(str);
 
-            return sliceWriter.CreateSlice();
+            return sliceWriter.CreateSlice(context, type);
         }
 
-        public static Slice ToSliceUsingBuffer(this string str, byte[] buffer)
+        public static Slice ToSliceUsingBuffer(this string str, ByteStringContext context, byte[] buffer, ByteStringType type = ByteStringType.Mutable)
         {
             var sliceWriter = new SliceWriter(buffer);
             sliceWriter.Write(str);
 
-            return sliceWriter.CreateSlice();
+            return sliceWriter.CreateSlice(context, type);
         }
     }
 }

--- a/src/Voron/ValueReader.cs
+++ b/src/Voron/ValueReader.cs
@@ -110,6 +110,7 @@ namespace Voron
             return val;
         }
 
+        //TODO: Move this to Sparrow Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static long SwapBitShift(long value)
         {
@@ -212,32 +213,27 @@ namespace Voron
 
         public int CompareTo(ValueReader other)
         {
-            int r = CompareData(other, Math.Min(Length, other.Length));
+            int r = Memory.CompareInline(_val, other._val, Math.Min(Length, other.Length));
             if (r != 0)
                 return r;
 
             return Length - other.Length;
         }
 
-        private int CompareData(ValueReader other, int len)
-        {
-            return Memory.Compare(_val, other._val, len);
-        }
-
-        public Slice AsSlice()
+        public Slice AsSlice(ByteStringContext context)
         {
             if (_len >= ushort.MaxValue)
                 throw new InvalidOperationException("Cannot convert to slice, len is too big: " + _len);
 
-            return new Slice(_val, (ushort)_len);
+            return Slice.From(context, _val, _len);
         }
 
-        public Slice AsPartialSlice(int removeFromEnd)
+        public Slice AsPartialSlice(ByteStringContext context, int removeFromEnd)
         {
             if (_len >= ushort.MaxValue)
                 throw new InvalidOperationException("Cannot convert to slice, len is too big: " + _len);
 
-            return new Slice(_val, (ushort)(_len - removeFromEnd));
+            return Slice.From(context, _val, _len - removeFromEnd);
         }
     }
 }

--- a/test/FastTests/SkippableFact.cs
+++ b/test/FastTests/SkippableFact.cs
@@ -1,0 +1,13 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FastTests
+{
+    [XunitTestCaseDiscoverer("FastTests.SkippableFactDiscoverer", "FastTests")]
+    public class SkippableFactAttribute : FactAttribute { }
+}

--- a/test/FastTests/SkippableTest.cs
+++ b/test/FastTests/SkippableTest.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FastTests
+{
+    public class SkippableFactDiscoverer : IXunitTestCaseDiscoverer
+    {
+        readonly IMessageSink diagnosticMessageSink;
+
+        public SkippableFactDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            this.diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            yield return new SkippableFactTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+        }
+    }
+
+    public class SkippableFactTestCase : XunitTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public SkippableFactTestCase() { }
+
+        public SkippableFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments) { }
+
+        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                        IMessageBus messageBus,
+                                                        object[] constructorArguments,
+                                                        ExceptionAggregator aggregator,
+                                                        CancellationTokenSource cancellationTokenSource)
+        {
+            var skipMessageBus = new SkippableFactMessageBus(messageBus);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            if (skipMessageBus.DynamicallySkippedTestCount > 0)
+            {
+                result.Failed -= skipMessageBus.DynamicallySkippedTestCount;
+                result.Skipped += skipMessageBus.DynamicallySkippedTestCount;
+            }
+
+            return result;
+        }
+    }
+
+    public class SkippableFactMessageBus : IMessageBus
+    {
+        readonly IMessageBus innerBus;
+
+        public SkippableFactMessageBus(IMessageBus innerBus)
+        {
+            this.innerBus = innerBus;
+        }
+
+        public int DynamicallySkippedTestCount { get; private set; }
+
+        public void Dispose() { }
+
+        public bool QueueMessage(IMessageSinkMessage message)
+        {
+            var testFailed = message as ITestFailed;
+            if (testFailed != null)
+            {
+                var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
+                if (exceptionType == typeof(SkipTestException).FullName)
+                {
+                    DynamicallySkippedTestCount++;
+                    return innerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
+                }
+            }
+
+            // Nothing we care about, send it on its way
+            return innerBus.QueueMessage(message);
+        }
+    }
+
+    public class SkipTestException : Exception
+    {
+        public SkipTestException(string reason)
+            : base(reason) { }
+    }
+}

--- a/test/FastTests/Sparrow/ByteString.cs
+++ b/test/FastTests/Sparrow/ByteString.cs
@@ -1,0 +1,191 @@
+﻿//#define VALIDATE
+
+using Sparrow;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FastTests.Sparrow
+{
+    public unsafe class ByteString
+    {
+        [Fact]
+        public void Lifecycle()
+        {
+            using (var context = new ByteStringContext())
+            {
+                var byteString = context.Allocate(512);
+
+                Assert.Equal(512, byteString.Length);
+                Assert.True(byteString.HasValue);
+                Assert.True((ByteStringType.Mutable & byteString.Flags) != 0);
+                Assert.True(byteString.IsMutable);
+                Assert.Equal(1024, byteString._pointer->Size);
+
+                var byteStringWithExactSize = context.Allocate(1024 - sizeof(ByteStringStorage));
+
+                Assert.True(byteStringWithExactSize.HasValue);
+                Assert.Equal(1024 - sizeof(ByteStringStorage), byteStringWithExactSize.Length);
+                Assert.True((ByteStringType.Mutable & byteStringWithExactSize.Flags) != 0);
+                Assert.True(byteStringWithExactSize.IsMutable);
+                Assert.Equal(1024, byteStringWithExactSize._pointer->Size);
+
+                context.Release(ref byteString);
+                Assert.False(byteString.HasValue);
+                Assert.True(byteString._pointer == null);
+            }
+        }
+
+        [Fact]
+        public void ConstructionInsideWholeSegment()
+        {
+            using (var context = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes))
+            {
+                var byteStringInFirstSegment = context.Allocate((ByteStringContext.MinBlockSizeInBytes / 2) - sizeof(ByteStringStorage));
+                var byteStringWholeSegment = context.Allocate((ByteStringContext.MinBlockSizeInBytes / 2) - sizeof(ByteStringStorage));
+                var byteStringNextSegment = context.Allocate(1);
+
+                long startLocation = (long)byteStringInFirstSegment._pointer;
+                Assert.InRange((long)byteStringWholeSegment._pointer, startLocation, startLocation + ByteStringContext.MinBlockSizeInBytes);
+                Assert.NotInRange((long)byteStringNextSegment._pointer, startLocation, startLocation + ByteStringContext.MinBlockSizeInBytes);
+            }
+        }
+
+        [Fact]
+        public void ConstructionReleaseForReuseTheLeftOver()
+        {
+            using (var context = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes))
+            {
+                var byteStringInFirstSegment = context.Allocate((ByteStringContext.MinBlockSizeInBytes / 2) - sizeof(ByteStringStorage));
+                var byteStringInNewSegment = context.Allocate((ByteStringContext.MinBlockSizeInBytes / 2) - sizeof(ByteStringStorage) + 1);
+                var byteStringInReusedSegment = context.Allocate((ByteStringContext.MinBlockSizeInBytes / 2) - sizeof(ByteStringStorage));
+
+                long startLocation = (long)byteStringInFirstSegment._pointer;
+                Assert.NotInRange((long)byteStringInNewSegment._pointer, startLocation, startLocation + ByteStringContext.MinBlockSizeInBytes);
+                Assert.InRange((long)byteStringInReusedSegment._pointer, startLocation, startLocation + ByteStringContext.MinBlockSizeInBytes);
+            }
+        }
+
+        [Fact]
+        public void AllocateAndReleaseShouldReuse()
+        {
+            using (var context = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes))
+            {
+                var byteStringInFirst = context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2 - sizeof(ByteStringStorage));
+                var byteStringInSecond = context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2 - sizeof(ByteStringStorage));
+
+                long ptrLocation = (long)byteStringInFirst._pointer;
+                Assert.InRange((long)byteStringInSecond._pointer, ptrLocation, ptrLocation + ByteStringContext.MinBlockSizeInBytes);
+
+                context.Release(ref byteStringInFirst);
+
+                var byteStringReused = context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2 - sizeof(ByteStringStorage));
+
+                Assert.InRange((long)byteStringReused._pointer, ptrLocation, ptrLocation + ByteStringContext.MinBlockSizeInBytes);
+                Assert.Equal(ptrLocation, (long)byteStringReused._pointer);
+
+                var byteStringNextSegment = context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2 - sizeof(ByteStringStorage));
+                Assert.NotInRange((long)byteStringNextSegment._pointer, ptrLocation, ptrLocation + ByteStringContext.MinBlockSizeInBytes);
+            }
+        }
+
+        [Fact]
+        public void AllocateAndReleaseShouldReuseAsSegment()
+        {
+            int allocationBlockSize = 2 * ByteStringContext.MinBlockSizeInBytes + 128 + sizeof(ByteStringStorage);
+            using (var context = new ByteStringContext(allocationBlockSize))
+            {
+                // Will be only 128 bytes left for the allocation unit.
+                var byteStringInFirst = context.Allocate(2 * ByteStringContext.MinBlockSizeInBytes - sizeof(ByteStringStorage));          
+
+                long ptrLocation = (long)byteStringInFirst._pointer;
+                long nextPtrLocation = ptrLocation + byteStringInFirst._pointer->Size;
+
+                context.Release(ref byteStringInFirst); // After the release the block should be reserved as a new segment. 
+
+                // We use a different size to ensure we are not reusing a reuse bucket but big enough to avoid having space available. 
+                var byteStringReused = context.Allocate(512);
+
+                Assert.InRange((long)byteStringReused._pointer, ptrLocation, ptrLocation + allocationBlockSize);
+                Assert.Equal(ptrLocation, (long)byteStringReused._pointer); // We are the first in the segment.
+
+                // This allocation will have an allocation unit size of 128 and fit into the rest of the initial segment, which should be 
+                // available for an exact reuse bucket allocation. 
+                var byteStringReusedFromBucket = context.Allocate(64);
+
+                Assert.Equal((long)byteStringReusedFromBucket._pointer, nextPtrLocation);
+            }
+        }
+
+        [Fact]
+        public void AllocateAndReleaseShouldReuseRepeatedly()
+        {
+            using (var context = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes))
+            {
+                var first = context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2 - sizeof(ByteStringStorage));
+                long ptrLocation = (long)first._pointer;
+                context.Release(ref first);
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var repeat = context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2 - sizeof(ByteStringStorage));
+                    Assert.Equal(ptrLocation, (long)repeat._pointer);
+                    context.Release(ref repeat);
+                }
+            }
+        }
+
+        [SkippableFact]
+        public void ValidationKeyAfterAllocateAndReleaseReuseShouldBeDifferent()
+        {
+#if VALIDATE
+            using (var context = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes))
+            {
+                var first = context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2 - sizeof(ByteStringStorage));
+                context.Release(ref first);
+
+                var repeat = context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2 - sizeof(ByteStringStorage));
+                Assert.NotEqual(first.Key, repeat._pointer->Key);
+                Assert.Equal(first.Key >> 32, repeat._pointer->Key >> 32);
+                context.Release(ref repeat);
+            }
+#else
+            throw new SkipTestException("Compile with the 'VALIDATE' compiler directive to create binaries compatible with validation");
+#endif
+        }
+
+        [SkippableFact]
+        public void FailValidationTryingToReleaseInAnotherContext()
+        {
+#if VALIDATE
+            using (var context = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes))
+            using (var otherContext = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes))
+            {
+                var first = context.Allocate(1);
+                Assert.Throws<InvalidOperationException>(() => otherContext.Release(ref first));
+            }
+#else
+            throw new SkipTestException("Compile with the 'VALIDATE' compiler directive to create binaries compatible with validation");
+#endif
+        }
+
+        [SkippableFact]
+        public void FailValidationReleasingAnAliasAfterReleasingOriginal()
+        {
+#if VALIDATE
+            using (var context = new ByteStringContext(ByteStringContext.MinBlockSizeInBytes))
+            {
+                var first = context.Allocate(1);
+                var firstAlias = first;
+                context.Release(ref first);
+
+                Assert.Throws<InvalidOperationException>(() => context.Release(ref firstAlias));
+            }
+#else
+            throw new SkipTestException("Compile with the 'VALIDATE' compiler directive to create binaries compatible with validation");
+#endif
+        }
+    }
+}

--- a/test/FastTests/Voron/Backups/Incremental.cs
+++ b/test/FastTests/Voron/Backups/Incremental.cs
@@ -8,122 +8,123 @@ using System;
 using System.IO;
 using Xunit;
 using Voron;
+using Voron.Data;
 using Voron.Impl.Backup;
 
 namespace FastTests.Voron.Backups
 {
-	public class Incremental : StorageTest
-	{
+    public class Incremental : StorageTest
+    {
         IncrementalBackupTestUtils IncrementalBackupTestUtils = new IncrementalBackupTestUtils();
         protected override void Configure(StorageEnvironmentOptions options)
-		{
-			options.MaxLogFileSize = 1000 * options.PageSize;
-			options.IncrementalBackupEnabled = true;
-			options.ManualFlushing = true;
-		}
+        {
+            options.MaxLogFileSize = 1000 * options.PageSize;
+            options.IncrementalBackupEnabled = true;
+            options.ManualFlushing = true;
+        }
 
-		public Incremental()
-		{
+        public Incremental()
+        {
             IncrementalBackupTestUtils.Clean();
-		}
+        }
 
-		[Fact]
-		public void CanBackupAndRestoreOnEmptyStorage()
-		{
+        [Fact]
+        public void CanBackupAndRestoreOnEmptyStorage()
+        {
             RequireFileBasedPager();
 
-			var random = new Random();
-			var buffer = new byte[8192];
-			random.NextBytes(buffer);
+            var random = new Random();
+            var buffer = new byte[8192];
+            random.NextBytes(buffer);
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 for (int i = 0; i < 500; i++)
-				{
-					tree.Add			("items/" + i, new MemoryStream(buffer));
-				}
+                {
+                    tree.Add			("items/" + i, new MemoryStream(buffer));
+                }
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
+            BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
 
-			var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
-			options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+            var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
+            options.MaxLogFileSize = Env.Options.MaxLogFileSize;
 
             BackupMethods.Incremental.Restore(options, new[] { IncrementalBackupTestUtils.IncrementalBackupFile(0) });
 
-			using (var env = new StorageEnvironment(options))
-			{
+            using (var env = new StorageEnvironment(options))
+            {
 
-				using (var tx = env.ReadTransaction())
-				{
+                using (var tx = env.ReadTransaction())
+                {
                     var tree = tx.CreateTree("foo");
                     for (int i = 0; i < 500; i++)
-					{
-						var readResult = tree.Read("items/" + i);
-						Assert.NotNull(readResult);
-						var memoryStream = new MemoryStream();
-						readResult.Reader.CopyTo(memoryStream);
-						Assert.Equal(memoryStream.ToArray(), buffer);
-					}
-				}
-			}
-		}
+                    {
+                        var readResult = tree.Read("items/" + i);
+                        Assert.NotNull(readResult);
+                        var memoryStream = new MemoryStream();
+                        readResult.Reader.CopyTo(memoryStream);
+                        Assert.Equal(memoryStream.ToArray(), buffer);
+                    }
+                }
+            }
+        }
 
-		[Fact]
-		public void CanDoMultipleIncrementalBackupsAndRestoreOneByOne()
-		{
+        [Fact]
+        public void CanDoMultipleIncrementalBackupsAndRestoreOneByOne()
+        {
             RequireFileBasedPager();
 
-			var random = new Random();
-			var buffer = new byte[1024];
-			random.NextBytes(buffer);
+            var random = new Random();
+            var buffer = new byte[1024];
+            random.NextBytes(buffer);
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 for (int i = 0; i < 300; i++)
-				{
-					tree.Add			("items/" + i, new MemoryStream(buffer));
-				}
+                {
+                    tree.Add			("items/" + i, new MemoryStream(buffer));
+                }
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
+            BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 for (int i = 300; i < 600; i++)
-				{
-					tree.Add			("items/" + i, new MemoryStream(buffer));
-				}
+                {
+                    tree.Add			("items/" + i, new MemoryStream(buffer));
+                }
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(1));
+            BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(1));
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 for (int i = 600; i < 1000; i++)
-				{
-					tree.Add			("items/" + i, new MemoryStream(buffer));
-				}
+                {
+                    tree.Add			("items/" + i, new MemoryStream(buffer));
+                }
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			Env.FlushLogToDataFile(); // make sure that incremental backup will work even if we flushed journals to the data file
+            Env.FlushLogToDataFile(); // make sure that incremental backup will work even if we flushed journals to the data file
 
-			BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(2));
+            BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(2));
 
-			var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
-			options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+            var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
+            options.MaxLogFileSize = Env.Options.MaxLogFileSize;
 
             BackupMethods.Incremental.Restore(options, new[]
             {
@@ -132,69 +133,69 @@ namespace FastTests.Voron.Backups
                 IncrementalBackupTestUtils.IncrementalBackupFile(2)
             });
 
-			using (var env = new StorageEnvironment(options))
-			{
-				using (var tx = env.ReadTransaction())
-				{
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.ReadTransaction())
+                {
                     var tree = tx.CreateTree("foo");
                     for (int i = 0; i < 1000; i++)
-					{
-						var readResult = tree.Read("items/" + i);
-						Assert.NotNull(readResult);
-						var memoryStream = new MemoryStream();
-						readResult.Reader.CopyTo(memoryStream);
-						Assert.Equal(memoryStream.ToArray(), buffer);
-					}
-				}
-			}
-		}
+                    {
+                        var readResult = tree.Read("items/" + i);
+                        Assert.NotNull(readResult);
+                        var memoryStream = new MemoryStream();
+                        readResult.Reader.CopyTo(memoryStream);
+                        Assert.Equal(memoryStream.ToArray(), buffer);
+                    }
+                }
+            }
+        }
 
-		[Fact]
-		public void IncrementalBackupShouldCopyJustNewPagesSinceLastBackup()
+        [Fact]
+        public void IncrementalBackupShouldCopyJustNewPagesSinceLastBackup()
         {
             RequireFileBasedPager();
-			var random = new Random();
-			var buffer = new byte[100];
-			random.NextBytes(buffer);
+            var random = new Random();
+            var buffer = new byte[100];
+            random.NextBytes(buffer);
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 for (int i = 0; i < 5; i++)
-				{
-					tree.Add			("items/" + i, new MemoryStream(buffer));
-				}
+                {
+                    tree.Add			("items/" + i, new MemoryStream(buffer));
+                }
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-		    var usedPagesInJournal = Env.Journal.CurrentFile.WritePagePosition;
+            var usedPagesInJournal = Env.Journal.CurrentFile.WritePagePosition;
 
-			var backedUpPages = BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
+            var backedUpPages = BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
 
-			Assert.Equal(usedPagesInJournal, backedUpPages);
+            Assert.Equal(usedPagesInJournal, backedUpPages);
 
-			var writePos = Env.Journal.CurrentFile.WritePagePosition;
-		
-			using (var tx = Env.WriteTransaction())
-			{
+            var writePos = Env.Journal.CurrentFile.WritePagePosition;
+        
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 for (int i = 5; i < 10; i++)
-				{
-					tree.Add			("items/" + i, new MemoryStream(buffer));
-				}
+                {
+                    tree.Add			("items/" + i, new MemoryStream(buffer));
+                }
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			var usedByLastTransaction = Env.Journal.CurrentFile.WritePagePosition - writePos;
+            var usedByLastTransaction = Env.Journal.CurrentFile.WritePagePosition - writePos;
 
-			backedUpPages = BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(1));
+            backedUpPages = BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(1));
 
-			Assert.Equal(usedByLastTransaction, backedUpPages);
+            Assert.Equal(usedByLastTransaction, backedUpPages);
 
-			var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
-			options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+            var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
+            options.MaxLogFileSize = Env.Options.MaxLogFileSize;
 
             BackupMethods.Incremental.Restore(options, new[]
             {
@@ -202,22 +203,22 @@ namespace FastTests.Voron.Backups
                 IncrementalBackupTestUtils.IncrementalBackupFile(1)
             });
 
-			using (var env = new StorageEnvironment(options))
-			{
-				using (var tx = env.ReadTransaction())
-				{
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.ReadTransaction())
+                {
                     var tree = tx.CreateTree("foo");
                     for (int i = 0; i < 10; i++)
-					{
-						var readResult = tree.Read("items/" + i);
-						Assert.NotNull(readResult);
-						var memoryStream = new MemoryStream();
-						readResult.Reader.CopyTo(memoryStream);
-						Assert.Equal(memoryStream.ToArray(), buffer);
-					}
-				}
-			}
-		}
+                    {
+                        var readResult = tree.Read("items/" + i);
+                        Assert.NotNull(readResult);
+                        var memoryStream = new MemoryStream();
+                        readResult.Reader.CopyTo(memoryStream);
+                        Assert.Equal(memoryStream.ToArray(), buffer);
+                    }
+                }
+            }
+        }
 
         [Fact]
         public void IncrementalBackupShouldAcceptEmptyIncrementalBackups()
@@ -281,199 +282,199 @@ namespace FastTests.Voron.Backups
             }
         }
 
-		[Fact]
-		public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_RavenDB_2806()
-		{
-			RequireFileBasedPager();
+        [Fact]
+        public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_RavenDB_2806()
+        {
+            RequireFileBasedPager();
 
-			const int testedOverflowSize = 20000;
+            const int testedOverflowSize = 20000;
 
-			var overflowValue = new byte[testedOverflowSize];
-			new Random(1).NextBytes(overflowValue);
+            var overflowValue = new byte[testedOverflowSize];
+            new Random(1).NextBytes(overflowValue);
 
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree( "test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree( "test");
 
-				var itemBytes = new byte[16000];
+                var itemBytes = new byte[16000];
 
-				new Random(2).NextBytes(itemBytes);
-				tree.Add("items/1", itemBytes);
+                new Random(2).NextBytes(itemBytes);
+                tree.Add("items/1", itemBytes);
 
-				new Random(3).NextBytes(itemBytes);
-				tree.Add("items/2", itemBytes);
+                new Random(3).NextBytes(itemBytes);
+                tree.Add("items/2", itemBytes);
 
-				tree.Delete("items/1");
-				tree.Delete("items/2");
+                tree.Delete("items/1");
+                tree.Delete("items/2");
 
-				tree.Add("items/3", overflowValue);
+                tree.Add("items/3", overflowValue);
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
+            BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
 
-			var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
-			options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+            var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
+            options.MaxLogFileSize = Env.Options.MaxLogFileSize;
 
-			BackupMethods.Incremental.Restore(options, new[]
+            BackupMethods.Incremental.Restore(options, new[]
             {
                 IncrementalBackupTestUtils.IncrementalBackupFile(0)
             });
 
-			using (var env = new StorageEnvironment(options))
-			{
-				using (var tx = env.ReadTransaction())
-				{
-					var tree = tx.ReadTree("test");
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.ReadTransaction())
+                {
+                    var tree = tx.ReadTree("test");
 
-					var readResult = tree.Read("items/3");
+                    var readResult = tree.Read("items/3");
 
-					var readBytes = new byte[testedOverflowSize];
+                    var readBytes = new byte[testedOverflowSize];
 
-					readResult.Reader.Read(readBytes, 0, testedOverflowSize);
+                    readResult.Reader.Read(readBytes, 0, testedOverflowSize);
 
-					Assert.Equal(overflowValue, readBytes);
-				}
-			}
-		}
+                    Assert.Equal(overflowValue, readBytes);
+                }
+            }
+        }
 
-		[Fact]
-		public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_2_RavenDB_2806()
-		{
-			RequireFileBasedPager();
+        [Fact]
+        public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_2_RavenDB_2806()
+        {
+            RequireFileBasedPager();
 
-			const int testedOverflowSize = 16000;
+            const int testedOverflowSize = 16000;
 
-			var overflowValue = new byte[testedOverflowSize];
-			new Random(1).NextBytes(overflowValue);
-
-
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree( "test");
-
-				var itemBytes = new byte[2000];
-
-				new Random(2).NextBytes(itemBytes);
-				tree.Add("items/1", itemBytes);
+            var overflowValue = new byte[testedOverflowSize];
+            new Random(1).NextBytes(overflowValue);
 
 
-				itemBytes = new byte[30000];
-				new Random(3).NextBytes(itemBytes);
-				tree.Add("items/2", itemBytes);
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree( "test");
 
-				tx.Commit();
-			}
+                var itemBytes = new byte[2000];
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree( "test");
-				tree.Delete("items/1");
-				tree.Delete("items/2");
+                new Random(2).NextBytes(itemBytes);
+                tree.Add("items/1", itemBytes);
 
-				tree.Add("items/3", overflowValue);
 
-				tx.Commit();
-			}
+                itemBytes = new byte[30000];
+                new Random(3).NextBytes(itemBytes);
+                tree.Add("items/2", itemBytes);
 
-			BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
+                tx.Commit();
+            }
 
-			var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
-			options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree( "test");
+                tree.Delete("items/1");
+                tree.Delete("items/2");
 
-			BackupMethods.Incremental.Restore(options, new[]
+                tree.Add("items/3", overflowValue);
+
+                tx.Commit();
+            }
+
+            BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
+
+            var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
+            options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+
+            BackupMethods.Incremental.Restore(options, new[]
             {
                 IncrementalBackupTestUtils.IncrementalBackupFile(0)
             });
 
-			using (var env = new StorageEnvironment(options))
-			{
-				using (var tx = env.ReadTransaction())
-				{
-					var tree = tx.ReadTree("test");
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.ReadTransaction())
+                {
+                    var tree = tx.ReadTree("test");
 
-					var readResult = tree.Read("items/3");
+                    var readResult = tree.Read("items/3");
 
-					var readBytes = new byte[testedOverflowSize];
+                    var readBytes = new byte[testedOverflowSize];
 
-					readResult.Reader.Read(readBytes, 0, testedOverflowSize);
+                    readResult.Reader.Read(readBytes, 0, testedOverflowSize);
 
-					Assert.Equal(overflowValue, readBytes);
-				}
-			}
-		}
+                    Assert.Equal(overflowValue, readBytes);
+                }
+            }
+        }
 
-		[Fact]
-		public void IncorrectWriteOfOverflowPagesFromJournalsInBackupToDataFile_RavenDB_2891()
-		{
-			RequireFileBasedPager();
+        [Fact]
+        public void IncorrectWriteOfOverflowPagesFromJournalsInBackupToDataFile_RavenDB_2891()
+        {
+            RequireFileBasedPager();
 
-			const int testedOverflowSize = 50000;
+            const int testedOverflowSize = 50000;
 
-			var overflowValue = new byte[testedOverflowSize];
-			new Random(1).NextBytes(overflowValue);
+            var overflowValue = new byte[testedOverflowSize];
+            new Random(1).NextBytes(overflowValue);
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree(  "test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree(  "test");
 
-				var itemBytes = new byte[30000];
+                var itemBytes = new byte[30000];
 
-				new Random(2).NextBytes(itemBytes);
-				tree.Add("items/1", itemBytes);
+                new Random(2).NextBytes(itemBytes);
+                tree.Add("items/1", itemBytes);
 
-				new Random(3).NextBytes(itemBytes);
-				tree.Add("items/2", itemBytes);
+                new Random(3).NextBytes(itemBytes);
+                tree.Add("items/2", itemBytes);
 
-				tree.Delete("items/1");
+                tree.Delete("items/1");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.ReadTree("test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("test");
 
-				tree.Delete("items/2");
+                tree.Delete("items/2");
 
-				tree.Add("items/3", overflowValue);
+                tree.Add("items/3", overflowValue);
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
+            BackupMethods.Incremental.ToFile(Env, IncrementalBackupTestUtils.IncrementalBackupFile(0));
 
-			var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
-			options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+            var options = StorageEnvironmentOptions.ForPath(IncrementalBackupTestUtils.RestoredStoragePath);
+            options.MaxLogFileSize = Env.Options.MaxLogFileSize;
 
-			BackupMethods.Incremental.Restore(options, new[]
+            BackupMethods.Incremental.Restore(options, new[]
             {
                 IncrementalBackupTestUtils.IncrementalBackupFile(0)
             });
 
-			using (var env = new StorageEnvironment(options))
-			{
-				using (var tx = env.ReadTransaction())
-				{
-					var tree = tx.ReadTree("test");
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.ReadTransaction())
+                {
+                    var tree = tx.ReadTree("test");
 
-					var readResult = tree.Read("items/3");
+                    var readResult = tree.Read("items/3");
 
-					var readBytes = new byte[testedOverflowSize];
+                    var readBytes = new byte[testedOverflowSize];
 
-					readResult.Reader.Read(readBytes, 0, testedOverflowSize);
+                    readResult.Reader.Read(readBytes, 0, testedOverflowSize);
 
-					Assert.Equal(overflowValue, readBytes);
-				}
-			}
-		}
+                    Assert.Equal(overflowValue, readBytes);
+                }
+            }
+        }
 
-		public override void Dispose()
-		{
-			base.Dispose();
-			IncrementalBackupTestUtils.Clean();
-		}	
-	}
+        public override void Dispose()
+        {
+            base.Dispose();
+            IncrementalBackupTestUtils.Clean();
+        }	
+    }
 }

--- a/test/FastTests/Voron/Bugs/AccessViolationWithIteratorUsage.cs
+++ b/test/FastTests/Voron/Bugs/AccessViolationWithIteratorUsage.cs
@@ -10,53 +10,53 @@ using Voron;
 
 namespace FastTests.Voron.Bugs
 {
-	public class AccessViolationWithIteratorUsage : StorageTest
-	{
-		protected override void Configure(StorageEnvironmentOptions options)
-		{
-			options.ManualFlushing = true;
-		}
+    public class AccessViolationWithIteratorUsage : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+        }
 
-		[Fact]
-		public void ShouldNotThrow()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree(  "test");
+        [Fact]
+        public void ShouldNotThrow()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree(  "test");
 
-				tree.Add("items/1", new MemoryStream());
-				tree.Add("items/2", new MemoryStream());
+                tree.Add("items/1", new MemoryStream());
+                tree.Add("items/2", new MemoryStream());
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var txr = Env.ReadTransaction())
-			using (var iterator = txr.ReadTree("test").Iterate())
-			{
-				using (var tx = Env.WriteTransaction())
-				{
-					for (int i = 0; i < 10; i++)
-					{
-						tx.CreateTree( "test").Add("items/" + i, new MemoryStream(new byte[2048]));
-					}
+            using (var txr = Env.ReadTransaction())
+            using (var iterator = txr.ReadTree("test").Iterate())
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        tx.CreateTree( "test").Add("items/" + i, new MemoryStream(new byte[2048]));
+                    }
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-				using (var tx = Env.WriteTransaction())
-				{
-					for (int i = 10; i < 40; i++)
-					{
-						tx.CreateTree("test").Add("items/" + i, new MemoryStream(new byte[2048]));
-					}
+                using (var tx = Env.WriteTransaction())
+                {
+                    for (int i = 10; i < 40; i++)
+                    {
+                        tx.CreateTree("test").Add("items/" + i, new MemoryStream(new byte[2048]));
+                    }
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				iterator.MoveNext();
-			}
-		}
-	}
+                iterator.MoveNext();
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Bugs/DeleteCurrentAndMoveNextShouldWorkWithKeysWithNulls.cs
+++ b/test/FastTests/Voron/Bugs/DeleteCurrentAndMoveNextShouldWorkWithKeysWithNulls.cs
@@ -4,83 +4,83 @@ using Voron;
 
 namespace FastTests.Voron.Bugs
 {
-	public class DeleteCurrentAndMoveNextTests : StorageTest
-	{
-		public DeleteCurrentAndMoveNextTests()
-		{
-			StartDatabase();
-		}
+    public class DeleteCurrentAndMoveNextTests : StorageTest
+    {
+        public DeleteCurrentAndMoveNextTests()
+        {
+            StartDatabase();
+        }
 
-		[Fact]
-		public void DeleteCurrentAndMoveNextShouldWork()
-		{
-			var treeName = CreateTrees(Env, 1, "test").First();
+        [Fact]
+        public void DeleteCurrentAndMoveNextShouldWork()
+        {
+            var treeName = CreateTrees(Env, 1, "test").First();
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var testTree = tx.ReadTree(treeName);
-				testTree.Add("a", "test_value_1");
-				testTree.Add("b", "test_value_2");
-				testTree.Add("c", "test_value_3");
+            using (var tx = Env.WriteTransaction())
+            {
+                var testTree = tx.ReadTree(treeName);
+                testTree.Add("a", "test_value_1");
+                testTree.Add("b", "test_value_2");
+                testTree.Add("c", "test_value_3");
 
-				tx.Commit();
-			}
-			
-			using (var tx = Env.WriteTransaction())
-			{
-				var testTree = tx.ReadTree(treeName);
-				using (var iter = testTree.Iterate())
-				{
-					iter.Seek(Slice.BeforeAllKeys);
-					while (iter.DeleteCurrentAndMoveNext())
-					{						
-					}
-					tx.Commit();
-				}
-			}
+                tx.Commit();
+            }
+            
+            using (var tx = Env.WriteTransaction())
+            {
+                var testTree = tx.ReadTree(treeName);
+                using (var iter = testTree.Iterate())
+                {
+                    iter.Seek(Slices.BeforeAllKeys);
+                    while (iter.DeleteCurrentAndMoveNext())
+                    {						
+                    }
+                    tx.Commit();
+                }
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var testTree = tx.ReadTree(treeName);
-				using (var iter = testTree.Iterate())
-					Assert.False(iter.Seek(Slice.BeforeAllKeys));				
-			}
-		}
+            using (var tx = Env.WriteTransaction())
+            {
+                var testTree = tx.ReadTree(treeName);
+                using (var iter = testTree.Iterate())
+                    Assert.False(iter.Seek(Slices.BeforeAllKeys));				
+            }
+        }
 
-		[Fact]
-		public void DeleteCurrentAndMoveNextShouldWorkWhenTreeModified()
-		{
-			var treeName = CreateTrees(Env, 1, "test").First();
+        [Fact]
+        public void DeleteCurrentAndMoveNextShouldWorkWhenTreeModified()
+        {
+            var treeName = CreateTrees(Env, 1, "test").First();
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var testTree = tx.ReadTree(treeName);
-				testTree.Add("a", "test_value_1");
-				testTree.Add("b", "test_value_2");
-				testTree.Add("c", "test_value_3");
+            using (var tx = Env.WriteTransaction())
+            {
+                var testTree = tx.ReadTree(treeName);
+                testTree.Add("a", "test_value_1");
+                testTree.Add("b", "test_value_2");
+                testTree.Add("c", "test_value_3");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var testTree = tx.ReadTree(treeName);
-				using (var iter = testTree.Iterate())
-				{
-					iter.Seek("b");
-					while (iter.DeleteCurrentAndMoveNext())
-					{
-					}
-					tx.Commit();
-				}
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                var testTree = tx.ReadTree(treeName);
+                using (var iter = testTree.Iterate())
+                {
+                    iter.Seek(Slice.From(tx.Allocator, "b"));
+                    while (iter.DeleteCurrentAndMoveNext())
+                    {
+                    }
+                    tx.Commit();
+                }
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var testTree = tx.ReadTree(treeName);
-				Assert.Equal(1, testTree.State.NumberOfEntries);
-			}
-		}
-	
-	}
+            using (var tx = Env.WriteTransaction())
+            {
+                var testTree = tx.ReadTree(treeName);
+                Assert.Equal(1, testTree.State.NumberOfEntries);
+            }
+        }
+    
+    }
 }

--- a/test/FastTests/Voron/Bugs/EmptyTree.cs
+++ b/test/FastTests/Voron/Bugs/EmptyTree.cs
@@ -20,7 +20,7 @@ namespace FastTests.Voron.Bugs
             {
                 var treeIterator = tx.CreateTree("events").Iterate();
 
-                Assert.False(treeIterator.Seek(Slice.AfterAllKeys));
+                Assert.False(treeIterator.Seek(Slices.AfterAllKeys));
 
                 tx.Commit();
             }

--- a/test/FastTests/Voron/Bugs/FlushingToDataFile.cs
+++ b/test/FastTests/Voron/Bugs/FlushingToDataFile.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Sparrow.Platform;
 using Xunit;
 using Voron;
+using Voron.Data;
 using Voron.Impl;
 
 namespace FastTests.Voron.Bugs
@@ -186,7 +187,7 @@ namespace FastTests.Voron.Bugs
                         {
                             using (var iterator = tx.CreateTree(tree).Iterate())
                             {
-                                if (!iterator.Seek(Slice.BeforeAllKeys))
+                                if (!iterator.Seek(Slices.BeforeAllKeys))
                                     continue;
 
                                 do

--- a/test/FastTests/Voron/Bugs/FreeSpaceAndOverflowPages.cs
+++ b/test/FastTests/Voron/Bugs/FreeSpaceAndOverflowPages.cs
@@ -6,6 +6,7 @@
 
 using Xunit;
 using Voron;
+using Voron.Data;
 
 namespace FastTests.Voron.Bugs
 {

--- a/test/FastTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
+++ b/test/FastTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
@@ -6,6 +6,7 @@
 
 using System.IO;
 using Voron;
+using Voron.Data;
 using Xunit;
 
 namespace FastTests.Voron.Bugs

--- a/test/FastTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/test/FastTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
@@ -1,11 +1,12 @@
 ﻿using System.IO;
 using Xunit;
 using Voron;
+using Voron.Data;
 
 namespace FastTests.Voron.Bugs
 {
     public class InvalidReleasesOfScratchPages : StorageTest
-	{
+    {
         [Fact]
         public void ReadTransactionCanReadJustCommittedValue()
         {
@@ -29,37 +30,37 @@ namespace FastTests.Voron.Bugs
         }
 
         protected override void Configure(StorageEnvironmentOptions options)
-		{
-			options.MaxScratchBufferSize *= 2;
-		}
+        {
+            options.MaxScratchBufferSize *= 2;
+        }
 
-		[Fact]
-		public void AllScratchPagesShouldBeReleased()
-		{
-			var options = StorageEnvironmentOptions.CreateMemoryOnly();
-			options.ManualFlushing = true;
-			using (var env = new StorageEnvironment(options))
-			{
-				using (var txw = env.WriteTransaction())
-				{
-					txw.CreateTree("test");
+        [Fact]
+        public void AllScratchPagesShouldBeReleased()
+        {
+            var options = StorageEnvironmentOptions.CreateMemoryOnly();
+            options.ManualFlushing = true;
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var txw = env.WriteTransaction())
+                {
+                    txw.CreateTree("test");
 
-					txw.Commit();
-				}
+                    txw.Commit();
+                }
 
-				using (var txw = env.WriteTransaction())
-				{
-					var tree = txw.CreateTree("test");
+                using (var txw = env.WriteTransaction())
+                {
+                    var tree = txw.CreateTree("test");
 
-					tree.Add("key/1", new MemoryStream(new byte[100]));
-					tree.Add("key/1", new MemoryStream(new byte[200]));
-					txw.Commit();
-				}
+                    tree.Add("key/1", new MemoryStream(new byte[100]));
+                    tree.Add("key/1", new MemoryStream(new byte[200]));
+                    txw.Commit();
+                }
 
-				env.FlushLogToDataFile(); // non read nor write transactions, so it should flush and release everything from scratch
+                env.FlushLogToDataFile(); // non read nor write transactions, so it should flush and release everything from scratch
 
-				Assert.Equal(0, env.ScratchBufferPool.GetNumberOfAllocations(0));
-			}
-		}
-	}
+                Assert.Equal(0, env.ScratchBufferPool.GetNumberOfAllocations(0));
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Bugs/Isolation.cs
+++ b/test/FastTests/Voron/Bugs/Isolation.cs
@@ -2,185 +2,186 @@
 using System.IO;
 using Xunit;
 using Voron;
+using Voron.Data;
 
 namespace FastTests.Voron.Bugs
 {
     public class Isolation : StorageTest
-	{
-		[Fact]
-		public void MultiTreeIteratorShouldBeIsolated1()
-		{
-			DeleteDirectory(DataDir);
+    {
+        [Fact]
+        public void MultiTreeIteratorShouldBeIsolated1()
+        {
+            DeleteDirectory(DataDir);
 
-			var options = StorageEnvironmentOptions.ForPath(DataDir);
+            var options = StorageEnvironmentOptions.ForPath(DataDir);
 
-			using (var env = new StorageEnvironment(options))
-			{
-				CreateTrees(env, 1, "tree");
+            using (var env = new StorageEnvironment(options))
+            {
+                CreateTrees(env, 1, "tree");
 
-				for (var i = 0; i < 10; i++)
-					Write(env, i);
+                for (var i = 0; i < 10; i++)
+                    Write(env, i);
 
-				using (var txr = env.ReadTransaction())
-				{
-					var key = Write(env, 10);
+                using (var txr = env.ReadTransaction())
+                {
+                    var key = Write(env, 10);
 
-					using (var iterator = txr.ReadTree("tree0").MultiRead("key/1"))
-					{
-						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                    using (var iterator = txr.ReadTree("tree0").MultiRead("key/1"))
+                    {
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-						var count = 0;
+                        var count = 0;
 
-						do
-						{
-							Assert.True(iterator.CurrentKey.ToString() != key, string.Format("Key '{0}' should not be present in multi-iterator", key));
+                        do
+                        {
+                            Assert.True(iterator.CurrentKey.ToString() != key, string.Format("Key '{0}' should not be present in multi-iterator", key));
 
-							count++;
-						}
-						while (iterator.MoveNext());
+                            count++;
+                        }
+                        while (iterator.MoveNext());
 
-						Assert.Equal(10, count);
-					}
-				}
-			}
-		}
+                        Assert.Equal(10, count);
+                    }
+                }
+            }
+        }
 
-		[Fact]
-		public void MultiTreeIteratorShouldBeIsolated2()
-		{
+        [Fact]
+        public void MultiTreeIteratorShouldBeIsolated2()
+        {
 
-			DeleteDirectory(DataDir);
+            DeleteDirectory(DataDir);
 
-			var options = StorageEnvironmentOptions.ForPath(DataDir);
+            var options = StorageEnvironmentOptions.ForPath(DataDir);
 
-			using (var env = new StorageEnvironment(options))
-			{
-				CreateTrees(env, 1, "tree");
+            using (var env = new StorageEnvironment(options))
+            {
+                CreateTrees(env, 1, "tree");
 
-				for (var i = 0; i < 11; i++)
-					Write(env, i);
+                for (var i = 0; i < 11; i++)
+                    Write(env, i);
 
-				using (var txr = env.ReadTransaction())
-				{
-					var key = Delete(env, 10);
+                using (var txr = env.ReadTransaction())
+                {
+                    var key = Delete(env, 10);
 
-					using (var iterator = txr.ReadTree("tree0").MultiRead("key/1"))
-					{
-						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                    using (var iterator = txr.ReadTree("tree0").MultiRead("key/1"))
+                    {
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-						var keys = new List<string>();
+                        var keys = new List<string>();
 
-						do
-						{
-							keys.Add(iterator.CurrentKey.ToString());
-						}
-						while (iterator.MoveNext());
+                        do
+                        {
+                            keys.Add(iterator.CurrentKey.ToString());
+                        }
+                        while (iterator.MoveNext());
 
-						Assert.Equal(11, keys.Count);
-						Assert.Contains(key, keys);
-					}
-				}
-			}
-		}
+                        Assert.Equal(11, keys.Count);
+                        Assert.Contains(key, keys);
+                    }
+                }
+            }
+        }
 
-		private static string Delete(StorageEnvironment env, int i)
-		{
-			using (var txw = env.WriteTransaction())
-			{
-				var key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.ToString("D2");
+        private static string Delete(StorageEnvironment env, int i)
+        {
+            using (var txw = env.WriteTransaction())
+            {
+                var key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.ToString("D2");
 
-				txw.ReadTree("tree0").MultiDelete("key/1", key);
-				txw.Commit();
+                txw.ReadTree("tree0").MultiDelete("key/1", key);
+                txw.Commit();
 
-				return key;
-			}
-		}
+                return key;
+            }
+        }
 
-		private static string Write(StorageEnvironment env, int i)
-		{
-			using (var txw = env.WriteTransaction())
-			{
-				var key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.ToString("D2");
+        private static string Write(StorageEnvironment env, int i)
+        {
+            using (var txw = env.WriteTransaction())
+            {
+                var key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.ToString("D2");
 
-				txw.ReadTree("tree0").MultiAdd("key/1", key);
-				txw.Commit();
+                txw.ReadTree("tree0").MultiAdd("key/1", key);
+                txw.Commit();
 
-				return key;
-			}
-		}
+                return key;
+            }
+        }
 
-		[Fact]
-		public void ScratchPagesShouldNotBeReleasedUntilNotUsed()
-		{
-			var options = StorageEnvironmentOptions.ForPath(DataDir);
+        [Fact]
+        public void ScratchPagesShouldNotBeReleasedUntilNotUsed()
+        {
+            var options = StorageEnvironmentOptions.ForPath(DataDir);
 
-			options.ManualFlushing = true;
-			using (var env = new StorageEnvironment(options))
-			{
-				CreateTrees(env, 2, "tree");
-				for (int a = 0; a < 3; a++)
-				{
-					using (var tx = env.WriteTransaction())
-					{
-						tx.CreateTree(  "tree0").Add(string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
-						tx.CreateTree(  "tree0").Add(string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
+            options.ManualFlushing = true;
+            using (var env = new StorageEnvironment(options))
+            {
+                CreateTrees(env, 2, "tree");
+                for (int a = 0; a < 3; a++)
+                {
+                    using (var tx = env.WriteTransaction())
+                    {
+                        tx.CreateTree(  "tree0").Add(string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
+                        tx.CreateTree(  "tree0").Add(string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
 
-						tx.Commit();
-					}
-				}
+                        tx.Commit();
+                    }
+                }
 
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree( "tree1").Add("yek/1", new MemoryStream());
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree( "tree1").Add("yek/1", new MemoryStream());
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var txr = env.ReadTransaction())
-				{
-					using (var iterator = txr.CreateTree("tree0").Iterate())
-					{
-						Assert.True(iterator.Seek(Slice.BeforeAllKeys)); // all pages are from scratch (one from position 11)
+                using (var txr = env.ReadTransaction())
+                {
+                    using (var iterator = txr.CreateTree("tree0").Iterate())
+                    {
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys)); // all pages are from scratch (one from position 11)
 
-						var currentKey = iterator.CurrentKey.ToString();
+                        var currentKey = iterator.CurrentKey.ToString();
 
-						env.FlushLogToDataFile(); // frees pages from scratch (including the one at position 11)
+                        env.FlushLogToDataFile(); // frees pages from scratch (including the one at position 11)
 
-						using (var txw = env.WriteTransaction())
-						{
-							var tree = txw.CreateTree("tree1");
-							tree.Add(string.Format("yek/{0}/0/0", new string('0', 1000)), new MemoryStream()); // allocates new page from scratch (position 11)
+                        using (var txw = env.WriteTransaction())
+                        {
+                            var tree = txw.CreateTree("tree1");
+                            tree.Add(string.Format("yek/{0}/0/0", new string('0', 1000)), new MemoryStream()); // allocates new page from scratch (position 11)
 
-							txw.Commit();
-						}
+                            txw.Commit();
+                        }
 
-						Assert.Equal(currentKey, iterator.CurrentKey.ToString());
+                        Assert.Equal(currentKey, iterator.CurrentKey.ToString());
 
-						using (var txw = env.WriteTransaction())
-						{
-							var tree = txw.CreateTree( "tree1");
-							tree.Add("fake", new MemoryStream());
+                        using (var txw = env.WriteTransaction())
+                        {
+                            var tree = txw.CreateTree( "tree1");
+                            tree.Add("fake", new MemoryStream());
 
-							txw.Commit();
-						}
+                            txw.Commit();
+                        }
 
-						Assert.Equal(currentKey, iterator.CurrentKey.ToString());
+                        Assert.Equal(currentKey, iterator.CurrentKey.ToString());
 
-						var count = 0;
+                        var count = 0;
 
-						do
-						{
-							currentKey = iterator.CurrentKey.ToString();
-							count++;
+                        do
+                        {
+                            currentKey = iterator.CurrentKey.ToString();
+                            count++;
 
-							Assert.Contains("key/", currentKey);
-						}
-						while (iterator.MoveNext());
+                            Assert.Contains("key/", currentKey);
+                        }
+                        while (iterator.MoveNext());
 
-						Assert.Equal(6, count);
-					}
-				}
-			}
-		}
-	}
+                        Assert.Equal(6, count);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Bugs/Iterating.cs
+++ b/test/FastTests/Voron/Bugs/Iterating.cs
@@ -6,37 +6,38 @@
 
 using Xunit;
 using Voron;
+using Voron.Data;
 
 namespace FastTests.Voron.Bugs
 {
-	public class Iterating : StorageTest
-	{
-		[Fact]
-		public void IterationShouldNotFindAnyRecordsAndShouldNotThrowWhenNumberOfEntriesOnPageIs1AndKeyDoesNotMatch()
-		{
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree("tree");
+    public class Iterating : StorageTest
+    {
+        [Fact]
+        public void IterationShouldNotFindAnyRecordsAndShouldNotThrowWhenNumberOfEntriesOnPageIs1AndKeyDoesNotMatch()
+        {
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree("tree");
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var tx = env.WriteTransaction())
-				{
-					var tree = tx.ReadTree("tree");
-					tree.Add(@"Raven\Database\1", StreamFor("123"));
+                using (var tx = env.WriteTransaction())
+                {
+                    var tree = tx.ReadTree("tree");
+                    tree.Add(@"Raven\Database\1", StreamFor("123"));
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var snapshot = env.ReadTransaction())
-				using (var iterator = snapshot.ReadTree("tree").Iterate())
-				{
-					Assert.False(iterator.Seek(@"Raven\Filesystem\"));
-				}
-			}
-		}
-	}
+                using (var snapshot = env.ReadTransaction())
+                using (var iterator = snapshot.ReadTree("tree").Iterate())
+                {
+                    Assert.False(iterator.Seek(Slice.From(snapshot.Allocator, @"Raven\Filesystem\")));
+                }
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Bugs/MemoryAccess.cs
+++ b/test/FastTests/Voron/Bugs/MemoryAccess.cs
@@ -2,64 +2,65 @@
 using System.Threading;
 using Xunit;
 using Voron;
+using Voron.Data;
 
 namespace FastTests.Voron.Bugs
 {
-	public class MemoryAccess : StorageTest
-	{
-		protected override void Configure(StorageEnvironmentOptions options)
-		{
-			base.Configure(options);
-			options.ManualFlushing = true;
-		}
+    public class MemoryAccess : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            base.Configure(options);
+            options.ManualFlushing = true;
+        }
 
-		[Fact]
-		public void ShouldNotThrowAccessViolation()
-		{
-			var trees = CreateTrees(Env, 1, "tree");
+        [Fact]
+        public void ShouldNotThrowAccessViolation()
+        {
+            var trees = CreateTrees(Env, 1, "tree");
 
-			for (int a = 0; a < 2; a++)
-			{
-				using (var tx = Env.WriteTransaction())
-				{
-					foreach (var tree in trees)
-					{
-						tx.ReadTree( tree).Add(string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
-						tx.ReadTree( tree).Add(string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
-					}
+            for (int a = 0; a < 2; a++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    foreach (var tree in trees)
+                    {
+                        tx.ReadTree( tree).Add(string.Format("key/{0}/{1}/1", new string('0', 1000), a), new MemoryStream());
+                        tx.ReadTree( tree).Add(string.Format("key/{0}/{1}/2", new string('0', 1000), a), new MemoryStream());
+                    }
 
-					tx.Commit();
-				}
-			}
+                    tx.Commit();
+                }
+            }
 
-			using (var txr = Env.ReadTransaction())
-			{
-				foreach (var tree in trees)
-				{
-					using (var iterator = txr.ReadTree(tree).Iterate())
-					{
-						if (!iterator.Seek(Slice.BeforeAllKeys))
-							continue;
+            using (var txr = Env.ReadTransaction())
+            {
+                foreach (var tree in trees)
+                {
+                    using (var iterator = txr.ReadTree(tree).Iterate())
+                    {
+                        if (!iterator.Seek(Slices.BeforeAllKeys))
+                            continue;
 
-						Env.FlushLogToDataFile();
+                        Env.FlushLogToDataFile();
 
-						using (var txw = Env.WriteTransaction())
-						{
-							txw.ReadTree(tree).Add(string.Format("key/{0}/0/0", new string('0', 1000)), new MemoryStream());
+                        using (var txw = Env.WriteTransaction())
+                        {
+                            txw.ReadTree(tree).Add(string.Format("key/{0}/0/0", new string('0', 1000)), new MemoryStream());
 
-							txw.Commit();
-						}
+                            txw.Commit();
+                        }
 
-						Thread.Sleep(1000);
+                        Thread.Sleep(1000);
 
-						do
-						{
-							Assert.Contains("key/", iterator.CurrentKey.ToString());
-						}
-						while (iterator.MoveNext());
-					}
-				}
-			}
-		}
-	}
+                        do
+                        {
+                            Assert.Contains("key/", iterator.CurrentKey.ToString());
+                        }
+                        while (iterator.MoveNext());
+                    }
+                }
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Bugs/MultiAdds.cs
+++ b/test/FastTests/Voron/Bugs/MultiAdds.cs
@@ -7,8 +7,8 @@ using Voron;
 namespace FastTests.Voron.Bugs
 {
     public class MultiAdds
-	{
-		readonly Random _random = new Random(1234);
+    {
+        readonly Random _random = new Random(1234);
 
         private string RandomString(int size)
         {
@@ -21,40 +21,40 @@ namespace FastTests.Voron.Bugs
             return builder.ToString();
         }
 
-		[Fact]
-		public void SplitterIssue()
-		{
-			const int DocumentCount = 10;
+        [Fact]
+        public void SplitterIssue()
+        {
+            const int DocumentCount = 10;
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
-			{
-				var rand = new Random();
-				var testBuffer = new byte[168];
-				rand.NextBytes(testBuffer);
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
+            {
+                var rand = new Random();
+                var testBuffer = new byte[168];
+                rand.NextBytes(testBuffer);
 
-				var multiTrees = CreateTrees(env, 1, "multitree");
+                var multiTrees = CreateTrees(env, 1, "multitree");
 
-				for (var i = 0; i < 50; i++)
-				{
-					AddMultiRecords(env, multiTrees, DocumentCount, true);
+                for (var i = 0; i < 50; i++)
+                {
+                    AddMultiRecords(env, multiTrees, DocumentCount, true);
 
-					ValidateMultiRecords(env, multiTrees, DocumentCount, i + 1);
-				}
-			}
-		}
+                    ValidateMultiRecords(env, multiTrees, DocumentCount, i + 1);
+                }
+            }
+        }
 
-		[Fact]
-		public void SplitterIssue2()
-		{
-			var storageEnvironmentOptions = StorageEnvironmentOptions.CreateMemoryOnly();
-			storageEnvironmentOptions.ManualFlushing = true;
-			using (var env = new StorageEnvironment(storageEnvironmentOptions))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree(  "multi");
-					tx.Commit();
-				}
+        [Fact]
+        public void SplitterIssue2()
+        {
+            var storageEnvironmentOptions = StorageEnvironmentOptions.CreateMemoryOnly();
+            storageEnvironmentOptions.ManualFlushing = true;
+            using (var env = new StorageEnvironment(storageEnvironmentOptions))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree(  "multi");
+                    tx.Commit();
+                }
 
                 using (var tx = env.WriteTransaction())
                 {
@@ -71,22 +71,22 @@ namespace FastTests.Voron.Bugs
                 }
 
 
-				using (var tx = env.ReadTransaction())
-				{
-					var tree = tx.CreateTree("multi");
-					using (var iterator = tree.MultiRead("0"))
-					{
-						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                using (var tx = env.ReadTransaction())
+                {
+                    var tree = tx.CreateTree("multi");
+                    using (var iterator = tree.MultiRead("0"))
+                    {
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-						var count = 0;
-						do
-						{
-							count++;
-						} while (iterator.MoveNext());
+                        var count = 0;
+                        do
+                        {
+                            count++;
+                        } while (iterator.MoveNext());
 
-						Assert.Equal(1, count);
-					}
-				}
+                        Assert.Equal(1, count);
+                    }
+                }
 
                 using (var tx = env.WriteTransaction())
                 {
@@ -104,35 +104,35 @@ namespace FastTests.Voron.Bugs
 
 
 
-				using (var tx = env.ReadTransaction())
-				{
-					var tree = tx.CreateTree("multi");
-					using (var iterator = tree.MultiRead("0"))
-					{
-						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                using (var tx = env.ReadTransaction())
+                {
+                    var tree = tx.CreateTree("multi");
+                    using (var iterator = tree.MultiRead("0"))
+                    {
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-						var count = 0;
-						do
-						{
-							count++;
-						} while (iterator.MoveNext());
+                        var count = 0;
+                        do
+                        {
+                            count++;
+                        } while (iterator.MoveNext());
 
-						Assert.Equal(2, count);
-					}
-				}
-			}
-		}
+                        Assert.Equal(2, count);
+                    }
+                }
+            }
+        }
 
-		[Fact]
-		public void CanAddMultiValuesUnderTheSameKeyToBatch()
-		{
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
-			{
-				var rand = new Random();
-				var testBuffer = new byte[168];
-				rand.NextBytes(testBuffer);
+        [Fact]
+        public void CanAddMultiValuesUnderTheSameKeyToBatch()
+        {
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
+            {
+                var rand = new Random();
+                var testBuffer = new byte[168];
+                rand.NextBytes(testBuffer);
 
-				CreateTrees(env, 1, "multitree");
+                CreateTrees(env, 1, "multitree");
 
                 using (var tx = env.WriteTransaction())
                 {
@@ -145,53 +145,53 @@ namespace FastTests.Voron.Bugs
                 }
 
 
-				using (var tx = env.ReadTransaction())
-				{
-					var tree = tx.CreateTree("multitree0");
-					using (var it = tree.MultiRead("key"))
-					{
-						Assert.True(it.Seek(Slice.BeforeAllKeys));
+                using (var tx = env.ReadTransaction())
+                {
+                    var tree = tx.CreateTree("multitree0");
+                    using (var it = tree.MultiRead("key"))
+                    {
+                        Assert.True(it.Seek(Slices.BeforeAllKeys));
 
-						Assert.Equal("value1", it.CurrentKey.ToString());
-						Assert.True(it.MoveNext());
+                        Assert.Equal("value1", it.CurrentKey.ToString());
+                        Assert.True(it.MoveNext());
 
-						Assert.Equal("value2", it.CurrentKey.ToString());
-					}
-				}
-			}
-		}
+                        Assert.Equal("value2", it.CurrentKey.ToString());
+                    }
+                }
+            }
+        }
 
-		private void ValidateMultiRecords(StorageEnvironment env, IEnumerable<string> trees, int documentCount, int i)
-		{
-			using (var tx = env.ReadTransaction())
-			{
-				for (var j = 0; j < 10; j++)
-				{
-					
-					foreach (var treeName in trees)
-					{
-					    var tree = tx.CreateTree(treeName);
-						using (var iterator = tree.MultiRead((j % 10).ToString()))
-						{
-							Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+        private void ValidateMultiRecords(StorageEnvironment env, IEnumerable<string> trees, int documentCount, int i)
+        {
+            using (var tx = env.ReadTransaction())
+            {
+                for (var j = 0; j < 10; j++)
+                {
+                    
+                    foreach (var treeName in trees)
+                    {
+                        var tree = tx.CreateTree(treeName);
+                        using (var iterator = tree.MultiRead((j % 10).ToString()))
+                        {
+                            Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-							var count = 0;
-							do
-							{
-								count++;
-							}
-							while (iterator.MoveNext());
+                            var count = 0;
+                            do
+                            {
+                                count++;
+                            }
+                            while (iterator.MoveNext());
 
-							Assert.Equal((i * documentCount) / 10, count);
-						}
-					}
-				}
-			}
-		}
-		private void AddMultiRecords(StorageEnvironment env, IList<string> trees, int documentCount, bool sequential)
-		{
-		    using (var tx = env.WriteTransaction())
-		    {
+                            Assert.Equal((i * documentCount) / 10, count);
+                        }
+                    }
+                }
+            }
+        }
+        private void AddMultiRecords(StorageEnvironment env, IList<string> trees, int documentCount, bool sequential)
+        {
+            using (var tx = env.WriteTransaction())
+            {
                 var key = Guid.NewGuid().ToString();
 
                 for (int i = 0; i < documentCount; i++)
@@ -207,23 +207,23 @@ namespace FastTests.Voron.Bugs
                 tx.Commit();
             }
 
-		}
+        }
 
-		private IList<string> CreateTrees(StorageEnvironment env, int number, string prefix)
-		{
-			var results = new List<string>();
+        private IList<string> CreateTrees(StorageEnvironment env, int number, string prefix)
+        {
+            var results = new List<string>();
 
-			using (var tx = env.WriteTransaction())
-			{
-				for (var i = 0; i < number; i++)
-				{
-					results.Add(tx.CreateTree( prefix + i).Name);
-				}
+            using (var tx = env.WriteTransaction())
+            {
+                for (var i = 0; i < number; i++)
+                {
+                    results.Add(tx.CreateTree( prefix + i).Name);
+                }
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			return results;
-		}
-	}
+            return results;
+        }
+    }
 }

--- a/test/FastTests/Voron/Bugs/MultiReads.cs
+++ b/test/FastTests/Voron/Bugs/MultiReads.cs
@@ -27,7 +27,7 @@ namespace FastTests.Voron.Bugs
                 using (var snapshot = Env.ReadTransaction())
                 using (var iterator = snapshot.CreateTree(treeName).MultiRead("queue1"))
                 {
-                    Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                    Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
                     Assert.Equal("queue1/07000000-0000-0000-0000-000000000001", iterator.CurrentKey.ToString());
                     Assert.True(iterator.MoveNext());
@@ -57,7 +57,7 @@ namespace FastTests.Voron.Bugs
                 using (var snapshot = Env.ReadTransaction())
                 using (var iterator = snapshot.CreateTree(treeName).MultiRead("etags"))
                 {
-                    Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                    Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
                     for (int i = 0; i < numberOfEntries; i++)
                     {

--- a/test/FastTests/Voron/Bugs/OverflowsReusage.cs
+++ b/test/FastTests/Voron/Bugs/OverflowsReusage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Voron;
+using Voron.Data;
 using Xunit;
 
 namespace FastTests.Voron.Bugs

--- a/test/FastTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
+++ b/test/FastTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
@@ -1,127 +1,128 @@
 ﻿using System.IO;
 using Xunit;
 using Voron;
+using Voron.Data;
 using Voron.Debugging;
 
 namespace FastTests.Voron.Bugs
 {
-	public class PagesFilteredOutByJournalApplicator : StorageTest
-	{
-		protected override void Configure(StorageEnvironmentOptions options)
-		{
-			base.Configure(options);
-			options.ManualFlushing = true;
-		}
+    public class PagesFilteredOutByJournalApplicator : StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            base.Configure(options);
+            options.ManualFlushing = true;
+        }
 
-		[Fact]
-		public void CouldNotReadPagesThatWereFilteredOutByJournalApplicator_1()
-		{
-			var bytes = new byte[1000];
+        [Fact]
+        public void CouldNotReadPagesThatWereFilteredOutByJournalApplicator_1()
+        {
+            var bytes = new byte[1000];
 
-			using (var txw = Env.WriteTransaction())
-			{
-				var tree = txw.CreateTree("foo");
+            using (var txw = Env.WriteTransaction())
+            {
+                var tree = txw.CreateTree("foo");
 
-				tree.Add("bars/1", new MemoryStream(bytes));
+                tree.Add("bars/1", new MemoryStream(bytes));
 
-				txw.Commit();
-
-				DebugStuff.RenderAndShow(tree);
-			}
-
-			using (var txw = Env.WriteTransaction())
-			{
-				txw.CreateTree("bar");
-
-				txw.Commit();
-			}
-
-			using (var txw = Env.WriteTransaction())
-			{
-				txw.CreateTree("baz");
-
-				txw.Commit();
-			}
-
-			using (var txr = Env.ReadTransaction())
-			{
-				using (var txw = Env.WriteTransaction())
-				{
-					var tree = txw.CreateTree("foo");
-
-					tree.Add("bars/1", new MemoryStream());
-
-					txw.Commit();
-
-				}
-
-				Env.FlushLogToDataFile();
-
-				Assert.NotNull(txr.CreateTree( "foo").Read("bars/1"));
-			}
-		} 
-
-		[Fact]
-		public void CouldNotReadPagesThatWereFilteredOutByJournalApplicator_2()
-		{
-			var bytes = new byte[1000];
-
-			using (var txw = Env.WriteTransaction())
-			{
-				var tree = txw.CreateTree( "foo");
-
-				tree.Add("bars/1", new MemoryStream(bytes));
-				tree.Add("bars/2", new MemoryStream(bytes));
-				tree.Add("bars/3", new MemoryStream(bytes));
-				tree.Add("bars/4", new MemoryStream(bytes));
-
-				txw.Commit();
-
-				DebugStuff.RenderAndShow(tree);
-			}
-
-			using (var txw = Env.WriteTransaction())
-			{
-				var tree = txw.CreateTree(  "foo");
-
-				tree.Add("bars/0", new MemoryStream());
-				tree.Add("bars/5", new MemoryStream());
-
-				txw.Commit();
+                txw.Commit();
 
                 DebugStuff.RenderAndShow(tree);
-			}
+            }
 
-			using (var txw = Env.WriteTransaction())
-			{
-                txw.CreateTree(  "bar");
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree("bar");
 
-				txw.Commit();
-			}
+                txw.Commit();
+            }
 
-			using (var txw = Env.WriteTransaction())
-			{
+            using (var txw = Env.WriteTransaction())
+            {
                 txw.CreateTree("baz");
 
-				txw.Commit();
-			}
+                txw.Commit();
+            }
 
-			using (var txr = Env.ReadTransaction())
-			{
-				using (var txw = Env.WriteTransaction())
-				{
-					var tree = txw.CreateTree(  "foo");
+            using (var txr = Env.ReadTransaction())
+            {
+                using (var txw = Env.WriteTransaction())
+                {
+                    var tree = txw.CreateTree("foo");
 
-					tree.Add("bars/4", new MemoryStream());
+                    tree.Add("bars/1", new MemoryStream());
 
-					txw.Commit();
+                    txw.Commit();
 
-				}
+                }
 
-				Env.FlushLogToDataFile();
+                Env.FlushLogToDataFile();
 
-				Assert.NotNull(txr.CreateTree( "foo").Read("bars/5"));
-			}
-		}
-	}
+                Assert.NotNull(txr.CreateTree( "foo").Read("bars/1"));
+            }
+        } 
+
+        [Fact]
+        public void CouldNotReadPagesThatWereFilteredOutByJournalApplicator_2()
+        {
+            var bytes = new byte[1000];
+
+            using (var txw = Env.WriteTransaction())
+            {
+                var tree = txw.CreateTree( "foo");
+
+                tree.Add("bars/1", new MemoryStream(bytes));
+                tree.Add("bars/2", new MemoryStream(bytes));
+                tree.Add("bars/3", new MemoryStream(bytes));
+                tree.Add("bars/4", new MemoryStream(bytes));
+
+                txw.Commit();
+
+                DebugStuff.RenderAndShow(tree);
+            }
+
+            using (var txw = Env.WriteTransaction())
+            {
+                var tree = txw.CreateTree(  "foo");
+
+                tree.Add("bars/0", new MemoryStream());
+                tree.Add("bars/5", new MemoryStream());
+
+                txw.Commit();
+
+                DebugStuff.RenderAndShow(tree);
+            }
+
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree(  "bar");
+
+                txw.Commit();
+            }
+
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree("baz");
+
+                txw.Commit();
+            }
+
+            using (var txr = Env.ReadTransaction())
+            {
+                using (var txw = Env.WriteTransaction())
+                {
+                    var tree = txw.CreateTree(  "foo");
+
+                    tree.Add("bars/4", new MemoryStream());
+
+                    txw.Commit();
+
+                }
+
+                Env.FlushLogToDataFile();
+
+                Assert.NotNull(txr.CreateTree( "foo").Read("bars/5"));
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Bugs/StartsWithSearch.cs
+++ b/test/FastTests/Voron/Bugs/StartsWithSearch.cs
@@ -32,11 +32,11 @@ namespace FastTests.Voron.Bugs
                     var tree = tx.ReadTree("data");
                     using (var it = tree.Iterate())
                     {
-                        Assert.True(it.Seek("users-7"));
+                        Assert.True(it.Seek(Slice.From(tx.Allocator, "users-7")));
 
                         for (int i = 0; i < 10; i++)
                         {
-                            Assert.True(it.Seek("users-"+i),i.ToString());
+                            Assert.True(it.Seek(Slice.From(tx.Allocator, "users-" +i)),i.ToString());
                         }
                     }
                 }

--- a/test/FastTests/Voron/Bugs/TreeRebalancer.cs
+++ b/test/FastTests/Voron/Bugs/TreeRebalancer.cs
@@ -7,129 +7,129 @@ using Voron;
 namespace FastTests.Voron.Bugs
 {
     public class TreeRebalancer : StorageTest
-	{
-		[Fact]
-		public void TreeRabalancerShouldCopyNodeFlagsWhenMultiValuePageRefIsSet()
-		{
-			var addedIds = new Dictionary<string, string>();
+    {
+        [Fact]
+        public void TreeRabalancerShouldCopyNodeFlagsWhenMultiValuePageRefIsSet()
+        {
+            var addedIds = new Dictionary<string, string>();
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
-			{
-				var multiTrees = CreateTrees(env, 1, "multiTree");
-				using (var tx = env.WriteTransaction())
-				{
-					for (var i = 0; i < 120; i++)
-					{
-						foreach (var multiTreeName in multiTrees)
-						{
-						    var multiTree = tx.CreateTree(multiTreeName);
-							var id = Guid.NewGuid().ToString();
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))
+            {
+                var multiTrees = CreateTrees(env, 1, "multiTree");
+                using (var tx = env.WriteTransaction())
+                {
+                    for (var i = 0; i < 120; i++)
+                    {
+                        foreach (var multiTreeName in multiTrees)
+                        {
+                            var multiTree = tx.CreateTree(multiTreeName);
+                            var id = Guid.NewGuid().ToString();
 
-							addedIds.Add("test/0/user-" + i, id);
+                            addedIds.Add("test/0/user-" + i, id);
 
-							multiTree.MultiAdd("test/0/user-" + i, id);
-						}
-					}
+                            multiTree.MultiAdd("test/0/user-" + i, id);
+                        }
+                    }
 
-					foreach (var multiTreeName in multiTrees)
-					{
+                    foreach (var multiTreeName in multiTrees)
+                    {
                         var multiTree = tx.CreateTree(multiTreeName);
-						multiTree.MultiAdd("test/0/user-50", Guid.NewGuid().ToString());
-					}
+                        multiTree.MultiAdd("test/0/user-50", Guid.NewGuid().ToString());
+                    }
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
 
-				for (var i = 119; i > 99; i--)
-				{
-					using (var tx = env.WriteTransaction())
-					{
+                for (var i = 119; i > 99; i--)
+                {
+                    using (var tx = env.WriteTransaction())
+                    {
                         foreach (var multiTreeName in multiTrees)
                         {
                             var multiTree = tx.CreateTree(multiTreeName);
-					
-							multiTree.MultiDelete("test/0/user-" + i, addedIds["test/0/user-" + i]);
-						}
+                    
+                            multiTree.MultiDelete("test/0/user-" + i, addedIds["test/0/user-" + i]);
+                        }
 
-						tx.Commit();
-					}
+                        tx.Commit();
+                    }
 
-					ValidateMulti(env, multiTrees);
-				}
+                    ValidateMulti(env, multiTrees);
+                }
 
-				for (var i = 0; i < 50; i++)
-				{
-					using (var tx = env.WriteTransaction())
-					{
-				
+                for (var i = 0; i < 50; i++)
+                {
+                    using (var tx = env.WriteTransaction())
+                    {
+                
 
                         foreach (var multiTreeName in multiTrees)
                         {
                             var multiTree = tx.CreateTree(multiTreeName);
-					
-							multiTree.MultiDelete("test/0/user-" + i, addedIds["test/0/user-" + i]);
-						}
+                    
+                            multiTree.MultiDelete("test/0/user-" + i, addedIds["test/0/user-" + i]);
+                        }
 
-						tx.Commit();
-					}
+                        tx.Commit();
+                    }
 
-					ValidateMulti(env, multiTrees);
-				}
+                    ValidateMulti(env, multiTrees);
+                }
 
-				ValidateMulti(env, multiTrees);
-			}
-		}
+                ValidateMulti(env, multiTrees);
+            }
+        }
 
-		private void ValidateMulti(StorageEnvironment env, IEnumerable<string> trees)
-		{
-			using (var snapshot = env.ReadTransaction())
-			{
-				foreach (var tree in trees)
-				{
-					using (var iterator = snapshot.ReadTree(tree).MultiRead( "test/0/user-50"))
-					{
-						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+        private void ValidateMulti(StorageEnvironment env, IEnumerable<string> trees)
+        {
+            using (var snapshot = env.ReadTransaction())
+            {
+                foreach (var tree in trees)
+                {
+                    using (var iterator = snapshot.ReadTree(tree).MultiRead( "test/0/user-50"))
+                    {
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-						var keys = new HashSet<string>();
+                        var keys = new HashSet<string>();
 
-						var count = 0;
-						do
-						{
-							keys.Add(iterator.CurrentKey.ToString());
-							Guid.Parse(iterator.CurrentKey.ToString());
+                        var count = 0;
+                        do
+                        {
+                            keys.Add(iterator.CurrentKey.ToString());
+                            Guid.Parse(iterator.CurrentKey.ToString());
 
-							count++;
-						}
-						while (iterator.MoveNext());
+                            count++;
+                        }
+                        while (iterator.MoveNext());
 
-						Assert.Equal(2, count);
-						Assert.Equal(2, keys.Count);
-					}
-				}
-			}
-		}
+                        Assert.Equal(2, count);
+                        Assert.Equal(2, keys.Count);
+                    }
+                }
+            }
+        }
 
-		[Fact]
-		public void ShouldNotThrowThatPageIsFullDuringTreeRebalancing()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree( "rebalancing-issue");
+        [Fact]
+        public void ShouldNotThrowThatPageIsFullDuringTreeRebalancing()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree( "rebalancing-issue");
 
-				var aKey = new string('a', 1024);
-				var bKey = new string('b', 1024);
-				var cKey = new string('c', 1024);
-				var dKey = new string('d', 1024);
-				var eKey = new string('e', 600);
-				var fKey = new string('f', 920);
+                var aKey = new string('a', 1024);
+                var bKey = new string('b', 1024);
+                var cKey = new string('c', 1024);
+                var dKey = new string('d', 1024);
+                var eKey = new string('e', 600);
+                var fKey = new string('f', 920);
 
-				tree.Add(aKey, new MemoryStream(new byte[1000]));
-				tree.Add(bKey, new MemoryStream(new byte[1000]));
-				tree.Add(cKey, new MemoryStream(new byte[1000]));
-				tree.Add(dKey, new MemoryStream(new byte[1000]));
-				tree.Add(eKey, new MemoryStream(new byte[800]));
-				tree.Add(fKey, new MemoryStream(new byte[10]));
+                tree.Add(aKey, new MemoryStream(new byte[1000]));
+                tree.Add(bKey, new MemoryStream(new byte[1000]));
+                tree.Add(cKey, new MemoryStream(new byte[1000]));
+                tree.Add(dKey, new MemoryStream(new byte[1000]));
+                tree.Add(eKey, new MemoryStream(new byte[800]));
+                tree.Add(fKey, new MemoryStream(new byte[10]));
 
                 // to expose the bug we need to delete the last item from the left most page
                 // tree rebalance will try to fix the first reference (the implicit ref page node) in the parent page which is almost full 
@@ -137,66 +137,66 @@ namespace FastTests.Voron.Bugs
 
                 tree.Delete(aKey); // this line throws "The page is full and cannot add an entry, this is probably a bug"
 
-				tx.Commit();
+                tx.Commit();
 
-				using (var iterator = tree.Iterate())
-				{
-					Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                using (var iterator = tree.Iterate())
+                {
+                    Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-					Assert.Equal(bKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(bKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(cKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(cKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(dKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(dKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(eKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(eKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(fKey, iterator.CurrentKey);
-					Assert.False(iterator.MoveNext());
-				}
-			}
-		}
+                    Assert.Equal(fKey, iterator.CurrentKey.ToString());
+                    Assert.False(iterator.MoveNext());
+                }
+            }
+        }
 
-		[Fact]
-		public void RavenDB_2543_CouldNotEnsureThatWeHaveEnoughSpace_When_MovingLeafNode()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree( "rebalancing-issue");
+        [Fact]
+        public void RavenDB_2543_CouldNotEnsureThatWeHaveEnoughSpace_When_MovingLeafNode()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree( "rebalancing-issue");
 
-				var aKey = new string('a', 1000);
-				var bKey = new string('b', 1000);
-				var cKey = new string('c', 1000);
-				var dKey = new string('d', 1020);
-				var eKey = new string('e', 1020);
-				var fKey = new string('f', 1020);
-				var gKey = new string('g', 1000);
-				var hKey = new string('h', 1000);
-				var iKey = new string('i', 1000);
-				var jKey = new string('j', 1000);
-				var kKey = new string('k', 1000);
-				var lKey = new string('l', 1000);
-				var mKey = new string('m', 820);
-				var nKey = new string('n', 102);
+                var aKey = new string('a', 1000);
+                var bKey = new string('b', 1000);
+                var cKey = new string('c', 1000);
+                var dKey = new string('d', 1020);
+                var eKey = new string('e', 1020);
+                var fKey = new string('f', 1020);
+                var gKey = new string('g', 1000);
+                var hKey = new string('h', 1000);
+                var iKey = new string('i', 1000);
+                var jKey = new string('j', 1000);
+                var kKey = new string('k', 1000);
+                var lKey = new string('l', 1000);
+                var mKey = new string('m', 820);
+                var nKey = new string('n', 102);
 
-				tree.Add(aKey, new MemoryStream(new byte[100]));
-				tree.Add(bKey, new MemoryStream(new byte[100]));
-				tree.Add(cKey, new MemoryStream(new byte[100]));
-				tree.Add(dKey, new MemoryStream(new byte[100]));
-				tree.Add(eKey, new MemoryStream(new byte[100]));
-				tree.Add(fKey, new MemoryStream(new byte[100]));
-				tree.Add(gKey, new MemoryStream(new byte[100]));
-				tree.Add(hKey, new MemoryStream(new byte[100]));
-				tree.Add(iKey, new MemoryStream(new byte[100]));
-				tree.Add(jKey, new MemoryStream(new byte[100]));
-				tree.Add(kKey, new MemoryStream(new byte[100]));
-				tree.Add(lKey, new MemoryStream(new byte[100]));
-				tree.Add(mKey, new MemoryStream(new byte[100]));
-				tree.Add(nKey, new MemoryStream(new byte[1000]));
+                tree.Add(aKey, new MemoryStream(new byte[100]));
+                tree.Add(bKey, new MemoryStream(new byte[100]));
+                tree.Add(cKey, new MemoryStream(new byte[100]));
+                tree.Add(dKey, new MemoryStream(new byte[100]));
+                tree.Add(eKey, new MemoryStream(new byte[100]));
+                tree.Add(fKey, new MemoryStream(new byte[100]));
+                tree.Add(gKey, new MemoryStream(new byte[100]));
+                tree.Add(hKey, new MemoryStream(new byte[100]));
+                tree.Add(iKey, new MemoryStream(new byte[100]));
+                tree.Add(jKey, new MemoryStream(new byte[100]));
+                tree.Add(kKey, new MemoryStream(new byte[100]));
+                tree.Add(lKey, new MemoryStream(new byte[100]));
+                tree.Add(mKey, new MemoryStream(new byte[100]));
+                tree.Add(nKey, new MemoryStream(new byte[1000]));
 
 
 
@@ -205,50 +205,50 @@ namespace FastTests.Voron.Bugs
 
                 tx.Commit();
 
-				using (var iterator = tree.Iterate())
-				{
-					Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                using (var iterator = tree.Iterate())
+                {
+                    Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
-					Assert.Equal(aKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(aKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(bKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(bKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(cKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(cKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(dKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(dKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(eKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(eKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(fKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(fKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(gKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(gKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(hKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(hKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(iKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(iKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(jKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(jKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(kKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(kKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(lKey, iterator.CurrentKey);
-					Assert.True(iterator.MoveNext());
+                    Assert.Equal(lKey, iterator.CurrentKey.ToString());
+                    Assert.True(iterator.MoveNext());
 
-					Assert.Equal(mKey, iterator.CurrentKey);
-					Assert.False(iterator.MoveNext());
-				}
-			}
-		}
-	}
+                    Assert.Equal(mKey, iterator.CurrentKey.ToString());
+                    Assert.False(iterator.MoveNext());
+                }
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Bugs/UpdateLastItem.cs
+++ b/test/FastTests/Voron/Bugs/UpdateLastItem.cs
@@ -4,36 +4,36 @@ using Voron.Data.BTrees;
 
 namespace FastTests.Voron.Bugs
 {
-	public unsafe class UpdateLastItem : StorageTest
-	{
-		[Fact]
-		public void ShouldWork()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-			    var tree = tx.CreateTree("t");
-				tree.DirectAdd((Slice) "events", sizeof (TreeRootHeader));
-				tree.DirectAdd((Slice) "aggregations", sizeof(TreeRootHeader));
-				tree.DirectAdd((Slice) "aggregation-status", sizeof(TreeRootHeader));
-				tx.Commit();
-			}
-			using (var tx = Env.WriteTransaction())
-			{
+    public unsafe class UpdateLastItem : StorageTest
+    {
+        [Fact]
+        public void ShouldWork()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("t");
-                tree.DirectAdd((Slice) "events", sizeof(TreeRootHeader));
-
-				tx.Commit();
-			}
-
-			RestartDatabase();
-
-			using (var tx = Env.WriteTransaction())
-			{
+                tree.DirectAdd("events", sizeof (TreeRootHeader));
+                tree.DirectAdd("aggregations", sizeof(TreeRootHeader));
+                tree.DirectAdd("aggregation-status", sizeof(TreeRootHeader));
+                tx.Commit();
+            }
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("t");
-                tree.DirectAdd((Slice) "events", sizeof(TreeRootHeader));
+                tree.DirectAdd("events", sizeof(TreeRootHeader));
 
-				tx.Commit();
-			}
-		}
-	}
+                tx.Commit();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("t");
+                tree.DirectAdd("events", sizeof(TreeRootHeader));
+
+                tx.Commit();
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/FixedSize/FixedSizeBugs.cs
+++ b/test/FastTests/Voron/FixedSize/FixedSizeBugs.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using Voron;
+using Xunit;
 
 namespace FastTests.Voron.FixedSize
 {
@@ -7,9 +8,10 @@ namespace FastTests.Voron.FixedSize
         [Fact]
         public void CanAddDuplicate()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 8);
+                var fst = tx.FixedTreeFor(treeId, valSize: 8);
 
                 fst.Add(2, new byte[8]);
                 fst.Add(3, new byte[8]);
@@ -19,7 +21,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 8);
+                var fst = tx.FixedTreeFor(treeId, valSize: 8);
                 fst.DebugRenderAndShow();
                 fst.Add(1, new byte[8]);
                 fst.Add(2, new byte[8]);
@@ -30,7 +32,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 8);
+                var fst = tx.FixedTreeFor(treeId, valSize: 8);
 
                 Assert.Equal(3, fst.NumberOfEntries);
                 using (var it = fst.Iterate())
@@ -49,11 +51,12 @@ namespace FastTests.Voron.FixedSize
         [Fact]
         public void CanAddDuplicate_Many()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
                 for (var i = 0; i < 300; i++)
                 {
-                    var fst = tx.FixedTreeFor("test", valSize: 8);
+                    var fst = tx.FixedTreeFor(treeId, valSize: 8);
 
                     fst.Add(i, new byte[8]);
                 }
@@ -65,7 +68,7 @@ namespace FastTests.Voron.FixedSize
             {
                 for (var i = 0; i < 300; i++)
                 {
-                    var fst = tx.FixedTreeFor("test", valSize: 8);
+                    var fst = tx.FixedTreeFor(treeId, valSize: 8);
 
                     fst.Delete(i);
                     fst.Add(i, new byte[8]);

--- a/test/FastTests/Voron/FixedSize/LargeFixedSizeTreeBugs.cs
+++ b/test/FastTests/Voron/FixedSize/LargeFixedSizeTreeBugs.cs
@@ -20,9 +20,10 @@ namespace FastTests.Voron.FixedSize
         [Fact]
         public void DeleteRangeShouldModifyPage()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 128);
+                var fst = tx.FixedTreeFor(treeId, valSize: 128);
                 var bytes = new byte[128];
                 for (int i = 0; i < 100; i++)
                 {
@@ -35,7 +36,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 128);
+                var fst = tx.FixedTreeFor(treeId, valSize: 128);
                 fst.DeleteRange(20, 70);
 
                 tx.Commit();
@@ -45,7 +46,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 128);
+                var fst = tx.FixedTreeFor(treeId, valSize: 128);
                 Assert.False(fst.Contains(21));
                 tx.Commit();
             }

--- a/test/FastTests/Voron/FixedSize/SimpleFixedSizeTrees.cs
+++ b/test/FastTests/Voron/FixedSize/SimpleFixedSizeTrees.cs
@@ -15,20 +15,21 @@ namespace FastTests.Voron.FixedSize
         [Fact]
         public void TimeSeries()
         {
+            var watchId = Slice.From(Allocator, "watches/12831-12345");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("watches/12831-12345", valSize: 8);
+                var fst = tx.FixedTreeFor(watchId, valSize: 8);
 
-                fst.Add(DateTime.Today.AddHours(8).Ticks, new Slice(BitConverter.GetBytes(80D)));
-                fst.Add(DateTime.Today.AddHours(9).Ticks, new Slice(BitConverter.GetBytes(65D)));
-                fst.Add(DateTime.Today.AddHours(10).Ticks, new Slice(BitConverter.GetBytes(44D)));
+                fst.Add(DateTime.Today.AddHours(8).Ticks, Slice.From(Allocator, BitConverter.GetBytes(80D)));
+                fst.Add(DateTime.Today.AddHours(9).Ticks, Slice.From(Allocator, BitConverter.GetBytes(65D)));
+                fst.Add(DateTime.Today.AddHours(10).Ticks, Slice.From(Allocator, BitConverter.GetBytes(44D)));
 
                 tx.Commit();
             }
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("watches/12831-12345", valSize: 8);
+                var fst = tx.FixedTreeFor(watchId, valSize: 8);
 
                 var it = fst.Iterate();
                 Assert.True(it.Seek(DateTime.Today.AddHours(7).Ticks));
@@ -50,9 +51,10 @@ namespace FastTests.Voron.FixedSize
         [Fact]
         public void CanAdd()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 fst.Add(1);
                 fst.Add(2);
@@ -62,7 +64,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 Assert.True(fst.Contains(1));
                 Assert.True(fst.Contains(2));
@@ -71,41 +73,43 @@ namespace FastTests.Voron.FixedSize
             }
         }
 
-		[Fact]
-		public void SeekShouldGiveTheNextKey()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 0);
+        [Fact]
+        public void SeekShouldGiveTheNextKey()
+        {
+            var treeId = Slice.From(Allocator, "test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 0);
 
-				fst.Add(635634432000000000);
-				fst.Add(635634468000000000);
-				fst.Add(635634504000000000);
+                fst.Add(635634432000000000);
+                fst.Add(635634468000000000);
+                fst.Add(635634504000000000);
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.ReadTransaction())
-			{
-				var it = tx.FixedTreeFor("test", 0).Iterate();
+            using (var tx = Env.ReadTransaction())
+            {
+                var it = tx.FixedTreeFor(treeId, 0).Iterate();
 
-				Assert.True(it.Seek(635634432000000000));
-				Assert.Equal(635634432000000000, it.CurrentKey);
-				Assert.True(it.Seek(635634468000000000));
-				Assert.Equal(635634468000000000, it.CurrentKey);
-				Assert.True(it.Seek(635634504000000000));
-				Assert.Equal(635634504000000000, it.CurrentKey);
-				Assert.False(it.Seek(635634504000000001));
-				tx.Commit();
-			}
-		}
+                Assert.True(it.Seek(635634432000000000));
+                Assert.Equal(635634432000000000, it.CurrentKey);
+                Assert.True(it.Seek(635634468000000000));
+                Assert.Equal(635634468000000000, it.CurrentKey);
+                Assert.True(it.Seek(635634504000000000));
+                Assert.Equal(635634504000000000, it.CurrentKey);
+                Assert.False(it.Seek(635634504000000001));
+                tx.Commit();
+            }
+        }
 
         [Fact]
         public void CanAdd_Mixed()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 fst.Add(2);
                 fst.Add(6);
@@ -118,7 +122,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 Assert.True(fst.Contains(1));
                 Assert.True(fst.Contains(2));
@@ -134,9 +138,10 @@ namespace FastTests.Voron.FixedSize
         [Fact]
         public void CanIterate()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 fst.Add(3);
                 fst.Add(1);
@@ -147,7 +152,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 var it = fst.Iterate();
                 Assert.True(it.Seek(long.MinValue));
@@ -167,9 +172,10 @@ namespace FastTests.Voron.FixedSize
         [Fact]
         public void CanRemove()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 fst.Add(1);
                 fst.Add(2);
@@ -179,7 +185,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 fst.Delete(2);
 
@@ -188,7 +194,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 0);
+                var fst = tx.FixedTreeFor(treeId, 0);
 
                 Assert.True(fst.Contains(1));
                 Assert.False(fst.Contains(2));
@@ -197,173 +203,177 @@ namespace FastTests.Voron.FixedSize
             }
         }
 
-		[Fact]
-		public void CanDeleteRange()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				for (int i = 1; i <= 10; i++)
-				{
-					fst.Add(i, new Slice(BitConverter.GetBytes(i + 10L)));
-				}
-				tx.Commit();
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				var itemsRemoved = fst.DeleteRange(2, 5);
-				Assert.Equal(4, itemsRemoved.NumberOfEntriesDeleted);
-				Assert.Equal(false, itemsRemoved.TreeRemoved);
-
-				tx.Commit();
-			}
-
-			using (var tx = Env.ReadTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				for (int i = 1; i <= 10; i++)
-				{
-					if (i >= 2 && i <= 5)
-					{
-						Assert.False(fst.Contains(i), i.ToString());
-						Assert.Null(fst.Read(i));
-					}
-					else
-					{
-						Assert.True(fst.Contains(i), i.ToString());
-						Assert.Equal(i + 10L, fst.Read(i).CreateReader().ReadLittleEndianInt64());
-					}
-				}
-				tx.Commit();
-			}
-		}
-
-		[Fact]
-		public void CanDeleteRangeWithGaps()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				for (int i = 1; i <= 10; i++)
-				{
-					fst.Add(i, new Slice(BitConverter.GetBytes(i + 10L)));
-				}
-				for (int i = 30; i <= 40; i++)
-				{
-					fst.Add(i, new Slice(BitConverter.GetBytes(i + 10L)));
-				}
-				tx.Commit();
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				var itemsRemoved = fst.DeleteRange(2, 35);
-				Assert.Equal(15, itemsRemoved.NumberOfEntriesDeleted);
-				Assert.Equal(false, itemsRemoved.TreeRemoved);
-
-				tx.Commit();
-			}
-
-			using (var tx = Env.ReadTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				for (int i = 1; i <= 10; i++)
-				{
-					if (i >= 2)
-					{
-						Assert.False(fst.Contains(i), i.ToString());
-						Assert.Null(fst.Read(i));
-					}
-					else
-					{
-						Assert.True(fst.Contains(i), i.ToString());
-						Assert.Equal(i + 10L, fst.Read(i).CreateReader().ReadLittleEndianInt64());
-					}
-				}
-				for (int i = 30; i <= 40; i++)
-				{
-					if (i <= 35)
-					{
-						Assert.False(fst.Contains(i), i.ToString());
-						Assert.Null(fst.Read(i));
-					}
-					else
-					{
-						Assert.True(fst.Contains(i), i.ToString());
-						Assert.Equal(i + 10L, fst.Read(i).CreateReader().ReadLittleEndianInt64());
-					}
-				}
-				tx.Commit();
-			}
-		}
-
-		[Fact]
-		public void CanDeleteAllRange()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				for (int i = 1; i <= 10; i++)
-				{
-					fst.Add(i, new Slice(BitConverter.GetBytes(i + 10L)));
-				}
-				tx.Commit();
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				var itemsRemoved = fst.DeleteRange(0, DateTime.MaxValue.Ticks);
-				Assert.Equal(10, itemsRemoved.NumberOfEntriesDeleted);
-				Assert.Equal(true, itemsRemoved.TreeRemoved);
-
-				tx.Commit();
-			}
-
-			using (var tx = Env.ReadTransaction())
-			{
-				var fst = tx.FixedTreeFor("test", 8);
-
-				for (int i = 1; i <= 10; i++)
-				{
-					Assert.False(fst.Contains(i), i.ToString());
-					Assert.Null(fst.Read(i));
-				}
-				tx.Commit();
-			}
-		}
-
         [Fact]
-        public void CanAdd_WithValue()
+        public void CanDeleteRange()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 8);
+                var fst = tx.FixedTreeFor(treeId, 8);
 
-                fst.Add(1, new Slice(BitConverter.GetBytes(1L)));
-                fst.Add(2, new Slice(BitConverter.GetBytes(2L)));
+                for (int i = 1; i <= 10; i++)
+                {
+                    fst.Add(i, Slice.From(Allocator, BitConverter.GetBytes(i + 10L)));
+                }
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                var itemsRemoved = fst.DeleteRange(2, 5);
+                Assert.Equal(4, itemsRemoved.NumberOfEntriesDeleted);
+                Assert.Equal(false, itemsRemoved.TreeRemoved);
 
                 tx.Commit();
             }
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 8);
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    if (i >= 2 && i <= 5)
+                    {
+                        Assert.False(fst.Contains(i), i.ToString());
+                        Assert.False(fst.Read(i).HasValue);
+                    }
+                    else
+                    {
+                        Assert.True(fst.Contains(i), i.ToString());
+                        Assert.Equal(i + 10L, fst.Read(i).CreateReader().ReadLittleEndianInt64());
+                    }
+                }
+                tx.Commit();
+            }
+        }
+
+        [Fact]
+        public void CanDeleteRangeWithGaps()
+        {
+            var treeId = Slice.From(Allocator, "test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    fst.Add(i, Slice.From(Allocator, BitConverter.GetBytes(i + 10L)));
+                }
+                for (int i = 30; i <= 40; i++)
+                {
+                    fst.Add(i, Slice.From(Allocator, BitConverter.GetBytes(i + 10L)));
+                }
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                var itemsRemoved = fst.DeleteRange(2, 35);
+                Assert.Equal(15, itemsRemoved.NumberOfEntriesDeleted);
+                Assert.Equal(false, itemsRemoved.TreeRemoved);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    if (i >= 2)
+                    {
+                        Assert.False(fst.Contains(i), i.ToString());
+                        Assert.False(fst.Read(i).HasValue);
+                    }
+                    else
+                    {
+                        Assert.True(fst.Contains(i), i.ToString());
+                        Assert.Equal(i + 10L, fst.Read(i).CreateReader().ReadLittleEndianInt64());
+                    }
+                }
+                for (int i = 30; i <= 40; i++)
+                {
+                    if (i <= 35)
+                    {
+                        Assert.False(fst.Contains(i), i.ToString());
+                        Assert.False(fst.Read(i).HasValue);
+                    }
+                    else
+                    {
+                        Assert.True(fst.Contains(i), i.ToString());
+                        Assert.Equal(i + 10L, fst.Read(i).CreateReader().ReadLittleEndianInt64());
+                    }
+                }
+                tx.Commit();
+            }
+        }
+
+        [Fact]
+        public void CanDeleteAllRange()
+        {
+            var treeId = Slice.From(Allocator, "test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    fst.Add(i, Slice.From(Allocator, BitConverter.GetBytes(i + 10L)));
+                }
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                var itemsRemoved = fst.DeleteRange(0, DateTime.MaxValue.Ticks);
+                Assert.Equal(10, itemsRemoved.NumberOfEntriesDeleted);
+                Assert.Equal(true, itemsRemoved.TreeRemoved);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    Assert.False(fst.Contains(i), i.ToString());
+                    Assert.False(fst.Read(i).HasValue);
+                }
+                tx.Commit();
+            }
+        }
+
+        [Fact]
+        public void CanAdd_WithValue()
+        {
+            var treeId = Slice.From(Allocator, "test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
+
+                fst.Add(1, Slice.From(Allocator, BitConverter.GetBytes(1L)));
+                fst.Add(2, Slice.From(Allocator, BitConverter.GetBytes(2L)));
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, 8);
 
                 Assert.Equal(1L, fst.Read(1).CreateReader().ReadLittleEndianInt64());
                 Assert.Equal(2L, fst.Read(2).CreateReader().ReadLittleEndianInt64());
-                Assert.Null(fst.Read(3));
+                Assert.False(fst.Read(3).HasValue);
                 tx.Commit();
             }
         }
@@ -371,13 +381,14 @@ namespace FastTests.Voron.FixedSize
         [Fact]
         public void CanRemove_WithValue()
         {
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 8);
+                var fst = tx.FixedTreeFor(treeId, 8);
 
-                fst.Add(1, new Slice(BitConverter.GetBytes(1L)));
-                fst.Add(2, new Slice(BitConverter.GetBytes(2L)));
-                fst.Add(3, new Slice(BitConverter.GetBytes(3L)));
+                fst.Add(1, Slice.From(Allocator, BitConverter.GetBytes(1L)));
+                fst.Add(2, Slice.From(Allocator, BitConverter.GetBytes(2L)));
+                fst.Add(3, Slice.From(Allocator, BitConverter.GetBytes(3L)));
 
                 tx.Commit();
             }
@@ -385,7 +396,7 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 8);
+                var fst = tx.FixedTreeFor(treeId, 8);
 
                 fst.Delete(2);
 
@@ -394,10 +405,10 @@ namespace FastTests.Voron.FixedSize
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", 8);
+                var fst = tx.FixedTreeFor(treeId, 8);
 
                 Assert.Equal(1L, fst.Read(1).CreateReader().ReadLittleEndianInt64());
-                Assert.Null(fst.Read(2));
+                Assert.False(fst.Read(2).HasValue);
                 Assert.Equal(3L, fst.Read(3).CreateReader().ReadLittleEndianInt64());
                 tx.Commit();
             }

--- a/test/FastTests/Voron/Journal/BasicActions.cs
+++ b/test/FastTests/Voron/Journal/BasicActions.cs
@@ -8,6 +8,7 @@ using System;
 using System.IO;
 using Xunit;
 using Voron;
+using Voron.Data;
 
 namespace FastTests.Voron.Journal
 {
@@ -98,7 +99,7 @@ namespace FastTests.Voron.Journal
                 {
                     var tree = tx.CreateTree("foo");
                     var readKey = ReadKey(tx, tree, "items/" + i);
-                    Assert.Equal("values/" + i, readKey.Item2);
+                    Assert.Equal("values/" + i, readKey.Item2.ToString());
                 }
             }
         }

--- a/test/FastTests/Voron/Journal/EdgeCases.cs
+++ b/test/FastTests/Voron/Journal/EdgeCases.cs
@@ -7,6 +7,7 @@
 using System.IO;
 using Xunit;
 using Voron;
+using Voron.Data;
 using Voron.Impl;
 using Voron.Impl.Journal;
 

--- a/test/FastTests/Voron/Journal/Mvcc.cs
+++ b/test/FastTests/Voron/Journal/Mvcc.cs
@@ -7,6 +7,7 @@
 using System.IO;
 using Xunit;
 using Voron;
+using Voron.Data;
 using System.Linq;
 
 namespace FastTests.Voron.Journal

--- a/test/FastTests/Voron/MultiValueTree.cs
+++ b/test/FastTests/Voron/MultiValueTree.cs
@@ -7,389 +7,389 @@ using Xunit;
 
 namespace FastTests.Voron
 {
-	public class MultiValueTree : StorageTest
-	{
-		[Fact]
-		public void Single_MultiAdd_And_Read_DataStored()
-		{
-			var random = new Random();
-			var buffer = new byte[1000];
-			random.NextBytes(buffer);
+    public class MultiValueTree : StorageTest
+    {
+        [Fact]
+        public void Single_MultiAdd_And_Read_DataStored()
+        {
+            var random = new Random();
+            var buffer = new byte[1000];
+            random.NextBytes(buffer);
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 tx.CreateTree( "foo");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.ReadTree("foo").MultiAdd("ChildTreeKey", new Slice(buffer));
-				tx.Commit();
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.ReadTree("foo").MultiAdd("ChildTreeKey", Slice.From(Allocator, buffer));
+                tx.Commit();
+            }
 
-			using (var tx = Env.ReadTransaction())
-			{
-				using (var fetchedDataIterator = tx.ReadTree("foo").MultiRead("ChildTreeKey"))
-				{
-					fetchedDataIterator.Seek(Slice.BeforeAllKeys);
+            using (var tx = Env.ReadTransaction())
+            {
+                using (var fetchedDataIterator = tx.ReadTree("foo").MultiRead("ChildTreeKey"))
+                {
+                    fetchedDataIterator.Seek(Slices.BeforeAllKeys);
 
-					Assert.True(fetchedDataIterator.CurrentKey.Compare(new Slice(buffer)) == 0);
-				}
-			}
-		}
+                    Assert.True(SliceComparer.Equals(fetchedDataIterator.CurrentKey, Slice.From(Allocator, buffer)));
+                }
+            }
+        }
 
-		[Fact]
-		public void MultiDelete_Remains_One_Entry_The_Data_Is_Retrieved_With_MultiRead()
-		{
-		    const int INPUT_COUNT = 3;
-		    const int INPUT_DATA_SIZE = 1000;
-		    const string CHILDTREE_KEY = "ChildTree";
+        [Fact]
+        public void MultiDelete_Remains_One_Entry_The_Data_Is_Retrieved_With_MultiRead()
+        {
+            const int INPUT_COUNT = 3;
+            const int INPUT_DATA_SIZE = 1000;
+            const string CHILDTREE_KEY = "ChildTree";
 
-		    var inputData = new List<string>();
-		    for (int i = 0; i < INPUT_COUNT; i++)
-		    {
-		        inputData.Add(RandomString(INPUT_DATA_SIZE));
-		    }
+            var inputData = new List<string>();
+            for (int i = 0; i < INPUT_COUNT; i++)
+            {
+                inputData.Add(RandomString(INPUT_DATA_SIZE));
+            }
 
-		    using (var tx = Env.WriteTransaction())
-		    {
-		        var tree = tx.CreateTree("foo");
-		        for (int i = 0; i < INPUT_COUNT; i++)
-		        {
-		            tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
-		        }
-		        tx.Commit();
-		    }
-
-		    using (var tx = Env.WriteTransaction())
-		    {
-                var tree = tx.CreateTree("foo");
-                for (int i = 0; i < INPUT_COUNT - 1; i++)
-		        {
-		            tree.MultiDelete(CHILDTREE_KEY, inputData[i]);
-		            inputData.Remove(inputData[i]);
-		        }
-		        tx.Commit();
-		    }
-		    
-            ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
-		}
-
-	    [Fact]
-		public void MultiDelete_Remains_No_Entries_ChildTreeKey_Doesnt_Exist()
-		{
-			const int INPUT_COUNT = 3;
-			const int INPUT_DATA_SIZE = 1000;
-			const string CHILDTREE_KEY = "ChildTree";
-
-			var inputData = new List<string>();
-			for (int i = 0; i < INPUT_COUNT; i++)
-			{
-				inputData.Add(RandomString(INPUT_DATA_SIZE));
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
-			    var tree = tx.CreateTree("foo");
-				for (int i = 0; i < INPUT_COUNT; i++)
-				{
-                    tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
-				}
-				tx.Commit();
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 for (int i = 0; i < INPUT_COUNT; i++)
-				{
-                    tree.MultiDelete(CHILDTREE_KEY, inputData[i]);
-				}
-				tx.Commit();
-			}
-
-			using (var tx = Env.ReadTransaction())
-			{
-				var iterator = tx.ReadTree("foo").MultiRead(CHILDTREE_KEY);
-				iterator.Seek(Slice.BeforeAllKeys);
-				Assert.False(iterator.MoveNext());
-			}
-		}
-
-		[Fact]
-		public void Single_MultiAdd_And_Single_MultiDelete_DataDeleted()
-		{
-			var random = new Random();
-			var buffer = new byte[1000];
-			random.NextBytes(buffer);
-
-			using (var tx = Env.WriteTransaction())
-			{
-			    tx.CreateTree("foo");
-				tx.Commit();
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("foo").MultiAdd("ChildTreeKey", new Slice(buffer));
-				tx.Commit();
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("foo").MultiDelete("ChildTreeKey", new Slice(buffer));
-				tx.Commit();
-			}
-
-			using (var tx = Env.ReadTransaction())
-			{
-				Assert.Equal(typeof(EmptyIterator), tx.ReadTree("foo").MultiRead("ChildTreeKey").GetType());
-			}
-		}
-
-		[Fact]
-		public void Multiple_MultiAdd_And_MultiDelete_InTheSame_Transaction_EntryDeleted()
-		{
-		    const int INPUT_COUNT = 25;
-		    const int INPUT_DATA_SIZE = 1000;
-		    const string CHILDTREE_KEY = "ChildTree";
-
-		    var inputData = new List<string>();
-		    for (int i = 0; i < INPUT_COUNT; i++)
-		    {
-		        inputData.Add(RandomString(INPUT_DATA_SIZE));
-		    }
-
-		    var indexToDelete = new Random(1234).Next(0, INPUT_COUNT - 1);
-		    using (var tx = Env.WriteTransaction())
-		    {
-		        var tree = tx.CreateTree("foo");
-		        for (int i = 0; i < INPUT_COUNT; i++)
-		        {
+                {
                     tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
-		        }
+                }
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                for (int i = 0; i < INPUT_COUNT - 1; i++)
+                {
+                    tree.MultiDelete(CHILDTREE_KEY, inputData[i]);
+                    inputData.Remove(inputData[i]);
+                }
+                tx.Commit();
+            }
+            
+            ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
+        }
+
+        [Fact]
+        public void MultiDelete_Remains_No_Entries_ChildTreeKey_Doesnt_Exist()
+        {
+            const int INPUT_COUNT = 3;
+            const int INPUT_DATA_SIZE = 1000;
+            const string CHILDTREE_KEY = "ChildTree";
+
+            var inputData = new List<string>();
+            for (int i = 0; i < INPUT_COUNT; i++)
+            {
+                inputData.Add(RandomString(INPUT_DATA_SIZE));
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                for (int i = 0; i < INPUT_COUNT; i++)
+                {
+                    tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
+                }
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                for (int i = 0; i < INPUT_COUNT; i++)
+                {
+                    tree.MultiDelete(CHILDTREE_KEY, inputData[i]);
+                }
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var iterator = tx.ReadTree("foo").MultiRead(CHILDTREE_KEY);
+                iterator.Seek(Slices.BeforeAllKeys);
+                Assert.False(iterator.MoveNext());
+            }
+        }
+
+        [Fact]
+        public void Single_MultiAdd_And_Single_MultiDelete_DataDeleted()
+        {
+            var random = new Random();
+            var buffer = new byte[1000];
+            random.NextBytes(buffer);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("foo");
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("foo").MultiAdd("ChildTreeKey", Slice.From(Allocator, buffer));
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("foo").MultiDelete("ChildTreeKey", Slice.From(Allocator, buffer));
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                Assert.Equal(typeof(EmptyIterator), tx.ReadTree("foo").MultiRead("ChildTreeKey").GetType());
+            }
+        }
+
+        [Fact]
+        public void Multiple_MultiAdd_And_MultiDelete_InTheSame_Transaction_EntryDeleted()
+        {
+            const int INPUT_COUNT = 25;
+            const int INPUT_DATA_SIZE = 1000;
+            const string CHILDTREE_KEY = "ChildTree";
+
+            var inputData = new List<string>();
+            for (int i = 0; i < INPUT_COUNT; i++)
+            {
+                inputData.Add(RandomString(INPUT_DATA_SIZE));
+            }
+
+            var indexToDelete = new Random(1234).Next(0, INPUT_COUNT - 1);
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                for (int i = 0; i < INPUT_COUNT; i++)
+                {
+                    tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
+                }
 
                 tree.MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
-		        tx.Commit();
-		    }
+                tx.Commit();
+            }
 
-		    inputData.Remove(inputData[indexToDelete]);
-		    ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
-		}
+            inputData.Remove(inputData[indexToDelete]);
+            ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
+        }
 
-	    [Fact]
-		public void NamedTree_Multiple_MultiAdd_And_MultiDelete_InTheSame_Transaction_EntryDeleted()
-		{
-			const int INPUT_COUNT = 25;
-			const int INPUT_DATA_SIZE = 1000;
-			const string CHILDTREE_KEY = "ChildTree";
+        [Fact]
+        public void NamedTree_Multiple_MultiAdd_And_MultiDelete_InTheSame_Transaction_EntryDeleted()
+        {
+            const int INPUT_COUNT = 25;
+            const int INPUT_DATA_SIZE = 1000;
+            const string CHILDTREE_KEY = "ChildTree";
 
-			var inputData = new List<string>();
-			for (int i = 0; i < INPUT_COUNT; i++)
-			{
-				inputData.Add(RandomString(INPUT_DATA_SIZE));
-			}
+            var inputData = new List<string>();
+            for (int i = 0; i < INPUT_COUNT; i++)
+            {
+                inputData.Add(RandomString(INPUT_DATA_SIZE));
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("foo");
-				tx.Commit();
-			}
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("foo");
+                tx.Commit();
+            }
 
-			var indexToDelete = new Random(1234).Next(0, INPUT_COUNT - 1);
-			using (var tx = Env.WriteTransaction())
-			{
-				for (int i = 0; i < INPUT_COUNT; i++)
-				{
-					tx.CreateTree("foo").MultiAdd(CHILDTREE_KEY, inputData[i]);
-				}
+            var indexToDelete = new Random(1234).Next(0, INPUT_COUNT - 1);
+            using (var tx = Env.WriteTransaction())
+            {
+                for (int i = 0; i < INPUT_COUNT; i++)
+                {
+                    tx.CreateTree("foo").MultiAdd(CHILDTREE_KEY, inputData[i]);
+                }
 
-				tx.CreateTree("foo").MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
-				tx.Commit();
-			}
+                tx.CreateTree("foo").MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
+                tx.Commit();
+            }
 
-			inputData.Remove(inputData[indexToDelete]);
-
-			ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
-		}
-
-		[Fact]
-		public void NamedTree_Multiple_MultiAdd_MultiDelete_Once_And_Read_EntryDeleted()
-		{
-			const int INPUT_COUNT = 25;
-			const int INPUT_DATA_SIZE = 1000;
-			const string CHILDTREE_KEY = "ChildTree";
-
-			var inputData = new List<string>();
-			for (int i = 0; i < INPUT_COUNT; i++)
-			{
-				inputData.Add(RandomString(INPUT_DATA_SIZE));
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree( "foo");
-				tx.Commit();
-			}
-
-			using (var tx = Env.WriteTransaction())
-			{
-				for (int i = 0; i < INPUT_COUNT; i++)
-				{
-					tx.CreateTree("foo").MultiAdd(CHILDTREE_KEY, inputData[i]);
-				}
-				tx.Commit();
-			}
-
-			var indexToDelete = new Random(1234).Next(0, INPUT_COUNT - 1);
-
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("foo").MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
-				tx.Commit();
-			}
-
-			inputData.Remove(inputData[indexToDelete]);
+            inputData.Remove(inputData[indexToDelete]);
 
             ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
-		}
+        }
 
-		[Fact]
-		public void MultiAdd_Twice_TheSame_KeyValue_MultiDelete_NotThrowsException_MultiTree_Deleted()
-		{
-			const string CHILDTREE_KEY = "ChildTree";
-			const string CHILDTREE_VALUE = "Foo";
-			using (var tx = Env.WriteTransaction())
-			{
-			    var tree = tx.CreateTree("foo");
+        [Fact]
+        public void NamedTree_Multiple_MultiAdd_MultiDelete_Once_And_Read_EntryDeleted()
+        {
+            const int INPUT_COUNT = 25;
+            const int INPUT_DATA_SIZE = 1000;
+            const string CHILDTREE_KEY = "ChildTree";
+
+            var inputData = new List<string>();
+            for (int i = 0; i < INPUT_COUNT; i++)
+            {
+                inputData.Add(RandomString(INPUT_DATA_SIZE));
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree( "foo");
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                for (int i = 0; i < INPUT_COUNT; i++)
+                {
+                    tx.CreateTree("foo").MultiAdd(CHILDTREE_KEY, inputData[i]);
+                }
+                tx.Commit();
+            }
+
+            var indexToDelete = new Random(1234).Next(0, INPUT_COUNT - 1);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("foo").MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
+                tx.Commit();
+            }
+
+            inputData.Remove(inputData[indexToDelete]);
+
+            ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
+        }
+
+        [Fact]
+        public void MultiAdd_Twice_TheSame_KeyValue_MultiDelete_NotThrowsException_MultiTree_Deleted()
+        {
+            const string CHILDTREE_KEY = "ChildTree";
+            const string CHILDTREE_VALUE = "Foo";
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
                 tree.MultiAdd(CHILDTREE_KEY, CHILDTREE_VALUE);
                 tree.MultiAdd(CHILDTREE_KEY, CHILDTREE_VALUE);
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 tree.MultiDelete(CHILDTREE_KEY, CHILDTREE_VALUE);
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.ReadTransaction())
-			{
+            using (var tx = Env.ReadTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 
                 Assert.Equal(0, tree.ReadVersion(CHILDTREE_KEY));
-			}
-		}
-		
-		[Fact]
-		public void Multiple_MultiAdd_MultiDelete_Once_And_Read_EntryDeleted()
-		{
-			const int INPUT_COUNT = 25;
-			const int INPUT_DATA_SIZE = 1000;
-			const string CHILDTREE_KEY = "ChildTree";
+            }
+        }
+        
+        [Fact]
+        public void Multiple_MultiAdd_MultiDelete_Once_And_Read_EntryDeleted()
+        {
+            const int INPUT_COUNT = 25;
+            const int INPUT_DATA_SIZE = 1000;
+            const string CHILDTREE_KEY = "ChildTree";
 
-			var inputData = new List<string>();
-			for (int i = 0; i < INPUT_COUNT; i++)
-			{
-				inputData.Add(RandomString(INPUT_DATA_SIZE));
-			}
+            var inputData = new List<string>();
+            for (int i = 0; i < INPUT_COUNT; i++)
+            {
+                inputData.Add(RandomString(INPUT_DATA_SIZE));
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 for (int i = 0; i < INPUT_COUNT; i++)
-				{
+                {
                     tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
-				}
-				tx.Commit();
-			}
+                }
+                tx.Commit();
+            }
 
             ValidateInputExistence(inputData.ToList(), CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
 
-			var indexToDelete = new Random(1234).Next(0, INPUT_COUNT - 1);
+            var indexToDelete = new Random(1234).Next(0, INPUT_COUNT - 1);
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 tree.MultiDelete(CHILDTREE_KEY, inputData[indexToDelete]);
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			inputData.Remove(inputData[indexToDelete]);
+            inputData.Remove(inputData[indexToDelete]);
 
             ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
-		}
+        }
 
-		[Fact]
-		public void Multiple_MultiAdd_And_Read_DataStored()
-		{
-			const int INPUT_COUNT = 3;
-			const int INPUT_DATA_SIZE = 1000;
-			const string CHILDTREE_KEY = "ChildTree";
+        [Fact]
+        public void Multiple_MultiAdd_And_Read_DataStored()
+        {
+            const int INPUT_COUNT = 3;
+            const int INPUT_DATA_SIZE = 1000;
+            const string CHILDTREE_KEY = "ChildTree";
 
-			var inputData = new List<string>();
-			for (int i = 0; i < INPUT_COUNT; i++)
-			{
-				inputData.Add(RandomString(INPUT_DATA_SIZE));
-			}
+            var inputData = new List<string>();
+            for (int i = 0; i < INPUT_COUNT; i++)
+            {
+                inputData.Add(RandomString(INPUT_DATA_SIZE));
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-			    var tree = tx.CreateTree("foo");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
 
                 for (int i = 0; i < INPUT_COUNT; i++)
-				{
-					tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
-				}
-				tx.Commit();
-			}
+                {
+                    tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
+                }
+                tx.Commit();
+            }
 
             ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
-		}
+        }
 
-		private void ValidateInputExistence(List<string> inputData, string childtreeKey, int inputDataSize, string treeName)
-		{
-			using (var tx = Env.ReadTransaction())
-			{
-			    var targetTree = tx.ReadTree(treeName);
+        private void ValidateInputExistence(List<string> inputData, string childtreeKey, int inputDataSize, string treeName)
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                var targetTree = tx.ReadTree(treeName);
 
-				int fetchedEntryCount = 0;
-				var inputEntryCount = inputData.Count;
-				using (var fetchedDataIterator = targetTree.MultiRead(childtreeKey))
-				{
-					fetchedDataIterator.Seek(Slice.BeforeAllKeys);
-					do
-					{
-						Assert.Equal(inputDataSize, fetchedDataIterator.CurrentKey.Size);
+                int fetchedEntryCount = 0;
+                var inputEntryCount = inputData.Count;
+                using (var fetchedDataIterator = targetTree.MultiRead(childtreeKey))
+                {
+                    fetchedDataIterator.Seek(Slices.BeforeAllKeys);
+                    do
+                    {
+                        Assert.Equal(inputDataSize, fetchedDataIterator.CurrentKey.Size);
 
-						var value = fetchedDataIterator.CurrentKey.ToString();
-						Assert.True(inputData.Contains(value));
-						inputData.Remove(value);
-						fetchedEntryCount++;
-					} while (fetchedDataIterator.MoveNext());
+                        var value = fetchedDataIterator.CurrentKey.ToString();
+                        Assert.True(inputData.Contains(value));
+                        inputData.Remove(value);
+                        fetchedEntryCount++;
+                    } while (fetchedDataIterator.MoveNext());
 
-					Assert.Equal(inputEntryCount, fetchedEntryCount);
-					Assert.Empty(inputData);
-				}
-			}
-		}
+                    Assert.Equal(inputEntryCount, fetchedEntryCount);
+                    Assert.Empty(inputData);
+                }
+            }
+        }
 
-		private readonly Random _rng = new Random(123746);
-		private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        private readonly Random _rng = new Random(123746);
+        private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-		private string RandomString(int size)
-		{
-			var buffer = new char[size];
+        private string RandomString(int size)
+        {
+            var buffer = new char[size];
 
-			for (int i = 0; i < size; i++)
-			{
-				buffer[i] = Chars[_rng.Next(Chars.Length)];
-			}
-			return new string(buffer);
-		}
+            for (int i = 0; i < size; i++)
+            {
+                buffer[i] = Chars[_rng.Next(Chars.Length)];
+            }
+            return new string(buffer);
+        }
 
-	}
+    }
 }

--- a/test/FastTests/Voron/Optimizations/Writes.cs
+++ b/test/FastTests/Voron/Optimizations/Writes.cs
@@ -7,66 +7,67 @@
 using System.IO;
 using Xunit;
 using Voron;
+using Voron.Data;
 using Voron.Debugging;
 
 namespace FastTests.Voron.Optimizations
 {
-	public class Writes : StorageTest
-	{
-		[Fact]
-		public void SinglePageModificationDoNotCauseCopyingAllIntermediatePages()
-		{
-		    var keySize = 1024;
-		    using (var tx = Env.WriteTransaction())
-		    {
-		        var tree = tx.CreateTree("foo");
-				tree.Add(new string('9', keySize), new MemoryStream(new byte[3]));
-				DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('1', keySize), new MemoryStream(new byte[3]));
+    public class Writes : StorageTest
+    {
+        [Fact]
+        public void SinglePageModificationDoNotCauseCopyingAllIntermediatePages()
+        {
+            var keySize = 1024;
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                tree.Add(new string('9', keySize), new MemoryStream(new byte[3]));
                 DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('4', 1000), new MemoryStream(new byte[2]));
+                tree.Add(new string('1', keySize), new MemoryStream(new byte[3]));
                 DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('5', keySize), new MemoryStream(new byte[2]));
+                tree.Add(new string('4', 1000), new MemoryStream(new byte[2]));
                 DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('8', keySize), new MemoryStream(new byte[3]));
+                tree.Add(new string('5', keySize), new MemoryStream(new byte[2]));
                 DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('2', keySize), new MemoryStream(new byte[2]));
+                tree.Add(new string('8', keySize), new MemoryStream(new byte[3]));
                 DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('6', keySize), new MemoryStream(new byte[2]));
+                tree.Add(new string('2', keySize), new MemoryStream(new byte[2]));
                 DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('0', keySize), new MemoryStream(new byte[4]));
+                tree.Add(new string('6', keySize), new MemoryStream(new byte[2]));
                 DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('3', 1000), new MemoryStream(new byte[1]));
+                tree.Add(new string('0', keySize), new MemoryStream(new byte[4]));
                 DebugStuff.RenderAndShow(tree);
-				tree.Add(new string('7', keySize), new MemoryStream(new byte[1]));
-				
-				tx.Commit();
-			}
+                tree.Add(new string('3', 1000), new MemoryStream(new byte[1]));
+                DebugStuff.RenderAndShow(tree);
+                tree.Add(new string('7', keySize), new MemoryStream(new byte[1]));
+                
+                tx.Commit();
+            }
 
-			var afterAdds = Env.NextPageNumber;
+            var afterAdds = Env.NextPageNumber;
 
-			using (var tx = Env.WriteTransaction())
-			{
+            using (var tx = Env.WriteTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 tree.Delete(new string('0', keySize));
 
                 tree.Add(new string('4', 1000), new MemoryStream(new byte[21]));
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			Assert.Equal(afterAdds, Env.NextPageNumber);
+            Assert.Equal(afterAdds, Env.NextPageNumber);
 
-			// ensure changes were applied
-			using (var tx = Env.ReadTransaction())
-			{
+            // ensure changes were applied
+            using (var tx = Env.ReadTransaction())
+            {
                 var tree = tx.CreateTree("foo");
                 Assert.Null(tree.Read(new string('0', keySize)));
 
                 var readResult = tree.Read(new string('4', 1000));
 
-				Assert.Equal(21, readResult.Reader.Length);
-			}
-		}
-	}
+                Assert.Equal(21, readResult.Reader.Length);
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/ScratchBuffer/ScratchCanForceToFlushOldPages.cs
+++ b/test/FastTests/Voron/ScratchBuffer/ScratchCanForceToFlushOldPages.cs
@@ -7,85 +7,86 @@
 using Xunit;
 using Voron;
 using Voron.Impl;
+using Voron.Data;
 
 namespace FastTests.Voron.ScratchBuffer
 {
-	public class ScratchCanForceToFlushOldPages: StorageTest
-	{
-		protected override void Configure(StorageEnvironmentOptions options)
-		{
+    public class ScratchCanForceToFlushOldPages: StorageTest
+    {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
             options.PageSize = 4 * Constants.Size.Kilobyte;
             options.ManualFlushing = true;
             base.Configure(options);
-		}
+        }
 
-		[Fact]
-		public void CanForceToFlushPagesOlderThanOldestActiveTransactionToFreePagesFromScratch()
-		{
-			using (var txw = Env.WriteTransaction())
-			{
-				var tree = txw.CreateTree( "foo");
+        [Fact]
+        public void CanForceToFlushPagesOlderThanOldestActiveTransactionToFreePagesFromScratch()
+        {
+            using (var txw = Env.WriteTransaction())
+            {
+                var tree = txw.CreateTree( "foo");
 
-				tree.Add("bars/1", new string('a', 1000));
+                tree.Add("bars/1", new string('a', 1000));
 
-				txw.Commit();
-			}
+                txw.Commit();
+            }
 
-			using (var txw = Env.WriteTransaction())
-			{
-				txw.CreateTree("bar");
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree("bar");
 
-				txw.Commit();
-			}
+                txw.Commit();
+            }
 
-			using (var txw = Env.WriteTransaction())
-			{
-				var tree = txw.CreateTree( "foo");
+            using (var txw = Env.WriteTransaction())
+            {
+                var tree = txw.CreateTree( "foo");
 
-				tree.Add("bars/1", new string('b', 1000));
+                tree.Add("bars/1", new string('b', 1000));
 
-				txw.Commit();
+                txw.Commit();
 
-			}
+            }
 
-			var txr = Env.ReadTransaction();
-			{
-				using (var txw = Env.WriteTransaction())
-				{
-					var tree = txw.CreateTree( "foo");
+            var txr = Env.ReadTransaction();
+            {
+                using (var txw = Env.WriteTransaction())
+                {
+                    var tree = txw.CreateTree( "foo");
 
-					tree.Add("bars/1", new string('c', 1000));
+                    tree.Add("bars/1", new string('c', 1000));
 
-					txw.Commit();
+                    txw.Commit();
 
-				}
+                }
 
-				Env.FlushLogToDataFile();
+                Env.FlushLogToDataFile();
 
-				txr.Dispose();
+                txr.Dispose();
 
-				using (var txr2 = Env.ReadTransaction())
-				{
-					var allocated1 = Env.ScratchBufferPool.GetNumberOfAllocations(0);
+                using (var txr2 = Env.ReadTransaction())
+                {
+                    var allocated1 = Env.ScratchBufferPool.GetNumberOfAllocations(0);
 
-					Env.FlushLogToDataFile();
+                    Env.FlushLogToDataFile();
 
-					var allocated2 = Env.ScratchBufferPool.GetNumberOfAllocations(0);
+                    var allocated2 = Env.ScratchBufferPool.GetNumberOfAllocations(0);
 
-					Assert.Equal(allocated1, allocated2);
+                    Assert.Equal(allocated1, allocated2);
 
-					Env.FlushLogToDataFile(allowToFlushOverwrittenPages: true);
+                    Env.FlushLogToDataFile(allowToFlushOverwrittenPages: true);
 
-					var allocated3 = Env.ScratchBufferPool.GetNumberOfAllocations(0);
+                    var allocated3 = Env.ScratchBufferPool.GetNumberOfAllocations(0);
 
-					Assert.True(allocated3 < allocated2);
+                    Assert.True(allocated3 < allocated2);
 
-					var read = txr2.CreateTree("foo").Read("bars/1");
+                    var read = txr2.CreateTree("foo").Read("bars/1");
 
-					Assert.NotNull(read);
-					Assert.Equal(new string('c', 1000), read.Reader.AsSlice().ToString());
-				}
-			}
-		} 
-	}
+                    Assert.NotNull(read);
+                    Assert.Equal(new string('c', 1000), read.Reader.AsSlice(txr2.Allocator).ToString());
+                }
+            }
+        } 
+    }
 }

--- a/test/FastTests/Voron/Storage/BigValue.cs
+++ b/test/FastTests/Voron/Storage/BigValue.cs
@@ -28,7 +28,7 @@ namespace FastTests.Voron.Storage
             using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                tree.Add(new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
+                tree.Add(Slice.From(Allocator, BitConverter.GetBytes(1203)), new MemoryStream(buffer));
                 tx.Commit();
             }
 
@@ -42,14 +42,14 @@ namespace FastTests.Voron.Storage
             using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                tree.Delete(new Slice(BitConverter.GetBytes(1203)));
+                tree.Delete(Slice.From(Allocator, BitConverter.GetBytes(1203)));
                 tx.Commit();
             }
 
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                var readResult = tree.Read(new Slice(BitConverter.GetBytes(1203)));
+                var readResult = tree.Read(Slice.From(Allocator, BitConverter.GetBytes(1203)));
                 Assert.Null(readResult);
             }
 
@@ -59,7 +59,7 @@ namespace FastTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                var readResult = tree.Read(new Slice(BitConverter.GetBytes(1203)));
+                var readResult = tree.Read(Slice.From(Allocator, BitConverter.GetBytes(1203)));
                 Assert.Null(readResult);
             }
 
@@ -68,14 +68,14 @@ namespace FastTests.Voron.Storage
                 buffer = new byte[1024 * 1024 * 3 + 1238];
                 random.NextBytes(buffer);
                 var tree = tx.CreateTree("foo");
-                tree.Add(new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
+                tree.Add(Slice.From(Allocator, BitConverter.GetBytes(1203)), new MemoryStream(buffer));
                 tx.Commit();
             }
 
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                var readResult = tree.Read(new Slice(BitConverter.GetBytes(1203)));
+                var readResult = tree.Read(Slice.From(Allocator, BitConverter.GetBytes(1203)));
                 Assert.NotNull(readResult);
 
                 var memoryStream = new MemoryStream();
@@ -90,7 +90,7 @@ namespace FastTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                var readResult = tree.Read(new Slice(BitConverter.GetBytes(1203)));
+                var readResult = tree.Read(Slice.From(Allocator, BitConverter.GetBytes(1203)));
                 Assert.NotNull(readResult);
 
                 var memoryStream = new MemoryStream();
@@ -104,7 +104,7 @@ namespace FastTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                var readResult = tree.Read(new Slice(BitConverter.GetBytes(1203)));
+                var readResult = tree.Read(Slice.From(Allocator, BitConverter.GetBytes(1203)));
                 Assert.NotNull(readResult);
 
                 var memoryStream = new MemoryStream();
@@ -121,7 +121,7 @@ namespace FastTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                var readResult = tree.Read(new Slice(BitConverter.GetBytes(1203)));
+                var readResult = tree.Read(Slice.From(Allocator, BitConverter.GetBytes(1203)));
                 Assert.NotNull(readResult);
 
                 var memoryStream = new MemoryStream();
@@ -151,7 +151,7 @@ namespace FastTests.Voron.Storage
                     var buffer = new byte[912];
                     random.NextBytes(buffer);
                     buffers.Add(buffer);
-                    tree.Add(new Slice(BitConverter.GetBytes(i)), new MemoryStream(buffer));
+                    tree.Add(Slice.From(Allocator, BitConverter.GetBytes(i)), new MemoryStream(buffer));
                 }
                 tx.Commit();
             }
@@ -161,7 +161,7 @@ namespace FastTests.Voron.Storage
                 var tree = tx.CreateTree("foo");
                 for (int i = 0; i < 1500; i++)
                 {
-                    var readResult = tree.Read(new Slice(BitConverter.GetBytes(i)));
+                    var readResult = tree.Read(Slice.From(Allocator, BitConverter.GetBytes(i)));
                     Assert.NotNull(readResult);
 
                     var memoryStream = new MemoryStream();

--- a/test/FastTests/Voron/Tables/BasicUsage.cs
+++ b/test/FastTests/Voron/Tables/BasicUsage.cs
@@ -37,7 +37,7 @@ namespace FastTests.Voron.Tables
             using (var tx = Env.ReadTransaction())
             {
                 var docs = new Table(DocsSchema, "docs", tx);
-                var handle = docs.ReadByKey("users/1");
+                var handle = docs.ReadByKey(Slice.From(tx.Allocator, "users/1"));
 
                 int size;
                 var read = handle.Read(3, out size);
@@ -75,7 +75,7 @@ namespace FastTests.Voron.Tables
             using (var tx = Env.ReadTransaction())
             {
                 var docs = new Table(DocsSchema, "docs", tx);
-                var handle = docs.ReadByKey("users/1");
+                var handle = docs.ReadByKey(Slice.From(tx.Allocator, "users/1"));
 
                 int size;
                 var read = handle.Read(3, out size);
@@ -108,7 +108,7 @@ namespace FastTests.Voron.Tables
             {
                 var docs = new Table(DocsSchema, "docs", tx);
 
-                docs.DeleteByKey("users/1");
+                docs.DeleteByKey(Slice.From(tx.Allocator, "users/1"));
 
                 tx.Commit();
             }
@@ -117,7 +117,7 @@ namespace FastTests.Voron.Tables
             {
                 var docs = new Table(DocsSchema, "docs", tx);
 
-                Assert.Null(docs.ReadByKey("users/1"));
+                Assert.Null(docs.ReadByKey(Slice.From(tx.Allocator, "users/1")));
             }
         }
 

--- a/test/FastTests/Voron/Tables/Bugs.cs
+++ b/test/FastTests/Voron/Tables/Bugs.cs
@@ -57,7 +57,7 @@ namespace FastTests.Voron.Tables
                 for (int i = 0; i < Transactions * ItemsPerTransaction; i++)
                 {
                     var key = i.ToString(Template);
-                    var tableReader = docs.ReadByKey(key);
+                    var tableReader = docs.ReadByKey(Slice.From(tx.Allocator, key));
 
                     Assert.NotNull(tableReader);
 
@@ -98,7 +98,7 @@ namespace FastTests.Voron.Tables
                     var docs = new Table(DocsSchema, "docs", tx);
 
                     var ids = new List<long>();
-                    foreach (var sr in docs.SeekForwardFrom(DocsSchema.Indexes["Etags"], Slice.BeforeAllKeys))
+                    foreach (var sr in docs.SeekForwardFrom(DocsSchema.Indexes["Etags"], Slices.BeforeAllKeys))
                     {
                         foreach (var tvr in sr.Results)
                             ids.Add(tvr.Id);
@@ -114,7 +114,7 @@ namespace FastTests.Voron.Tables
                 {
                     var docs = new Table(DocsSchema, "docs", tx);
 
-                    var reader = docs.SeekForwardFrom(DocsSchema.Indexes["Etags"], new Slice(EndianBitConverter.Big.GetBytes(1)));
+                    var reader = docs.SeekForwardFrom(DocsSchema.Indexes["Etags"], Slice.From(Allocator, EndianBitConverter.Big.GetBytes(1)));
                     Assert.Empty(reader);
                 }
             }

--- a/test/FastTests/Voron/Tables/CompositeIndex.cs
+++ b/test/FastTests/Voron/Tables/CompositeIndex.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Text;
+using Voron;
 using Voron.Data.Tables;
 using Xunit;
 
@@ -79,7 +80,7 @@ namespace FastTests.Voron.Tables
             {
                 var docs = new Table(DocsSchema, "docs", tx);
 
-                docs.DeleteByKey("users/1");
+                docs.DeleteByKey(Slice.From(tx.Allocator, "users/1"));
 
                 tx.Commit();
             }

--- a/test/FastTests/Voron/Tables/SecondayIndex.cs
+++ b/test/FastTests/Voron/Tables/SecondayIndex.cs
@@ -33,7 +33,7 @@ namespace FastTests.Voron.Tables
             {
                 var docs = new Table(DocsSchema, "docs", tx);
 
-                var etag = new Slice(EndianBitConverter.Big.GetBytes(1L));
+                var etag = Slice.From(Allocator, EndianBitConverter.Big.GetBytes(1L));
                 var reader = docs.SeekForwardFrom(DocsSchema.Indexes["Etags"], etag)
                                  .First();
 
@@ -69,7 +69,7 @@ namespace FastTests.Voron.Tables
             {
                 var docs = new Table(DocsSchema, "docs", tx);
 
-                docs.DeleteByKey("users/1");
+                docs.DeleteByKey(Slice.From(tx.Allocator, "users/1"));
 
                 tx.Commit();
             }
@@ -78,7 +78,7 @@ namespace FastTests.Voron.Tables
             {
                 var docs = new Table(DocsSchema, "docs", tx);
 
-                var reader = docs.SeekForwardFrom(DocsSchema.Indexes["Etags"], new Slice(EndianBitConverter.Big.GetBytes(1)));
+                var reader = docs.SeekForwardFrom(DocsSchema.Indexes["Etags"], Slice.From(Allocator, EndianBitConverter.Big.GetBytes(1)));
                 Assert.Empty(reader);
             }
         }
@@ -116,7 +116,7 @@ namespace FastTests.Voron.Tables
             {
                 var docs = new Table(DocsSchema, "docs", tx);
 
-                var etag = new Slice(EndianBitConverter.Big.GetBytes(1L));
+                var etag = Slice.From(Allocator, EndianBitConverter.Big.GetBytes(1L));
                 var reader = docs.SeekForwardFrom(DocsSchema.Indexes["Etags"], etag)
                                  .First();
 

--- a/test/FastTests/Voron/Tables/TableStorageTest.cs
+++ b/test/FastTests/Voron/Tables/TableStorageTest.cs
@@ -1,3 +1,4 @@
+using Sparrow;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -55,15 +56,10 @@ namespace FastTests.Voron.Tables
                     continue;
                 }
 
-                var slice = o as Slice;
-                if (slice != null)
+                if (o is Slice)
                 {
-                    if (slice.Array == null)
-                        throw new NotSupportedException();
-
-                    gcHandle = GCHandle.Alloc(slice.Array, GCHandleType.Pinned);
-                    builder.Add((byte*)gcHandle.AddrOfPinnedObject(), slice.Array.Length);
-                    handles1.Add(gcHandle);
+                    var slice = (Slice)o;
+                    builder.Add(slice.Content.Ptr, slice.Content.Length);
 
                     continue;
                 }

--- a/test/FastTests/Voron/Trees/Basic.cs
+++ b/test/FastTests/Voron/Trees/Basic.cs
@@ -64,7 +64,7 @@ namespace FastTests.Voron.Trees
 
                 using (var it = tree.Iterate())
                 {
-                    Assert.True(it.Seek("a"));
+                    Assert.True(it.Seek(Slice.From(tx.Allocator, "a")));
                     Assert.Equal("a", it.CurrentKey.ToString());
                 }
 
@@ -77,7 +77,7 @@ namespace FastTests.Voron.Trees
         {
             using (var tx = Env.WriteTransaction())
             {
-                Slice key = "test";
+                Slice key = Slice.From(tx.Allocator, "test");
                 var tree = tx.CreateTree("foo");
                 tree.Add(key, StreamFor("value"));
 
@@ -135,7 +135,7 @@ namespace FastTests.Voron.Trees
                 {
                     for (int i = 0; i < count; i++)
                     {
-                        Assert.True(it.Seek("test-" + i.ToString("000")));
+                        Assert.True(it.Seek(Slice.From(tx.Allocator, "test-" + i.ToString("000"))));
                         Assert.Equal("test-" + i.ToString("000"), it.CurrentKey.ToString());
                         Assert.Equal("val-" + i, it.CreateReaderForCurrent().ToString());
                     }

--- a/test/FastTests/Voron/Trees/CanIterateBackward.cs
+++ b/test/FastTests/Voron/Trees/CanIterateBackward.cs
@@ -14,7 +14,7 @@ namespace FastTests.Voron.Trees
                 var tree = tx.CreateTree("foo");
                 using (var it = tree.Iterate())
                 {
-                    Assert.False(it.Seek(Slice.AfterAllKeys));
+                    Assert.False(it.Seek(Slices.AfterAllKeys));
 
                     tx.Commit();
                 }
@@ -39,7 +39,7 @@ namespace FastTests.Voron.Trees
                 var tree = tx.CreateTree("foo");
                 using (var it = tree.Iterate())
                 {
-                    Assert.True(it.Seek(Slice.AfterAllKeys));
+                    Assert.True(it.Seek(Slices.AfterAllKeys));
                     Assert.Equal("c", it.CurrentKey.ToString());
 
                     tx.Commit();
@@ -65,7 +65,7 @@ namespace FastTests.Voron.Trees
                 var tree = tx.ReadTree("foo");
                 using (var it = tree.Iterate())
                 {
-                    Assert.True(it.Seek(Slice.AfterAllKeys));
+                    Assert.True(it.Seek(Slices.AfterAllKeys));
                     Assert.Equal("c", it.CurrentKey.ToString());
 
                     Assert.True(it.MovePrev());

--- a/test/FastTests/Voron/Trees/Deletes.cs
+++ b/test/FastTests/Voron/Trees/Deletes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Xunit;
 using Voron;
 using Voron.Data.BTrees;
@@ -79,7 +80,7 @@ namespace FastTests.Voron.Trees
                 tx.Commit();
             }
 
-            var expected = new List<Slice>();
+            var expected = new List<string>();
             for (int i = 15; i < 1000; i++)
             {
                 expected.Add(string.Format("{0,5}", i));
@@ -99,7 +100,8 @@ namespace FastTests.Voron.Trees
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.ReadTree("foo");
-                var list = Keys(tree, tx);
+                var list = Keys(tree, tx).Select( x => x.ToString());
+
                 Assert.Equal(expected, list);
             }
         }
@@ -109,12 +111,13 @@ namespace FastTests.Voron.Trees
             var results = new List<Slice>();
             using (var it = t.Iterate())
             {
-                if (it.Seek(Slice.BeforeAllKeys) == false)
+                if (it.Seek(Slices.BeforeAllKeys) == false)
                     return results;
                 do
                 {
-                    results.Add(it.CurrentKey);
-                } while (it.MoveNext());
+                    results.Add(it.CurrentKey.Clone(tx.Allocator));
+                }
+                while (it.MoveNext());
             }
             return results;
         }

--- a/test/FastTests/Voron/Trees/Iteration.cs
+++ b/test/FastTests/Voron/Trees/Iteration.cs
@@ -19,14 +19,14 @@ namespace FastTests.Voron.Trees
             {
                 var tree = tx.ReadTree("foo");
                 var iterator = tree.Iterate();
-                Assert.False(iterator.Seek(Slice.BeforeAllKeys));
+                Assert.False(iterator.Seek(Slices.BeforeAllKeys));
             }
 
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.ReadTree("foo");
                 var iterator = tree.Iterate();
-                Assert.False(iterator.Seek(Slice.AfterAllKeys));
+                Assert.False(iterator.Seek(Slices.AfterAllKeys));
             }
         }
 
@@ -52,16 +52,16 @@ namespace FastTests.Voron.Trees
             {
                 var tree = tx.ReadTree("foo");
                 var iterator = tree.Iterate();
-                Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
                 for (int i = 0; i < 24; i++)
                 {
-                    Assert.Equal(i.ToString("0000"), iterator.CurrentKey);
+                    Assert.Equal(i.ToString("0000"), iterator.CurrentKey.ToString());
 
                     Assert.True(iterator.MoveNext());
                 }
 
-                Assert.Equal(24.ToString("0000"), iterator.CurrentKey);
+                Assert.Equal(24.ToString("0000"), iterator.CurrentKey.ToString());
                 Assert.False(iterator.MoveNext());
             }
         }

--- a/test/FastTests/Voron/Trees/Updates.cs
+++ b/test/FastTests/Voron/Trees/Updates.cs
@@ -69,8 +69,8 @@ namespace FastTests.Voron.Trees
                 tree.Add("test", StreamFor("2"));
 
                 var readKey = ReadKey(tx, tree, "test");
-                Assert.Equal("test", readKey.Item1);
-                Assert.Equal("2", readKey.Item2);
+                Assert.Equal("test", readKey.Item1.ToString());
+                Assert.Equal("2", readKey.Item2.ToString());
             }
         }
 
@@ -86,12 +86,12 @@ namespace FastTests.Voron.Trees
                 tree.Add("test/1", StreamFor("3"));
 
                 var readKey = ReadKey(tx, tree, "test/1");
-                Assert.Equal("test/1", readKey.Item1);
-                Assert.Equal("3", readKey.Item2);
+                Assert.Equal("test/1", readKey.Item1.ToString());
+                Assert.Equal("3", readKey.Item2.ToString());
 
                 readKey = ReadKey(tx, tree, "test/2");
-                Assert.Equal("test/2", readKey.Item1);
-                Assert.Equal("2", readKey.Item2);
+                Assert.Equal("test/2", readKey.Item1.ToString());
+                Assert.Equal("2", readKey.Item2.ToString());
 
             }
         }
@@ -108,12 +108,12 @@ namespace FastTests.Voron.Trees
                 tree.Add("test/2", StreamFor("3"));
 
                 var readKey = ReadKey(tx, tree, "test/1");
-                Assert.Equal("test/1", readKey.Item1);
-                Assert.Equal("1", readKey.Item2);
+                Assert.Equal("test/1", readKey.Item1.ToString());
+                Assert.Equal("1", readKey.Item2.ToString());
 
                 readKey = ReadKey(tx, tree, "test/2");
-                Assert.Equal("test/2", readKey.Item1);
-                Assert.Equal("3", readKey.Item2);
+                Assert.Equal("test/2", readKey.Item1.ToString());
+                Assert.Equal("3", readKey.Item2.ToString());
 
             }
         }

--- a/test/SlowTests/Voron/BigValue.cs
+++ b/test/SlowTests/Voron/BigValue.cs
@@ -22,14 +22,14 @@ namespace SlowTests.Voron
             using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                tree.Add(new Slice(BitConverter.GetBytes(1203)), new MemoryStream(buffer));
+                tree.Add(Slice.From(tx.Allocator, BitConverter.GetBytes(1203)), new MemoryStream(buffer));
                 tx.Commit();
             }
 
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                var readResult = tree.Read(new Slice(BitConverter.GetBytes(1203)));
+                var readResult = tree.Read(Slice.From(tx.Allocator, BitConverter.GetBytes(1203)));
                 Assert.NotNull(readResult);
 
                 var memoryStream = new MemoryStream();

--- a/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
+++ b/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
@@ -92,7 +92,7 @@ namespace SlowTests.Voron.Bugs
                 var count = 0;
                 using (var iterator = keyByEtagTree.Iterate())
                 {
-                    iterator.Seek(Slice.BeforeAllKeys);
+                    iterator.Seek(Slices.BeforeAllKeys);
                     do
                     {
                         var etag = Guid.Parse(iterator.CurrentKey.ToString());

--- a/test/SlowTests/Voron/DuplicatePageUsage.cs
+++ b/test/SlowTests/Voron/DuplicatePageUsage.cs
@@ -57,7 +57,7 @@ namespace SlowTests.Voron
                     }
 
                     var val = long.MaxValue/2;
-                    options.Add("LastEntryId", new Slice((byte*)&val, sizeof(long)));
+                    options.Add(Slice.From(tx.Allocator, "LastEntryId"), Slice.From(tx.Allocator, (byte*)&val, sizeof(long)));
                     tx.Commit();
                 }
             }

--- a/test/SlowTests/Voron/InvalidReleasesOfScratchPages.cs
+++ b/test/SlowTests/Voron/InvalidReleasesOfScratchPages.cs
@@ -8,111 +8,111 @@ using Xunit;
 namespace SlowTests.Voron
 {
     public class InvalidReleasesOfScratchPages : StorageTest
-	{
-		
-		protected override void Configure(StorageEnvironmentOptions options)
-		{
-			options.MaxScratchBufferSize *= 2;
-		}
+    {
+        
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.MaxScratchBufferSize *= 2;
+        }
 
-		[Fact]
-		public void ParallelWritesInBatchesAndReadsByUsingTreeIterator()
-		{
-			const int numberOfWriteThreads = 10;
-			const int numberOfReadThreads = 10;
-			const int numberOfTrees = 2;
+        [Fact]
+        public void ParallelWritesInBatchesAndReadsByUsingTreeIterator()
+        {
+            const int numberOfWriteThreads = 10;
+            const int numberOfReadThreads = 10;
+            const int numberOfTrees = 2;
 
-			var trees = CreateTrees(Env, numberOfTrees, "tree");
+            var trees = CreateTrees(Env, numberOfTrees, "tree");
 
-			Task readParallelTask = null;
+            Task readParallelTask = null;
 
-			var taskWorkTime = TimeSpan.FromSeconds(60);
+            var taskWorkTime = TimeSpan.FromSeconds(60);
 
-			var writeTime = Stopwatch.StartNew();
+            var writeTime = Stopwatch.StartNew();
 
-			var writeParallelTask = Task.Factory.StartNew(
-				() =>
-				{
-					Parallel.For(
-						0,
-						numberOfWriteThreads,
-						i =>
-						{
-							var random = new Random(i ^ 1337);
-							var dataSize = random.Next(100, 100);
-							var buffer = new byte[dataSize];
-							random.NextBytes(buffer);
+            var writeParallelTask = Task.Factory.StartNew(
+                () =>
+                {
+                    Parallel.For(
+                        0,
+                        numberOfWriteThreads,
+                        i =>
+                        {
+                            var random = new Random(i ^ 1337);
+                            var dataSize = random.Next(100, 100);
+                            var buffer = new byte[dataSize];
+                            random.NextBytes(buffer);
 
-							while (writeTime.Elapsed < taskWorkTime && (readParallelTask == null || readParallelTask.Exception == null))
-							{
-								var tIndex = random.Next(0, numberOfTrees - 1);
-								var treeName = trees[tIndex];
+                            while (writeTime.Elapsed < taskWorkTime && (readParallelTask == null || readParallelTask.Exception == null))
+                            {
+                                var tIndex = random.Next(0, numberOfTrees - 1);
+                                var treeName = trees[tIndex];
 
-							    using (var tx = Env.WriteTransaction())
-							    {
-							        var tree = tx.CreateTree(treeName);
-							        tree.Add("testdocuments/" + random.Next(0, 100000), new MemoryStream(buffer));
+                                using (var tx = Env.WriteTransaction())
+                                {
+                                    var tree = tx.CreateTree(treeName);
+                                    tree.Add("testdocuments/" + random.Next(0, 100000), new MemoryStream(buffer));
                                     tx.Commit();
-							    }
+                                }
 
-							}
-						});
-				},
-				TaskCreationOptions.LongRunning);
+                            }
+                        });
+                },
+                TaskCreationOptions.LongRunning);
 
-			var readTime = Stopwatch.StartNew();
-			readParallelTask = Task.Factory.StartNew(
-				() =>
-					{
-						Parallel.For(
-							0,
-							numberOfReadThreads,
-							i =>
-								{
-									var random = new Random(i);
+            var readTime = Stopwatch.StartNew();
+            readParallelTask = Task.Factory.StartNew(
+                () =>
+                    {
+                        Parallel.For(
+                            0,
+                            numberOfReadThreads,
+                            i =>
+                                {
+                                    var random = new Random(i);
 
-									while (readTime.Elapsed < taskWorkTime)
-									{
-										var tIndex = random.Next(0, numberOfTrees - 1);
-										var treeName = trees[tIndex];
+                                    while (readTime.Elapsed < taskWorkTime)
+                                    {
+                                        var tIndex = random.Next(0, numberOfTrees - 1);
+                                        var treeName = trees[tIndex];
 
-										using (var snapshot = Env.ReadTransaction())
-										using (var iterator = snapshot.ReadTree(treeName).Iterate())
-										{
-											if (!iterator.Seek(Slice.BeforeAllKeys))
-											{
-												continue;
-											}
+                                        using (var snapshot = Env.ReadTransaction())
+                                        using (var iterator = snapshot.ReadTree(treeName).Iterate())
+                                        {
+                                            if (!iterator.Seek(Slices.BeforeAllKeys))
+                                            {
+                                                continue;
+                                            }
 
-											do
-											{
-												Assert.Contains("testdocuments/", iterator.CurrentKey.ToString());
-											} while (iterator.MoveNext());
-										}
-									}
-								});
-					},
-				TaskCreationOptions.LongRunning);
+                                            do
+                                            {
+                                                Assert.Contains("testdocuments/", iterator.CurrentKey.ToString());
+                                            } while (iterator.MoveNext());
+                                        }
+                                    }
+                                });
+                    },
+                TaskCreationOptions.LongRunning);
 
 
-			try
-			{
-				Task.WaitAll(new[] { writeParallelTask, readParallelTask });
-			}
-			catch (Exception ex)
-			{
-				var aggregate = ex as AggregateException;
+            try
+            {
+                Task.WaitAll(new[] { writeParallelTask, readParallelTask });
+            }
+            catch (Exception ex)
+            {
+                var aggregate = ex as AggregateException;
 
-				if (aggregate != null)
-				{
-					foreach (var innerEx in aggregate.InnerExceptions)
-					{
-						Console.WriteLine(innerEx);
-					}
-				}
+                if (aggregate != null)
+                {
+                    foreach (var innerEx in aggregate.InnerExceptions)
+                    {
+                        Console.WriteLine(innerEx);
+                    }
+                }
 
-				throw ex;
-			}
-		}
-	}
+                throw ex;
+            }
+        }
+    }
 }

--- a/test/SlowTests/Voron/LargeFixedSizeTrees.cs
+++ b/test/SlowTests/Voron/LargeFixedSizeTrees.cs
@@ -23,9 +23,11 @@ namespace SlowTests.Voron
         public void CanAdd_ALot_ForPageSplits(int count)
         {
             var bytes = new byte[48];
+            var treeId = Slice.From(Allocator, "test");
+
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 0; i < count; i++)
                 {
@@ -39,7 +41,7 @@ namespace SlowTests.Voron
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 0; i < count; i++)
                 {
@@ -60,14 +62,17 @@ namespace SlowTests.Voron
         public void CanCIterate_ALot_ForPageSplits(int count)
         {
             var bytes = new byte[48];
-            var slice = new Slice(bytes);
+
+            var treeId = Slice.From(Allocator, "test");
+
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 0; i < count; i++)
                 {
                     EndianBitConverter.Little.CopyBytes(i, bytes, 0);
+                    var slice = Slice.From(Allocator, bytes);
                     fst.Add(i, slice);
                 }
 
@@ -76,7 +81,7 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
                 var total = 0;
                 using (var it = fst.Iterate())
                 {
@@ -84,7 +89,8 @@ namespace SlowTests.Voron
                     do
                     {
                         Assert.Equal(total++, it.CreateReaderForCurrent().ReadLittleEndianInt64());
-                    } while (it.MoveNext());
+                    }
+                    while (it.MoveNext());
                 }
                 Assert.Equal(count, total);
                 tx.Commit();
@@ -99,10 +105,11 @@ namespace SlowTests.Voron
         public void CanRemove_ALot_ForPageSplits(int count)
         {
             var bytes = new byte[48];
-            var slice = new Slice(bytes);
+            var slice = Slice.From(Allocator, bytes);
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 0; i < count; i++)
                 {
@@ -115,7 +122,7 @@ namespace SlowTests.Voron
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 0; i < count; i++)
                 {
@@ -127,7 +134,7 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 0; i < count; i++)
                 {
@@ -144,17 +151,18 @@ namespace SlowTests.Voron
         [InlineData(1024 * 256)]
         public void CanDeleteRange(int count)
         {
-            var bytes = new byte[48];
-            var slice = new Slice(bytes);
-
+            var bytes = new byte[48];           
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 1; i <= count; i++)
                 {
                     EndianBitConverter.Little.CopyBytes(i, bytes, 0);
                     Assert.Equal(i - 1, fst.NumberOfEntries);
+
+                    var slice = Slice.From(Allocator, bytes);
                     fst.Add(i, slice);
                 }
 
@@ -164,13 +172,13 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
                 Assert.Equal(count, fst.NumberOfEntries);
             }
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 var itemsRemoved = fst.DeleteRange(4, count - 3);
                 Assert.Equal(count - 6, itemsRemoved.NumberOfEntriesDeleted);
@@ -181,14 +189,14 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 1; i <= count; i++)
                 {
                     if (i >= 4 && i <= count - 3)
                     {
                         Assert.False(fst.Contains(i), i.ToString());
-                        Assert.Null(fst.Read(i));
+                        Assert.False(fst.Read(i).HasValue);
                     }
                     else
                     {
@@ -208,15 +216,16 @@ namespace SlowTests.Voron
         public void CanDeleteAllRange(int count)
         {
             var bytes = new byte[48];
-            var slice = new Slice(bytes);
-
+           
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 1; i <= count; i++)
                 {
                     EndianBitConverter.Little.CopyBytes(i, bytes, 0);
+                    var slice = Slice.From(Allocator, bytes);
                     fst.Add(i, slice);
                 }
 
@@ -225,7 +234,7 @@ namespace SlowTests.Voron
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 var itemsRemoved = fst.DeleteRange(0, DateTime.MaxValue.Ticks);
                 Assert.Equal(count, itemsRemoved.NumberOfEntriesDeleted);
@@ -236,12 +245,12 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 1; i <= count; i++)
                 {
                     Assert.False(fst.Contains(i), i.ToString());
-                    Assert.Null(fst.Read(i));
+                    Assert.False(fst.Read(i).HasValue);
                 }
                 tx.Commit();
             }
@@ -255,24 +264,26 @@ namespace SlowTests.Voron
         public void CanDeleteRange_TryToFindABranchNextToLeaf(int count, int seed)
         {
             var bytes = new byte[48];
-            var slice = new Slice(bytes);
+     
             var status = new BitArray(count + 1);
-
+            var treeId = Slice.From(Allocator, "test");
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 1; i <= count; i++)
                 {
                     EndianBitConverter.Little.CopyBytes(i, bytes, 0);
+                    var slice = Slice.From(Allocator, bytes);
                     fst.Add(i, slice);
+
                     status[i] = true;
                 }
 
                 tx.Commit();
             }
 
-			var random = new Random(seed);
+            var random = new Random(seed);
             // del exactly 1 page
             for (var i = 0; i < count/100; i++)
             {
@@ -282,7 +293,7 @@ namespace SlowTests.Voron
 
                 using (var tx = Env.WriteTransaction())
                 {
-                    var fst = tx.FixedTreeFor("test", valSize: 48);
+                    var fst = tx.FixedTreeFor(treeId, valSize: 48);
                     for (int j = (int) start; j <= (int) end; j++)
                     {
                         status[j] = false;
@@ -301,10 +312,10 @@ namespace SlowTests.Voron
 
                 using (var tx = Env.WriteTransaction())
                 {
-                    var fst = tx.FixedTreeFor("test", valSize: 48);
-					if (fst.NumberOfEntries == 0)
-						break;
-					for (int j = start; j <= end; j++)
+                    var fst = tx.FixedTreeFor(treeId, valSize: 48);
+                    if (fst.NumberOfEntries == 0)
+                        break;
+                    for (int j = start; j <= end; j++)
                     {
                         status.Set(j, false);
                     }
@@ -316,7 +327,7 @@ namespace SlowTests.Voron
 
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
                 for (int i = 0; i < count; i++)
                 {
                     if (status[i] != fst.Contains(i))
@@ -338,16 +349,16 @@ namespace SlowTests.Voron
         public void CanDeleteRange_RandomRanges(int count, int seed)
         {
             var bytes = new byte[48];
-            var slice = new Slice(bytes);
-
+            var treeId = Slice.From(Allocator, "test");
             var status = new BitArray(count + 1);
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 1; i <= count; i++)
                 {
                     EndianBitConverter.Little.CopyBytes(i, bytes, 0);
+                    var slice = Slice.From(Allocator, bytes);
                     fst.Add(i, slice);
                     status[i] = true;
                 }
@@ -355,18 +366,18 @@ namespace SlowTests.Voron
                 tx.Commit();
             }
 
-			var random = new Random(seed);
-			for (var i = 0; i < count/100; i++)
+            var random = new Random(seed);
+            for (var i = 0; i < count/100; i++)
             {
                 var start = random.Next(count);
                 var end = random.Next(start, count);
 
                 using (var tx = Env.WriteTransaction())
                 {
-                    var fst = tx.FixedTreeFor("test", valSize: 48);
-					if (fst.NumberOfEntries == 0)
-						break;
-					for (int j = start; j <= end; j++)
+                    var fst = tx.FixedTreeFor(treeId, valSize: 48);
+                    if (fst.NumberOfEntries == 0)
+                        break;
+                    for (int j = start; j <= end; j++)
                     {
                         status[j] = false;
                     }
@@ -377,7 +388,7 @@ namespace SlowTests.Voron
             }
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
                 for (int i = 0; i <= count; i++)
                 {
                     Assert.Equal(status[i], fst.Contains(i));
@@ -393,12 +404,12 @@ namespace SlowTests.Voron
         public void CanDeleteRange_RandomRanges_WithGaps(int count, int seed)
         {
             var bytes = new byte[48];
-            var slice = new Slice(bytes);
-
+            var slice = Slice.From(Allocator, bytes);
+            var treeId = Slice.From(Allocator, "test");
             var status = new BitArray(count * 3);
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
                 for (var i = 1; i < count; i++)
                 {
                     fst.Add(i*3, slice);
@@ -414,10 +425,10 @@ namespace SlowTests.Voron
                 var end = random.Next(start, status.Length);
                 using (var tx = Env.WriteTransaction())
                 {
-                    var fst = tx.FixedTreeFor("test", valSize: 48);
-	                if (fst.NumberOfEntries == 0)
-		                break;
-	                for (int j = start; j <= end; j++)
+                    var fst = tx.FixedTreeFor(treeId, valSize: 48);
+                    if (fst.NumberOfEntries == 0)
+                        break;
+                    for (int j = start; j <= end; j++)
                     {
                         status[j] = false;
                     }
@@ -428,7 +439,7 @@ namespace SlowTests.Voron
             }
             using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
 
                 for (int i = 0; i < count; i++)
                 {
@@ -446,16 +457,16 @@ namespace SlowTests.Voron
         public void SeekToLast_ShouldWork(int count)
         {
             var bytes = new byte[48];
-            var slice = new Slice(bytes);
-
-	        int lastId = -1;
-	        using (var tx = Env.WriteTransaction())
+            var slice = Slice.From(Allocator, bytes);
+            var treeId = Slice.From(Allocator, "test");
+            int lastId = -1;
+            using (var tx = Env.WriteTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
                 for (var i = 1; i < count; i++)
                 {
                     fst.Add(i, slice);
-	                lastId = i;
+                    lastId = i;
                 }
 
                 tx.Commit();
@@ -463,12 +474,12 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                var fst = tx.FixedTreeFor("test", valSize: 48);
-	            using (var it = fst.Iterate())
-	            {
-		            Assert.True(it.SeekToLast(), "Failed to seek to last");
-		            Assert.Equal(lastId, it.CurrentKey);
-	            }
+                var fst = tx.FixedTreeFor(treeId, valSize: 48);
+                using (var it = fst.Iterate())
+                {
+                    Assert.True(it.SeekToLast(), "Failed to seek to last");
+                    Assert.Equal(lastId, it.CurrentKey);
+                }
             }
         }
     }

--- a/test/SlowTests/Voron/LargeValues.cs
+++ b/test/SlowTests/Voron/LargeValues.cs
@@ -61,7 +61,7 @@ namespace SlowTests.Voron
                     var tree = snapshot.ReadTree(treeName);
                     using (var iterator = tree.Iterate())
                     {
-                        Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
                         var keys = new HashSet<string>();
 

--- a/test/SlowTests/Voron/MemoryMapWithoutBackingPagerTest.cs
+++ b/test/SlowTests/Voron/MemoryMapWithoutBackingPagerTest.cs
@@ -73,7 +73,7 @@ namespace SlowTests.Voron
             {
                 using (var iterator = snapshot.ReadTree(TestTreeName).Iterate())
                 {
-                    Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                    Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
                     do
                     {

--- a/test/SlowTests/Voron/PageSplitter.cs
+++ b/test/SlowTests/Voron/PageSplitter.cs
@@ -128,9 +128,9 @@ namespace SlowTests.Voron
         {
             var ids = ReadIds("data2.txt");
 
-	        StorageEnvironmentOptions storageEnvironmentOptions = StorageEnvironmentOptions.CreateMemoryOnly();
-			storageEnvironmentOptions.MaxScratchBufferSize *=2;
-	        using (var env = new StorageEnvironment(storageEnvironmentOptions))
+            StorageEnvironmentOptions storageEnvironmentOptions = StorageEnvironmentOptions.CreateMemoryOnly();
+            storageEnvironmentOptions.MaxScratchBufferSize *=2;
+            using (var env = new StorageEnvironment(storageEnvironmentOptions))
             {
                 var rand = new Random();
                 var testBuffer = new byte[69];
@@ -165,7 +165,7 @@ namespace SlowTests.Voron
                     var readTree = snapshot.ReadTree(tree);
                     using (var iterator = readTree.Iterate())
                     {
-                        Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys));
 
                         var keys = new HashSet<string>();
 
@@ -212,93 +212,93 @@ namespace SlowTests.Voron
             }
         }
 
-		[Fact]
-	    public void ShouldNotThrowPageFullExceptionDuringPageSplit()
-	    {
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree( "foo");
-				tx.Commit();
-			}
+        [Fact]
+        public void ShouldNotThrowPageFullExceptionDuringPageSplit()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree( "foo");
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.ReadTree("foo");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("foo");
 
-				var normal = new byte[150];
+                var normal = new byte[150];
 
-				var small = new byte[0];
+                var small = new byte[0];
 
-				var large = new byte[366];
+                var large = new byte[366];
 
-				new Random(1).NextBytes(small);
+                new Random(1).NextBytes(small);
 
-				tree.Add("01", small);
-				tree.Add("02", small);
-				tree.Add("03", small);
-				tree.Add("04", small);
-				tree.Add("05", small);
-				tree.Add("06", small);
-				tree.Add("07", small);
-				tree.Add("08", small);
-				tree.Add("09", small);
-				tree.Add("10", small);
-				tree.Add("11", large);
-				tree.Add("12", large);
-				tree.Add("13", large);
-				tree.Add("14", large);
-				tree.Add("15", large);
-				tree.Add("16", large);
-				tree.Add("17", large);
-				tree.Add("18", large);
-				tree.Add("19", large);
-				tree.Add("21", large);
-				tree.Add("22", large);
-				tree.Add("23", large);
-				tree.Add("24", normal);
-				tree.Add("25", normal);
-				tree.Add("26", normal);
-				tree.Add("27", normal);
-				tree.Add("28", normal);
-				tree.Add("29", normal);
-				tree.Add("30", normal);
+                tree.Add("01", small);
+                tree.Add("02", small);
+                tree.Add("03", small);
+                tree.Add("04", small);
+                tree.Add("05", small);
+                tree.Add("06", small);
+                tree.Add("07", small);
+                tree.Add("08", small);
+                tree.Add("09", small);
+                tree.Add("10", small);
+                tree.Add("11", large);
+                tree.Add("12", large);
+                tree.Add("13", large);
+                tree.Add("14", large);
+                tree.Add("15", large);
+                tree.Add("16", large);
+                tree.Add("17", large);
+                tree.Add("18", large);
+                tree.Add("19", large);
+                tree.Add("21", large);
+                tree.Add("22", large);
+                tree.Add("23", large);
+                tree.Add("24", normal);
+                tree.Add("25", normal);
+                tree.Add("26", normal);
+                tree.Add("27", normal);
+                tree.Add("28", normal);
+                tree.Add("29", normal);
+                tree.Add("30", normal);
 
 
-				const int toInsert = 230;
+                const int toInsert = 230;
 
-				tree.Add("20", new byte[toInsert]);
+                tree.Add("20", new byte[toInsert]);
 
-			}
-	    }
+            }
+        }
 
-	    [Fact]
-	    public void ShouldNotThrowPageFullExceptionDuringPageSplit2()
-	    {
-		    using (var tx = Env.WriteTransaction())
-		    {
-			    tx.CreateTree( "foo");
-			    tx.Commit();
-		    }
+        [Fact]
+        public void ShouldNotThrowPageFullExceptionDuringPageSplit2()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree( "foo");
+                tx.Commit();
+            }
 
-		    using (var tx = Env.WriteTransaction())
-		    {
-			    var tree = tx.ReadTree("foo");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("foo");
 
-				tree.Add("thumbproducts/57337", new byte[1998]);
-				tree.Add("thumbproducts/57338", new byte[1993]);
+                tree.Add("thumbproducts/57337", new byte[1998]);
+                tree.Add("thumbproducts/57338", new byte[1993]);
 
-				tree.Add("thumbproducts/573370", new byte[2016]); // originally here the exception was thrown during a page split
-				tx.Commit();
-		    }
+                tree.Add("thumbproducts/573370", new byte[2016]); // originally here the exception was thrown during a page split
+                tx.Commit();
+            }
 
-		    using (var tx = Env.WriteTransaction())
-		    {
-			    var tree = tx.ReadTree("foo");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("foo");
 
-				Assert.Equal(1998, tree.Read("thumbproducts/57337").Reader.Length);
-				Assert.Equal(1993, tree.Read("thumbproducts/57338").Reader.Length);
-				Assert.Equal(2016, tree.Read("thumbproducts/573370").Reader.Length);
-		    }
-	    }
+                Assert.Equal(1998, tree.Read("thumbproducts/57337").Reader.Length);
+                Assert.Equal(1993, tree.Read("thumbproducts/57338").Reader.Length);
+                Assert.Equal(2016, tree.Read("thumbproducts/573370").Reader.Length);
+            }
+        }
     }
 }

--- a/test/SlowTests/Voron/Recovery.cs
+++ b/test/SlowTests/Voron/Recovery.cs
@@ -8,315 +8,315 @@ using Xunit;
 namespace SlowTests.Voron
 {
     public class Recovery : StorageTest
-	{
-		[Fact]
-		public void StorageRecoveryShouldWorkWhenThereAreNoTransactionsToRecoverFromLog()
-		{
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-			}
+    {
+        [Fact]
+        public void StorageRecoveryShouldWorkWhenThereAreNoTransactionsToRecoverFromLog()
+        {
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+            }
 
-		    using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-		    {
-		    }
-		}
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+            }
+        }
 
-		[Fact]
-		public void StorageRecoveryShouldWorkWhenThereSingleTransactionToRecoverFromLog()
-		{
+        [Fact]
+        public void StorageRecoveryShouldWorkWhenThereSingleTransactionToRecoverFromLog()
+        {
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					var tree = tx.CreateTree(  "tree");
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree(  "tree");
 
-					for (var i = 0; i < 100; i++)
-					{
-						tree.Add("key" + i, new MemoryStream());
-					}
+                    for (var i = 0; i < 100; i++)
+                    {
+                        tree.Add("key" + i, new MemoryStream());
+                    }
 
-					tx.Commit();
-				}
-			}
+                    tx.Commit();
+                }
+            }
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree(  "tree");
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree(  "tree");
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
 
-				using (var tx = env.ReadTransaction())
-				{
-					var tree = tx.CreateTree("tree");
+                using (var tx = env.ReadTransaction())
+                {
+                    var tree = tx.CreateTree("tree");
 
-					for (var i = 0; i < 100; i++)
-					{
-						Assert.NotNull(tree.Read("key" + i));
-					}
-				}
-			}
-		}
+                    for (var i = 0; i < 100; i++)
+                    {
+                        Assert.NotNull(tree.Read("key" + i));
+                    }
+                }
+            }
+        }
 
-		[Fact]
-		public void StorageRecoveryShouldWorkWhenThereAreCommitedAndUncommitedTransactions()
-		{
+        [Fact]
+        public void StorageRecoveryShouldWorkWhenThereAreCommitedAndUncommitedTransactions()
+        {
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree(  "tree");
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree(  "tree");
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var tx = env.WriteTransaction())
-				{
-					for (var i = 0; i < 10000; i++)
-					{
-						tx.CreateTree("tree").Add("a" + i, new MemoryStream());
-					}
-				}
-			}
+                using (var tx = env.WriteTransaction())
+                {
+                    for (var i = 0; i < 10000; i++)
+                    {
+                        tx.CreateTree("tree").Add("a" + i, new MemoryStream());
+                    }
+                }
+            }
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-			}
-		}
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+            }
+        }
 
-		[Fact]
-		public void StorageRecoveryShouldWorkWhenThereAreCommitedAndUncommitedTransactions2()
-		{
+        [Fact]
+        public void StorageRecoveryShouldWorkWhenThereAreCommitedAndUncommitedTransactions2()
+        {
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree("atree");
-					tx.CreateTree("btree");
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree("atree");
+                    tx.CreateTree("btree");
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var tx = env.WriteTransaction())
-				{
-					for (var i = 0; i < 10000; i++)
-					{
-						tx.CreateTree("atree").Add("a" + i, new MemoryStream());
-						tx.CreateTree("btree").MultiAdd("a" + i, "a" + i);
-					}
-				}
-			}
+                using (var tx = env.WriteTransaction())
+                {
+                    for (var i = 0; i < 10000; i++)
+                    {
+                        tx.CreateTree("atree").Add("a" + i, new MemoryStream());
+                        tx.CreateTree("btree").MultiAdd("a" + i, "a" + i);
+                    }
+                }
+            }
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-			}
-		}
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+            }
+        }
 
-		[Fact]
-		public void StorageRecoveryShouldWorkWhenThereAreMultipleCommitedTransactions()
-		{
+        [Fact]
+        public void StorageRecoveryShouldWorkWhenThereAreMultipleCommitedTransactions()
+        {
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					var tree = tx.CreateTree( "atree");
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree( "atree");
 
-					for (var i = 0; i < 1000; i++)
-					{
-						tree.Add("key" + i, new MemoryStream());
-					}
+                    for (var i = 0; i < 1000; i++)
+                    {
+                        tree.Add("key" + i, new MemoryStream());
+                    }
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var tx = env.WriteTransaction())
-				{
-					var tree = tx.CreateTree( "btree");
+                using (var tx = env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree( "btree");
 
-					for (var i = 0; i < 1; i++)
-					{
-						tree.Add("key" + i, new MemoryStream());
-					}
+                    for (var i = 0; i < 1; i++)
+                    {
+                        tree.Add("key" + i, new MemoryStream());
+                    }
 
-					tx.Commit();
-				}
-			}
+                    tx.Commit();
+                }
+            }
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree("atree");
-					tx.CreateTree("btree");
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree("atree");
+                    tx.CreateTree("btree");
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var tx = env.ReadTransaction())
-				{
-					var aTree = tx.CreateTree("atree");
-					var bTree = tx.CreateTree("btree");
+                using (var tx = env.ReadTransaction())
+                {
+                    var aTree = tx.CreateTree("atree");
+                    var bTree = tx.CreateTree("btree");
 
-					for (var i = 0; i < 1000; i++)
-					{
-						Assert.NotNull(aTree.Read("key" + i));
-					}
+                    for (var i = 0; i < 1000; i++)
+                    {
+                        Assert.NotNull(aTree.Read("key" + i));
+                    }
 
-					for (var i = 0; i < 1; i++)
-					{
-						Assert.NotNull(bTree.Read("key" + i));
-					}
-				}
-			}
+                    for (var i = 0; i < 1; i++)
+                    {
+                        Assert.NotNull(bTree.Read("key" + i));
+                    }
+                }
+            }
 
-		}
+        }
 
-		[Fact]
-		public void StorageRecoveryShouldWorkWhenThereAreMultipleCommitedTransactions2()
-		{
+        [Fact]
+        public void StorageRecoveryShouldWorkWhenThereAreMultipleCommitedTransactions2()
+        {
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					var tree = tx.CreateTree( "atree");
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree( "atree");
 
-					for (var i = 0; i < 1000; i++)
-					{
-						tree.Add("key" + i, new MemoryStream());
-					}
+                    for (var i = 0; i < 1000; i++)
+                    {
+                        tree.Add("key" + i, new MemoryStream());
+                    }
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var tx = env.WriteTransaction())
-				{
-					var tree = tx.CreateTree("btree");
+                using (var tx = env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("btree");
 
-					for (var i = 0; i < 5; i++)
-					{
-						tree.Add("key" + i, new MemoryStream());
-					}
+                    for (var i = 0; i < 5; i++)
+                    {
+                        tree.Add("key" + i, new MemoryStream());
+                    }
 
-					tx.Commit();
-				}
-			}
+                    tx.Commit();
+                }
+            }
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree( "atree");
-					tx.CreateTree( "btree");
-
-					tx.Commit();
-				}
-
-				using (var tx = env.ReadTransaction())
-				{
-					var aTree = tx.CreateTree("atree");
-					var bTree = tx.CreateTree("btree");
-
-					for (var i = 0; i < 1000; i++)
-					{
-						Assert.NotNull(aTree.Read("key" + i));
-					}
-
-					for (var i = 0; i < 5; i++)
-					{
-						Assert.NotNull(bTree.Read("key" + i));
-					}
-				}
-			}
-
-		}
-
-		[Fact]
-		public void StorageRecoveryShouldWorkForSplitTransactions()
-		{
-			var random = new Random(1234);
-			var buffer = new byte[4096];
-			random.NextBytes(buffer);
-			var count = 1000;
-
-			var options = StorageEnvironmentOptions.ForPath(DataDir);
-			options.MaxLogFileSize = 10 * options.PageSize;
-
-			using (var env = new StorageEnvironment(options))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree( "atree");
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree( "atree");
                     tx.CreateTree( "btree");
 
-					tx.Commit();
-				}
+                    tx.Commit();
+                }
 
-				using (var tx = env.WriteTransaction())
-				{
-					var aTree = tx.CreateTree("atree");
-					var bTree = tx.CreateTree("btree");
+                using (var tx = env.ReadTransaction())
+                {
+                    var aTree = tx.CreateTree("atree");
+                    var bTree = tx.CreateTree("btree");
 
-					for (var i = 0; i < count; i++)
-					{
-						aTree.Add("a" + i, new MemoryStream(buffer));
-						bTree.MultiAdd("a", "a" + i);
-					}
+                    for (var i = 0; i < 1000; i++)
+                    {
+                        Assert.NotNull(aTree.Read("key" + i));
+                    }
 
-					tx.Commit();
-				}
-			}
+                    for (var i = 0; i < 5; i++)
+                    {
+                        Assert.NotNull(bTree.Read("key" + i));
+                    }
+                }
+            }
 
-			var expectedString = Encoding.UTF8.GetString(buffer);
+        }
 
-			options = StorageEnvironmentOptions.ForPath(DataDir);
-			options.MaxLogFileSize = 10 * options.PageSize;
+        [Fact]
+        public void StorageRecoveryShouldWorkForSplitTransactions()
+        {
+            var random = new Random(1234);
+            var buffer = new byte[4096];
+            random.NextBytes(buffer);
+            var count = 1000;
 
-			using (var env = new StorageEnvironment(options))
-			{
-				using (var tx = env.WriteTransaction())
-				{
-					tx.CreateTree( "atree");
-					tx.CreateTree( "btree");
+            var options = StorageEnvironmentOptions.ForPath(DataDir);
+            options.MaxLogFileSize = 10 * options.PageSize;
 
-					tx.Commit();
-				}
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree( "atree");
+                    tx.CreateTree( "btree");
 
-				using (var tx = env.ReadTransaction())
-				{
-					var aTree = tx.CreateTree("atree");
-					var bTree = tx.CreateTree("btree");
+                    tx.Commit();
+                }
 
-					for (var i = 0; i < count; i++)
-					{
-					    var read = aTree.Read("a" + i);
-					    Assert.NotNull(read);
-					    Assert.Equal(expectedString, read.Reader.ToStringValue());
-					}
+                using (var tx = env.WriteTransaction())
+                {
+                    var aTree = tx.CreateTree("atree");
+                    var bTree = tx.CreateTree("btree");
 
-				    using (var iterator = bTree.MultiRead("a"))
-					{
-						Assert.True(iterator.Seek(Slice.BeforeAllKeys));
+                    for (var i = 0; i < count; i++)
+                    {
+                        aTree.Add("a" + i, new MemoryStream(buffer));
+                        bTree.MultiAdd("a", "a" + i);
+                    }
 
-						var keys = new HashSet<string>();
-						do
-						{
-							keys.Add(iterator.CurrentKey.ToString());
-						}
-						while (iterator.MoveNext());
+                    tx.Commit();
+                }
+            }
 
-						Assert.Equal(count, keys.Count);
-					}
-				}
-			}
+            var expectedString = Encoding.UTF8.GetString(buffer);
 
-		}
-	}
+            options = StorageEnvironmentOptions.ForPath(DataDir);
+            options.MaxLogFileSize = 10 * options.PageSize;
+
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree( "atree");
+                    tx.CreateTree( "btree");
+
+                    tx.Commit();
+                }
+
+                using (var tx = env.ReadTransaction())
+                {
+                    var aTree = tx.CreateTree("atree");
+                    var bTree = tx.CreateTree("btree");
+
+                    for (var i = 0; i < count; i++)
+                    {
+                        var read = aTree.Read("a" + i);
+                        Assert.NotNull(read);
+                        Assert.Equal(expectedString, read.Reader.ToStringValue());
+                    }
+
+                    using (var iterator = bTree.MultiRead("a"))
+                    {
+                        Assert.True(iterator.Seek(Slices.BeforeAllKeys));
+
+                        var keys = new HashSet<string>();
+                        do
+                        {
+                            keys.Add(iterator.CurrentKey.ToString());
+                        }
+                        while (iterator.MoveNext());
+
+                        Assert.Equal(count, keys.Count);
+                    }
+                }
+            }
+
+        }
+    }
 }

--- a/test/SlowTests/Voron/StorageCompactionTests.cs
+++ b/test/SlowTests/Voron/StorageCompactionTests.cs
@@ -14,148 +14,148 @@ using Xunit;
 
 namespace SlowTests.Voron
 {
-	public class StorageCompactionTests : StorageTest
-	{
-	    public StorageCompactionTests()
-		{
-	        if (Directory.Exists(DataDir))
-	            StorageTest.DeleteDirectory(DataDir);
+    public class StorageCompactionTests : StorageTest
+    {
+        public StorageCompactionTests()
+        {
+            if (Directory.Exists(DataDir))
+                StorageTest.DeleteDirectory(DataDir);
 
-	        var compactedData = Path.Combine(DataDir, "Compacted");
-	        if (Directory.Exists(compactedData))
-	            StorageTest.DeleteDirectory(compactedData);
-		}
+            var compactedData = Path.Combine(DataDir, "Compacted");
+            if (Directory.Exists(compactedData))
+                StorageTest.DeleteDirectory(compactedData);
+        }
 
-		[Fact]
-		public void CompactionMustNotLooseAnyData()
-		{
-			var treeNames = new List<string>();
-			var multiValueTreeNames = new List<string>();
+        [Fact]
+        public void CompactionMustNotLooseAnyData()
+        {
+            var treeNames = new List<string>();
+            var multiValueTreeNames = new List<string>();
 
-			var random = new Random();
+            var random = new Random();
 
-			var value1 = new byte[random.Next(1024*1024*2)];
-			var value2 = new byte[random.Next(1024*1024*2)];
+            var value1 = new byte[random.Next(1024*1024*2)];
+            var value2 = new byte[random.Next(1024*1024*2)];
 
-			random.NextBytes(value1);
-			random.NextBytes(value2);
+            random.NextBytes(value1);
+            random.NextBytes(value2);
 
-			const int treeCount = 5;
-			const int recordCount = 6;
-			const int multiValueTreeCount = 7;
-			const int multiValueRecordsCount = 4;
-			const int multiValuesCount = 3;
+            const int treeCount = 5;
+            const int recordCount = 6;
+            const int multiValueTreeCount = 7;
+            const int multiValueRecordsCount = 4;
+            const int multiValuesCount = 3;
 
-			using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
-			{
-				for (int i = 0; i < treeCount; i++)
-				{
-					using (var tx = env.WriteTransaction())
-					{
-						string name = "tree/" + i;
-						treeNames.Add(name);
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                for (int i = 0; i < treeCount; i++)
+                {
+                    using (var tx = env.WriteTransaction())
+                    {
+                        string name = "tree/" + i;
+                        treeNames.Add(name);
 
-						var tree = tx.CreateTree( name);
+                        var tree = tx.CreateTree( name);
 
-						for (int j = 0; j < recordCount; j++)
-						{
-							tree.Add(string.Format("{0}/items/{1}", name, j), j%2 == 0 ? value1 : value2);
-						}
+                        for (int j = 0; j < recordCount; j++)
+                        {
+                            tree.Add(string.Format("{0}/items/{1}", name, j), j%2 == 0 ? value1 : value2);
+                        }
 
-						tx.Commit();
-					}
-				}
+                        tx.Commit();
+                    }
+                }
 
-				for (int i = 0; i < multiValueTreeCount; i++)
-				{
-					using (var tx = env.WriteTransaction())
-					{
-						var name = "multiValueTree/" + i;
-						multiValueTreeNames.Add(name);
+                for (int i = 0; i < multiValueTreeCount; i++)
+                {
+                    using (var tx = env.WriteTransaction())
+                    {
+                        var name = "multiValueTree/" + i;
+                        multiValueTreeNames.Add(name);
 
-						var tree = tx.CreateTree(  name);
+                        var tree = tx.CreateTree(  name);
 
-						for (int j = 0; j < multiValueRecordsCount; j++)
-						{
-							for (int k = 0; k < multiValuesCount; k++)
-							{
-								tree.MultiAdd("record/" + j, "value/" + k);
-							}
-						}
+                        for (int j = 0; j < multiValueRecordsCount; j++)
+                        {
+                            for (int k = 0; k < multiValuesCount; k++)
+                            {
+                                tree.MultiAdd("record/" + j, "value/" + k);
+                            }
+                        }
 
-						tx.Commit();
-					}
-				}
-			}
+                        tx.Commit();
+                    }
+                }
+            }
 
-		    var compactedData = Path.Combine(DataDir, "Compacted");
-		    StorageCompaction.Execute(StorageEnvironmentOptions.ForPath(DataDir), (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(compactedData));
+            var compactedData = Path.Combine(DataDir, "Compacted");
+            StorageCompaction.Execute(StorageEnvironmentOptions.ForPath(DataDir), (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(compactedData));
 
-			using (var compacted = new StorageEnvironment(StorageEnvironmentOptions.ForPath(compactedData)))
-			{
-				using (var tx = compacted.ReadTransaction())
-				{
-					foreach (var treeName in treeNames)
-					{
-						var tree = tx.CreateTree( treeName);
+            using (var compacted = new StorageEnvironment(StorageEnvironmentOptions.ForPath(compactedData)))
+            {
+                using (var tx = compacted.ReadTransaction())
+                {
+                    foreach (var treeName in treeNames)
+                    {
+                        var tree = tx.CreateTree( treeName);
 
-						for (int i = 0; i < recordCount; i++)
-						{
-							var readResult = tree.Read(string.Format("{0}/items/{1}", treeName, i));
+                        for (int i = 0; i < recordCount; i++)
+                        {
+                            var readResult = tree.Read(string.Format("{0}/items/{1}", treeName, i));
 
-							Assert.NotNull(readResult);
+                            Assert.NotNull(readResult);
 
-							if (i%2 == 0)
-							{
-								var readBytes = new byte[value1.Length];
-								readResult.Reader.Read(readBytes, 0, readBytes.Length);
+                            if (i%2 == 0)
+                            {
+                                var readBytes = new byte[value1.Length];
+                                readResult.Reader.Read(readBytes, 0, readBytes.Length);
 
-								Assert.Equal(value1, readBytes);
-							}
-							else
-							{
-								var readBytes = new byte[value2.Length];
-								readResult.Reader.Read(readBytes, 0, readBytes.Length);
+                                Assert.Equal(value1, readBytes);
+                            }
+                            else
+                            {
+                                var readBytes = new byte[value2.Length];
+                                readResult.Reader.Read(readBytes, 0, readBytes.Length);
 
-								Assert.Equal(value2, readBytes);
-							}
-						}
-					}
+                                Assert.Equal(value2, readBytes);
+                            }
+                        }
+                    }
 
-					foreach (var treeName in multiValueTreeNames)
-					{
-						var tree = tx.CreateTree( treeName);
+                    foreach (var treeName in multiValueTreeNames)
+                    {
+                        var tree = tx.CreateTree( treeName);
 
-						for (int i = 0; i < multiValueRecordsCount; i++)
-						{
-							var multiRead = tree.MultiRead("record/" + i);
+                        for (int i = 0; i < multiValueRecordsCount; i++)
+                        {
+                            var multiRead = tree.MultiRead("record/" + i);
 
-							Assert.True(multiRead.Seek(Slice.BeforeAllKeys));
+                            Assert.True(multiRead.Seek(Slices.BeforeAllKeys));
 
-							int count = 0;
-							do
-							{
-								Assert.Equal("value/" + count, multiRead.CurrentKey.ToString());
-								count++;
-							} while (multiRead.MoveNext());
+                            int count = 0;
+                            do
+                            {
+                                Assert.Equal("value/" + count, multiRead.CurrentKey.ToString());
+                                count++;
+                            } while (multiRead.MoveNext());
 
-							Assert.Equal(multiValuesCount, count);
-						}
-					}
-				}
-			}
-		}
+                            Assert.Equal(multiValuesCount, count);
+                        }
+                    }
+                }
+            }
+        }
 
-	
-		public static long GetDirSize(DirectoryInfo d)
-		{
-			var files = d.GetFiles();
-			var size = files.Sum(x => x.Length);
+    
+        public static long GetDirSize(DirectoryInfo d)
+        {
+            var files = d.GetFiles();
+            var size = files.Sum(x => x.Length);
 
-			var directories = d.GetDirectories();
-			size += directories.Sum(x => GetDirSize(x));
+            var directories = d.GetDirectories();
+            size += directories.Sum(x => GetDirSize(x));
 
-			return size;
-		}
-	}
+            return size;
+        }
+    }
 }

--- a/test/SlowTests/Voron/StorageTest.cs
+++ b/test/SlowTests/Voron/StorageTest.cs
@@ -7,6 +7,7 @@ using FastTests;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl;
+using Sparrow;
 
 namespace SlowTests.Voron
 {
@@ -15,6 +16,8 @@ namespace SlowTests.Voron
         private StorageEnvironment _storageEnvironment;
         protected StorageEnvironmentOptions _options;
         protected readonly string DataDir = GenerateDataDir();
+
+        private ByteStringContext _allocator = new ByteStringContext();
 
         public static string GenerateDataDir()
         {
@@ -38,6 +41,11 @@ namespace SlowTests.Voron
                 }
                 return _storageEnvironment;
             }
+        }
+
+        protected ByteStringContext Allocator
+        {
+            get { return _allocator; }
         }
 
         protected StorageTest(StorageEnvironmentOptions options)
@@ -162,7 +170,7 @@ namespace SlowTests.Voron
             return results;
         }
 
-        protected unsafe Tuple<Slice, Slice> ReadKey(Transaction txh, Tree tree, Slice key)
+        protected unsafe Tuple<Slice, Slice> ReadKey(Transaction txh, Tree tree, Slice key) 
         {
             TreeNodeHeader* node;
             var p = tree.FindPageFor(key, out node);
@@ -171,13 +179,12 @@ namespace SlowTests.Voron
             if (node == null)
                 return null;
 
-            var item1 = p.GetNodeKey(node).ToSlice();
+            var item1 = TreeNodeHeader.ToSlicePtr(txh.Allocator, node);
 
-            if (item1.Compare(key) != 0)
+            if (SliceComparer.CompareInline(item1,key) != 0)
                 return null;
-            return Tuple.Create(item1,
-                new Slice((byte*)node + node->KeySize + Constants.NodeHeaderSize,
-                    (ushort)node->DataSize));
+
+            return Tuple.Create(item1, Slice.External( txh.Allocator, (byte*)node + node->KeySize + Constants.NodeHeaderSize, (ushort)node->DataSize, ByteStringType.Immutable));
         }
     }
 }


### PR DESCRIPTION
RavenDB-4333: ByteString implementation

The new ByteString will allow to allocate everything from unmanaged buffers and kill all the memory in one go or release memory and being reused.
It will also allow to create external pointers to memory, while still retaining the ability to allocate them very fast.
The ByteString will be allocated by the ByteStringContext and for the caller code purpose it behaves like a pointer using some struct/JIT magic.

RavenDB-4568: Slice are now pointers

Exploiting the implementation of the ByteString we could create Slices that are entirely allocated on the stack and whose size is exactly the same to a reference pointer.
The side effect is that Slices are not very fast to pass-around, but they will also create aliases (the older slices didn't) which is a breaking change.

(+11 squashed commits)
