### PR TITLE
RavenDB-4705-3.0 Updating index side-by-side unlocks the index

### DIFF
--- a/Raven.Abstractions/Indexing/IndexDefinition.cs
+++ b/Raven.Abstractions/Indexing/IndexDefinition.cs
@@ -33,6 +33,7 @@ namespace Raven.Abstractions.Indexing
         /// <para>- Unlock - all index definition changes acceptable</para>
         /// <para>- LockedIgnore - all index definition changes will be ignored, only log entry will be created</para>
         /// <para>- LockedError - all index definition changes will raise exception</para>
+        /// <para>- SideBySide - all index definition changes will raise exception except when updated by a side by side index</para>
         /// </summary>
         public IndexLockMode LockMode { get; set; }
 

--- a/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
+++ b/Raven.Client.Lightweight/Indexes/AbstractIndexCreationTask.cs
@@ -249,8 +249,12 @@ namespace Raven.Client.Indexes
 
                 switch (serverDef.LockMode)
                 {
-                    //Nothing to do we just ignore this index
+                    case IndexLockMode.SideBySide:
+                        //keep the SideBySide lock mode from the replaced index
+                        indexDefinition.LockMode = IndexLockMode.SideBySide;
+                        break;
                     case IndexLockMode.LockedIgnore:
+                        //Nothing to do we just ignore this index
                         return;
                     case IndexLockMode.LockedError:
                         throw new InvalidOperationException(string.Format("Can't replace locked index {0} its lock mode is set to: LockedError", serverDef.IndexId));
@@ -447,8 +451,12 @@ namespace Raven.Client.Indexes
 
                 switch (serverDef.LockMode)
                 {
-                    //Nothing to do we just ignore this index
+                    case IndexLockMode.SideBySide:
+                        //keep the SideBySide lock mode from the replaced index
+                        indexDefinition.LockMode = IndexLockMode.SideBySide;
+                        break;
                     case IndexLockMode.LockedIgnore:
+                        //Nothing to do we just ignore this index
                         return;
                     case IndexLockMode.LockedError:
                         throw new InvalidOperationException(string.Format("Can't replace locked index {0} its lock mode is set to: LockedError", serverDef.IndexId));

--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -238,10 +238,12 @@ namespace Raven.Database.Actions
             return PutIndexInternal(name, definition, out opId);
         }
 
-        private string PutIndexInternal(string name, IndexDefinition definition, out long opId,bool disableIndexBeforePut = false, bool isUpdateBySideSide = false, IndexCreationOptions? creationOptions = null)
+        private string PutIndexInternal(string name, IndexDefinition definition, out long opId, bool disableIndexBeforePut = false,
+            bool isUpdateBySideSide = false, IndexCreationOptions? creationOptions = null, Action afterAddToIndexStorage = null)
         {
             if (name == null)
                 throw new ArgumentNullException("name");
+
             opId = -1;
             name = name.Trim();
             IsIndexNameValid(name);
@@ -257,6 +259,10 @@ namespace Raven.Database.Actions
                             Log.Info("Index {0} not saved because it might be only updated by side-by-side index");
                             throw new InvalidOperationException("Can not overwrite locked index: " + name + ". This index can be only updated by side-by-side index.");
                         }
+
+                        //keep the SideBySide lock mode from the replaced index
+                        definition.LockMode = IndexLockMode.SideBySide;
+
                         break;
                     case IndexLockMode.LockedIgnore:
                         Log.Info("Index {0} not saved because it was lock (with ignore)", name);
@@ -285,7 +291,7 @@ namespace Raven.Database.Actions
                     break;
             }
 
-            opId = PutNewIndexIntoStorage(name, definition, disableIndexBeforePut);
+            opId = PutNewIndexIntoStorage(name, definition, disableIndexBeforePut, afterAddToIndexStorage);
 
             WorkContext.ClearErrorsFor(name);
 
