### PR TITLE
RavenDB-4717: Remove the namespace Platform from source

### DIFF
--- a/src/Raven.Client/Platform/RavenClientWebSocket.cs
+++ b/src/Raven.Client/Platform/RavenClientWebSocket.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Platform
 
         public RavenClientWebSocket()
         {
-            if (Sparrow.Platform.Platform.RunningOnPosix)
+            if (Sparrow.Platform.RunningOnPosix)
                 unixInstance = new RavenUnixClientWebSocket();
             else
                 winInstance = new ClientWebSocket();
@@ -23,7 +23,7 @@ namespace Raven.Client.Platform
         {
             get
             {
-                if (Sparrow.Platform.Platform.RunningOnPosix)
+                if (Sparrow.Platform.RunningOnPosix)
                     return unixInstance.State;
                 return winInstance.State;
             }
@@ -31,7 +31,7 @@ namespace Raven.Client.Platform
 
         public async Task ConnectAsync(Uri uri, CancellationToken token)
         {
-            if (Sparrow.Platform.Platform.RunningOnPosix)
+            if (Sparrow.Platform.RunningOnPosix)
                 await unixInstance.ConnectAsync(uri, token);
             else
                 await winInstance.ConnectAsync(uri, token);
@@ -39,14 +39,14 @@ namespace Raven.Client.Platform
 
         public async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> arraySegment, CancellationToken token)
         {
-            if (Sparrow.Platform.Platform.RunningOnPosix)
+            if (Sparrow.Platform.RunningOnPosix)
                 return await unixInstance.ReceiveAsync(arraySegment, token);
             return await winInstance.ReceiveAsync(arraySegment, token).ConfigureAwait(false);
         }
 
         public async Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken token)
         {
-            if (Sparrow.Platform.Platform.RunningOnPosix)
+            if (Sparrow.Platform.RunningOnPosix)
                 await unixInstance.CloseOutputAsync(closeStatus, statusDescription, token);
             else
                 await winInstance.CloseOutputAsync(closeStatus, statusDescription, token);
@@ -54,7 +54,7 @@ namespace Raven.Client.Platform
 
         public async Task SendAsync(ArraySegment<byte> segment, WebSocketMessageType messageType, bool endOfMessage, CancellationToken token)
         {
-            if (Sparrow.Platform.Platform.RunningOnPosix)
+            if (Sparrow.Platform.RunningOnPosix)
                 await unixInstance.SendAsync(segment, messageType, endOfMessage, token);
             else
                 await winInstance.SendAsync(segment, messageType, endOfMessage, token);
@@ -62,7 +62,7 @@ namespace Raven.Client.Platform
 
         public void Dispose()
         {
-            if (Sparrow.Platform.Platform.RunningOnPosix)
+            if (Sparrow.Platform.RunningOnPosix)
                 unixInstance.Dispose();
             else
                 winInstance.Dispose();
@@ -70,7 +70,7 @@ namespace Raven.Client.Platform
 
         public async Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken token)
         {
-            if (Sparrow.Platform.Platform.RunningOnPosix)
+            if (Sparrow.Platform.RunningOnPosix)
                 await unixInstance.CloseAsync(closeStatus, statusDescription, token);
             else
                 await winInstance.CloseAsync(closeStatus, statusDescription, token);

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -6,8 +6,8 @@ using Microsoft.Extensions.Configuration;
 
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Categories;
-using Sparrow.Platform;
 using ExpressionExtensions = Raven.Server.Extensions.ExpressionExtensions;
+using Sparrow;
 
 namespace Raven.Server.Config
 {

--- a/src/Raven.Server/Documents/FilePathTools.cs
+++ b/src/Raven.Server/Documents/FilePathTools.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using Raven.Server.Utils;
-using Sparrow.Platform;
+using Sparrow;
 
 namespace Raven.Server.Documents
 {

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -17,7 +17,7 @@ using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Utils;
 using Voron.Platform.Posix;
-using Sparrow.Platform;
+using Sparrow;
 
 namespace Raven.Server.Documents.Indexes
 {

--- a/src/Raven.Server/Documents/Replication/DocumentReplicationTransport.cs
+++ b/src/Raven.Server/Documents/Replication/DocumentReplicationTransport.cs
@@ -12,6 +12,7 @@ using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow;
 
 namespace Raven.Server.ReplicationUtil
 {
@@ -82,7 +83,7 @@ namespace Raven.Server.ReplicationUtil
                         .EscapeLongDataString(_srcDbName)}");
             try
             {
-                if (Sparrow.Platform.Platform.RunningOnPosix)
+                if (Platform.RunningOnPosix)
                 {
                     var webSocketUnix = new RavenUnixClientWebSocket();
                     await webSocketUnix.ConnectAsync(uri, _cancellationToken);

--- a/src/Raven.Server/ServerWide/LowMemoryNotification/AbstractLowMemoryNotification.cs
+++ b/src/Raven.Server/ServerWide/LowMemoryNotification/AbstractLowMemoryNotification.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using Raven.Abstractions.Logging;
 using Raven.Server.Config;
 using Sparrow.Collections;
-using Sparrow.Platform;
+using Sparrow;
 
 namespace Raven.Server.ServerWide.LowMemoryNotification
 {

--- a/src/Sparrow/Compression/LZ4.cs
+++ b/src/Sparrow/Compression/LZ4.cs
@@ -64,7 +64,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System;
 using System.Runtime.InteropServices;
-using Sparrow.Platform;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable TooWideLocalVariableScope

--- a/src/Sparrow/Constants.cs
+++ b/src/Sparrow/Constants.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Sparrow.Global
+{
+    internal static class Constants
+    {
+        internal static class Size
+        {
+            public const int Kilobyte = 1024;
+            public const int Megabyte = 1024 * Kilobyte;
+            public const int Gigabyte = 1024 * Megabyte;
+            public const long Terabyte = 1024 * (long)Gigabyte;
+        }
+    }
+}

--- a/src/Sparrow/Memory.cs
+++ b/src/Sparrow/Memory.cs
@@ -1,5 +1,4 @@
 using DotNetCross.Memory;
-using Sparrow.Platform;
 using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;

--- a/src/Sparrow/Platform/Platform.cs
+++ b/src/Sparrow/Platform/Platform.cs
@@ -2,10 +2,13 @@
 using System;
 
 
-namespace Sparrow.Platform
+namespace Sparrow
 {
     public static class Platform
     {
+        public static readonly bool Is64Bits = IntPtr.Size == 8;
+
+
         public static readonly bool RunningOnPosix = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
                                                      RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 

--- a/src/Sparrow/Platform/Posix/PosixUnmanagedMemory.cs
+++ b/src/Sparrow/Platform/Posix/PosixUnmanagedMemory.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 
-namespace Sparrow.Platform
+namespace Sparrow
 {
     public static unsafe class PosixUnmanagedMemory
     {

--- a/src/Sparrow/Platform/UnmanagedMemory.cs
+++ b/src/Sparrow/Platform/UnmanagedMemory.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Sparrow.Platform
+namespace Sparrow
 {
     public unsafe static class UnmanagedMemory
     {

--- a/src/Sparrow/Platform/Win32/Win32UnmanagedMemory.cs
+++ b/src/Sparrow/Platform/Win32/Win32UnmanagedMemory.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 
-namespace Sparrow.Platform
+namespace Sparrow
 {
     public static unsafe class Win32UnmanagedMemory
     {

--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -1,7 +1,7 @@
 ﻿using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 
-namespace Voron.Impl
+namespace Voron.Global
 {
     public unsafe class Constants
     {

--- a/src/Voron/Data/BTrees/ParentPageAction.cs
+++ b/src/Voron/Data/BTrees/ParentPageAction.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 #endif
 using System.Runtime.CompilerServices;
+using Voron.Global;
 using Voron.Impl;
 
 namespace Voron.Data.BTrees

--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -2,14 +2,10 @@
 using System.Diagnostics;
 using System.IO;
 using Sparrow;
+using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.Paging;
 using Sparrow.Binary;
-// -----------------------------------------------------------------------
-//  <copyright file="Tree.MultiTree.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-//  </copyright>
-// -----------------------------------------------------------------------
 
 namespace Voron.Data.BTrees
 {

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -6,6 +6,7 @@ using Sparrow;
 using Voron.Data.Fixed;
 using Voron.Debugging;
 using Voron.Exceptions;
+using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.Paging;
 

--- a/src/Voron/Data/BTrees/TreeIterator.cs
+++ b/src/Voron/Data/BTrees/TreeIterator.cs
@@ -139,7 +139,7 @@ namespace Voron.Data.BTrees
 
         private void MaybePrefetchOverflowPages(TreePage page)
         {
-            if (Sparrow.Platform.Platform.CanPrefetch)
+            if (Sparrow.Platform.CanPrefetch)
             {
                 _tx.DataPager.MaybePrefetchMemory(page.GetAllOverflowPages());
             }

--- a/src/Voron/Data/BTrees/TreeNodeHeader.cs
+++ b/src/Voron/Data/BTrees/TreeNodeHeader.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Sparrow;
+using Voron.Global;
 using Voron.Impl;
 
 namespace Voron.Data.BTrees

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -5,8 +5,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Sparrow;
 using Voron.Debugging;
+using Voron.Global;
 using Voron.Impl;
-using Voron.Impl.FileHeaders;
 using Voron.Impl.Paging;
 
 namespace Voron.Data.BTrees

--- a/src/Voron/Data/BTrees/TreePageIterator.cs
+++ b/src/Voron/Data/BTrees/TreePageIterator.cs
@@ -1,4 +1,5 @@
 using System;
+using Voron.Global;
 using Voron.Impl;
 
 namespace Voron.Data.BTrees

--- a/src/Voron/Data/BTrees/TreePageSplitter.cs
+++ b/src/Voron/Data/BTrees/TreePageSplitter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
+using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.FreeSpace;
 

--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow;
+using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.FreeSpace;
 using Voron.Impl.Paging;

--- a/src/Voron/Data/BTrees/TreeSizeOf.cs
+++ b/src/Voron/Data/BTrees/TreeSizeOf.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Voron.Data.BTrees;
+using Voron.Global;
 
 namespace Voron.Impl
 {

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -9,9 +9,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow;
-using Sparrow.Platform;
 using Voron.Data.BTrees;
 using Voron.Debugging;
+using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.Paging;
 

--- a/src/Voron/Data/Fixed/FixedSizeTreePage.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTreePage.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
-using Voron.Impl;
+using Voron.Global;
 
 namespace Voron.Data.Fixed
 {

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -6,6 +6,7 @@ using Sparrow;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Data.RawData;
+using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.Paging;
 using Voron.Util.Conversion;

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -13,8 +13,8 @@ using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Exceptions;
+using Voron.Global;
 using Voron.Impl;
-using Voron.Impl.FileHeaders;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
 

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using Voron.Global;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;

--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -14,7 +14,7 @@ using System.Linq;
 using Voron.Data.BTrees;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
-using Voron.Platform.Win32;
+using Voron.Global;
 using Voron.Util;
 
 namespace Voron.Impl.Backup

--- a/src/Voron/Impl/Backup/MinimalIncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/MinimalIncrementalBackup.cs
@@ -1,9 +1,9 @@
 ﻿using Sparrow;
-using Sparrow.Platform;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using Voron.Global;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
 using Voron.Util;

--- a/src/Voron/Impl/Compaction/StorageCompaction.cs
+++ b/src/Voron/Impl/Compaction/StorageCompaction.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using Voron.Data;
 using Voron.Data.BTrees;
+using Voron.Global;
 using Voron.Impl.FreeSpace;
 
 namespace Voron.Impl.Compaction

--- a/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Voron.Global;
 
 namespace Voron.Impl.FileHeaders
 {

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -1,12 +1,11 @@
 ﻿using Sparrow;
-using Sparrow.Platform;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Sparrow.Compression;
+using Voron.Global;
 using Voron.Impl.Paging;
-using Voron.Util;
 
 namespace Voron.Impl.Journal
 {

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -6,11 +6,9 @@
 
 using Sparrow;
 using Sparrow.Binary;
-using Sparrow.Platform;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using Sparrow.Compression;
@@ -18,9 +16,8 @@ using Voron.Data.BTrees;
 using Voron.Exceptions;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Paging;
-using Voron.Platform.Posix;
-using Voron.Platform.Win32;
 using Voron.Util;
+using Voron.Global;
 
 namespace Voron.Impl.Journal
 {

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Sparrow;
-using Sparrow.Platform;
 using Voron.Data.BTrees;
 using Voron.Exceptions;
 using Voron.Impl.FreeSpace;
@@ -12,6 +11,7 @@ using Voron.Impl.Journal;
 using Voron.Impl.Paging;
 using Voron.Impl.Scratch;
 using Voron.Data;
+using Voron.Global;
 using System.Runtime.InteropServices;
 
 namespace Voron.Impl

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Sparrow;
 using Sparrow.Binary;
 using Voron.Platform.Win32;
-using System.Runtime.InteropServices;
+using Voron.Global;
 
 namespace Voron.Impl.Paging
 {
@@ -263,7 +263,7 @@ namespace Voron.Impl.Paging
 
         public void MaybePrefetchMemory(List<long> pagesToPrefetch)
         {
-            if (Sparrow.Platform.Platform.CanPrefetch == false)
+            if (Sparrow.Platform.CanPrefetch == false)
                 return; // not supported
 
             if (pagesToPrefetch.Count == 0)

--- a/src/Voron/Impl/Paging/AbstractPagerExtensions.cs
+++ b/src/Voron/Impl/Paging/AbstractPagerExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.InteropServices;
+using Voron.Global;
 using Voron.Data.BTrees;
 using Voron.Platform.Win32;
 
@@ -56,7 +56,7 @@ namespace Voron.Impl.Paging
 
         public static void TryPrefetchingWholeFile(this AbstractPager pager)
         {
-            if (Sparrow.Platform.Platform.CanPrefetch == false)
+            if (Sparrow.Platform.CanPrefetch == false)
                 return; // not supported
 
             var pagerState = pager.PagerState;
@@ -78,7 +78,7 @@ namespace Voron.Impl.Paging
 
         public static void MaybePrefetchMemory(this AbstractPager pager, List<TreePage> sortedPages)
         {
-            if (Sparrow.Platform.Platform.CanPrefetch == false)
+            if (Sparrow.Platform.CanPrefetch == false)
                 return; // not supported
 
             if (sortedPages.Count == 0)

--- a/src/Voron/Impl/Paging/TemporaryPage.cs
+++ b/src/Voron/Impl/Paging/TemporaryPage.cs
@@ -1,51 +1,52 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using Voron.Global;
 using Voron.Data.BTrees;
 
 namespace Voron.Impl.Paging
 {
     public unsafe class TemporaryPage : IDisposable
     {
-	    private readonly StorageEnvironmentOptions _options;
-	    private readonly byte[] _tempPageBuffer;
+        private readonly StorageEnvironmentOptions _options;
+        private readonly byte[] _tempPageBuffer;
         private readonly GCHandle _tempPageHandle;
         private readonly IntPtr _tempPage;
 
-		public TemporaryPage(StorageEnvironmentOptions options)
-		{
-			_options = options;
-			_tempPageBuffer = new byte[options.PageSize];
-			_tempPageHandle = GCHandle.Alloc(_tempPageBuffer, GCHandleType.Pinned);
-			_tempPage = _tempPageHandle.AddrOfPinnedObject();
-		}
+        public TemporaryPage(StorageEnvironmentOptions options)
+        {
+            _options = options;
+            _tempPageBuffer = new byte[options.PageSize];
+            _tempPageHandle = GCHandle.Alloc(_tempPageBuffer, GCHandleType.Pinned);
+            _tempPage = _tempPageHandle.AddrOfPinnedObject();
+        }
 
-		public void Dispose()
-		{
-			if (_tempPageHandle.IsAllocated)
-			{
-				_tempPageHandle.Free();
-			}
-		}
+        public void Dispose()
+        {
+            if (_tempPageHandle.IsAllocated)
+            {
+                _tempPageHandle.Free();
+            }
+        }
 
         public byte[] TempPageBuffer
         {
             get { return _tempPageBuffer; }
         }
 
-		public byte* TempPagePointer
-		{
-			get { return (byte*)_tempPage.ToPointer(); }
-		}
+        public byte* TempPagePointer
+        {
+            get { return (byte*)_tempPage.ToPointer(); }
+        }
 
         public TreePage GetTempPage()
         {
-			return new TreePage((byte*)_tempPage.ToPointer(), "temp", _options.PageSize)
-	        {
-				Upper = (ushort)_options.PageSize,
-		        Lower = (ushort) Constants.TreePageHeaderSize,
-		        TreeFlags = TreePageFlags.None,
-	        };
+            return new TreePage((byte*)_tempPage.ToPointer(), "temp", _options.PageSize)
+            {
+                Upper = (ushort)_options.PageSize,
+                Lower = (ushort) Constants.TreePageHeaderSize,
+                TreeFlags = TreePageFlags.None,
+            };
         }
-	    public IDisposable ReturnTemporaryPageToPool { get; set; }
+        public IDisposable ReturnTemporaryPageToPool { get; set; }
     }
 }

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
+using Voron.Global;
 
 namespace Voron.Impl
 {

--- a/src/Voron/Platform/Win32/Win32JournalWriter.cs
+++ b/src/Voron/Platform/Win32/Win32JournalWriter.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
 using Voron.Exceptions;
-using Voron.Impl;
+using Voron.Global;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
 using Voron.Util;

--- a/src/Voron/Platform/Win32/Win32MemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/Win32MemoryMapPager.cs
@@ -151,7 +151,7 @@ namespace Voron.Platform.Win32
             PagerState.Files = PagerState.Files.Concat(allocationInfo.MappedFile);
             PagerState.AllocationInfos = PagerState.AllocationInfos.Concat(allocationInfo);
 
-            if (Sparrow.Platform.Platform.CanPrefetch)
+            if (Sparrow.Platform.CanPrefetch)
             {
                 // We are asking to allocate pages. It is a good idea that they should be already in memory to only cause a single page fault (as they are continuous).
                 Win32MemoryMapNativeMethods.WIN32_MEMORY_RANGE_ENTRY entry;

--- a/src/Voron/SliceComparer.cs
+++ b/src/Voron/SliceComparer.cs
@@ -1,5 +1,4 @@
 using Sparrow;
-using Sparrow.Platform;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -13,6 +13,7 @@ using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Debugging;
 using Voron.Exceptions;
+using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.FreeSpace;

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Sparrow;
-using Voron.Impl;
+using Voron.Global;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;

--- a/src/Voron/ValueReader.cs
+++ b/src/Voron/ValueReader.cs
@@ -3,9 +3,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Sparrow;
-using Voron.Util;
 using Sparrow.Binary;
-using Sparrow.Platform;
 
 namespace Voron
 {

--- a/test/FastTests/LinuxRaceConditionWorkAround.cs
+++ b/test/FastTests/LinuxRaceConditionWorkAround.cs
@@ -1,5 +1,5 @@
 ﻿using Voron.Platform.Posix;
-using Platform = Sparrow.Platform.Platform;
+using Sparrow;
 
 namespace FastTests
 {

--- a/test/FastTests/RavenTestHelper.cs
+++ b/test/FastTests/RavenTestHelper.cs
@@ -6,8 +6,8 @@ using System.Threading;
 using Raven.Server.Extensions;
 using Raven.Server.Utils;
 using Voron.Platform.Posix;
-using Sparrow.Platform;
 
+using Sparrow;
 using Sparrow.Collections;
 
 namespace FastTests

--- a/test/FastTests/Server/Documents/SqlReplication/CanReplicate.cs
+++ b/test/FastTests/Server/Documents/SqlReplication/CanReplicate.cs
@@ -19,7 +19,7 @@ using Raven.Database.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.SqlReplication;
 using Raven.Tests.Core;
-using Sparrow.Platform;
+using Sparrow;
 using Xunit;
 using Xunit.Sdk;
 

--- a/test/FastTests/Voron/Bugs/FlushingToDataFile.cs
+++ b/test/FastTests/Voron/Bugs/FlushingToDataFile.cs
@@ -8,10 +8,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Sparrow.Platform;
+using Sparrow;
 using Xunit;
 using Voron;
-using Voron.Data;
 using Voron.Impl;
 
 namespace FastTests.Voron.Bugs

--- a/test/FastTests/Voron/Bugs/RavenDB_2850.cs
+++ b/test/FastTests/Voron/Bugs/RavenDB_2850.cs
@@ -7,7 +7,7 @@
 using System;
 using Xunit;
 using Voron;
-using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron.Bugs
 {

--- a/test/FastTests/Voron/Journal/EdgeCases.cs
+++ b/test/FastTests/Voron/Journal/EdgeCases.cs
@@ -7,9 +7,7 @@
 using System.IO;
 using Xunit;
 using Voron;
-using Voron.Data;
-using Voron.Impl;
-using Voron.Impl.Journal;
+using Voron.Global;
 
 namespace FastTests.Voron.Journal
 {

--- a/test/FastTests/Voron/ScratchBuffer/ScratchCanForceToFlushOldPages.cs
+++ b/test/FastTests/Voron/ScratchBuffer/ScratchCanForceToFlushOldPages.cs
@@ -6,7 +6,7 @@
 
 using Xunit;
 using Voron;
-using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron.ScratchBuffer
 {

--- a/test/FastTests/Voron/Storage/InitialSize.cs
+++ b/test/FastTests/Voron/Storage/InitialSize.cs
@@ -7,7 +7,7 @@
 using System.IO;
 using Xunit;
 using Voron;
-using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron.Storage
 {

--- a/test/FastTests/Voron/Storage/StorageReportGenerationTests.cs
+++ b/test/FastTests/Voron/Storage/StorageReportGenerationTests.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
-using Voron;
+using Voron.Global;
 using Voron.Data.BTrees;
 using Voron.Debugging;
 using Voron.Impl;

--- a/test/FastTests/Voron/StorageTest.cs
+++ b/test/FastTests/Voron/StorageTest.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron
 {

--- a/test/FastTests/Voron/Trees/Basic.cs
+++ b/test/FastTests/Voron/Trees/Basic.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using Voron;
-using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron.Trees
 {

--- a/test/FastTests/Voron/Trees/Deletes.cs
+++ b/test/FastTests/Voron/Trees/Deletes.cs
@@ -6,6 +6,7 @@ using Xunit;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron.Trees
 {

--- a/test/FastTests/Voron/Trees/TreeRenaming.cs
+++ b/test/FastTests/Voron/Trees/TreeRenaming.cs
@@ -6,93 +6,92 @@
 
 using System;
 using Xunit;
-using Voron;
-using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron.Trees
 {
-	public class TreeRenaming : StorageTest
-	{
-		[Fact]
-		public void CanRenameTree()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree("tree");
+    public class TreeRenaming : StorageTest
+    {
+        [Fact]
+        public void CanRenameTree()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("tree");
 
-				tree.Add("items/1", new byte[] { 1, 2, 3 });
-				tree.Add("items/2", new byte[] { 1, 2, 3 });
-				tree.Add("items/3", new byte[] { 1, 2, 3 });
+                tree.Add("items/1", new byte[] { 1, 2, 3 });
+                tree.Add("items/2", new byte[] { 1, 2, 3 });
+                tree.Add("items/3", new byte[] { 1, 2, 3 });
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.RenameTree( "tree", "renamed_tree");
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.RenameTree( "tree", "renamed_tree");
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.ReadTransaction())
-			{
-				var tree = tx.ReadTree("renamed_tree");
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("renamed_tree");
 
-				var readResult = tree.Read("items/1");
-				Assert.NotNull(readResult);
+                var readResult = tree.Read("items/1");
+                Assert.NotNull(readResult);
 
-				readResult = tree.Read("items/2");
-				Assert.NotNull(readResult);
+                readResult = tree.Read("items/2");
+                Assert.NotNull(readResult);
 
-				readResult = tree.Read("items/3");
-				Assert.NotNull(readResult);
-			}
-		}
+                readResult = tree.Read("items/3");
+                Assert.NotNull(readResult);
+            }
+        }
 
-		[Fact]
-		public void ShouldNotAllowToRenameTreeIfTreeAlreadyExists()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				tx.CreateTree("tree_1");
-				tx.CreateTree("tree_2");
+        [Fact]
+        public void ShouldNotAllowToRenameTreeIfTreeAlreadyExists()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree_1");
+                tx.CreateTree("tree_2");
 
-				var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree("tree_1", "tree_2"));
+                var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree("tree_1", "tree_2"));
 
-				Assert.Equal("Cannot rename a tree with the name of an existing tree: tree_2", ae.Message);
-			}
-		}
+                Assert.Equal("Cannot rename a tree with the name of an existing tree: tree_2", ae.Message);
+            }
+        }
 
-		[Fact]
-		public void ShouldThrowIfTreeDoesNotExist()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree( "tree_1", "tree_2"));
+        [Fact]
+        public void ShouldThrowIfTreeDoesNotExist()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree( "tree_1", "tree_2"));
 
-				Assert.Equal("Tree tree_1 does not exists", ae.Message);
-			}
-		}
+                Assert.Equal("Tree tree_1 does not exists", ae.Message);
+            }
+        }
 
-		[Fact]
-		public void MustNotRenameToRootAndFreeSpaceRootTrees()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var ex = Assert.Throws<InvalidOperationException>(() => tx.RenameTree("tree_1", Constants.RootTreeName));
-				Assert.Equal("Cannot create a tree with reserved name: " + Constants.RootTreeName, ex.Message);
-			}
-		}
+        [Fact]
+        public void MustNotRenameToRootAndFreeSpaceRootTrees()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var ex = Assert.Throws<InvalidOperationException>(() => tx.RenameTree("tree_1", Constants.RootTreeName));
+                Assert.Equal("Cannot create a tree with reserved name: " + Constants.RootTreeName, ex.Message);
+            }
+        }
 
-		[Fact]
-		public void ShouldPreventFromRenamingTreeInReadTransaction()
-		{
-			using (var tx = Env.ReadTransaction())
-			{
-				var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree( "tree_1", "tree_2"));
+        [Fact]
+        public void ShouldPreventFromRenamingTreeInReadTransaction()
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree( "tree_1", "tree_2"));
 
-				Assert.Equal("Cannot rename a new tree with a read only transaction", ae.Message);
-			}
-		}
-	}
+                Assert.Equal("Cannot rename a new tree with a read only transaction", ae.Message);
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Trees/TreeStateTests.cs
+++ b/test/FastTests/Voron/Trees/TreeStateTests.cs
@@ -8,12 +8,12 @@ using System;
 using System.Linq;
 using Xunit;
 using Voron;
-using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron.Trees
 {
-	public class TreeStateTests : StorageTest
-	{
+    public class TreeStateTests : StorageTest
+    {
         protected override void Configure(StorageEnvironmentOptions options)
         {
             options.PageSize = 4 * Constants.Size.Kilobyte;
@@ -21,179 +21,179 @@ namespace FastTests.Voron.Trees
 
         [Theory]
         [InlineData(5, 2)]
-		[InlineData(35, 13)]
-		[InlineData(256, 32)]
-		public void TotalPageCountConsistsOfLeafBrancheAndOverflowPages(int regularItemsCount, int overflowsCount)
-		{
-			var r = new Random();
+        [InlineData(35, 13)]
+        [InlineData(256, 32)]
+        public void TotalPageCountConsistsOfLeafBrancheAndOverflowPages(int regularItemsCount, int overflowsCount)
+        {
+            var r = new Random();
 
-			using (var tx = Env.WriteTransaction())
-			{
-			    var tree = tx.CreateTree("foo");
-				for (int i = 0; i < regularItemsCount; i++)
-				{
-					tree.Add("test" + new string('-', r.Next(128)) + i, new byte[r.Next(512)]);
-				}
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                for (int i = 0; i < regularItemsCount; i++)
+                {
+                    tree.Add("test" + new string('-', r.Next(128)) + i, new byte[r.Next(512)]);
+                }
 
-				for (int i = 0; i < overflowsCount; i++)
-				{
-					tree.Add("overflow" + new string('-', r.Next(128)) + i, new byte[r.Next(8192)]);
-				}
+                for (int i = 0; i < overflowsCount; i++)
+                {
+                    tree.Add("overflow" + new string('-', r.Next(128)) + i, new byte[r.Next(8192)]);
+                }
 
-				tx.Commit();
+                tx.Commit();
 
-				var treeState = tree.State;
+                var treeState = tree.State;
 
-				Assert.True(treeState.PageCount > 0);
-				Assert.Equal(treeState.PageCount, treeState.BranchPages + treeState.LeafPages + treeState.OverflowPages);
-			}
-		}
+                Assert.True(treeState.PageCount > 0);
+                Assert.Equal(treeState.PageCount, treeState.BranchPages + treeState.LeafPages + treeState.OverflowPages);
+            }
+        }
 
-		[Fact]
-		public void HasReducedNumberOfPagesAfterRemovingHalfOfEntries()
-		{
-			const int numberOfRegularItems = 256;
-			const int numberOfOverflowItems = 3;
+        [Fact]
+        public void HasReducedNumberOfPagesAfterRemovingHalfOfEntries()
+        {
+            const int numberOfRegularItems = 256;
+            const int numberOfOverflowItems = 3;
 
-			using (var tx = Env.WriteTransaction())
-			{
-			    var tree = tx.CreateTree("foo");
-				for (int i = 0; i < numberOfRegularItems; i++)
-				{
-					tree.Add("test" + new string('-', 128) + i, new byte[256]);
-				}
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                for (int i = 0; i < numberOfRegularItems; i++)
+                {
+                    tree.Add("test" + new string('-', 128) + i, new byte[256]);
+                }
 
-				for (int i = 0; i < numberOfOverflowItems; i++)
-				{
-					tree.Add("overflow" + new string('-', 128) + i, new byte[8192]);
-				}
+                for (int i = 0; i < numberOfOverflowItems; i++)
+                {
+                    tree.Add("overflow" + new string('-', 128) + i, new byte[8192]);
+                }
 
-				tx.Commit();
+                tx.Commit();
 
-				Assert.Equal(50, tree.State.PageCount);
-				Assert.Equal(38, tree.State.LeafPages);
-				Assert.Equal(3, tree.State.BranchPages);
-				Assert.Equal(9, tree.State.OverflowPages);
-				Assert.Equal(3, tree.State.Depth);				
-			}
+                Assert.Equal(50, tree.State.PageCount);
+                Assert.Equal(38, tree.State.LeafPages);
+                Assert.Equal(3, tree.State.BranchPages);
+                Assert.Equal(9, tree.State.OverflowPages);
+                Assert.Equal(3, tree.State.Depth);				
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-			    var tree = tx.CreateTree("foo");
-				for (int i = 0; i < numberOfRegularItems / 2; i++)
-				{
-					tree.Delete("test" + new string('-', 128) + i);
-				}
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+                for (int i = 0; i < numberOfRegularItems / 2; i++)
+                {
+                    tree.Delete("test" + new string('-', 128) + i);
+                }
 
-				tree.Delete("overflow" + new string('-', 128) + 0);
+                tree.Delete("overflow" + new string('-', 128) + 0);
 
-				tx.Commit();
+                tx.Commit();
 
 
-				Assert.Equal(31, tree.AllPages().Count);
-				Assert.Equal(31, tree.State.PageCount);
-				Assert.Equal(22, tree.State.LeafPages);
-				Assert.Equal(3, tree.State.BranchPages);
-				Assert.Equal(6, tree.State.OverflowPages);
-				Assert.Equal(3, tree.State.Depth);
+                Assert.Equal(31, tree.AllPages().Count);
+                Assert.Equal(31, tree.State.PageCount);
+                Assert.Equal(22, tree.State.LeafPages);
+                Assert.Equal(3, tree.State.BranchPages);
+                Assert.Equal(6, tree.State.OverflowPages);
+                Assert.Equal(3, tree.State.Depth);
 
-			}
-		}
+            }
+        }
 
-		[Fact]
-		public void HasReducedTreeDepthValueAfterRemovingEntries()
-		{
-			const int numberOfItems = 1024;
+        [Fact]
+        public void HasReducedTreeDepthValueAfterRemovingEntries()
+        {
+            const int numberOfItems = 1024;
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree("test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("test");
 
-				for (int i = 0; i < numberOfItems; i++)
-				{
-					tree.Add("test" + new string('-', 256) + i, new byte[256]);
-				}
+                for (int i = 0; i < numberOfItems; i++)
+                {
+                    tree.Add("test" + new string('-', 256) + i, new byte[256]);
+                }
 
-				Assert.Equal(4, tree.State.Depth);
+                Assert.Equal(4, tree.State.Depth);
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.ReadTree("test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("test");
 
-				for (int i = 0; i < numberOfItems * 0.75; i++)
-				{
-					tree.Delete("test" + new string('-', 256) + i);
-				}
+                for (int i = 0; i < numberOfItems * 0.75; i++)
+                {
+                    tree.Delete("test" + new string('-', 256) + i);
+                }
 
-				Assert.Equal(3, tree.State.Depth);
+                Assert.Equal(3, tree.State.Depth);
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.ReadTree("test");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("test");
 
-				for (int i = 0; i < numberOfItems; i++)
-				{
-					tree.Delete("test" + new string('-', 256) + i);
-				}
+                for (int i = 0; i < numberOfItems; i++)
+                {
+                    tree.Delete("test" + new string('-', 256) + i);
+                }
 
-				Assert.Equal(1, tree.State.Depth);
-			}
-		}
+                Assert.Equal(1, tree.State.Depth);
+            }
+        }
 
-		[Fact]
-		public void AllPagesCantHasDuplicatesInMultiTrees()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree("multi-tree");
+        [Fact]
+        public void AllPagesCantHasDuplicatesInMultiTrees()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("multi-tree");
 
-				for (int i = 0; i < 100; i++)
-				{
-					tree.MultiAdd("key", "items/" + i + "/" + new string('p', i));
-				}
+                for (int i = 0; i < 100; i++)
+                {
+                    tree.MultiAdd("key", "items/" + i + "/" + new string('p', i));
+                }
 
-				var allPages = tree.AllPages();
-				var allPagesDistinct = allPages.Distinct().ToList();
-				
-				Assert.Equal(allPagesDistinct.Count, allPages.Count);
-			}
-		}
+                var allPages = tree.AllPages();
+                var allPagesDistinct = allPages.Distinct().ToList();
+                
+                Assert.Equal(allPagesDistinct.Count, allPages.Count);
+            }
+        }
 
-		[Fact]
-		public void MustNotProduceNegativePageCountNumber()
-		{
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.CreateTree("multi-tree");
+        [Fact]
+        public void MustNotProduceNegativePageCountNumber()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("multi-tree");
 
-				for (int i = 0; i < 50; i++)
-				{
-					tree.MultiAdd("key", "items/" + i + "/" + new string('p', i));
-					tree.MultiAdd("key2", "items/" + i + "/" + new string('p', i));
-				}
+                for (int i = 0; i < 50; i++)
+                {
+                    tree.MultiAdd("key", "items/" + i + "/" + new string('p', i));
+                    tree.MultiAdd("key2", "items/" + i + "/" + new string('p', i));
+                }
 
-				tx.Commit();
-			}
+                tx.Commit();
+            }
 
-			using (var tx = Env.WriteTransaction())
-			{
-				var tree = tx.ReadTree("multi-tree");
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("multi-tree");
 
-				for (int i = 0; i < 50; i++)
-				{
-					tree.MultiDelete("key", "items/" + i + "/" + new string('p', i));
-					tree.MultiDelete("key2", "items/" + i + "/" + new string('p', i));
-				}
+                for (int i = 0; i < 50; i++)
+                {
+                    tree.MultiDelete("key", "items/" + i + "/" + new string('p', i));
+                    tree.MultiDelete("key2", "items/" + i + "/" + new string('p', i));
+                }
 
-				Assert.True(tree.State.PageCount >= 0);
-				Assert.Equal(tree.AllPages().Count, tree.State.PageCount);
-			}
-		}
-	}
+                Assert.True(tree.State.PageCount >= 0);
+                Assert.Equal(tree.AllPages().Count, tree.State.PageCount);
+            }
+        }
+    }
 }

--- a/test/FastTests/Voron/Trees/Updates.cs
+++ b/test/FastTests/Voron/Trees/Updates.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using Xunit;
 using Voron;
-using Voron.Impl;
+using Voron.Global;
 
 namespace FastTests.Voron.Trees
 {

--- a/test/FastTests/Voron/ValidHeaders.cs
+++ b/test/FastTests/Voron/ValidHeaders.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using FastTests.Voron.FixedSize;
 using Voron.Data;
 using Voron.Data.BTrees;
-using Voron.Impl;
+using Voron.Global;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Journal;
 using Xunit;

--- a/test/SlowTests/Voron/StorageTest.cs
+++ b/test/SlowTests/Voron/StorageTest.cs
@@ -7,6 +7,7 @@ using FastTests;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl;
+using Voron.Global;
 using Sparrow;
 
 namespace SlowTests.Voron


### PR DESCRIPTION
Also moved the constants classes to their own namespace to avoid name clashes.
