### PR TITLE
RavenDB-4788 Implement OperateToTypes in export and import

### DIFF
--- a/src/Raven.Client/Data/DatabaseStatistics.cs
+++ b/src/Raven.Client/Data/DatabaseStatistics.cs
@@ -42,9 +42,9 @@ namespace Raven.Client.Data
         public long CountOfDocuments { get; set; }
 
         /// <summary>
-        /// Total number of versioning revision documents in database.
+        /// Total number of revision documents in database.
         /// </summary>
-        public long? CountOfVersioningRevisionDocuments { get; set; }
+        public long? CountOfRevisionDocuments { get; set; }
 
         /// <summary>
         /// List of stale index names in database..

--- a/src/Raven.Client/Smuggler/DatabaseItemType.cs
+++ b/src/Raven.Client/Smuggler/DatabaseItemType.cs
@@ -5,12 +5,14 @@ namespace Raven.Client.Smuggler
     [Flags]
     public enum DatabaseItemType
     {
-        Documents = 0x1,
-        Indexes = 0x2,
-        Transformers = 0x4,
+        None = 0,
 
-        RevisionDocuments = 0x32,
+        Documents = 1 << 0,
+        RevisionDocuments = 1 << 1,
+        Indexes = 1 << 2,
+        Transformers = 1 << 3,
+        Identities = 1 << 4,
 
-        RemoveAnalyzers = 0x8000,
+        RemoveAnalyzers = 1 << 7,
     }
 }

--- a/src/Raven.Client/Smuggler/DatabaseItemType.cs
+++ b/src/Raven.Client/Smuggler/DatabaseItemType.cs
@@ -9,7 +9,7 @@ namespace Raven.Client.Smuggler
         Indexes = 0x2,
         Transformers = 0x4,
 
-        VersioningRevisionDocuments = 0x32,
+        RevisionDocuments = 0x32,
 
         RemoveAnalyzers = 0x8000,
     }

--- a/src/Raven.Client/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Smuggler/DatabaseSmuggler.cs
@@ -34,14 +34,16 @@ namespace Raven.Client.Smuggler
             var httpClient = GetHttpClient();
             ShowProgress("Starting to export file");
             var database = options.Database ?? _store.DefaultDatabase;
+
             var url = $"{_store.Url}/databases/{database}/smuggler/export";
             var query = new Dictionary<string, object>();
             if (options.DocumentsLimit.HasValue)
                 query.Add("documentsLimit", options.DocumentsLimit.Value);
-            if (options.VersioningRevisionsLimit.HasValue)
-                query.Add("versioningRevisionsLimit", options.VersioningRevisionsLimit.Value);
-            url = UrlHelper.BuildUrl(url, query);
+            if (options.RevisionDocumentsLimit.HasValue)
+                query.Add("RevisionDocumentsLimit", options.RevisionDocumentsLimit.Value);
             // todo: send more options here
+            url = UrlHelper.BuildUrl(url, query);
+
             var response = await httpClient.PostAsync(url, new StringContent(""), token).ConfigureAwait(false);
             var stream = await response.Content.ReadAsStreamAsync();
             return stream;

--- a/src/Raven.Client/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Smuggler/DatabaseSmuggler.cs
@@ -35,16 +35,13 @@ namespace Raven.Client.Smuggler
             ShowProgress("Starting to export file");
             var database = options.Database ?? _store.DefaultDatabase;
             var url = $"{_store.Url}/databases/{database}/smuggler/export";
-            var query = new Dictionary<string, string>();
+            var query = new Dictionary<string, object>();
             if (options.DocumentsLimit.HasValue)
-                query.Add("documentsLimit", options.DocumentsLimit.Value.ToString());
+                query.Add("documentsLimit", options.DocumentsLimit.Value);
             if (options.VersioningRevisionsLimit.HasValue)
-                query.Add("versioningRevisionsLimit", options.VersioningRevisionsLimit.Value.ToString());
-            if (query.Count > 0)
-            {
-                url += "?" + string.Join("&", query.Select(pair => pair.Key + "=" + pair.Value));
-            }
-            // todo: send the options here
+                query.Add("versioningRevisionsLimit", options.VersioningRevisionsLimit.Value);
+            url = UrlHelper.BuildUrl(url, query);
+            // todo: send more options here
             var response = await httpClient.PostAsync(url, new StringContent(""), token).ConfigureAwait(false);
             var stream = await response.Content.ReadAsStreamAsync();
             return stream;

--- a/src/Raven.Client/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Smuggler/DatabaseSmuggler.cs
@@ -36,7 +36,10 @@ namespace Raven.Client.Smuggler
             var database = options.Database ?? _store.DefaultDatabase;
 
             var url = $"{_store.Url}/databases/{database}/smuggler/export";
-            var query = new Dictionary<string, object>();
+            var query = new Dictionary<string, object>
+            {
+                {"operateOnTypes", options.OperateOnTypes},
+            };
             if (options.DocumentsLimit.HasValue)
                 query.Add("documentsLimit", options.DocumentsLimit.Value);
             if (options.RevisionDocumentsLimit.HasValue)
