### PR TITLE
RavenDB-4726 Properly removing multi trees to make sure freed pages o…

### DIFF
--- a/Raven.Voron/Voron/Impl/Transaction.cs
+++ b/Raven.Voron/Voron/Impl/Transaction.cs
@@ -636,9 +636,29 @@ namespace Voron.Impl
             return _multiValueTrees.Remove(keyToRemove);
         }
 
-        internal bool RemoveTree(string name)
+        internal void RemoveTree(string name)
         {
-            return _trees.Remove(name);
+            if (_multiValueTrees != null)
+            {
+                var toRemove = new List<Tuple<Tree, Slice>>();
+
+                foreach (var valueTree in _multiValueTrees)
+                {
+                    var multiTree = valueTree.Key.Item1;
+
+                    if (multiTree.Name == name)
+                    {
+                        toRemove.Add(valueTree.Key);
+                    }
+                }
+
+                foreach (var recordToRemove in toRemove)
+                {
+                    _multiValueTrees.Remove(recordToRemove);
+                }
+            }
+
+            _trees.Remove(name);
         }
 
         private void AddJournalSnapshot(JournalSnapshot snapshot)


### PR DESCRIPTION
…f a deleted tree won't be overwritten on a transaction commit (in particular freed pages can be used by free space handling)