@@ -342,13 +348,13 @@ namespace Raven.Database.Actions
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public SideBySideIndexInfo[] PutSideBySideIndexes(IndexToAdd[] indexesToAdd)
+        public List<IndexInfo> PutSideBySideIndexes(SideBySideIndexes sideBySideIndexes)
         {
-            var createdIndexes = new List<SideBySideIndexInfo>();
+            var createdIndexes = new List<IndexInfo>();
             var prioritiesList = new List<IndexingPriority>();
             try
             {
-                foreach (var indexToAdd in indexesToAdd)
+                foreach (var indexToAdd in sideBySideIndexes.IndexesToAdd)
                 {
                     var originalIndexName = indexToAdd.Name.Trim();
                     var indexName = Constants.SideBySideIndexNamePrefix + originalIndexName;
@@ -373,17 +379,39 @@ namespace Raven.Database.Actions
                                 creationOptions = originalIndexCreationOptions;
                                 break;
                         }
+
+                        //keep the SideBySide lock mode from the replaced index
+                        indexToAdd.Definition.LockMode = GetCurrentLockMode(originalIndexName) ?? indexToAdd.Definition.LockMode;
                     }
 
                     long _;
-                    var nameToAdd = PutIndexInternal(indexName, indexToAdd.Definition,out _, disableIndexBeforePut: true, isUpdateBySideSide: true, creationOptions: creationOptions);
+                    var nameToAdd = PutIndexInternal(indexName, indexToAdd.Definition,
+                        out _, disableIndexBeforePut: true, isUpdateBySideSide: true,
+                        creationOptions: creationOptions, afterAddToIndexStorage: () =>
+                        {
+                            if (isSideBySide == false)
+                                return;
+
+                            //add the replace index document
+                            Database.Documents.Put(
+                                Constants.IndexReplacePrefix + indexName,
+                                null,
+                                RavenJObject.FromObject(new IndexReplaceDocument
+                                {
+                                    IndexToReplace = originalIndexName,
+                                    MinimumEtagBeforeReplace = sideBySideIndexes.MinimumEtagBeforeReplace,
+                                    ReplaceTimeUtc = sideBySideIndexes.ReplaceTimeUtc
+                                }),
+                                new RavenJObject(),
+                                null);
+                        });
+
                     if (nameToAdd == null)
                         continue;
 
-                    createdIndexes.Add(new SideBySideIndexInfo
+                    createdIndexes.Add(new IndexInfo
                     {
-                        OriginalName = originalIndexName,
-                        Name = nameToAdd,
+                        Name = indexName,
                         IsSideBySide = isSideBySide
                     });
                     prioritiesList.Add(indexToAdd.Priority);
@@ -394,14 +422,14 @@ namespace Raven.Database.Actions
 
                 for (var i = 0; i < createdIndexes.Count; i++)
                 {
-                    var index = createdIndexes[i].Name;
+                    var indexName = createdIndexes[i].Name;
                     var priority = prioritiesList[i];
 
-                    var instance = Database.IndexStorage.GetIndexInstance(index);
+                    var instance = Database.IndexStorage.GetIndexInstance(indexName);
                     instance.Priority = priority;
                 }
 
-                return createdIndexes.ToArray();
+                return createdIndexes;
             }
             catch (Exception e)
             {
@@ -409,15 +437,26 @@ namespace Raven.Database.Actions
                 foreach (var index in createdIndexes)
                 {
                     DeleteIndex(index.Name);
+                    if (index.IsSideBySide)
+                        Database.Documents.Delete(index.Name, null, null);
                 }
                 throw;
             }
         }
 
-        public class SideBySideIndexInfo
+        private IndexLockMode? GetCurrentLockMode(string indexName)
         {
-            public string OriginalName { get; set; }
+            var currentIndexDefinition = IndexDefinitionStorage.GetIndexDefinition(indexName);
+            if (currentIndexDefinition != null)
+            {
+                return currentIndexDefinition.LockMode;
+            }
 
+            return null;
+        }
+
+        public class IndexInfo
+        {
             public string Name { get; set; }
 
             public bool IsSideBySide { get; set; }
@@ -432,7 +471,8 @@ namespace Raven.Database.Actions
             }
         }
 
-        internal long PutNewIndexIntoStorage(string name, IndexDefinition definition, bool disableIndex = false)
+        internal long PutNewIndexIntoStorage(string name, IndexDefinition definition,
+            bool disableIndex = false, Action afterAddToIndexStorage = null)
         {
             Debug.Assert(Database.IndexStorage != null);
             Debug.Assert(TransactionalStorage != null);
@@ -497,6 +537,9 @@ namespace Raven.Database.Actions
             // we have to do it in this way so first we prepare all the elements of the 
             // index, then we add it to the storage in a way that make it public
             IndexDefinitionStorage.AddIndex(definition.IndexId, definition);
+
+            if (afterAddToIndexStorage != null)
+                afterAddToIndexStorage();
 
             // we start the precomuteTask _after_ we finished adding the index
             long operationId = -1;
@@ -876,7 +919,8 @@ namespace Raven.Database.Actions
             return true;
         }
 