@@ -102,6 +105,13 @@ namespace Raven.Client.Smuggler
             using (var content = new StreamContent(stream))
             {
                 var uri = $"{url}/databases/{database}/smuggler/import";
+                var query = new Dictionary<string, object>
+                {
+                    {"operateOnTypes", options.OperateOnTypes},
+                };
+                // todo: send more options here
+                uri = UrlHelper.BuildUrl(uri, query);
+
                 var response = await httpClient.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
                 {

--- a/src/Raven.Client/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Smuggler/DatabaseSmugglerOptions.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.Smuggler
         public bool IgnoreErrorsAndContinue { get; set; }
 
         public int? DocumentsLimit { get; set; }
-        public int? VersioningRevisionsLimit { get; set; }
+        public int? RevisionDocumentsLimit { get; set; }
 
         public string TransformScript { get; set; }
 

--- a/src/Raven.Client/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Smuggler/DatabaseSmugglerOptions.cs
@@ -4,7 +4,8 @@ namespace Raven.Client.Smuggler
     {
         public DatabaseSmugglerOptions()
         {
-            OperateOnTypes = DatabaseItemType.Indexes | DatabaseItemType.Documents | DatabaseItemType.Transformers;
+            OperateOnTypes = DatabaseItemType.Indexes | DatabaseItemType.Transformers 
+                | DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Identities;
         }
 
         public long? StartDocsEtag { get; set; }

--- a/src/Raven.Client/Smuggler/UrlHelper.cs
+++ b/src/Raven.Client/Smuggler/UrlHelper.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Raven.Client.Smuggler
+{
+    public static class UrlHelper
+    {
+        public static string BuildUrl(string url, Dictionary<string, object> query)
+        {
+            if (query.Count > 0)
+                url += "?" + string.Join("&", query.Select(pair => pair.Key + "=" + pair.Value.ToString()));
+            return url;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -793,7 +793,7 @@ namespace Raven.Server.Documents
 
             if (isSystemDocument == false)
             {
-                _documentDatabase.BundleLoader.VersioningStorage?.PutVersion(context, originalCollectionName, key, newEtagBigEndian, document);
+                _documentDatabase.BundleLoader.VersioningStorage?.PutFromDocument(context, originalCollectionName, key, newEtagBigEndian, document);
                 _documentDatabase.BundleLoader.ExpiredDocumentsCleaner?.Put(context, Slice.External(context.Allocator, lowerKey, (ushort)lowerSize), document);
             }
 

--- a/src/Raven.Server/Documents/Handlers/StatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/StatsHandler.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.Handlers
 
                 var stats = new DatabaseStatistics();
                 stats.CountOfDocuments = Database.DocumentsStorage.GetNumberOfDocuments(context);
-                stats.CountOfVersioningRevisionDocuments = Database.BundleLoader.VersioningStorage?.GetNumberOfRevisionDocuments(context);
+                stats.CountOfRevisionDocuments = Database.BundleLoader.VersioningStorage?.GetNumberOfRevisionDocuments(context);
                 stats.ApproximateTaskCount = 0; // TODO [ppekrol]
                 stats.CountOfIndexes = indexes.Count;
                 stats.CountOfTransformers = 0; // TODO [ppekrol]

--- a/src/Raven.Server/Documents/PeriodicExport/PeriodicExportRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicExport/PeriodicExportRunner.cs
@@ -209,7 +209,7 @@ namespace Raven.Server.Documents.PeriodicExport
                         var dataExporter = new DatabaseDataExporter(_database)
                         {
                             DocumentsLimit = _exportLimit,
-                            VersioningRevisionsLimit = _exportLimit,
+                            RevisionDocumentsLimit = _exportLimit,
                         };
 
                         string exportFilePath;

--- a/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
+++ b/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
@@ -22,8 +22,8 @@ namespace Raven.Server.Documents.Versioning
 
         private readonly VersioningConfiguration _versioningConfiguration;
 
-        private const string VersioningRevisions = "VersioningRevisions";
-        private const string VersioningRevisionsCount = "VersioningRevisionsCount";
+        private const string RevisionDocuments = "RevisionDocuments";
+        private const string RevisionsCount = "RevisionsCount";
 
         private readonly VersioningConfigurationCollection _emptyConfiguration = new VersioningConfigurationCollection();
 
@@ -48,10 +48,10 @@ namespace Raven.Server.Documents.Versioning
 
             using (var tx = database.DocumentsStorage.Environment.WriteTransaction())
             {
-                tx.CreateTree(VersioningRevisions);
-                _docsSchema.Create(tx, VersioningRevisions);
+                tx.CreateTree(RevisionDocuments);
+                _docsSchema.Create(tx, RevisionDocuments);
 
-                tx.CreateTree(VersioningRevisionsCount);
+                tx.CreateTree(RevisionsCount);
 
                 tx.Commit();
             }
@@ -134,7 +134,7 @@ namespace Raven.Server.Documents.Versioning
             if (enableVersioning == false && configuration.Active == false)
                 return;
 
-            var table = new Table(_docsSchema, VersioningRevisions, context.Transaction.InnerTransaction);
+            var table = new Table(_docsSchema, RevisionDocuments, context.Transaction.InnerTransaction);
             var prefixSlice = GetSliceFromKey(context, key);
             var revisionsCount = IncrementCountOfRevisions(context, prefixSlice, 1);
             DeleteOldRevisions(context, table, prefixSlice, configuration.MaxRevisions, revisionsCount);
@@ -149,7 +149,7 @@ namespace Raven.Server.Documents.Versioning
         {
             var newEtagBigEndian = IPAddress.HostToNetworkOrder(etag);
 
-            var table = new Table(_docsSchema, VersioningRevisions, context.Transaction.InnerTransaction);
+            var table = new Table(_docsSchema, RevisionDocuments, context.Transaction.InnerTransaction);
             PutInternal(context, key, newEtagBigEndian, document, table);
         }
 
@@ -191,13 +191,13 @@ namespace Raven.Server.Documents.Versioning
 
         private long IncrementCountOfRevisions(DocumentsOperationContext context, Slice prefixedLoweredKey, long delta)
         {
-            var numbers = context.Transaction.InnerTransaction.ReadTree(VersioningRevisionsCount);
+            var numbers = context.Transaction.InnerTransaction.ReadTree(RevisionsCount);
             return numbers.Increment(prefixedLoweredKey, delta);
         }
 
         private void DeleteCountOfRevisions(DocumentsOperationContext context, Slice prefixedLoweredKey)
         {
-            var numbers = context.Transaction.InnerTransaction.ReadTree(VersioningRevisionsCount);
+            var numbers = context.Transaction.InnerTransaction.ReadTree(RevisionsCount);
             numbers.Delete(prefixedLoweredKey);
         }
 
@@ -212,7 +212,7 @@ namespace Raven.Server.Documents.Versioning
             if (configuration.PurgeOnDelete == false)
                 return;
 
-            var table = new Table(_docsSchema, VersioningRevisions, context.Transaction.InnerTransaction);
+            var table = new Table(_docsSchema, RevisionDocuments, context.Transaction.InnerTransaction);
             var prefixKeyMem = context.Allocator.Allocate(loweredKey.Size +1);
             loweredKey.CopyTo(0, prefixKeyMem.Ptr, 0, loweredKey.Size);
             prefixKeyMem.Ptr[loweredKey.Size] = (byte)30; // the record separator
@@ -223,7 +223,7 @@ namespace Raven.Server.Documents.Versioning
 
         public IEnumerable<Document> GetRevisions(DocumentsOperationContext context, string key, int start, int take)
         {
-            var table = new Table(_docsSchema, VersioningRevisions, context.Transaction.InnerTransaction);
+            var table = new Table(_docsSchema, RevisionDocuments, context.Transaction.InnerTransaction);
 
             var prefixSlice = GetSliceFromKey(context, key);
             // ReSharper disable once LoopCanBeConvertedToQuery
@@ -249,7 +249,7 @@ namespace Raven.Server.Documents.Versioning
 
         public IEnumerable<Document> GetRevisionsAfter(DocumentsOperationContext context, long etag)
         {
-            var table = new Table(_docsSchema, VersioningRevisions, context.Transaction.InnerTransaction);
+            var table = new Table(_docsSchema, RevisionDocuments, context.Transaction.InnerTransaction);
 
             foreach (var tvr in table.SeekForwardFrom(_docsSchema.FixedSizeIndexes["Etag"], etag))
             {
@@ -260,7 +260,7 @@ namespace Raven.Server.Documents.Versioning
 
         public IEnumerable<Document> GetRevisionsAfter(DocumentsOperationContext context, long etag, int take)
         {
-            var table = new Table(_docsSchema, VersioningRevisions, context.Transaction.InnerTransaction);
+            var table = new Table(_docsSchema, RevisionDocuments, context.Transaction.InnerTransaction);
 
             foreach (var tvr in table.SeekForwardFrom(_docsSchema.FixedSizeIndexes["Etag"], etag))
             {
@@ -326,7 +326,7 @@ namespace Raven.Server.Documents.Versioning
 
         public long GetNumberOfRevisionDocuments(DocumentsOperationContext context)
         {
-            var table = new Table(_docsSchema, VersioningRevisions, context.Transaction.InnerTransaction);
+            var table = new Table(_docsSchema, RevisionDocuments, context.Transaction.InnerTransaction);
             return table.GetNumberEntriesFor(_docsSchema.FixedSizeIndexes["Etag"]);
         }
     }

--- a/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
+++ b/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
@@ -100,10 +100,7 @@ namespace Raven.Server.Documents.Versioning
             return _emptyConfiguration;
         }
 
-        /// <summary>
-        /// Should be used from document put
-        /// </summary>
-        public void PutVersion(DocumentsOperationContext context, string collectionName, string key, long newEtagBigEndian, BlittableJsonReaderObject document)
+        public void PutFromDocument(DocumentsOperationContext context, string collectionName, string key, long newEtagBigEndian, BlittableJsonReaderObject document)
         {
             var enableVersioning = false;
             BlittableJsonReaderObject metadata;
@@ -142,10 +139,7 @@ namespace Raven.Server.Documents.Versioning
             PutInternal(context, key, newEtagBigEndian, document, table);
         }
 
-        /// <summary>
-        /// Should be used from smuggler import
-        /// </summary>
-        public void Put(DocumentsOperationContext context, string key, long etag, BlittableJsonReaderObject document)
+        public void PutDirect(DocumentsOperationContext context, string key, long etag, BlittableJsonReaderObject document)
         {
             var newEtagBigEndian = IPAddress.HostToNetworkOrder(etag);
 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -440,10 +440,10 @@ namespace Raven.Server.Json
             writer.WriteInteger(statistics.CountOfDocuments);
             writer.WriteComma();
 
-            if (statistics.CountOfVersioningRevisionDocuments.HasValue)
+            if (statistics.CountOfRevisionDocuments.HasValue)
             {
-                writer.WritePropertyName(context.GetLazyString(nameof(statistics.CountOfVersioningRevisionDocuments)));
-                writer.WriteInteger(statistics.CountOfVersioningRevisionDocuments.Value);
+                writer.WritePropertyName(context.GetLazyString(nameof(statistics.CountOfRevisionDocuments)));
+                writer.WriteInteger(statistics.CountOfRevisionDocuments.Value);
                 writer.WriteComma();
             }
 

--- a/src/Raven.Server/Smuggler/DatabaseDataExporter.cs
+++ b/src/Raven.Server/Smuggler/DatabaseDataExporter.cs
@@ -24,6 +24,8 @@ namespace Raven.Server.Smuggler
         public DatabaseDataExporter(DocumentDatabase database)
         {
             _database = database;
+            OperateOnTypes = DatabaseItemType.Indexes | DatabaseItemType.Transformers
+                | DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Identities;
         }
 
         public ExportResult Export(DocumentsOperationContext context, string destinationFilePath)

--- a/src/Raven.Server/Smuggler/DatabaseDataExporter.cs
+++ b/src/Raven.Server/Smuggler/DatabaseDataExporter.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.IO.Compression;
 using Raven.Client.Data.Indexes;
+using Raven.Client.Smuggler;
 using Raven.Server.Documents;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
@@ -17,6 +18,8 @@ namespace Raven.Server.Smuggler
 
         public long? StartRevisionDocumentsEtag;
         public int? RevisionDocumentsLimit;
+
+        public DatabaseItemType OperateOnTypes;
 
         public DatabaseDataExporter(DocumentDatabase database)
         {
@@ -43,110 +46,125 @@ namespace Raven.Server.Smuggler
                 writer.WritePropertyName(context.GetLazyString("BuildVersion"));
                 writer.WriteInteger(40000);
 
-                writer.WriteComma();
-                writer.WritePropertyName(context.GetLazyString("Docs"));
-                var documents = DocumentsLimit.HasValue
-                      ? _database.DocumentsStorage.GetDocumentsAfter(context, StartDocsEtag ?? 0, 0, DocumentsLimit.Value)
-                      : _database.DocumentsStorage.GetDocumentsAfter(context, StartDocsEtag ?? 0);
-                writer.WriteStartArray();
-                bool first = true;
-                foreach (var document in documents)
-                {
-                    if (document == null)
-                        continue;
-
-                    using (document.Data)
-                    {
-                        if (first == false)
-                            writer.WriteComma();
-                        first = false;
-
-                        document.EnsureMetadata();
-                        context.Write(writer, document.Data);
-                        result.LastDocsEtag = document.Etag;
-                    }
-                }
-                writer.WriteEndArray();
-
-                var versioningStorage = _database.BundleLoader.VersioningStorage;
-                if (versioningStorage != null)
+                if (OperateOnTypes.HasFlag(DatabaseItemType.Documents))
                 {
                     writer.WriteComma();
-                    writer.WritePropertyName(context.GetLazyString("RevisionDocuments"));
+                    writer.WritePropertyName(context.GetLazyString("Docs"));
+                    var documents = DocumentsLimit.HasValue
+                        ? _database.DocumentsStorage.GetDocumentsAfter(context, StartDocsEtag ?? 0, 0, DocumentsLimit.Value)
+                        : _database.DocumentsStorage.GetDocumentsAfter(context, StartDocsEtag ?? 0);
                     writer.WriteStartArray();
-                    first = true;
-                    var revisionDocuments = RevisionDocumentsLimit.HasValue 
-                        ? versioningStorage.GetRevisionsAfter(context, StartRevisionDocumentsEtag ?? 0, RevisionDocumentsLimit.Value)
-                        : versioningStorage.GetRevisionsAfter(context, StartRevisionDocumentsEtag ?? 0);
-                    foreach (var revisionDocument in revisionDocuments)
+                    bool first = true;
+                    foreach (var document in documents)
                     {
-                        if (revisionDocument == null)
+                        if (document == null)
                             continue;
 
-                        using (revisionDocument.Data)
+                        using (document.Data)
                         {
                             if (first == false)
                                 writer.WriteComma();
                             first = false;
 
-                            revisionDocument.EnsureMetadata();
-                            context.Write(writer, revisionDocument.Data);
-                            result.LastRevisionDocumentsEtag = revisionDocument.Etag;
+                            document.EnsureMetadata();
+                            context.Write(writer, document.Data);
+                            result.LastDocsEtag = document.Etag;
                         }
                     }
                     writer.WriteEndArray();
                 }
 
-                writer.WriteComma();
-                writer.WritePropertyName(context.GetLazyString("Indexes"));
-                writer.WriteStartArray();
-                foreach (var index in _database.IndexStore.GetIndexes())
+                if (OperateOnTypes.HasFlag(DatabaseItemType.RevisionDocuments))
                 {
-                    if (index.Type == IndexType.Map || index.Type == IndexType.MapReduce)
+                    var versioningStorage = _database.BundleLoader.VersioningStorage;
+                    if (versioningStorage != null)
                     {
-                        var indexDefinition = index.GetIndexDefinition();
-                        writer.WriteIndexDefinition(context, indexDefinition);
-                    }
-                    else if (index.Type == IndexType.Faulty)
-                    {
-                        // TODO: Should we export them?
-                    }
-                    else
-                    {
-                        // TODO: Export auto indexes.
-                    }
-                }
-                writer.WriteEndArray();
-
-                writer.WriteComma();
-                writer.WritePropertyName(context.GetLazyString("Transformers"));
-                writer.WriteStartArray();
-                foreach (var transformer in _database.TransformerStore.GetTransformers())
-                {
-                    writer.WriteTransformerDefinition(context, transformer.Definition);
-                }
-                writer.WriteEndArray();
-
-                writer.WriteComma();
-                writer.WritePropertyName(context.GetLazyString("Identities"));
-                writer.WriteStartArray();
-                var identities = _database.DocumentsStorage.GetIdentities(context);
-                first = true;
-                foreach (var identity in identities)
-                {
-                    if (first == false)
                         writer.WriteComma();
-                    first = false;
+                        writer.WritePropertyName(context.GetLazyString("RevisionDocuments"));
+                        writer.WriteStartArray();
+                        var first = true;
+                        var revisionDocuments = RevisionDocumentsLimit.HasValue
+                            ? versioningStorage.GetRevisionsAfter(context, StartRevisionDocumentsEtag ?? 0, RevisionDocumentsLimit.Value)
+                            : versioningStorage.GetRevisionsAfter(context, StartRevisionDocumentsEtag ?? 0);
+                        foreach (var revisionDocument in revisionDocuments)
+                        {
+                            if (revisionDocument == null)
+                                continue;
 
-                    writer.WriteStartObject();
-                    writer.WritePropertyName(context.GetLazyString("Key"));
-                    writer.WriteString(context.GetLazyString(identity.Key));
-                    writer.WriteComma();
-                    writer.WritePropertyName(context.GetLazyString("Value"));
-                    writer.WriteString(context.GetLazyString(identity.Value.ToString()));
-                    writer.WriteEndObject();
+                            using (revisionDocument.Data)
+                            {
+                                if (first == false)
+                                    writer.WriteComma();
+                                first = false;
+
+                                revisionDocument.EnsureMetadata();
+                                context.Write(writer, revisionDocument.Data);
+                                result.LastRevisionDocumentsEtag = revisionDocument.Etag;
+                            }
+                        }
+                        writer.WriteEndArray();
+                    }
                 }
-                writer.WriteEndArray();
+
+                if (OperateOnTypes.HasFlag(DatabaseItemType.Indexes))
+                {
+                    writer.WriteComma();
+                    writer.WritePropertyName(context.GetLazyString("Indexes"));
+                    writer.WriteStartArray();
+                    foreach (var index in _database.IndexStore.GetIndexes())
+                    {
+                        if (index.Type == IndexType.Map || index.Type == IndexType.MapReduce)
+                        {
+                            var indexDefinition = index.GetIndexDefinition();
+                            writer.WriteIndexDefinition(context, indexDefinition);
+                        }
+                        else if (index.Type == IndexType.Faulty)
+                        {
+                            // TODO: Should we export them?
+                        }
+                        else
+                        {
+                            // TODO: Export auto indexes.
+                        }
+                    }
+                    writer.WriteEndArray();
+                }
+
+                if (OperateOnTypes.HasFlag(DatabaseItemType.Transformers))
+                {
+                    writer.WriteComma();
+                    writer.WritePropertyName(context.GetLazyString("Transformers"));
+                    writer.WriteStartArray();
+                    foreach (var transformer in _database.TransformerStore.GetTransformers())
+                    {
+                        writer.WriteTransformerDefinition(context, transformer.Definition);
+                    }
+                    writer.WriteEndArray();
+                }
+
+                if (OperateOnTypes.HasFlag(DatabaseItemType.Identities))
+                {
+                    writer.WriteComma();
+                    writer.WritePropertyName(context.GetLazyString("Identities"));
+                    writer.WriteStartArray();
+                    var identities = _database.DocumentsStorage.GetIdentities(context);
+                    var first = true;
+                    foreach (var identity in identities)
+                    {
+                        if (first == false)
+                            writer.WriteComma();
+                        first = false;
+
+                        writer.WriteStartObject();
+                        writer.WritePropertyName(context.GetLazyString("Key"));
+                        writer.WriteString(context.GetLazyString(identity.Key));
+                        writer.WriteComma();
+                        writer.WritePropertyName(context.GetLazyString("Value"));
+                        writer.WriteString(context.GetLazyString(identity.Value.ToString()));
+                        writer.WriteEndObject();
+                    }
+                    writer.WriteEndArray();
+                }
 
                 writer.WriteEndObject();
             }

--- a/src/Raven.Server/Smuggler/DatabaseDataExporter.cs
+++ b/src/Raven.Server/Smuggler/DatabaseDataExporter.cs
@@ -15,8 +15,8 @@ namespace Raven.Server.Smuggler
         public long? StartDocsEtag;
         public int? DocumentsLimit;
 
-        public long? StartVersioningRevisionsEtag;
-        public int? VersioningRevisionsLimit;
+        public long? StartRevisionDocumentsEtag;
+        public int? RevisionDocumentsLimit;
 
         public DatabaseDataExporter(DocumentDatabase database)
         {
@@ -72,12 +72,12 @@ namespace Raven.Server.Smuggler
                 if (versioningStorage != null)
                 {
                     writer.WriteComma();
-                    writer.WritePropertyName(context.GetLazyString("VersioningRevisions"));
+                    writer.WritePropertyName(context.GetLazyString("RevisionDocuments"));
                     writer.WriteStartArray();
                     first = true;
-                    var revisionDocuments = VersioningRevisionsLimit.HasValue 
-                        ? versioningStorage.GetRevisionsAfter(context, StartVersioningRevisionsEtag ?? 0, VersioningRevisionsLimit.Value)
-                        : versioningStorage.GetRevisionsAfter(context, StartVersioningRevisionsEtag ?? 0);
+                    var revisionDocuments = RevisionDocumentsLimit.HasValue 
+                        ? versioningStorage.GetRevisionsAfter(context, StartRevisionDocumentsEtag ?? 0, RevisionDocumentsLimit.Value)
+                        : versioningStorage.GetRevisionsAfter(context, StartRevisionDocumentsEtag ?? 0);
                     foreach (var revisionDocument in revisionDocuments)
                     {
                         if (revisionDocument == null)
@@ -91,7 +91,7 @@ namespace Raven.Server.Smuggler
 
                             revisionDocument.EnsureMetadata();
                             context.Write(writer, revisionDocument.Data);
-                            result.LastVersioningRevisionsEtag = revisionDocument.Etag;
+                            result.LastRevisionDocumentsEtag = revisionDocument.Etag;
                         }
                     }
                     writer.WriteEndArray();

--- a/src/Raven.Server/Smuggler/DatabaseDataImporter.cs
+++ b/src/Raven.Server/Smuggler/DatabaseDataImporter.cs
@@ -99,12 +99,12 @@ namespace Raven.Server.Smuggler
                                     batchPutCommand.Clean();
                                 }
                             }
-                            else if (operateOnType == "VersioningRevisions")
+                            else if (operateOnType == "RevisionDocuments")
                             {
                                 if (versioningStorage == null)
                                     break;
 
-                                result.VersioningRevisionDocumentsCount++;
+                                result.RevisionDocumentsCount++;
 
                                 batchPutCommand.Add(builder);
                                 if (batchPutCommand.Count >= 16)
@@ -197,7 +197,7 @@ namespace Raven.Server.Smuggler
                                     versioningStorage = _database.BundleLoader.VersioningStorage;
                                     batchPutCommand.IsRevision = true;
                                     break;
-                                case "VersioningRevisions":
+                                case "RevisionDocuments":
                                     if (batchPutCommand.Count > 0)
                                     {
                                         await _database.TxMerger.Enqueue(batchPutCommand);

--- a/src/Raven.Server/Smuggler/DatabaseDataImporter.cs
+++ b/src/Raven.Server/Smuggler/DatabaseDataImporter.cs
@@ -35,7 +35,6 @@ namespace Raven.Server.Smuggler
             {
                 string operateOnType = "__top_start_object";
                 var batchPutCommand = new MergedBatchPutCommand(_database);
-                var batchVerioningRevisionsPutCommand = new MergedBatchVerioningRevisionsPutCommand(_database);
                 var identities = new Dictionary<string, long>();
                 VersioningStorage versioningStorage = null;
 
@@ -63,158 +62,124 @@ namespace Raven.Server.Smuggler
                                 operateOnType = new LazyStringValue(null, state.StringBuffer, state.StringSize, context).ToString();
                             }
                             break;
-                        case JsonParserToken.StartObject:
+                        case JsonParserToken.Integer:
                             switch (operateOnType)
                             {
-                                case "Docs":
-                                    result.DocumentsCount++;
-                                    var documentBuilder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.ToDisk, "f", parser, state);
-                                    documentBuilder.ReadNestedObject();
-                                    while (documentBuilder.Read() == false)
-                                    {
-                                        var read = await stream.ReadAsync(buffer, 0, buffer.Length);
-                                        if (read == 0)
-                                            throw new EndOfStreamException("Stream ended without reaching end of json content");
-                                        parser.SetBuffer(buffer, read);
-                                    }
-                                    documentBuilder.FinalizeDocument();
-                                    batchPutCommand.Add(documentBuilder);
-                                    if (batchPutCommand.Count >= 16)
-                                    {
-                                        await _database.TxMerger.Enqueue(batchPutCommand);
-                                        batchPutCommand.Dispose();
-                                        batchPutCommand = new MergedBatchPutCommand(_database);
-                                    }
-                                    break;
-                                case "VersioningRevisions":
-                                    if (versioningStorage == null)
-                                        break;
-
-                                    result.VersioningRevisionDocumentsCount++;
-                                    var versioningRevisionsBuilder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.ToDisk, "VersioningRevisions", parser, state);
-                                    versioningRevisionsBuilder.ReadNestedObject();
-                                    while (versioningRevisionsBuilder.Read() == false)
-                                    {
-                                        var read = await stream.ReadAsync(buffer, 0, buffer.Length);
-                                        if (read == 0)
-                                            throw new EndOfStreamException("Stream ended without reaching end of json content");
-                                        parser.SetBuffer(buffer, read);
-                                    }
-                                    versioningRevisionsBuilder.FinalizeDocument();
-                                    batchVerioningRevisionsPutCommand.Add(versioningRevisionsBuilder);
-                                    if (batchVerioningRevisionsPutCommand.Count >= 16)
-                                    {
-                                        await _database.TxMerger.Enqueue(batchVerioningRevisionsPutCommand);
-                                        batchVerioningRevisionsPutCommand.Dispose();
-                                        batchVerioningRevisionsPutCommand = new MergedBatchVerioningRevisionsPutCommand(_database);
-                                    }
-                                    break;
-                                case "Attachments":
-                                    result.Warnings.Add("Attachments are not supported anymore. Use RavenFS isntead. Skipping.");
-                                    break;
-                                case "Indexes":
-                                    result.IndexesCount++;
-                                    using (var indexBuilder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.None, "Indexes", parser, state))
-                                    {
-                                        indexBuilder.ReadNestedObject();
-                                        while (indexBuilder.Read() == false)
-                                        {
-                                            var read = await stream.ReadAsync(buffer, 0, buffer.Length);
-                                            if (read == 0)
-                                                throw new EndOfStreamException("Stream ended without reaching end of json content");
-                                            parser.SetBuffer(buffer, read);
-                                        }
-                                        indexBuilder.FinalizeDocument();
-                                        using (var reader = indexBuilder.CreateReader())
-                                        {
-                                         /*   var index = new IndexDefinition();
-                                            string name;
-                                            if (reader.TryGet("Name", out name) == false)
-                                            {
-                                                result.Warnings.Add($"Cannot import the following index as it does not contain a name: '{reader}'. Skipping.");
-                                            }
-                                            index.Name = name;
-                                            _database.IndexStore.CreateIndex(index);*/
-                                        }
-                                    }
-                                    break;
-                                case "Transformers":
-                                    result.TransformersCount++;
-                                    using (var transformerBuilder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.None, "Indexes", parser, state))
-                                    {
-                                        transformerBuilder.ReadNestedObject();
-                                        while (transformerBuilder.Read() == false)
-                                        {
-                                            var read = await stream.ReadAsync(buffer, 0, buffer.Length);
-                                            if (read == 0)
-                                                throw new EndOfStreamException("Stream ended without reaching end of json content");
-                                            parser.SetBuffer(buffer, read);
-                                        }
-                                        transformerBuilder.FinalizeDocument();
-                                        using (var reader = transformerBuilder.CreateReader())
-                                        {
-                                           /* var transformerDefinition = new TransformerDefinition();
-                                            // TODO: Import
-                                            _database.TransformerStore.CreateTransformer(transformerDefinition);*/
-                                        }
-                                    }
-                                    break;
-                                case "Identities":
-                                    result.IdentitiesCount++;
-                                    using (var identitiesBuilder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.None, "Identities", parser, state))
-                                    {
-                                        identitiesBuilder.ReadNestedObject();
-                                        while (identitiesBuilder.Read() == false)
-                                        {
-                                            var read = await stream.ReadAsync(buffer, 0, buffer.Length);
-                                            if (read == 0)
-                                                throw new EndOfStreamException("Stream ended without reaching end of json content");
-                                            parser.SetBuffer(buffer, read);
-                                        }
-                                        identitiesBuilder.FinalizeDocument();
-                                        using (var reader = identitiesBuilder.CreateReader())
-                                        {
-                                            try
-                                            {
-                                                string identityKey, identityValueString;
-                                                long identityValue;
-                                                if (reader.TryGet("Key", out identityKey) == false ||
-                                                    reader.TryGet("Value", out identityValueString) == false ||
-                                                    long.TryParse(identityValueString, out identityValue) == false)
-                                                {
-                                                    result.Warnings.Add($"Cannot import the following identity: '{reader}'. Skipping.");
-                                                }
-                                                else
-                                                {
-                                                    identities[identityKey] = identityValue;
-                                                }
-                                            }
-                                            catch (Exception e)
-                                            {
-                                                result.Warnings.Add($"Cannot import the following identity: '{reader}'. Error: {e}. Skipping.");
-                                            }
-                                        }
-                                    }
-                                    break;
-                                case "__top_start_object":
-                                    operateOnType = null;
-                                    break;
-                                default:
-                                    result.Warnings.Add($"The following type is not recognized: '{operateOnType}'. Skipping.");
-                                    using (var builder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.None, "NotRecognizedType", parser, state))
-                                    {
-                                        builder.ReadNestedObject();
-                                        while (builder.Read() == false)
-                                        {
-                                            var read = await stream.ReadAsync(buffer, 0, buffer.Length);
-                                            if (read == 0)
-                                                throw new EndOfStreamException("Stream ended without reaching end of json content");
-                                            parser.SetBuffer(buffer, read);
-                                        }
-                                        builder.FinalizeDocument();
-                                    }
+                                case "BuildVersion":
+                                    batchPutCommand.BuildVersion = state.Long;
                                     break;
                             }
+                            break;
+                        case JsonParserToken.StartObject:
+                            if (operateOnType == "__top_start_object")
+                            {
+                                operateOnType = null;
+                                break;
+                            }
+
+                            var builder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.ToDisk, "ImportObject", parser, state);
+                            builder.ReadNestedObject();
+                            while (builder.Read() == false)
+                            {
+                                var read = await stream.ReadAsync(buffer, 0, buffer.Length);
+                                if (read == 0)
+                                    throw new EndOfStreamException("Stream ended without reaching end of json content");
+                                parser.SetBuffer(buffer, read);
+                            }
+                            builder.FinalizeDocument();
+
+                            if (operateOnType == "Docs")
+                            {
+                                result.DocumentsCount++;
+
+                                batchPutCommand.Add(builder);
+                                if (batchPutCommand.Count >= 16)
+                                {
+                                    await _database.TxMerger.Enqueue(batchPutCommand);
+                                    batchPutCommand.Clean();
+                                }
+                            }
+                            else if (operateOnType == "VersioningRevisions")
+                            {
+                                if (versioningStorage == null)
+                                    break;
+
+                                result.VersioningRevisionDocumentsCount++;
+
+                                batchPutCommand.Add(builder);
+                                if (batchPutCommand.Count >= 16)
+                                {
+                                    await _database.TxMerger.Enqueue(batchPutCommand);
+                                    batchPutCommand.Clean();
+                                }
+                            }
+                            else
+                            {
+                                using (builder)
+                                {
+                                    switch (operateOnType)
+                                    {
+                                        case "Attachments":
+                                            result.Warnings.Add("Attachments are not supported anymore. Use RavenFS isntead. Skipping.");
+                                            break;
+                                        case "Indexes":
+                                            result.IndexesCount++;
+
+                                            using (var reader = builder.CreateReader())
+                                            {
+                                                /*   var index = new IndexDefinition();
+                                                   string name;
+                                                   if (reader.TryGet("Name", out name) == false)
+                                                   {
+                                                       result.Warnings.Add($"Cannot import the following index as it does not contain a name: '{reader}'. Skipping.");
+                                                   }
+                                                   index.Name = name;
+                                                   _database.IndexStore.CreateIndex(index);*/
+                                            }
+                                            break;
+                                        case "Transformers":
+                                            result.TransformersCount++;
+
+                                            using (var reader = builder.CreateReader())
+                                            {
+                                                /* var transformerDefinition = new TransformerDefinition();
+                                                 // TODO: Import
+                                                 _database.TransformerStore.CreateTransformer(transformerDefinition);*/
+                                            }
+                                            break;
+                                        case "Identities":
+                                            result.IdentitiesCount++;
+                                           
+                                            using (var reader = builder.CreateReader())
+                                            {
+                                                try
+                                                {
+                                                    string identityKey, identityValueString;
+                                                    long identityValue;
+                                                    if (reader.TryGet("Key", out identityKey) == false ||
+                                                        reader.TryGet("Value", out identityValueString) == false ||
+                                                        long.TryParse(identityValueString, out identityValue) == false)
+                                                    {
+                                                        result.Warnings.Add($"Cannot import the following identity: '{reader}'. Skipping.");
+                                                    }
+                                                    else
+                                                    {
+                                                        identities[identityKey] = identityValue;
+                                                    }
+                                                }
+                                                catch (Exception e)
+                                                {
+                                                    result.Warnings.Add($"Cannot import the following identity: '{reader}'. Error: {e}. Skipping.");
+                                                }
+                                            }
+                                            break;
+                                        default:
+                                            result.Warnings.Add($"The following type is not recognized: '{operateOnType}'. Skipping.");
+                                            break;
+                                    }
+                                }
+                            }
+
                             break;
                         case JsonParserToken.EndArray:
                             switch (operateOnType)
@@ -223,21 +188,21 @@ namespace Raven.Server.Smuggler
                                     if (batchPutCommand.Count > 0)
                                     {
                                         await _database.TxMerger.Enqueue(batchPutCommand);
-                                        batchPutCommand.Dispose();
-                                        batchPutCommand = null;
+                                        batchPutCommand.Clean();
                                     }
 
                                     // We are taking a reference here since the documents import can activate or disable the versioning.
                                     // We holad a local copy because the user can disable the bundle during the import process, exteranly.
                                     // In this case we want to continue to import the revisions documents.
                                     versioningStorage = _database.BundleLoader.VersioningStorage;
+                                    batchPutCommand.IsRevision = true;
                                     break;
                                 case "VersioningRevisions":
-                                    if (batchVerioningRevisionsPutCommand.Count > 0)
+                                    if (batchPutCommand.Count > 0)
                                     {
-                                        await _database.TxMerger.Enqueue(batchVerioningRevisionsPutCommand);
-                                        batchVerioningRevisionsPutCommand.Dispose();
-                                        batchVerioningRevisionsPutCommand = null;
+                                        await _database.TxMerger.Enqueue(batchPutCommand);
+                                        batchPutCommand.Clean();
+                                        batchPutCommand = null;
                                     }
                                     break;
                                 case "Identities":
@@ -257,10 +222,13 @@ namespace Raven.Server.Smuggler
             return result;
         }
 
-        private class MergedBatchPutCommand : TransactionOperationsMerger.MergedTransactionCommand, IDisposable
+        private class MergedBatchPutCommand : TransactionOperationsMerger.MergedTransactionCommand
         {
+            public long BuildVersion;
+            public bool IsRevision;
+
             private readonly DocumentDatabase _database;
-            private readonly List<IDisposable> _buildersToDispose = new List<IDisposable>();
+            private readonly List<BlittableJsonDocumentBuilder> _buildersToDispose = new List<BlittableJsonDocumentBuilder>();
             private readonly List<BlittableJsonReaderObject> _documents = new List<BlittableJsonReaderObject>();
 
             public MergedBatchPutCommand(DocumentDatabase database)
@@ -274,6 +242,7 @@ namespace Raven.Server.Smuggler
                 get { return _documents.Count; }
             }
 
+
             public override void Execute(DocumentsOperationContext context, RavenTransaction tx)
             {
                 foreach (var document in _documents)
@@ -291,11 +260,33 @@ namespace Raven.Server.Smuggler
                     mutatedMetadata.Remove(Constants.MetadataDocId);
                     mutatedMetadata.Remove(Constants.MetadataEtagId);
 
-                    _database.DocumentsStorage.Put(context, key, null, document);
+                    if (IsRevision)
+                    {
+                        long etag;
+                        if (metadata.TryGet(Constants.MetadataEtagId, out etag) == false)
+                            throw new InvalidOperationException("Document's metadata must include the document's key.");
+
+                        _database.BundleLoader.VersioningStorage.Put(context, key, etag, document);
+                    }
+                    else if (BuildVersion < 4000 && key.Contains("/revisions/"))
+                    {
+                        long etag;
+                        if (metadata.TryGet(Constants.MetadataEtagId, out etag) == false)
+                            throw new InvalidOperationException("Document's metadata must include the document's key.");
+
+                        var endIndex = key.IndexOf("/revisions/", StringComparison.OrdinalIgnoreCase);
+                        key = key.Substring(0, endIndex);
+
+                        _database.BundleLoader.VersioningStorage.Put(context, key, etag, document);
+                    }
+                    else
+                    {
+                        _database.DocumentsStorage.Put(context, key, null, document);
+                    }
                 }
             }
 
-            public void Dispose()
+            public void Clean()
             {
                 foreach (var documentBuilder in _buildersToDispose)
                 {
@@ -305,67 +296,8 @@ namespace Raven.Server.Smuggler
                 {
                     documentBuilder.Dispose();
                 }
-            }
-
-            public void Add(BlittableJsonDocumentBuilder documentBuilder)
-            {
-                _buildersToDispose.Add(documentBuilder);
-                var reader = documentBuilder.CreateReader();
-                _documents.Add(reader);
-            }
-        }
-
-        private class MergedBatchVerioningRevisionsPutCommand : TransactionOperationsMerger.MergedTransactionCommand, IDisposable
-        {
-            private readonly DocumentDatabase _database;
-            private readonly List<IDisposable> _buildersToDispose = new List<IDisposable>();
-            private readonly List<BlittableJsonReaderObject> _documents = new List<BlittableJsonReaderObject>();
-
-            public MergedBatchVerioningRevisionsPutCommand(DocumentDatabase database)
-            {
-                _database = database;
-            }
-
-            public int Count
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get { return _documents.Count; }
-            }
-
-            public override void Execute(DocumentsOperationContext context, RavenTransaction tx)
-            {
-                foreach (var document in _documents)
-                {
-                    BlittableJsonReaderObject metadata;
-                    if (document.TryGet(Constants.Metadata, out metadata) == false)
-                        throw new InvalidOperationException("A document must have a metadata");
-                    // We are using the id term here and not key in order to be backward compatiable with old export files.
-                    string key;
-                    if (metadata.TryGet(Constants.MetadataDocId, out key) == false)
-                        throw new InvalidOperationException("Document's metadata must include the document's key.");
-                    long etag;
-                    if (metadata.TryGet(Constants.MetadataEtagId, out etag) == false)
-                        throw new InvalidOperationException("Document's metadata must include the document's key.");
-
-                    DynamicJsonValue mutatedMetadata;
-                    metadata.Modifications = mutatedMetadata = new DynamicJsonValue(metadata);
-                    mutatedMetadata.Remove(Constants.MetadataDocId);
-                    mutatedMetadata.Remove(Constants.MetadataEtagId);
-
-                    _database.BundleLoader.VersioningStorage.Put(context, key, etag, document);
-                }
-            }
-
-            public void Dispose()
-            {
-                foreach (var documentBuilder in _buildersToDispose)
-                {
-                    documentBuilder.Dispose();
-                }
-                foreach (var documentBuilder in _documents)
-                {
-                    documentBuilder.Dispose();
-                }
+                _buildersToDispose.Clear();
+                _documents.Clear();
             }
 
             public void Add(BlittableJsonDocumentBuilder documentBuilder)

--- a/src/Raven.Server/Smuggler/DatabaseDataImporter.cs
+++ b/src/Raven.Server/Smuggler/DatabaseDataImporter.cs
@@ -23,6 +23,8 @@ namespace Raven.Server.Smuggler
         public DatabaseDataImporter(DocumentDatabase database)
         {
             _database = database;
+            OperateOnTypes = DatabaseItemType.Indexes | DatabaseItemType.Transformers
+                | DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Identities;
         }
 
         public async Task<ImportResult> Import(DocumentsOperationContext context, Stream stream)

--- a/src/Raven.Server/Smuggler/DatabaseDataImporter.cs
+++ b/src/Raven.Server/Smuggler/DatabaseDataImporter.cs
@@ -276,7 +276,7 @@ namespace Raven.Server.Smuggler
                         if (metadata.TryGet(Constants.MetadataEtagId, out etag) == false)
                             throw new InvalidOperationException("Document's metadata must include the document's key.");
 
-                        _database.BundleLoader.VersioningStorage.Put(context, key, etag, document);
+                        _database.BundleLoader.VersioningStorage.PutDirect(context, key, etag, document);
                     }
                     else if (BuildVersion < 4000 && key.Contains("/revisions/"))
                     {
@@ -287,7 +287,7 @@ namespace Raven.Server.Smuggler
                         var endIndex = key.IndexOf("/revisions/", StringComparison.OrdinalIgnoreCase);
                         key = key.Substring(0, endIndex);
 
-                        _database.BundleLoader.VersioningStorage.Put(context, key, etag, document);
+                        _database.BundleLoader.VersioningStorage.PutDirect(context, key, etag, document);
                     }
                     else
                     {

--- a/src/Raven.Server/Smuggler/ExportResult.cs
+++ b/src/Raven.Server/Smuggler/ExportResult.cs
@@ -3,6 +3,6 @@ namespace Raven.Server.Smuggler
     public class ExportResult
     {
         public long LastDocsEtag;
-        public long LastVersioningRevisionsEtag;
+        public long LastRevisionDocumentsEtag;
     }
 }

