### PR TITLE
RavenDB-4690 If a file is conflicted on a destination side we need to…

### DIFF
--- a/Raven.Database/FileSystem/Synchronization/SynchronizationTask.cs
+++ b/Raven.Database/FileSystem/Synchronization/SynchronizationTask.cs
@@ -10,6 +10,7 @@ using Raven.Abstractions.Extensions;
 using Raven.Abstractions.FileSystem;
 using Raven.Abstractions.FileSystem.Notifications;
 using Raven.Abstractions.Logging;
+using Raven.Abstractions.Util;
 using Raven.Client.FileSystem;
 using Raven.Client.FileSystem.Extensions;
 using Raven.Database.Config;
@@ -402,7 +403,8 @@ namespace Raven.Database.FileSystem.Synchronization
 
             var destinationUrl = destinationSyncClient.BaseUrl;
 
-            bool enqueued = true;
+            bool enqueued = false;
+            Etag incrementedEtag = Etag.Empty;
 
             foreach (var fileHeader in filteredFilesToSynchronization)
             {
@@ -428,17 +430,31 @@ namespace Raven.Database.FileSystem.Synchronization
 
                 NoSyncReason reason;
                 var work = synchronizationStrategy.DetermineWork(file, localMetadata, destinationMetadata, FileSystemUrl, out reason);
+
                 if (work == null)
                 {
                     Log.Debug("File '{0}' were not synchronized to {1}. {2}", file, destinationUrl, reason.GetDescription());
 
                     if (reason == NoSyncReason.ContainedInDestinationHistory)
                     {
-                        var etag = localMetadata.Value<Guid>(Constants.MetadataEtagField);
+                        var etag = Etag.Parse(localMetadata.Value<string>(Constants.MetadataEtagField));
+
                         await destinationSyncClient.IncrementLastETagAsync(storage.Id, FileSystemUrl, etag).ConfigureAwait(false);
                         RemoveSyncingConfiguration(file, destinationUrl);
 
-                        enqueued = false;
+                        if (EtagUtil.IsGreaterThan(etag, incrementedEtag))
+                            incrementedEtag = etag;
+                    }
+                    else if (reason == NoSyncReason.DestinationFileConflicted)
+                    {
+                        if (needSyncingAgain.Contains(fileHeader, FileHeaderNameEqualityComparer.Instance) == false)
+                            CreateSyncingConfiguration(fileHeader.Name, fileHeader.Etag, destinationUrl, SynchronizationType.Unknown);
+
+                        var etag = Etag.Parse(localMetadata.Value<string>(Constants.MetadataEtagField));
+                        await destinationSyncClient.IncrementLastETagAsync(storage.Id, FileSystemUrl, etag).ConfigureAwait(false);
+
+                        if (EtagUtil.IsGreaterThan(etag, incrementedEtag))
+                            incrementedEtag = etag;
                     }
 
                     continue;
@@ -461,7 +477,10 @@ namespace Raven.Database.FileSystem.Synchronization
                 enqueued = true;
             }
 
-            return enqueued;
+            if (enqueued == false && EtagUtil.IsGreaterThan(incrementedEtag, synchronizationInfo.LastSourceFileEtag))
+                return false; // we bumped the last synced etag on a destination server, let it know it need to repeat the operation
+
+            return true;
         }
 
         private IEnumerable<Task<SynchronizationReport>> SynchronizePendingFilesAsync(ISynchronizationServerClient destinationCommands, bool forceSyncingAll)

--- a/Raven.Tests.FileSystem/Issues/RavenDB_4690.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_4690.cs
@@ -1,0 +1,74 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_4690.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Abstractions.FileSystem;
+using Raven.Client.FileSystem.Extensions;
+using Raven.Database.FileSystem.Synchronization;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+    public class RavenDB_4690 : RavenFilesTestBase
+    {
+        [Fact]
+        public async Task LotsOfConflictsShouldNotCauseSynchronizationOutage()
+        {
+            var source = NewAsyncClient();
+            var destination = NewAsyncClient(1);
+
+            var emptyFile = new MemoryStream();
+
+            for (int i = 0; i < SynchronizationTask.NumberOfFilesToCheckForSynchronization; i++)
+            {
+                await destination.UploadAsync(i.ToString(), emptyFile);
+            }
+            
+            for (int i = 0; i < SynchronizationTask.NumberOfFilesToCheckForSynchronization; i++)
+            {
+                await source.UploadAsync(i.ToString(), emptyFile);
+            }
+
+            await source.UploadAsync("non-conflicted", emptyFile);
+
+            // configure synchronization
+            await source.Configuration.SetKeyAsync(SynchronizationConstants.RavenSynchronizationConfig, new SynchronizationConfig
+            {
+                MaxNumberOfSynchronizationsPerDestination = SynchronizationTask.NumberOfFilesToCheckForSynchronization // let it sync all files that it get internally in one shot
+            });
+
+            await source.Synchronization.SetDestinationsAsync(destination.ToSynchronizationDestination());
+
+            var firstSyncAttempt = await source.Synchronization.StartAsync();
+            
+            Assert.True(firstSyncAttempt[0].Reports.All(x => x.Exception.Message.Contains("conflict")));
+
+            var secondSyncAttempt = await source.Synchronization.StartAsync();
+
+            Assert.Equal(1, secondSyncAttempt[0].Reports.Count());
+
+            var file = await destination.GetAsync(new[] {"non-conflicted" });
+
+            Assert.False(file[0].Metadata.ContainsKey(SynchronizationConstants.RavenSynchronizationConflict));
+
+            // resolve conflicts in favor of remote version
+
+            foreach (var conflict in (await destination.Synchronization.GetConflictsAsync(0, 1024)).Items)
+            {
+                await destination.Synchronization.ResolveConflictAsync(conflict.FileName, ConflictResolutionStrategy.RemoteVersion);
+            }
+
+            // sync once again so all files should be synchronized without any errors
+
+            var thirdSyncAttempt = await source.Synchronization.StartAsync();
+
+            Assert.Equal(SynchronizationTask.NumberOfFilesToCheckForSynchronization, thirdSyncAttempt[0].Reports.Count());
+            Assert.True(thirdSyncAttempt[0].Reports.All(x => x.Exception == null));
+        }
+    }
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Issues\RavenDB_4069.cs" />
     <Compile Include="Issues\RavenDB_4092.cs" />
     <Compile Include="Issues\RavenDB_4189.cs" />
+    <Compile Include="Issues\RavenDB_4690.cs" />
     <Compile Include="Issues\RavenDB_FEI_2.cs" />
     <Compile Include="Issues\RavenDB_3648.cs" />
     <Compile Include="Issues\RavenDB_2889.cs" />


### PR DESCRIPTION
… move on to prevent from getting stuck the entire synchronization process.
