### PR TITLE
RavenDB-4701 Removing Raven/Voron/SkipConsistencyChecks configuration…

### DIFF
--- a/Raven.Abstractions/Data/Constants.cs
+++ b/Raven.Abstractions/Data/Constants.cs
@@ -404,8 +404,9 @@ namespace Raven.Abstractions.Data
             public const string InitialSize = "Raven/Voron/InitialSize";
 
             public const string MaxScratchBufferSize = "Raven/Voron/MaxScratchBufferSize";
+
             public const string AllowOn32Bits = "Raven/Voron/AllowOn32Bits";
-            public const string SkipConsistencyChecks = "Raven/Voron/SkipConsistencyChecks";
+
             public const string ScratchBufferSizeNotificationThreshold = "Raven/Voron/ScratchBufferSizeNotificationThreshold";
         }
 

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -313,7 +313,6 @@ namespace Raven.Database.Config
             Storage.Voron.TempPath = ravenSettings.Voron.TempPath.Value;
             Storage.Voron.JournalsStoragePath = ravenSettings.Voron.JournalsStoragePath.Value;
             Storage.Voron.AllowOn32Bits = ravenSettings.Voron.AllowOn32Bits.Value;
-            Storage.SkipConsistencyCheck = ravenSettings.Voron.SkipConsistencyChecks.Value;
 
             // Esent settings
             Storage.Esent.JournalsStoragePath = ravenSettings.Esent.JournalsStoragePath.Value;

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -248,7 +248,6 @@ namespace Raven.Database.Config
 
             Voron.AllowIncrementalBackups = new BooleanSetting(settings[Constants.Voron.AllowIncrementalBackups], false);
             Voron.AllowOn32Bits = new BooleanSetting(settings[Constants.Voron.AllowOn32Bits], false);
-            Voron.SkipConsistencyChecks = new BooleanSetting(settings[Constants.Voron.SkipConsistencyChecks], false);
             Voron.TempPath = new StringSetting(settings[Constants.Voron.TempPath], (string)null);
 
             var txJournalPath = settings[Constants.RavenTxJournalPath];
@@ -532,8 +531,6 @@ namespace Raven.Database.Config
             public StringSetting JournalsStoragePath { get; set; }
 
             public BooleanSetting AllowOn32Bits { get; set; }
-
-            public BooleanSetting SkipConsistencyChecks { get; set; }
 
         }
 

--- a/Raven.Tests.Core/Configuration/ConfigurationTests.cs
+++ b/Raven.Tests.Core/Configuration/ConfigurationTests.cs
@@ -200,7 +200,6 @@ namespace Raven.Tests.Core.Configuration
             configurationComparer.Assert(expected => expected.Prefetcher.FetchingDocumentsFromDiskTimeoutInSeconds.Value, actual => actual.Prefetcher.FetchingDocumentsFromDiskTimeoutInSeconds);
             configurationComparer.Assert(expected => expected.Voron.AllowIncrementalBackups.Value, actual => actual.Storage.Voron.AllowIncrementalBackups);
             configurationComparer.Assert(expected => expected.Voron.AllowOn32Bits.Value, actual => actual.Storage.Voron.AllowOn32Bits);
-            configurationComparer.Assert(expected => expected.Voron.SkipConsistencyChecks.Value, actual => actual.Storage.SkipConsistencyCheck);
             configurationComparer.Assert(expected => expected.Voron.InitialFileSize.Value, actual => actual.Storage.Voron.InitialFileSize);
             configurationComparer.Assert(expected => expected.Voron.ScratchBufferSizeNotificationThreshold.Value, actual => actual.Storage.Voron.ScratchBufferSizeNotificationThreshold);
             configurationComparer.Assert(expected => expected.Voron.MaxBufferPoolSize.Value, actual => actual.Storage.Voron.MaxBufferPoolSize);
@@ -331,6 +330,7 @@ namespace Raven.Tests.Core.Configuration
             
             configurationComparer.Ignore(x => x.Storage.Esent.JournalsStoragePath);
             configurationComparer.Ignore(x => x.Storage.Voron.JournalsStoragePath);
+            configurationComparer.Ignore(x => x.Storage.SkipConsistencyCheck);
             configurationComparer.Ignore(x => x.IgnoreSslCertificateErrors);
             configurationComparer.Ignore(x => x.AnonymousUserAccessMode);
             configurationComparer.Ignore(x => x.TransactionMode);
@@ -351,6 +351,7 @@ namespace Raven.Tests.Core.Configuration
             Assert.True(inMemoryConfiguration.CreatePluginsDirectoryIfNotExisting);
             Assert.Equal(null, inMemoryConfiguration.Storage.Esent.JournalsStoragePath);
             Assert.Equal(null, inMemoryConfiguration.Storage.Voron.JournalsStoragePath);
+            Assert.Equal(false, inMemoryConfiguration.Storage.SkipConsistencyCheck);
 
             configurationComparer.Validate();
         }


### PR DESCRIPTION
… option since it's used only for internal purposes (by StorageExporter tool).
