### PR TITLE
Preventing unsafe double-cheked locking

### DIFF
--- a/Raven.Database/Rhino.Licensing/AbstractLicenseValidator.cs
+++ b/Raven.Database/Rhino.Licensing/AbstractLicenseValidator.cs
@@ -52,7 +52,7 @@ namespace Rhino.Licensing
         private bool disableFutureChecks;
         private bool currentlyValidatingLicense;
         private readonly DiscoveryHost discoveryHost;
-        private DiscoveryClient discoveryClient;
+        private volatile DiscoveryClient discoveryClient;
         private readonly Guid senderId = Guid.NewGuid();
         private readonly SntpClient sntpClient;
 


### PR DESCRIPTION
Potentially unsafe double-checked locking.  I suppose use discoveryClient as volatile.
Maybe using 'Thread.VolatileRead'/'Thread.VolatileWriite' will be better solution.
