### PR TITLE
RavenDB-4866

### DIFF
--- a/src/Sparrow/ByteString.cs
+++ b/src/Sparrow/ByteString.cs
@@ -27,12 +27,12 @@ namespace Sparrow
         UserDefined4 = 0x80,
 
         /// <summary>
-        /// Use this value to mask out the user defined bits using the & (Bitwise AND) operator.
+        /// Use this value to mask out the user defined bits using the (Bitwise AND) operator.
         /// </summary>
         ByteStringMask = 0x0F,
 
         /// <summary>
-        /// Use this value to mask out the ByteStringType bits using the & (Bitwise AND) operator.
+        /// Use this value to mask out the ByteStringType bits using the (Bitwise AND) operator.
         /// </summary>
         UserDefinedMask = 0xF0
     }
@@ -332,12 +332,64 @@ namespace Sparrow
         }
     }
 
+    sealed class UnmanagedGlobalSegment : IDisposable
+    {
+        public readonly IntPtr Segment;
+        public readonly int Size;
+
+        public UnmanagedGlobalSegment(int size)
+        {
+            Size = size;
+            Segment = Marshal.AllocHGlobal(size);
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                disposedValue = true;
+
+                if (disposing)
+                {
+
+                }
+
+                if (Segment != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(Segment);                    
+                }
+            }
+        }
+
+        ~UnmanagedGlobalSegment()
+        {            
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);            
+        }
+        #endregion
+    }
 
     public unsafe class ByteStringContext : IDisposable
