### PR TITLE
RavenDB-4814 Pre-computed Indexing batch should take into account the available memory

### DIFF
--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -19,6 +19,7 @@ using Raven.Abstractions.Exceptions;
 using Raven.Abstractions.Indexing;
 using Raven.Abstractions.Logging;
 using Raven.Abstractions.Util.Encryptors;
+using Raven.Database.Config;
 using Raven.Database.Data;
 using Raven.Database.Extensions;
 using Raven.Database.Impl;
@@ -610,12 +611,8 @@ namespace Raven.Database.Actions
                     }
                     catch (TotalDataSizeExceededException e)
                     {
-                        Log.Warn(string.Format(
-                            @"Aborting applying precomputed batch for index {0}, 
-                                because total data size gatherered exceeded 
-                                configured data size ({1} bytes)", 
-                            index, Database.Configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes) , e);
-                        throw;
+                        //expected error
+                        Log.Info(e.Message);
                     }
                     catch (Exception e)
                     {
@@ -714,9 +711,14 @@ namespace Raven.Database.Actions
                     }
 
                     if (Log.IsDebugEnabled)
-                        Log.Debug("For new index {0}, using precomputed indexing batch optimization for {1} docs", index,
-                              op.Header.TotalResults);
-                    int totalLoadedDocumentSize = 0;
+                    {
+                        Log.Debug("For new index {0}, using precomputed indexing batch optimization for {1} docs",
+                            index, op.Header.TotalResults);
+                    }
+
+                    var totalLoadedDocumentSize = 0;
+                    const int totalSizeToCheck = 16 * 1024 * 1024; //16MB
+                    var localLoadedDocumentSize = 0;
                     op.Execute(document =>
                     {
                         var metadata = document.Value<RavenJObject>(Constants.Metadata);
@@ -738,16 +740,44 @@ namespace Raven.Database.Actions
                             Metadata = metadata
                         };
 
+                        docsToIndex.Add(doc);
                         totalLoadedDocumentSize += serializedSizeOnDisk;
-                        if (totalLoadedDocumentSize >= Database.Configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes)
+                        localLoadedDocumentSize += serializedSizeOnDisk;
+
+                        if (totalLoadedDocumentSize > Database.Configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes)
                         {
+                            var error = string.Format(
+                                @"Aborting applying precomputed batch for index id: {0}, name: {1}
+                                    because we have {2}mb of documents that were fetched
+                                    and the configured max data to fetch is {3}mb",
+                                index.indexId, index.PublicName, totalLoadedDocumentSize,
+                                Database.Configuration.MaxPrecomputedBatchTotalDocumentSizeInBytes / 1024 / 1024);
+
                             //we are aborting operation, so don't keep the references
-                            docsToIndex.Clear(); 
-                            throw new TotalDataSizeExceededException();
+                            docsToIndex.Clear();
+                            throw new TotalDataSizeExceededException(error);
                         }
 
-                        docsToIndex.Add(doc);
+
+                        if (localLoadedDocumentSize <= totalSizeToCheck)
+                            return;
+
+                        localLoadedDocumentSize = 0;
+
+                        if (Database.Configuration.MemoryLimitForProcessingInMb > MemoryStatistics.AvailableMemoryInMb)
+                        {
+                            var error = string.Format(
+                                @"Aborting applying precomputed batch for index id: {0}, name: {1}
+                                    because we have {2}mb of available memory and the available memory for processing is: {3}mb",
+                                index.indexId, index.PublicName,
+                                MemoryStatistics.AvailableMemoryInMb, Database.Configuration.MemoryLimitForProcessingInMb);
+
+                            //we are aborting operation, so don't keep the references
+                            docsToIndex.Clear();
+                            throw new TotalDataSizeExceededException(error);
+                        }
                     });
+
                     result = new PrecomputedIndexingBatch
                     {
                         LastIndexed = op.Header.IndexEtag,

--- a/Raven.Database/Prefetching/PrefetchingBehavior.cs
+++ b/Raven.Database/Prefetching/PrefetchingBehavior.cs
@@ -793,7 +793,7 @@ namespace Raven.Database.Prefetching
             // ensure we don't do TOO much future caching
             if (MemoryStatistics.AvailableMemoryInMb < context.Configuration.AvailableMemoryForRaisingBatchSizeLimit)
             {
-                log.Info("Skipping background prefetching because we have {0}mb of availiable memory and the availiable memory for raising the batch size limit is: {1}mb",
+                log.Info("Skipping background prefetching because we have {0}mb of available memory and the available memory for raising the batch size limit is: {1}mb",
                         MemoryStatistics.AvailableMemoryInMb, context.Configuration.AvailableMemoryForRaisingBatchSizeLimit / 1024 / 1024);
                 return;
             }


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-4814
