### PR TITLE
RavenDB-4794 Fix the FailoverBehavior

### DIFF
--- a/Raven.Abstractions/Cluster/ClusterInformation.cs
+++ b/Raven.Abstractions/Cluster/ClusterInformation.cs
@@ -13,19 +13,24 @@ namespace Raven.Abstractions.Cluster
         {
         }
 
-        public ClusterInformation(bool isInCluster, bool isLeader)
+        public ClusterInformation(bool isInCluster, bool isLeader, bool withClusterFailoverHeader = false)
         {
             IsInCluster = isInCluster;
             IsLeader = isInCluster && isLeader;
+            WithClusterFailoverHeader = withClusterFailoverHeader;
         }
 
         public bool IsInCluster { get; set; }
 
         public bool IsLeader { get; set; }
 
+        public bool WithClusterFailoverHeader { get; set; }
+
         protected bool Equals(ClusterInformation other)
         {
-            return IsInCluster.Equals(other.IsInCluster) && IsLeader.Equals(other.IsLeader);
+            return IsInCluster.Equals(other.IsInCluster) 
+                && IsLeader.Equals(other.IsLeader) 
+                && WithClusterFailoverHeader.Equals(other.WithClusterFailoverHeader);
         }
 
         public override bool Equals(object obj)
@@ -49,7 +54,7 @@ namespace Raven.Abstractions.Cluster
         {
             unchecked
             {
-                return (IsInCluster.GetHashCode() * 397) ^ IsLeader.GetHashCode();
+                return (IsInCluster.GetHashCode() * 397) ^ IsLeader.GetHashCode() ^ WithClusterFailoverHeader.GetHashCode();
             }
         }
     }

--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -130,7 +130,7 @@ namespace Raven.Client.Connection.Async
         {
             return ExecuteWithReplication(HttpMethod.Get, async (operationMetadata, requestTimeMetric) =>
             {
-                using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.IndexNames(start, pageSize), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.IndexNames(start, pageSize), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
                 {
                     var json = (RavenJArray)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                     return json.Select(x => x.Value<string>()).ToArray();
@@ -145,7 +145,7 @@ namespace Raven.Client.Connection.Async
                 var operationUrl = operationMetadata.Url + "/indexes/?start=" + start + "&pageSize=" + pageSize;
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationUrl, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
 
                     var json = (RavenJArray)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                     //NOTE: To review, I'm not confidence this is the correct way to deserialize the index definition
@@ -165,7 +165,7 @@ namespace Raven.Client.Connection.Async
                 var operationUrl = operationMetadata.Url + "/transformers?start=" + start + "&pageSize=" + pageSize;
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationUrl, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
 
                     var json = (RavenJArray)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
 
@@ -183,7 +183,7 @@ namespace Raven.Client.Connection.Async
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationUrl, HttpMethod.Post, operationMetadata.Credentials, convention)))
                 {
                     request.AddOperationHeaders(OperationsHeaders);
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
 
                     return await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                 }
@@ -205,7 +205,7 @@ namespace Raven.Client.Connection.Async
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/indexes/" + name, HttpMethods.Reset, operationMetadata.Credentials, convention, requestTimeMetric)))
                 {
                     request.AddOperationHeaders(OperationsHeaders);
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
 
                     return await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                 }
@@ -220,7 +220,7 @@ namespace Raven.Client.Connection.Async
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationUrl, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric)))
                 {
                     request.AddOperationHeaders(OperationsHeaders);
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
 
                     return await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                 }
@@ -234,7 +234,7 @@ namespace Raven.Client.Connection.Async
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationUrl, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric)))
                 {
                     request.AddOperationHeaders(OperationsHeaders);
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
 
                     return await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                 }