-    {
-        class SegmentInformation
+    {        
+        private static readonly ObjectPool<UnmanagedGlobalSegment, int> _globalPool = new ObjectPool<UnmanagedGlobalSegment, int>(size => new UnmanagedGlobalSegment(size), 50);
+
+        private class SegmentInformation
         {
-            public bool CanDispose; 
+            public bool CanDispose;
+
+            public UnmanagedGlobalSegment Memory;
 
             public byte* Start;
             public byte* Current;
@@ -359,7 +411,8 @@ namespace Sparrow
         public const int MinBlockSizeInBytes = 64 * 1024; // If this is changed, we need to change also LogMinBlockSize.
         private const int LogMinBlockSize = 16;
 
-        public const int DefaultAllocationBlockSizeInBytes = 2 * MinBlockSizeInBytes;
+        public const int MaxAllocationBlockSizeInBytes = 256 * MinBlockSizeInBytes; 
+        public const int DefaultAllocationBlockSizeInBytes = 1 * MinBlockSizeInBytes; 
         public const int MinReusableBlockSizeInBytes = 8;
         
         /// <summary>
@@ -552,8 +605,10 @@ namespace Sparrow
                 return byteString;
             }
         }
+
         [ThreadStatic]
         private static char[] _toLowerTempBuffer;
+
         /// <summary>
         /// Mutate the string to lower case
         /// </summary>
@@ -586,6 +641,7 @@ namespace Sparrow
                 str._pointer->Length = Encoding.UTF8.GetBytes(pChars, charCount, str._pointer->Ptr, str._pointer->Size);
             }
         }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ByteString Create(void* ptr, int length, int size, ByteStringType type = ByteStringType.Immutable)
         {
@@ -605,8 +661,22 @@ namespace Sparrow
 
         private ByteString AllocateWholeSegment(int length, ByteStringType type)
         {
-            // The allocation is big, therefore we will just allocate the segment and move on.                
-            var segment = AllocateSegment(length + sizeof(ByteStringStorage));
+            // The allocation is big, therefore we will just allocate the segment and move on.   
+
+            SegmentInformation segment;
+            if (length > MaxAllocationBlockSizeInBytes)
+            {
+                var memory = new UnmanagedGlobalSegment(length);
+                byte* start = (byte*)memory.Segment.ToPointer();
+                byte* end = start + memory.Size;
+                                
+                segment = new SegmentInformation { Memory = memory, Start = start, Current = start, End = end, CanDispose = true };
+                _wholeSegments.Add(segment);
+            }
+            else
+            {                                                     
+                segment = AllocateSegment(length + sizeof(ByteStringStorage));
+            }
 
             var byteString = Create(segment.Current, length, segment.Size, type);
             segment.Current += byteString._pointer->Size;
@@ -704,6 +774,7 @@ namespace Sparrow
                     byte* start = (byte*)value._pointer;
                     byte* end = start + value._pointer->Size;
 
+                    // Given that this is put into a reuse queue, we are not providing the Segment because it has no ownership of it.
                     var segment = new SegmentInformation { Start = start, Current = start, End = end, CanDispose = false };
                     _internalReadyToUseMemorySegments.Add(segment);
                 }
@@ -725,10 +796,19 @@ namespace Sparrow
 
         private SegmentInformation AllocateSegment(int size)
         {
-            byte* start = (byte*)Marshal.AllocHGlobal(size).ToPointer();
-            byte* end = start + size;
+            // We try to allocate from the pool (fast allocate).
+            var memorySegment = _globalPool.Allocate(size);
+            if (memorySegment.Size < size)
+            {
+                // The size is not big enough. We don't care, we will pay the cost and be done with it. 
+                _globalPool.Free(memorySegment);
+                memorySegment = _globalPool.AllocateInstance(size);
+            }            
 
-            var segment = new SegmentInformation { Start = start, Current = start, End = end, CanDispose = true };
+            byte* start = (byte*)memorySegment.Segment.ToPointer();
+            byte* end = start + memorySegment.Size;
+
+            var segment = new SegmentInformation { Memory = memorySegment, Start = start, Current = start, End = end, CanDispose = true };
             _wholeSegments.Add(segment);
 
             return segment;
@@ -737,10 +817,19 @@ namespace Sparrow
 
         private void AllocateExternalSegment(int size)
         {
-            byte* start = (byte*)Marshal.AllocHGlobal(size).ToPointer();
-            byte* end = start + size;
+            // We try to allocate from the pool (fast allocate).
+            var memorySegment = _globalPool.Allocate(size);
+            if (memorySegment.Size < size)
+            {
+                // The size is not big enough. We don't care, we will pay the cost and be done with it. 
+                _globalPool.Free(memorySegment);
+                memorySegment = _globalPool.AllocateInstance(size);
+            }
 
-            _externalCurrent = new SegmentInformation { Start = start, Current = start, End = end, CanDispose = true };
+            byte* start = (byte*)memorySegment.Segment.ToPointer();
+            byte* end = start + memorySegment.Size;
+
+            _externalCurrent = new SegmentInformation { Memory = memorySegment, Start = start, Current = start, End = end, CanDispose = true };
             _externalAlignedSize = (sizeof(ByteStringStorage) + (sizeof(long) - sizeof(ByteStringStorage) % sizeof(long)));
             _externalCurrentLeft = (int)(_externalCurrent.End - _externalCurrent.Start) / _externalAlignedSize;
 
@@ -925,7 +1014,7 @@ namespace Sparrow
             // There shouldn't be reuse for the storage, unless we have a different allocation on reused memory.
             // Therefore, monotonically increasing the key we ensure that we can check when we have dangling pointers in our code.
             // We use interlocked in order to avoid validation bugs when validating (we are playing it safe).
-            ((ByteStringStorage*)storage)->Key = (ulong)(((long)this.ContextId << 32) + Interlocked.Increment(ref _allocationCount)); ;
+            ((ByteStringStorage*)storage)->Key = (ulong)(((long)this.ContextId << 32) + Interlocked.Increment(ref _allocationCount));
         }
 
         private void RegisterForValidation(ByteString value)
@@ -1005,33 +1094,45 @@ namespace Sparrow
                 if (disposing)
                 {
                     // TODO: dispose managed state (managed objects).
-                }
-
 #if VALIDATE
-                foreach ( var item in _immutableTracker.ToArray() )
-                {
-                    var storage = (ByteStringStorage*) item.Value.Item1.ToPointer();
+                    foreach (var item in _immutableTracker.ToArray())
+                    {
+                        var storage = (ByteStringStorage*)item.Value.Item1.ToPointer();
 
-                    ValidateAndUnregister(storage);
-                }
+                        ValidateAndUnregister(storage);
+                    }
 #endif
 
-                foreach (var segment in _wholeSegments)
-                {
-                    if ( segment.CanDispose)
-                        Marshal.FreeHGlobal(new IntPtr(segment.Start));
-                }
+                    foreach (var segment in _wholeSegments)
+                    {
+                        if (segment.CanDispose)
+                        {
+                            // Check if we have allocated from the pool or directly.
+                            if (segment.Memory.Size > MaxAllocationBlockSizeInBytes)
+                            {
+                                segment.Memory.Dispose();
+                            }
+                            else
+                            {
+                                // We have allocated from the pool. Then we are releasing it. 
+                                _globalPool.Free(segment.Memory);
+                            }
+                        }
+                    }
 
-                _wholeSegments.Clear();
-                _internalReadyToUseMemorySegments.Clear();
+                    _wholeSegments.Clear();
+                    _internalReadyToUseMemorySegments.Clear();
+                }
 
                 isDisposed = true;
             }
         }
 
         // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-         ~ByteStringContext()
