### PR TITLE
RavenDB-4718 RavenFS: Use more specific HTTP status code when number …

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
+++ b/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
@@ -709,14 +709,18 @@ namespace Raven.Client.FileSystem
                     }
                 }).ConfigureAwait(false);
 
-                if (request.ResponseStatusCode == HttpStatusCode.BadRequest)
-                {
-                    throw new BadRequestException("There is a mismatch between the size reported in the RavenFS-Size header and the data read server side.");
-                }
 
                 try
                 {
                     await response.AssertNotFailingResponse().ConfigureAwait(false);
+                }
+                catch (ErrorResponseException e)
+                {
+                    if (request.ResponseStatusCode == HttpStatusCode.ExpectationFailed)
+                    {
+                        throw new BadRequestException(e.Message);
+                    }
+                    throw;
                 }
                 catch (Exception e)
                 {

--- a/Raven.Database/FileSystem/Actions/FileActions.cs
+++ b/Raven.Database/FileSystem/Actions/FileActions.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
@@ -25,6 +26,7 @@ using Raven.Database.FileSystem.Storage;
 using Raven.Database.FileSystem.Storage.Exceptions;
 using Raven.Database.FileSystem.Util;
 using Raven.Json.Linq;
+using Raven.Database.Server.WebApi;
 
 namespace Raven.Database.FileSystem.Actions
 {
@@ -134,7 +136,11 @@ namespace Raven.Database.FileSystem.Actions
 
                     if (size != null && readFileToDatabase.TotalSizeRead != size)
                     {
-                        throw new HttpResponseException(HttpStatusCode.BadRequest);
+
+                        throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.ExpectationFailed)
+                        {
+                            Content = new MultiGetSafeStringContent($"There is a mismatch between the size reported in the RavenFS-Size header and the data read server side. Declared {size} bytes, but got {readFileToDatabase.TotalSizeRead}")
+                        });
                     }
 
                     if (options.PreserveTimestamps == false)


### PR DESCRIPTION
…of received bytes is different than declared on upload
