### PR TITLE
RavenDB-4718 RavenFS: Use more specific HTTP status code when number …

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
+++ b/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
@@ -716,11 +716,6 @@ namespace Raven.Client.FileSystem
                 }
                 catch (Exception e)
                 {
-                    if (request.ResponseStatusCode == HttpStatusCode.ExpectationFailed)
-                    {
-                        throw new BadRequestException(e.Message);
-                    }
-
                     var simplified = e.SimplifyException();
 
                     if (simplified != e)

--- a/Raven.Tests.FileSystem/ClientApi/FileSessionTests.cs
+++ b/Raven.Tests.FileSystem/ClientApi/FileSessionTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Abstractions.Connection;
 using Xunit;
 using Xunit.Extensions;
 
@@ -146,7 +147,7 @@ namespace Raven.Tests.FileSystem.ClientApi
                         x.WriteByte(i);
                 });
 
-                await AssertAsync.Throws<BadRequestException>(() => session.SaveChangesAsync());
+                await AssertAsync.Throws<ErrorResponseException>(() => session.SaveChangesAsync());
             }
         }
 
@@ -541,7 +542,7 @@ namespace Raven.Tests.FileSystem.ClientApi
                     });
                     session.RegisterRename("test2.file", "test3.file");
 
-                    await AssertAsync.Throws<BadRequestException>(() => session.SaveChangesAsync());
+                    await AssertAsync.Throws<ErrorResponseException>(() => session.SaveChangesAsync());
 
                     var shouldExist = await session.LoadFileAsync("test2.file");
                     Assert.NotNull(shouldExist);

--- a/Raven.Tests.FileSystem/Issues/RavenDB_3920.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_3920.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.IO;
 using System.Threading.Tasks;
+using Raven.Abstractions.Connection;
 using Raven.Abstractions.Exceptions;
 using Raven.Abstractions.FileSystem;
 using Raven.Database.FileSystem.Extensions;
@@ -37,7 +38,7 @@ namespace Raven.Tests.FileSystem.Issues
                         s.WriteByte(3);
                     });
 
-                    await ThrowsAsync<BadRequestException>(() => session.SaveChangesAsync()); // 10 bytes declared but only 3 has been uploaded, IndicateFileToDelete is going to be called underhood
+                    await ThrowsAsync<ErrorResponseException>(() => session.SaveChangesAsync()); // 10 bytes declared but only 3 has been uploaded, IndicateFileToDelete is going to be called underhood
                 }
 
                 using (var session = store.OpenAsyncSession())


### PR DESCRIPTION
…of received bytes is different than declared on upload - throw original exception
