### PR TITLE
RavenDB-4854-3.5 - Fix failing test: AfterBatch_Gets_Count_Of_Processed_Docs

### DIFF
--- a/Raven.Tests.Issues/RavenDB_3612.cs
+++ b/Raven.Tests.Issues/RavenDB_3612.cs
@@ -53,8 +53,8 @@ namespace Raven.Tests.Issues
                 var afterBatchCalled = new ManualResetEvent(false);
                 subscription.AfterBatch += count =>
                 {
-                    afterBatchCalled.Set();
                     processed = count;
+                    afterBatchCalled.Set();
                 };
 
                 subscription.Subscribe(x => { });


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-4854
