### PR TITLE
RavenDB-4855 - Support arrays on dynamic documents for MoreLikeThis queries.

### DIFF
--- a/Raven.Tests.Bundles/MoreLikeThis/MoreLikeThisShouldSupportMapReduceIndexes.cs
+++ b/Raven.Tests.Bundles/MoreLikeThis/MoreLikeThisShouldSupportMapReduceIndexes.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Specialized;
 using System.Linq;
+using Raven.Abstractions.Connection;
 using Raven.Abstractions.Data;
 using Raven.Abstractions.Indexing;
 using Raven.Client;
@@ -23,8 +25,8 @@ namespace Raven.Tests.Bundles.MoreLikeThis
             store = NewDocumentStore();
             using (var session = store.OpenSession())
             {
-                var javascriptBook = new Book { Title = "Javascript: The Good Parts" };
-                var phpBook = new Book { Title = "PHP: The Good Parts" };
+                var javascriptBook = new Book { Title = "Javascript: The Good Parts", Tags = new[] { "javascript" } };
+                var phpBook = new Book { Title = "PHP: The Good Parts", Tags = new[] { "php" } };
                 var eclipseBook = new Book { Title = "Zend Studio for Eclipse Developer's Guide" };
 
                 session.Store(javascriptBook);
@@ -57,10 +59,11 @@ namespace Raven.Tests.Bundles.MoreLikeThis
                 var list = session.Advanced.MoreLikeThis<IndexDocument, MapReduceIndex>(
                     new MoreLikeThisQuery
                     {
-                        MapGroupFields = new NameValueCollection()
+                        MapGroupFields = new NameValueCollection
                         {
                             {"BookId", javascriptBookId}
                         },
+                        Fields = new[] { "Text" },
                         MinimumTermFrequency = 1,
                         MinimumDocumentFrequency = 1
                     });
@@ -79,10 +82,11 @@ namespace Raven.Tests.Bundles.MoreLikeThis
                 var list = session.Advanced.MoreLikeThis<IndexDocument, MapReduceIndex>(
                     new MoreLikeThisQuery
                     {
-                        MapGroupFields = new NameValueCollection()
+                        MapGroupFields = new NameValueCollection
                         {
-                            {"BookId", eclipseBookId}
+                            {"BookId", eclipseBookId},
                         },
+                        Fields = new[] { "Text" },
                         MinimumTermFrequency = 1,
                         MinimumDocumentFrequency = 1
                     });
@@ -111,10 +115,50 @@ namespace Raven.Tests.Bundles.MoreLikeThis
             }
         }
 
+        [Fact]
+        public void CanMakeDynamicDocumentWithArrayQueries()
+        {
+            WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var list = session.Advanced.MoreLikeThis<IndexDocument, MapReduceIndex>(
+                    new MoreLikeThisQuery
+                    {
+                        Document = "{ \"Tags\": [\"javascript\"] }",
+                        Fields = new[] { "Tags" },
+                        MinimumTermFrequency = 1,
+                        MinimumDocumentFrequency = 1
+                    });
+
+                Assert.Equal(1, list.Count());
+                Assert.Equal("javascript", list.First().Tags.First());
+            }
+        }
+
+        [Fact]
+        public void ThrowExceptionForDynamicDocumentQueriesWithNonSupportedDocuments()
+        {
+            WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                Assert.Throws<ErrorResponseException>(() => session.Advanced.MoreLikeThis<IndexDocument, MapReduceIndex>(
+                    new MoreLikeThisQuery
+                    {
+                        Document = "{ \"ComplexObj\": { \"Something\": \"some value\" } }",
+                        Fields = new[] { "ComplexObj" },
+                        MinimumTermFrequency = 1,
+                        MinimumDocumentFrequency = 1
+                    }));
+            }
+        }
+
         private class Book
         {
             public string Id { get; set; }
             public string Title;
+            public string[] Tags;
         }
 
         private class Author
@@ -128,6 +172,7 @@ namespace Raven.Tests.Bundles.MoreLikeThis
 #pragma warning disable 0649
             public string BookId;
             public string Text;
+            public string[] Tags;
 #pragma warning restore 0649
         }
 
@@ -142,26 +187,29 @@ namespace Raven.Tests.Bundles.MoreLikeThis
             public MapReduceIndex()
             {
                 AddMap<Book>(things => from thing in things
-                                       select new IndexDocument()
+                                       select new IndexDocument
                                        {
                                            BookId = thing.Id,
-                                           Text = thing.Title
+                                           Text = thing.Title,
+                                           Tags = thing.Tags
                                        });
 
                 AddMap<Author>(opinions => from opinion in opinions
-                                           select new IndexDocument()
+                                           select new IndexDocument
                                            {
                                                BookId = opinion.BookId,
-                                               Text = opinion.Name
+                                               Text = opinion.Name,
+                                               Tags = new string[] { }
                                            });
 
                 Reduce = documents => from doc in documents
                                       group doc by doc.BookId
                                           into g
-                                      select new IndexDocument()
+                                      select new IndexDocument
                                       {
                                           BookId = g.Key,
-                                          Text = string.Join(" ", g.Select(d => d.Text))
+                                          Text = string.Join(" ", g.Select(d => d.Text)),
+                                          Tags = g.SelectMany(x => x.Tags).ToArray()
                                       };
 
 
@@ -169,6 +217,7 @@ namespace Raven.Tests.Bundles.MoreLikeThis
                 Index(x => x.BookId, FieldIndexing.NotAnalyzed);
                 Store(x => x.BookId, FieldStorage.Yes);
                 Store(x => x.Text, FieldStorage.Yes);
+                Store(x => x.Tags, FieldStorage.Yes);
                 TermVector(x => x.Text, FieldTermVector.Yes);
             }
         }


### PR DESCRIPTION
We only deal with string and array of string values.

@fitzchak this is an improvement to #4045.
