### PR TITLE
Condition was always true, so replaced || by &&

### DIFF
--- a/Raven.Client.Lightweight/Counters/Operations/CountersBatchOperation.cs
+++ b/Raven.Client.Lightweight/Counters/Operations/CountersBatchOperation.cs
@@ -352,7 +352,7 @@ namespace Raven.Client.Counters.Operations
             changesQueue.CompleteAdding();
 
             batchOperationTcs.Task.Wait();
-            if (batchOperationTask.Status != TaskStatus.RanToCompletion ||
+            if (batchOperationTask.Status != TaskStatus.RanToCompletion &&
                 batchOperationTask.Status != TaskStatus.Canceled)
                 cts.Cancel();
 

--- a/Raven.Client.Lightweight/TimeSeries/Operations/TimeSeriesBatchOperation.cs
+++ b/Raven.Client.Lightweight/TimeSeries/Operations/TimeSeriesBatchOperation.cs
@@ -351,7 +351,7 @@ namespace Raven.Client.TimeSeries.Operations
             appendQueue.CompleteAdding();
 
             batchOperationTcs.Task.Wait();
-            if (batchOperationTask.Status != TaskStatus.RanToCompletion ||
+            if (batchOperationTask.Status != TaskStatus.RanToCompletion &&
                 batchOperationTask.Status != TaskStatus.Canceled)
                 cts.Cancel();
 


### PR DESCRIPTION
Condition was always true, so I replaced || by &&. I suppose it is more correct.
