### PR TITLE
RavenDB-3948 & RavenDB-4892

### DIFF
--- a/Raven.Database/Util/DebugInfoProvider.cs
+++ b/Raven.Database/Util/DebugInfoProvider.cs
@@ -480,6 +480,7 @@ internal static object GetRequestTrackingForDebug(RequestManager requestManager,
             {
                 var prefetcherDocs = prefetchingBehavior.DebugGetDocumentsInPrefetchingQueue().ToArray();
                 var futureBatches = prefetchingBehavior.DebugGetDocumentsInFutureBatches();
+                var ioSummary = prefetchingBehavior.DebugIOSummary();
 
                 var compareToCollection = new Dictionary<Etag, int>();
 
@@ -511,6 +512,7 @@ internal static object GetRequestTrackingForDebug(RequestManager requestManager,
                     result.Add(new
                     {
                         Default = prefetchingBehavior.IsDefault,
+                        IOSummary = ioSummary,
                         Indexes = indexesText,
                         LastIndexedEtag = prefetchingBehavior.LastIndexedEtag,
                         LastTimeUsed = lastTimeUsed,
@@ -536,6 +538,7 @@ internal static object GetRequestTrackingForDebug(RequestManager requestManager,
                     result.Add(new
                     {
                         Default = prefetchingBehavior.IsDefault,
+                        IOSummary = ioSummary,
                         Indexes = indexesText,
                         LastIndexedEtag = prefetchingBehavior.LastIndexedEtag,
                         LastTimeUsed = lastTimeUsed,


### PR DESCRIPTION
RavenDB-3948 Add loadTimes to the prefetching debug endpoint
http://issues.hibernatingrhinos.com/issue/RavenDB-3948

RavenDB-4892 FutureBatch should be canceled if it isn't needed
http://issues.hibernatingrhinos.com/issue/RavenDB-4892