+        ~ByteStringContext()
         {
+
+
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(false);
         }
@@ -1044,7 +1145,7 @@ namespace Sparrow
             GC.SuppressFinalize(this);
         }
 
-        #endregion
+#endregion
     }
 
     public class ByteStringValidationException : Exception

--- a/src/Sparrow/ObjectPool.cs
+++ b/src/Sparrow/ObjectPool.cs
@@ -1,20 +1,21 @@
 
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the Roslyn project root for license information.
 
-// define TRACE_LEAKS to get additional diagnostics that can lead to the leak sources. note: it will
-// make everything about 2-3x slower
-// 
+//// define TRACE_LEAKS to get additional diagnostics that can lead to the leak sources. note: it will
+//// make everything about 2-3x slower
+//// 
 //#define TRACE_LEAKS
 
-// define DETECT_LEAKS to detect possible leaks
+//// define DETECT_LEAKS to detect possible leaks
 //#if DEBUG
 //    #define DETECT_LEAKS  //for now always enable DETECT_LEAKS in debug.
 //#endif
 
 namespace Sparrow
-{    
+{
     using System;
     using System.Diagnostics;
+    using System.Runtime.CompilerServices;
     using System.Threading;
 
 #if DETECT_LEAKS
@@ -213,6 +214,282 @@ namespace Sparrow
                     break;
                 }
             }