--- a/src/Raven.Server/Smuggler/ImportResult.cs
+++ b/src/Raven.Server/Smuggler/ImportResult.cs
@@ -5,7 +5,7 @@ namespace Raven.Server.Smuggler
     public class ImportResult
     {
         public long DocumentsCount;
-        public long VersioningRevisionDocumentsCount;
+        public long RevisionDocumentsCount;
         public long IndexesCount;
         public long TransformersCount;
         public long IdentitiesCount;

--- a/src/Raven.Server/Smuggler/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/SmugglerHandler.cs
@@ -4,8 +4,10 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using Raven.Client.Smuggler;
 using Raven.Server.Documents;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
@@ -21,11 +23,20 @@ namespace Raven.Server.Smuggler
             using (ContextPool.AllocateOperationContext(out context))
             using (context.OpenReadTransaction())
             {
-                new DatabaseDataExporter(Database)
+                var exporter = new DatabaseDataExporter(Database)
                 {
                     DocumentsLimit = GetIntValueQueryString("documentsLimit", required: false),
                     RevisionDocumentsLimit = GetIntValueQueryString("RevisionDocumentsLimit", required: false),
-                }.Export(context, ResponseBodyStream());
+                };
+
+                var operateOnTypes = GetStringQueryString("operateOnTypes", required: false);
+                DatabaseItemType databaseItemType;
+                if (Enum.TryParse(operateOnTypes, true, out databaseItemType))
+                {
+                    exporter.OperateOnTypes = databaseItemType;
+                }
+                
+                exporter.Export(context, ResponseBodyStream());
             }
             return Task.CompletedTask;
         }