-        internal void DeleteIndex(IndexDefinition instance, bool removeByNameMapping = true, bool clearErrors = true, bool removeIndexReplaceDocument = true, bool isSideBySideReplacement = false)
+        internal void DeleteIndex(IndexDefinition instance, bool removeByNameMapping = true,
+            bool clearErrors = true, bool removeIndexReplaceDocument = true, bool isSideBySideReplacement = false)
         {
             using (IndexDefinitionStorage.TryRemoveIndexContext())
             {

--- a/Raven.Database/Indexing/IndexReplacer.cs
+++ b/Raven.Database/Indexing/IndexReplacer.cs
@@ -94,7 +94,7 @@ namespace Raven.Database.Indexing
             var replaceIndexId = replaceIndex.IndexId;
 
             var indexDefinition = Database.IndexDefinitionStorage.GetIndexDefinition(replaceIndexId);
-            if (!indexDefinition.IsSideBySideIndex)
+            if (indexDefinition.IsSideBySideIndex == false)
             {
                 indexDefinition.IsSideBySideIndex = true;
                 Database.IndexDefinitionStorage.UpdateIndexDefinitionWithoutUpdatingCompiledIndex(indexDefinition);
@@ -257,7 +257,7 @@ namespace Raven.Database.Indexing
             {
                 wasReplaced = Database.IndexStorage.TryReplaceIndex(indexReplaceInformation.ReplaceIndex, indexReplaceInformation.IndexToReplace);
             }
-            //this is thrown when a locked inedx (with LockError mode) is been replaced by a side by side index
+            //this is thrown when a locked index (with LockError mode) is been replaced by a side by side index
             //we need to stop the timer and delete the document so it will not continue throwing errors
             catch (InvalidOperationException ie)
             {

--- a/Raven.Database/Server/Controllers/IndexController.cs
+++ b/Raven.Database/Server/Controllers/IndexController.cs
@@ -140,10 +140,10 @@ namespace Raven.Database.Server.Controllers
                     return GetMessageWithString("Expected json document with 'Map' or 'Maps' property", HttpStatusCode.BadRequest);
             }
 
-            IndexActions.SideBySideIndexInfo[] createdIndexes;
+            List<IndexActions.IndexInfo> createdIndexes;
             try
             {
-                createdIndexes = Database.Indexes.PutSideBySideIndexes(sideBySideIndexes.IndexesToAdd);
+                createdIndexes = Database.Indexes.PutSideBySideIndexes(sideBySideIndexes);
             }
             catch (Exception ex)
             {
@@ -157,19 +157,6 @@ namespace Raven.Database.Server.Controllers
                     Error = ex.ToString()
                 }, HttpStatusCode.BadRequest);
             }
-
-            Database.TransactionalStorage.Batch(accessor =>
-            {
-                foreach (var createdIndex in createdIndexes.Where(x => x.IsSideBySide))
-                {
-                    Database.Documents.Put(
-                        Constants.IndexReplacePrefix + createdIndex.Name,
-                        null,
-                        RavenJObject.FromObject(new IndexReplaceDocument {IndexToReplace = createdIndex.OriginalName, MinimumEtagBeforeReplace = sideBySideIndexes.MinimumEtagBeforeReplace, ReplaceTimeUtc = sideBySideIndexes.ReplaceTimeUtc}),
-                        new RavenJObject(),
-                        null);
-                }
-            });
 
             return GetMessageWithObject(new { Indexes = createdIndexes.Select(x => x.Name).ToArray() }, HttpStatusCode.Created);
         }

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -229,7 +229,7 @@
     <Compile Include="IndexResestWithReplication.cs" />
     <Compile Include="LongIndexAndTransformerNames.cs" />
     <Compile Include="NestedPropertiesIndex_1182.cs" />
-    <Compile Include="RavenDB-1279.cs" />
+    <Compile Include="RavenDB-4705.cs" />
     <Compile Include="RavenDB-1847.cs" />
     <Compile Include="RavenDb-1934.cs" />
     <Compile Include="RavenDB-2036.cs" />

