### PR TITLE
RavenDB-4718 RavenFS: Use more specific HTTP status code when number …

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
+++ b/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
@@ -714,16 +714,13 @@ namespace Raven.Client.FileSystem
                 {
                     await response.AssertNotFailingResponse().ConfigureAwait(false);
                 }
-                catch (ErrorResponseException e)
+                catch (Exception e)
                 {
                     if (request.ResponseStatusCode == HttpStatusCode.ExpectationFailed)
                     {
                         throw new BadRequestException(e.Message);
                     }
-                    throw;
-                }
-                catch (Exception e)
-                {
+
                     var simplified = e.SimplifyException();
 
                     if (simplified != e)


### PR DESCRIPTION
…of received bytes is different than declared on upload - failing tests fix