@@ -39,7 +50,16 @@ namespace Raven.Server.Smuggler
             //TODO: detect gzip or not based on query string param
             using (var stream = new GZipStream(HttpContext.Request.Body, CompressionMode.Decompress))
             {
-                await new DatabaseDataImporter(Database).Import(context, stream);
+                var importer = new DatabaseDataImporter(Database);
+
+                var operateOnTypes = GetStringQueryString("operateOnTypes", required: false);
+                DatabaseItemType databaseItemType;
+                if (Enum.TryParse(operateOnTypes, true, out databaseItemType))
+                {
+                    importer.OperateOnTypes = databaseItemType;
+                }
+
+                await importer.Import(context, stream);
             }
         }
     }

--- a/src/Raven.Server/Smuggler/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/SmugglerHandler.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Smuggler
                 new DatabaseDataExporter(Database)
                 {
                     DocumentsLimit = GetIntValueQueryString("documentsLimit", required: false),
-                    VersioningRevisionsLimit = GetIntValueQueryString("versioningRevisionsLimit", required: false),
+                    RevisionDocumentsLimit = GetIntValueQueryString("RevisionDocumentsLimit", required: false),
                 }.Export(context, ResponseBodyStream());
             }
             return Task.CompletedTask;

--- a/src/Sparrow/Hashing.cs
+++ b/src/Sparrow/Hashing.cs
@@ -72,7 +72,7 @@ namespace Sparrow
         /// <summary>
         /// A port of the original XXHash algorithm from Google in 32bits 
         /// </summary>