@@ -261,7 +261,7 @@ namespace Raven.Client.Connection.Async
             var requestUri = operationMetadata.Url.Indexes(name) + "?op=hasChanged";
             using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUri, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
             {
-                request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
 
                 var serializeObject = JsonConvert.SerializeObject(indexDef, Default.Converters);
 
@@ -301,7 +301,7 @@ namespace Raven.Client.Connection.Async
             var requestUri = operationMetadata.Url + "/indexes/" + Uri.EscapeUriString(name) + "?definition=yes";
             using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUri, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
             {
-                request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
 
                 try
                 {
@@ -427,7 +427,7 @@ namespace Raven.Client.Connection.Async
             {
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.Indexes(name), HttpMethod.Delete, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(operationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
                     await request.ExecuteRequestAsync().WithCancellation(token).ConfigureAwait(false);
                 }
             }, token);
@@ -448,7 +448,7 @@ namespace Raven.Client.Connection.Async
                 token.ThrowCancellationIfNotDefault(); //maybe the operation is canceled and we can spare the request..
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, path, HttpMethod.Delete, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader);
                     RavenJToken jsonResponse;
                     try
                     {
@@ -476,7 +476,7 @@ namespace Raven.Client.Connection.Async
             {
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.Transformer(name), HttpMethod.Delete, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(operationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
                     await request.ExecuteRequestAsync().WithCancellation(token).ConfigureAwait(false);
                 }
             }, token);
@@ -604,7 +604,7 @@ namespace Raven.Client.Connection.Async
 
             using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/docs/" + key, method, metadata, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
             {
-                request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                 ErrorResponseException responseException;
                 try
@@ -686,7 +686,7 @@ namespace Raven.Client.Connection.Async
             {
                 try
                 {
-                    using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.Transformer(name), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                    using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.Transformer(name), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
                     {
                         var transformerDefinitionJson = (RavenJObject)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                         var value = transformerDefinitionJson.Value<RavenJObject>("Transformer");
@@ -709,7 +709,7 @@ namespace Raven.Client.Connection.Async
             {
                 try
                 {
-                    using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.IndexDefinition(name), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                    using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.IndexDefinition(name), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
                     {
                         var indexDefinitionJson = (RavenJObject)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                         var value = indexDefinitionJson.Value<RavenJObject>("Index");
@@ -732,7 +732,7 @@ namespace Raven.Client.Connection.Async
             return ExecuteWithReplication(HttpMethod.Get, async (operationMetadata, requestTimeMetric) =>
             {
                 var url = operationMetadata.Url.IndexingPerformanceStatistics();
-                using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, url, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, url, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
                 {
                     var indexingPerformanceStatisticsJson = (RavenJArray)await request.ReadResponseJsonAsync().ConfigureAwait(false);
                     var results = new IndexingPerformanceStatistics[indexingPerformanceStatisticsJson.Length];
@@ -771,7 +771,7 @@ namespace Raven.Client.Connection.Async
 
             using (var request = jsonRequestFactory.CreateHttpJsonRequest(
                 createHttpJsonRequestParams.AddOperationHeaders(OperationsHeaders))
-                                           .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                                           .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 Task<JsonDocument> resolveConflictTask;
                 try
@@ -852,7 +852,7 @@ namespace Raven.Client.Connection.Async
             var createHttpJsonRequestParams = new CreateHttpJsonRequestParams(this, path, method, metadata, operationMetadata.Credentials, convention)
                 .AddOperationHeaders(OperationsHeaders);
             using (var request = jsonRequestFactory.CreateHttpJsonRequest(createHttpJsonRequestParams)
-                .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 if (isGet == false)
                 {
@@ -1073,7 +1073,7 @@ namespace Raven.Client.Connection.Async
 
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUri, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     var cachedRequestDetails = jsonRequestFactory.ConfigureCaching(requestUri, (key, val) => request.AddHeader(key, val));
                     request.CachedRequestDetails = cachedRequestDetails.CachedRequest;
@@ -1185,7 +1185,7 @@ namespace Raven.Client.Connection.Async
 
                 if (method == HttpMethod.Get)
                     requestUri += "&facets=" + Uri.EscapeDataString(facetsJson);
-                using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUri, method, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUri, method, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
                 {
                     if (method != HttpMethod.Get)
                     {
@@ -1230,7 +1230,7 @@ namespace Raven.Client.Connection.Async
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUri, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)))
                 {
                     request.AddOperationHeaders(OperationsHeaders);
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     var result = await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                     return convention.CreateSerializer().Deserialize<LogItem[]>(new RavenJTokenReader(result));
@@ -1316,7 +1316,7 @@ namespace Raven.Client.Connection.Async
 
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, actualUrl, HttpMethod.Get, metadata, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     var result = (RavenJArray)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
 
@@ -1353,7 +1353,7 @@ namespace Raven.Client.Connection.Async
 
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, multiGetOperation.RequestUri, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     var requestsForServer = multiGetOperation.PreparingForCachingRequest(jsonRequestFactory);
 
@@ -1409,7 +1409,7 @@ namespace Raven.Client.Connection.Async
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, path, method, operationMetadata.Credentials, convention, requestTimeMetric) { AvoidCachingRequest = query.DisableCaching }.AddOperationHeaders(OperationsHeaders)))
                 {
                     RavenJObject json = null;
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     json = (RavenJObject)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
 
@@ -1549,7 +1549,7 @@ namespace Raven.Client.Connection.Async
 
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, requestUri, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     var json = (RavenJObject)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                     return new SuggestionQueryResult { Suggestions = ((RavenJArray)json["Suggestions"]).Select(x => x.Value<string>()).ToArray(), };
@@ -1566,7 +1566,7 @@ namespace Raven.Client.Connection.Async
 
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/bulk_docs", HttpMethod.Post, metadata, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     var serializedData = commandDatas.Select(x => x.ToJson()).ToList();
                     var jArray = new RavenJArray(serializedData);
@@ -1669,7 +1669,7 @@ namespace Raven.Client.Connection.Async
             {
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/static/?pageSize=" + pageSize + "&etag=" + startEtag + "&start=" + start, HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     var json = (RavenJArray)await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                     return convention.CreateSerializer().Deserialize<AttachmentInformation[]>(new RavenJTokenReader(json));
@@ -1693,7 +1693,7 @@ namespace Raven.Client.Connection.Async
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, Static(operationMetadata.Url, key), HttpMethod.Put, metadata, operationMetadata.Credentials, convention, requestTimeMetric)))
                 {
                     request.AddOperationHeaders(OperationsHeaders);
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     await request.WriteAsync(data).WithCancellation(token).ConfigureAwait(false);
                 }
@@ -1722,7 +1722,7 @@ namespace Raven.Client.Connection.Async
             var metadata = new RavenJObject();
             AddTransactionInformation(metadata);
             var createHttpJsonRequestParams = new CreateHttpJsonRequestParams(this, (operationMetadata.Url + "/static/" + key), method, metadata, operationMetadata.Credentials, convention, requestTimeMetric);
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(createHttpJsonRequestParams.AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(createHttpJsonRequestParams.AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 ErrorResponseException responseException;
                 try
@@ -1799,7 +1799,7 @@ namespace Raven.Client.Connection.Async
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, Static(operationMetadata.Url, key), HttpMethod.Delete, metadata, operationMetadata.Credentials, convention, requestTimeMetric)))
                 {
                     request.AddOperationHeaders(OperationsHeaders);
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
                     return request.ExecuteRequestAsync();
                 }
@@ -1820,7 +1820,7 @@ namespace Raven.Client.Connection.Async
         {
             return ExecuteWithReplication(HttpMethod.Get, async (operationMetadata, requestTimeMetric) =>
             {
-                using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.Terms(index, field, fromValue, pageSize), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.Terms(index, field, fromValue, pageSize), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
                 {
                     var result = await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
                     var json = ((RavenJArray)result);
@@ -1918,7 +1918,7 @@ namespace Raven.Client.Connection.Async
             var request = jsonRequestFactory
                 .CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, path, method, operationMetadata.Credentials, convention, requestTimeMetric)
                 .AddOperationHeaders(OperationsHeaders))
-                .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
             request.RemoveAuthorizationHeader();
 
@@ -2230,7 +2230,7 @@ namespace Raven.Client.Connection.Async
             var request = jsonRequestFactory
                 .CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, sb.ToString(), HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric)
                 .AddOperationHeaders(OperationsHeaders))
-                .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
 
             request.RemoveAuthorizationHeader();
 
@@ -2278,7 +2278,7 @@ namespace Raven.Client.Connection.Async
             {
                 using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url.Doc(key), HttpMethod.Delete, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(operationsHeaders)))
                 {
-                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url);
+                    request.AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader );
                     if (etag != null)
                         request.AddHeader("If-None-Match", etag);
 
@@ -2313,7 +2313,7 @@ namespace Raven.Client.Connection.Async
         {
             var metadata = new RavenJObject();
             AddTransactionInformation(metadata);
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/docs/" + key, HttpMethod.Head, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/docs/" + key, HttpMethod.Head, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 try
                 {
@@ -2367,6 +2367,7 @@ namespace Raven.Client.Connection.Async
             createHttpJsonRequestParams.DisableRequestCompression = disableRequestCompression;
             createHttpJsonRequestParams.DisableAuthentication = disableAuthentication;
 
+
             return jsonRequestFactory.CreateHttpJsonRequest(createHttpJsonRequestParams)
                                      .AddRequestExecuterAndReplicationHeaders(this, currentServerUrl);
         }
@@ -2384,7 +2385,7 @@ namespace Raven.Client.Connection.Async
             {
                 metadata[Constants.MetadataEtagField] = etag.ToString();
             }
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/static/" + key, HttpMethod.Post, metadata, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/static/" + key, HttpMethod.Post, metadata, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 ErrorResponseException responseException;
                 try
@@ -2409,7 +2410,7 @@ namespace Raven.Client.Connection.Async
         [Obsolete("Use RavenFS instead.")]
         private async Task<IAsyncEnumerator<Attachment>> DirectGetAttachmentHeadersStartingWith(HttpMethod method, string idPrefix, int start, int pageSize, OperationMetadata operationMetadata, IRequestTimeMetric requestTimeMetric, CancellationToken token = default(CancellationToken))
         {
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/static/?startsWith=" + idPrefix + "&start=" + start + "&pageSize=" + pageSize, method, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/static/?startsWith=" + idPrefix + "&start=" + start + "&pageSize=" + pageSize, method, operationMetadata.Credentials, convention, requestTimeMetric)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 RavenJToken result = await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
 
@@ -2435,7 +2436,7 @@ namespace Raven.Client.Connection.Async
 
         private async Task DirectCommit(string txId, OperationMetadata operationMetadata, IRequestTimeMetric requestTimeMetric, CancellationToken token)
         {
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/transaction/commit?tx=" + txId, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/transaction/commit?tx=" + txId, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
             }
@@ -2448,7 +2449,7 @@ namespace Raven.Client.Connection.Async
 
         private async Task DirectRollback(string txId, OperationMetadata operationMetadata, IRequestTimeMetric requestTimeMetric, CancellationToken token = default(CancellationToken))
         {
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/transaction/rollback?tx=" + txId, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/transaction/rollback?tx=" + txId, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric).AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 await request.ReadResponseJsonAsync().WithCancellation(token).ConfigureAwait(false);
             }
@@ -2467,7 +2468,7 @@ namespace Raven.Client.Connection.Async
 
             using (var request = jsonRequestFactory.CreateHttpJsonRequest(new CreateHttpJsonRequestParams(this, opUrl, HttpMethod.Post, operationMetadata.Credentials, convention, requestTimeMetric)
                 .AddOperationHeaders(OperationsHeaders))
-                .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+                .AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 if (recoveryInformation != null)
                 {
@@ -2674,7 +2675,7 @@ namespace Raven.Client.Connection.Async
         internal async Task<ReplicationDocumentWithClusterInformation> DirectGetReplicationDestinationsAsync(OperationMetadata operationMetadata, IRequestTimeMetric requestTimeMetric, TimeSpan? timeout = null)
         {
             var createHttpJsonRequestParams = new CreateHttpJsonRequestParams(this, operationMetadata.Url + "/replication/topology", HttpMethod.Get, operationMetadata.Credentials, convention, requestTimeMetric, timeout);
-            using (var request = jsonRequestFactory.CreateHttpJsonRequest(createHttpJsonRequestParams.AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url))
+            using (var request = jsonRequestFactory.CreateHttpJsonRequest(createHttpJsonRequestParams.AddOperationHeaders(OperationsHeaders)).AddRequestExecuterAndReplicationHeaders(this, operationMetadata.Url, operationMetadata.ClusterInformation.WithClusterFailoverHeader))
             {
                 try
                 {

--- a/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequest.cs
+++ b/Raven.Client.Lightweight/Connection/Implementation/HttpJsonRequest.cs
@@ -611,9 +611,9 @@ namespace Raven.Client.Connection.Implementation
 
         public HttpJsonRequest AddRequestExecuterAndReplicationHeaders(
             AsyncServerClient serverClient,
-            string currentUrl)
+            string currentUrl, bool withClusterFailoverHeader = false)
         {
-            serverClient.RequestExecuter.AddHeaders(this, serverClient, currentUrl);
+            serverClient.RequestExecuter.AddHeaders(this, serverClient, currentUrl,withClusterFailoverHeader);
             return this; // not because of failover, no need to do this.
         }
 

--- a/Raven.Client.Lightweight/Connection/Request/ClusterAwareRequestExecuter.cs
+++ b/Raven.Client.Lightweight/Connection/Request/ClusterAwareRequestExecuter.cs
@@ -29,7 +29,7 @@ namespace Raven.Client.Connection.Request
 {
     public class ClusterAwareRequestExecuter : IRequestExecuter
     {
-        private const int WaitForLeaderTimeoutInSeconds = 30;
+        private const int WaitForLeaderTimeoutInSeconds = 5;
 
         private const int GetReplicationDestinationsTimeoutInSeconds = 2;
 
@@ -116,14 +116,14 @@ namespace Raven.Client.Connection.Request
             });
         }
 
-        public void AddHeaders(HttpJsonRequest httpJsonRequest, AsyncServerClient serverClient, string currentUrl)
+        public void AddHeaders(HttpJsonRequest httpJsonRequest, AsyncServerClient serverClient, string currentUrl, bool withClusterFailoverHeader = false)
         {
             httpJsonRequest.AddHeader(Constants.Cluster.ClusterAwareHeader, "true");
 
             if (serverClient.convention.FailoverBehavior == FailoverBehavior.ReadFromAllWriteToLeader)
                 httpJsonRequest.AddHeader(Constants.Cluster.ClusterReadBehaviorHeader, "All");
 
-            if (serverClient.convention.FailoverBehavior == FailoverBehavior.ReadFromAllWriteToLeaderWithFailovers || serverClient.convention.FailoverBehavior == FailoverBehavior.ReadFromLeaderWriteToLeaderWithFailovers)
+            if (withClusterFailoverHeader)
                 httpJsonRequest.AddHeader(Constants.Cluster.ClusterFailoverBehaviorHeader, "true");
         }
 
@@ -132,7 +132,7 @@ namespace Raven.Client.Connection.Request
             this.readStripingBase = strippingBase;
         }
 
-        private async Task<T> ExecuteWithinClusterInternalAsync<T>(AsyncServerClient serverClient, HttpMethod method, Func<OperationMetadata, IRequestTimeMetric, Task<T>> operation, CancellationToken token, int numberOfRetries = 2)
+        private async Task<T> ExecuteWithinClusterInternalAsync<T>(AsyncServerClient serverClient, HttpMethod method, Func<OperationMetadata, IRequestTimeMetric, Task<T>> operation, CancellationToken token, int numberOfRetries = 2, bool withClusterFailoverHeader = false)
         {
             token.ThrowIfCancellationRequested();
 
@@ -143,15 +143,15 @@ namespace Raven.Client.Connection.Request
             if (node == null)
             {
 #pragma warning disable 4014
-                UpdateReplicationInformationIfNeededAsync(serverClient); // maybe start refresh task
+                // If withClusterFailover set to true we will need to force the update and choose another leader.
+                Console.WriteLine(serverClient.convention.FailoverBehavior);
+                UpdateReplicationInformationIfNeededAsync(serverClient, force:withClusterFailoverHeader); // maybe start refresh task
 #pragma warning restore 4014
-
                 switch (serverClient.convention.FailoverBehavior)
                 {
                     case FailoverBehavior.ReadFromAllWriteToLeaderWithFailovers:
                     case FailoverBehavior.ReadFromLeaderWriteToLeaderWithFailovers:
-                        if (Nodes.Count == 0)
-                            leaderNodeSelected.Wait(TimeSpan.FromSeconds(WaitForLeaderTimeoutInSeconds));
+                        leaderNodeSelected.Wait(TimeSpan.FromSeconds(WaitForLeaderTimeoutInSeconds));
                         break;
                     default:
                         if (leaderNodeSelected.Wait(TimeSpan.FromSeconds(WaitForLeaderTimeoutInSeconds)) == false)
@@ -171,7 +171,9 @@ namespace Raven.Client.Connection.Request
                 case FailoverBehavior.ReadFromAllWriteToLeaderWithFailovers:
                     if (node == null)
                     {
-                        return await HandleWithFailovers(operation, token).ConfigureAwait(false);
+                        Console.WriteLine($"{serverClient.convention.FailoverBehavior} readfrom all");
+                        return await HandleWithFailovers(operation, token,withClusterFailoverHeader).ConfigureAwait(false);
+                        
                     }
 
                     if (method == HttpMethods.Get)
@@ -179,16 +181,29 @@ namespace Raven.Client.Connection.Request
                     break;
                 case FailoverBehavior.ReadFromLeaderWriteToLeaderWithFailovers:
                     if (node == null)
-                        return await HandleWithFailovers(operation, token).ConfigureAwait(false);
+                    {
+                        return await HandleWithFailovers(operation, token, withClusterFailoverHeader).ConfigureAwait(false);
+                    }
                     break;
             }
+
             var operationResult = await TryClusterOperationAsync(node, operation, false, token).ConfigureAwait(false);
+
             if (operationResult.Success)
+            {
                 return operationResult.Result;
+            }
+            
 
             LeaderNode = null;
             FailureCounters.IncrementFailureCount(node.Url);
-            return await ExecuteWithinClusterInternalAsync(serverClient, method, operation, token, numberOfRetries - 1).ConfigureAwait(false);
+            if (serverClient.convention.FailoverBehavior == FailoverBehavior.ReadFromLeaderWriteToLeaderWithFailovers
+                || serverClient.convention.FailoverBehavior == FailoverBehavior.ReadFromAllWriteToLeaderWithFailovers)
+            {
+                withClusterFailoverHeader = true;
+            }
+
+            return await ExecuteWithinClusterInternalAsync(serverClient, method, operation, token, numberOfRetries - 1, withClusterFailoverHeader).ConfigureAwait(false);
         }
 
         private OperationMetadata GetNodeForReadOperation(OperationMetadata node)
@@ -212,12 +227,15 @@ namespace Raven.Client.Connection.Request
             return node;
         }
 
-        private async Task<T> HandleWithFailovers<T>(Func<OperationMetadata, IRequestTimeMetric, Task<T>> operation, CancellationToken token)
+        private async Task<T> HandleWithFailovers<T>(Func<OperationMetadata, IRequestTimeMetric, Task<T>> operation, CancellationToken token, bool withClusterFailoverHeader)
         {
             var nodes = NodeUrls;
             for (var i = 0; i < nodes.Count; i++)
             {
                 var n = nodes[i];
+
+                // Have to be here more thread safe
+                n.ClusterInformation.WithClusterFailoverHeader = withClusterFailoverHeader;
                 if (ShouldExecuteUsing(n) == false)
                     continue;
 
@@ -392,7 +410,10 @@ namespace Raven.Client.Connection.Request
                             ReplicationInformerLocalCache.TrySavingClusterNodesToLocalCache(serverHash, Nodes);
 
                             if (newestTopology.Task.Result.ClientConfiguration != null)
+                            {
+                                newestTopology.Task.Result.ClientConfiguration.FailoverBehavior = serverClient.convention.FailoverBehavior;
                                 serverClient.convention.UpdateFrom(newestTopology.Task.Result.ClientConfiguration);
+                            }
 
                             if (LeaderNode != null)
                                 return;

--- a/Raven.Client.Lightweight/Connection/Request/IRequestExecuter.cs
+++ b/Raven.Client.Lightweight/Connection/Request/IRequestExecuter.cs
@@ -24,7 +24,7 @@ namespace Raven.Client.Connection.Request
 
         event EventHandler<FailoverStatusChangedEventArgs> FailoverStatusChanged;
 
-        void AddHeaders(HttpJsonRequest httpJsonRequest, AsyncServerClient serverClient, string currentUrl);
+        void AddHeaders(HttpJsonRequest httpJsonRequest, AsyncServerClient serverClient, string currentUrl, bool withClusterFailoverHeader = false);
         void SetReadStripingBase(int strippingBase);
     }
 }

--- a/Raven.Client.Lightweight/Connection/Request/ReplicationAwareRequestExecuter.cs
+++ b/Raven.Client.Lightweight/Connection/Request/ReplicationAwareRequestExecuter.cs
@@ -65,7 +65,7 @@ namespace Raven.Client.Connection.Request
             return replicationInformer.UpdateReplicationInformationIfNeededAsync(serverClient);
         }
 
-        public void AddHeaders(HttpJsonRequest httpJsonRequest, AsyncServerClient serverClient, string currentUrl)
+        public void AddHeaders(HttpJsonRequest httpJsonRequest, AsyncServerClient serverClient, string currentUrl, bool withClusterFailoverHeader = false)
         {
             if (serverClient.Url.Equals(currentUrl, StringComparison.OrdinalIgnoreCase))
                 return;


### PR DESCRIPTION
Client send Failover header only if needed, reduce the time the client wait for leader,Client now sync with the user failover
