### PR TITLE
RavenDB-4914

### DIFF
--- a/Raven.Database/Server/Controllers/ClusterAwareRavenDbApiController.cs
+++ b/Raven.Database/Server/Controllers/ClusterAwareRavenDbApiController.cs
@@ -103,12 +103,11 @@ namespace Raven.Database.Server.Controllers
             }
 
             var message = request.CreateResponse(HttpStatusCode.Redirect);
-            message.Headers.Location = new UriBuilder(leaderNode.Uri)
-            {
-                Path = request.RequestUri.LocalPath,
-                Query = request.RequestUri.Query.TrimStart('?'),
-                Fragment = request.RequestUri.Fragment
-            }.Uri;
+            message.Headers.Add("Raven-Leader-Redirect", "true");
+            var uriBuilder = new UriBuilder(leaderNode.Uri);
+            if (DatabaseName != null)
+                uriBuilder.Path = "/databases/" + DatabaseName;
+            message.Headers.Location = uriBuilder.Uri;
 
             return message;
         }

--- a/Raven.Tests.Raft/Client/Documents.cs
+++ b/Raven.Tests.Raft/Client/Documents.cs
@@ -93,7 +93,7 @@ namespace Raven.Tests.Raft.Client
             var clusterStores = CreateRaftCluster(numberOfNodes, activeBundles: "Replication", configureStore: store => store.Conventions.FailoverBehavior = FailoverBehavior.ReadFromLeaderWriteToLeader);
 
             SetupClusterConfiguration(clusterStores);
-
+            UpdateTopologyForAllClients(clusterStores);
             for (int i = 0; i < clusterStores.Count; i++)
             {
                 var store = clusterStores[i];

--- a/Raven.Tests.Raft/RaftTestBase.cs
+++ b/Raven.Tests.Raft/RaftTestBase.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Raven.Client.Connection.Async;
 using Raven.Client.Connection.Request;
 using Raven.Tests.Common;
 using Xunit;
@@ -259,6 +260,11 @@ namespace Raven.Tests.Raft
                     }
                 }));
             }
+        }
+
+        protected void UpdateTopologyForAllClients(IEnumerable<DocumentStore> clusterStores)
+        {
+            clusterStores.ForEach(store => ((ServerClient)store.DatabaseCommands).RequestExecuter.UpdateReplicationInformationIfNeededAsync((AsyncServerClient)store.AsyncDatabaseCommands, force: true));
         }
     }
 }


### PR DESCRIPTION
- changed WaitForLeaderTimeoutInSeconds and GetReplicationDestinationsTimeoutInSeconds to be a public properties (mainly so we can modify this in tests)
- added Raven-Leader-Redirect header so we can verify Raven sent the redirect request and not a proxy
- Added a test to check RedirectToLeader actually works.
- added UpdateTopologyForAllClients method to RaftTestBase