-        /// <<remarks>The 32bits and 64bits hashes for the same data are different. In short those are 2 entirely different algorithms</remarks>
+        /// <remarks>The 32bits and 64bits hashes for the same data are different. In short those are 2 entirely different algorithms</remarks>
         public static class XXHash32
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -214,7 +214,7 @@ namespace Sparrow
         /// <summary>
         /// A port of the original XXHash algorithm from Google in 64bits 
         /// </summary>
-        /// <<remarks>The 32bits and 64bits hashes for the same data are different. In short those are 2 entirely different algorithms</remarks>
+        /// <remarks>The 32bits and 64bits hashes for the same data are different. In short those are 2 entirely different algorithms</remarks>
         public static class XXHash64
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/FastTests/Smuggler/SmugglerApiTests.cs
+++ b/test/FastTests/Smuggler/SmugglerApiTests.cs
@@ -105,7 +105,7 @@ namespace FastTests.Smuggler
 
                     var stats = await store1.AsyncDatabaseCommands.GetStatisticsAsync();
                     Assert.Equal(5, stats.CountOfDocuments);
-                    Assert.Equal(7, stats.CountOfVersioningRevisionDocuments);
+                    Assert.Equal(7, stats.CountOfRevisionDocuments);
                 }
 
                 using (var store2 = await GetDocumentStore(dbSuffixIdentifier: "store2"))
@@ -114,7 +114,7 @@ namespace FastTests.Smuggler
 
                     var stats = await store2.AsyncDatabaseCommands.GetStatisticsAsync();
                     Assert.Equal(5, stats.CountOfDocuments);
-                    Assert.Equal(7, stats.CountOfVersioningRevisionDocuments);
+                    Assert.Equal(7, stats.CountOfRevisionDocuments);
                 }
             }
             finally


### PR DESCRIPTION
And when importing old export file, make sure to put documents with /revisions/ in the key in the revisions storage
