### PR TITLE
RavenDB-2633 Use semantic versioning for nuget package.

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -612,12 +612,12 @@ task Upload {
 }
 
 task InitNuget {
-
-    $global:nugetVersion = "$version.$env:buildlabel"
-    if ($global:uploadCategory -and $global:uploadCategory.EndsWith("-Unstable")){
-        $global:nugetVersion += "-Unstable"
+    if ($global:uploadCategory -and $global:uploadCategory.EndsWith("-Unstable")) {
+        $global:nugetVersion = "$version-rc-$env:buildlabel"
     }
-
+    else {
+        $global:nugetVersion = "$version.$env:buildlabel"
+    }
 }
 
 task PushNugetPackages {


### PR DESCRIPTION
This allow the users to use "3.5._" for getting the latest stable and "3.5-rc-_ for getting the latest unstable.