+        }
+
+        /// <summary>
+        /// Removes an object from leak tracking.  
+        /// 
+        /// This is called when an object is returned to the pool.  It may also be explicitly 
+        /// called if an object allocated from the pool is intentionally not being returned
+        /// to the pool.  This can be of use with pooled arrays if the consumer wants to 
+        /// return a larger array to the pool than was originally allocated.
+        /// </summary>
+        [Conditional("DEBUG")]
+        public void ForgetTrackedObject(T old, T replacement = null)
+        {
+#if DETECT_LEAKS
+        LeakTracker tracker;
+        if (leakTrackers.TryGetValue(old, out tracker))
+        {
+            tracker.Dispose();
+            leakTrackers.Remove(old);
+        }
+        else
+        {
+            var trace = CaptureStackTrace();
+            Debug.WriteLine(string.Format("TRACEOBJECTPOOLLEAKS_BEGIN\nObject of type {0} was freed, but was not from pool. \n Callstack: \n {1} TRACEOBJECTPOOLLEAKS_END", typeof(T), trace));
+        }
+
+        if (replacement != null)
+        {
+            tracker = new LeakTracker();
+            leakTrackers.Add(replacement, tracker);
+        }
+#endif
+        }
+
+#if DETECT_LEAKS
+    private static Lazy<Type> _stackTraceType = new Lazy<Type>(() => Type.GetType("System.Diagnostics.StackTrace"));
+
+    private static object CaptureStackTrace()
+    {
+        return Activator.CreateInstance(_stackTraceType.Value);
+    }
+#endif
+
+        [Conditional("DEBUG")]
+        private void Validate(object obj)
+        {
+            Debug.Assert(obj != null, "freeing null?");
+
+            var items = _items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                var value = items[i].Value;
+                if (value == null)
+                {
+                    return;
+                }
+
+                Debug.Assert(value != obj, "freeing twice?");
+            }
+        }
+    }
+
+
+
+    /// <summary>
+    /// Generic implementation of object pooling pattern with predefined pool size limit. The main
+    /// purpose is that limited number of frequently used objects can be kept in the pool for
+    /// further recycling.
+    /// 
+    /// Notes: 
+    /// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
+    ///    is no space in the pool, extra returned objects will be dropped.
+    /// 
+    /// 2) it is implied that if object was obtained from a pool, the caller will return it back in
+    ///    a relatively short time. Keeping checked out objects for long durations is ok, but 
+    ///    reduces usefulness of pooling. Just new up your own.
+    /// 
+    /// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice. 
+    /// Rationale: 
+    ///    If there is no intent for reusing the object, do not use pool - just use "new". 
+    /// </summary>
+    public class ObjectPool<T, TFactoryParam> where T : class
+    {
+        private struct Element
+        {
+            internal T Value;
+        }
+
+        /// <remarks>
+        /// Not using System.Func{T} because this file is linked into the (debugger) Formatter,
+        /// which does not have that type (since it compiles against .NET 2.0).
+        /// </remarks>
+        public delegate T Factory(TFactoryParam param);
+
+        // Storage for the pool objects. The first item is stored in a dedicated field because we
+        // expect to be able to satisfy most requests from it.
+        private T _firstItem;
+        private readonly Element[] _items;
+
+        // factory is stored for the lifetime of the pool. We will call this only when pool needs to
+        // expand. compared to "new T()", Func gives more flexibility to implementers and faster
+        // than "new T()".
+        private readonly Factory _factory;
+
+#if DETECT_LEAKS
+    private static readonly ConditionalWeakTable<T, LeakTracker> leakTrackers = new ConditionalWeakTable<T, LeakTracker>();
+
+    private class LeakTracker : IDisposable
+    {
+        private volatile bool disposed;
+
+#if TRACE_LEAKS
+        internal volatile object Trace = null;
+#endif
+
+        public void Dispose()
+        {
+            disposed = true;
+            GC.SuppressFinalize(this);
+        }
+
+        private string GetTrace()
+        {
+#if TRACE_LEAKS
+            return Trace == null ? "" : Trace.ToString();
+#else
+            return "Leak tracing information is disabled. Define TRACE_LEAKS on ObjectPool`1.cs to get more info \n";
+#endif
+        }
+
+        ~LeakTracker()
+        {
+            if (!this.disposed && !Environment.HasShutdownStarted)
+            {
+                var trace = GetTrace();
+
+                // If you are seeing this message it means that object has been allocated from the pool 
+                // and has not been returned back. This is not critical, but turns pool into rather 
+                // inefficient kind of "new".
+                Debug.WriteLine(string.Format("TRACEOBJECTPOOLLEAKS_BEGIN\nPool detected potential leaking of {0}. \n Location of the leak: \n {1} TRACEOBJECTPOOLLEAKS_END", typeof(T), GetTrace()));
+            }
+        }
+    }
+#endif
+
+        public ObjectPool(Factory factory)
+            : this(factory, Environment.ProcessorCount * 2)
+        { }
+
+        public ObjectPool(Factory factory, int size)
+        {
+            Debug.Assert(size >= 1);
+            _factory = factory;
+            _items = new Element[size - 1];
+        }
+
+        private T CreateInstance(TFactoryParam param)
+        {
+            var inst = _factory(param);
+            return inst;
+        }
+
+        public T AllocateInstance(TFactoryParam param)
+        {
+            T inst = CreateInstance(param);
+
+#if DETECT_LEAKS
+            var tracker = new LeakTracker();
+            leakTrackers.Add(inst, tracker);
+
+#if TRACE_LEAKS
+            var frame = CaptureStackTrace();
+            tracker.Trace = frame;
+#endif
+#endif
+            return inst;
+        }
+
+        /// <summary>
+        /// Produces an instance.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically 
+        /// reducing how far we will typically search.
+        /// </remarks>
+        public T Allocate(TFactoryParam param)
+        {
+            // PERF: Examine the first element. If that fails, AllocateSlow will look at the remaining elements.
+            // Note that the initial read is optimistically not synchronized. That is intentional. 
+            // We will interlock only when we have a candidate. in a worst case we may miss some
+            // recently returned objects. Not a big deal.
+            T inst = _firstItem;
+            if (inst == null || inst != Interlocked.CompareExchange(ref _firstItem, null, inst))
+            {
+                inst = AllocateSlow(param);
+            }
+
+#if DETECT_LEAKS
+        var tracker = new LeakTracker();
+        leakTrackers.Add(inst, tracker);
+
+#if TRACE_LEAKS
+        var frame = CaptureStackTrace();
+        tracker.Trace = frame;
+#endif
+#endif
+            return inst;
+        }
+
+        
+
+        private T AllocateSlow(TFactoryParam param)
+        {
+            var items = _items;
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                // Note that the initial read is optimistically not synchronized. That is intentional. 
+                // We will interlock only when we have a candidate. in a worst case we may miss some
+                // recently returned objects. Not a big deal.
+                T inst = items[i].Value;
+                if (inst != null)
+                {
+                    if (inst == Interlocked.CompareExchange(ref items[i].Value, null, inst))
+                    {
+                        return inst;
+                    }
+                }
+            }
+
+            return CreateInstance(param);
+        }
+
+        /// <summary>
+        /// Returns objects to the pool.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically 
+        /// reducing how far we will typically search in Allocate.
+        /// </remarks>
+        public void Free(T obj)
+        {
+            Validate(obj);
+            ForgetTrackedObject(obj);
+
+            if (_firstItem == null)
+            {
+                // Intentionally not using interlocked here. 
+                // In a worst case scenario two objects may be stored into same slot.
+                // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                _firstItem = obj;
+            }
+            else
+            {
+                FreeSlow(obj);
+            }            
+        }
+
+        private void FreeSlow(T obj)
+        {
+            var items = _items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i].Value == null)
+                {
+                    // Intentionally not using interlocked here. 
+                    // In a worst case scenario two objects may be stored into same slot.
+                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                    items[i].Value = obj;
+                    return;
+                }
+            }
+
+            using (obj as IDisposable) { }
         }
 
         /// <summary>

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -24,6 +24,7 @@ namespace Voron.Impl
         private readonly StorageEnvironment _env;
         private readonly long _id;
         private readonly ByteStringContext _allocator;
+        private readonly bool _disposeAllocator;
         private readonly PageCache _pageCache;
         private Tree _root;
 
@@ -106,6 +107,7 @@ namespace Voron.Impl
             _id = id;
             _freeSpaceHandling = freeSpaceHandling;
             _allocator = context ?? new ByteStringContext();
+            _disposeAllocator = context == null;
             _pageCache = new PageCache(this, 8);
 
             Flags = flags;
@@ -468,6 +470,9 @@ namespace Voron.Impl
             {
                 pagerState.Release();
             }
+
+            if (_disposeAllocator)
+                _allocator.Dispose();
         }
 
         internal void FreePageOnCommit(long pageNumber)


### PR DESCRIPTION
RavenDB-4866: Performance degradation is being caused by memory fragmentation.

The current ByteStringContext change will try to diminish the fragmentation keeping track of a global pool. While potentially complicated to fix the issue for good, this is an initial approximation (good enough) to deal with the issue. More strict long term performance profiling should be performed to ensure that this strategy can lower fragmentation of the unmanaged heap to the point we need it.