--- a/Raven.Tests.Issues/RavenDB-4705.cs
+++ b/Raven.Tests.Issues/RavenDB-4705.cs
@@ -1,0 +1,206 @@
+using System.ComponentModel.Composition.Hosting;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Abstractions.Indexing;
+using Raven.Client.Indexes;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_4705 : RavenTestBase
+    {
+        public class Entity
+        {
+            public int Id { get; set; }
+        }
+
+        public class Entity_ById_V1 : AbstractIndexCreationTask<Entity>
+        {
+            public override string IndexName
+            {
+                get { return "Entity/ById"; }
+            }
+
+            public Entity_ById_V1()
+            {
+                Map = entities => from entity in entities select new { entity.Id, Version = 1 };
+            }
+        }
+
+        public class Entity_ById_V2 : AbstractIndexCreationTask<Entity>
+        {
+            public override string IndexName
+            {
+                get { return "Entity/ById"; }
+            }
+
+            public Entity_ById_V2()
+            {
+                Map = entities => from entity in entities select new { entity.Id, Version = 2 };
+            }
+        }
+
+        [Fact]
+        public void should_not_reset_lock_mode_on_side_by_side_index_creation()
+        {
+            using (var documentStore = NewDocumentStore())
+            {
+                new Entity_ById_V1().SideBySideExecute(documentStore);
+                WaitForIndexing(documentStore);
+
+                documentStore.DatabaseCommands.SetIndexLock("Entity/ById", IndexLockMode.SideBySide);
+
+                var databaseStatisticsBefore = documentStore.DatabaseCommands.GetStatistics();
+                var indexStatsBefore = databaseStatisticsBefore.Indexes.Single(i => i.Name == "Entity/ById");
+
+                Assert.Equal(2, databaseStatisticsBefore.Indexes.Length);
+                Assert.Equal(IndexLockMode.SideBySide, indexStatsBefore.LockMode);
+
+                while (true)
+                {
+                    var index = documentStore.DatabaseCommands.GetStatistics().Indexes.FirstOrDefault(x => x.Name == "Entity/ById");
+                    if (index != null)
+                        break;
+                    Thread.Sleep(100);
+                }
+
+                new Entity_ById_V2().SideBySideExecute(documentStore);
+                WaitForIndexing(documentStore);
+
+                while (documentStore.DatabaseCommands.GetStatistics().Indexes.Length != 2)
+                    Thread.Sleep(100);
+
+                var databaseStatisticsAfter = documentStore.DatabaseCommands.GetStatistics();
+                var indexStatsAfter = databaseStatisticsAfter.Indexes.Single(i => i.Name == "Entity/ById");
+
+                Assert.Equal(2, databaseStatisticsAfter.Indexes.Length);
+                Assert.Equal(IndexLockMode.SideBySide, indexStatsAfter.LockMode);
+            }
+        }
+
+        [Fact]
+        public async Task should_not_reset_lock_mode_on_async_side_by_side_index_creation()
+        {
+            using (var documentStore = NewDocumentStore())
+            {
+                await new Entity_ById_V1().SideBySideExecuteAsync(documentStore).ConfigureAwait(false);
+                WaitForIndexing(documentStore);
+
+                documentStore.DatabaseCommands.SetIndexLock("Entity/ById", IndexLockMode.SideBySide);
+
+                var databaseStatisticsBefore = documentStore.DatabaseCommands.GetStatistics();
+                var indexStatsBefore = databaseStatisticsBefore.Indexes.Single(i => i.Name == "Entity/ById");
+
+                Assert.Equal(2, databaseStatisticsBefore.Indexes.Length);
+                Assert.Equal(IndexLockMode.SideBySide, indexStatsBefore.LockMode);
+
+                while (true)
+                {
+                    var index = documentStore.DatabaseCommands.GetStatistics().Indexes.FirstOrDefault(x => x.Name == "Entity/ById");
+                    if (index != null)
+                        break;
+                    Thread.Sleep(100);
+                }
+
+                await new Entity_ById_V2().SideBySideExecuteAsync(documentStore).ConfigureAwait(false);
+                WaitForIndexing(documentStore);
+
+                while (documentStore.DatabaseCommands.GetStatistics().Indexes.Length != 2)
+                    Thread.Sleep(100);
+
+                var databaseStatisticsAfter = documentStore.DatabaseCommands.GetStatistics();
+                var indexStatsAfter = databaseStatisticsAfter.Indexes.Single(i => i.Name == "Entity/ById");
+
+                Assert.Equal(2, databaseStatisticsAfter.Indexes.Length);
+                Assert.Equal(IndexLockMode.SideBySide, indexStatsAfter.LockMode);
+            }
+        }
+
+
+        [Fact]
+        public void should_not_reset_lock_mode_on_multiple_side_by_side_index_creation()
+        {
+            using (var documentStore = NewDocumentStore())
+            {
+                var container = new CompositionContainer(new TypeCatalog(typeof(Entity_ById_V1)));
+                IndexCreation.SideBySideCreateIndexes(container, documentStore.DatabaseCommands, documentStore.Conventions);
+                WaitForIndexing(documentStore);
+
+                documentStore.DatabaseCommands.SetIndexLock("Entity/ById", IndexLockMode.SideBySide);
+
+                var databaseStatisticsBefore = documentStore.DatabaseCommands.GetStatistics();
+                var indexStatsBefore = databaseStatisticsBefore.Indexes.Single(i => i.Name == "Entity/ById");
+
+                Assert.Equal(2, databaseStatisticsBefore.Indexes.Length);
+                Assert.Equal(IndexLockMode.SideBySide, indexStatsBefore.LockMode);
+
+                while (true)
+                {
+                    var index = documentStore.DatabaseCommands.GetStatistics().Indexes.FirstOrDefault(x => x.Name == "Entity/ById");
+                    if (index != null)
+                        break;
+                    Thread.Sleep(100);
+                }
+
+                container = new CompositionContainer(new TypeCatalog(typeof(Entity_ById_V2)));
+                IndexCreation.SideBySideCreateIndexes(container, documentStore.DatabaseCommands, documentStore.Conventions);
+                WaitForIndexing(documentStore);
+
+                while (documentStore.DatabaseCommands.GetStatistics().Indexes.Length != 2)
+                    Thread.Sleep(100);
+
+                var databaseStatisticsAfter = documentStore.DatabaseCommands.GetStatistics();
+                var indexStatsAfter = databaseStatisticsAfter.Indexes.Single(i => i.Name == "Entity/ById");
+
+                Assert.Equal(2, databaseStatisticsAfter.Indexes.Length);
+                Assert.Equal(IndexLockMode.SideBySide, indexStatsAfter.LockMode);
+            }
+        }
+
+        [Fact]
+        public async Task should_not_reset_lock_mode_on_multiple_async_side_by_side_index_creation()
+        {
+            using (var documentStore = NewDocumentStore())
+            {
+                var container = new CompositionContainer(new TypeCatalog(typeof(Entity_ById_V1)));
+                await IndexCreation
+                    .SideBySideCreateIndexesAsync(container, documentStore.AsyncDatabaseCommands, documentStore.Conventions)
+                    .ConfigureAwait(false);
+                WaitForIndexing(documentStore);
+
+                documentStore.DatabaseCommands.SetIndexLock("Entity/ById", IndexLockMode.SideBySide);
+
+                var databaseStatisticsBefore = documentStore.DatabaseCommands.GetStatistics();
+                var indexStatsBefore = databaseStatisticsBefore.Indexes.Single(i => i.Name == "Entity/ById");
+
+                Assert.Equal(2, databaseStatisticsBefore.Indexes.Length);
+                Assert.Equal(IndexLockMode.SideBySide, indexStatsBefore.LockMode);
+
+                while (true)
+                {
+                    var index = documentStore.DatabaseCommands.GetStatistics().Indexes.FirstOrDefault(x => x.Name == "Entity/ById");
+                    if (index != null)
+                        break;
+                    Thread.Sleep(100);
+                }
+
+                container = new CompositionContainer(new TypeCatalog(typeof(Entity_ById_V2)));
+                await IndexCreation
+                    .SideBySideCreateIndexesAsync(container, documentStore.AsyncDatabaseCommands, documentStore.Conventions)
+                    .ConfigureAwait(false);
+                WaitForIndexing(documentStore);
+
+                while (documentStore.DatabaseCommands.GetStatistics().Indexes.Length != 2)
+                    Thread.Sleep(100);
+
+                var databaseStatisticsAfter = documentStore.DatabaseCommands.GetStatistics();
+                var indexStatsAfter = databaseStatisticsAfter.Indexes.Single(i => i.Name == "Entity/ById");
+
+                Assert.Equal(2, databaseStatisticsAfter.Indexes.Length);
+                Assert.Equal(IndexLockMode.SideBySide, indexStatsAfter.LockMode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- added a test
- fixed an issue when deleting the original index before the side by side replacement
- handling the case when the index is LockedIgnore or LockedError

http://issues.hibernatingrhinos.com/issue/RavenDB-4705
