### PR TITLE
RavenDB-4965

### DIFF
--- a/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
+++ b/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
@@ -349,7 +349,7 @@ namespace Raven.Database.Bundles.Replication.Controllers
                 {
                     //indicates to the replication task that this thread is going to insert documents.
                     ReplicationTask.IsThreadProcessingReplication.Value = true;
-                    ReplicationTask.HandleHeartbeat(src);
+                    ReplicationTask.HandleHeartbeat(src, wake: false);
                 }
 
                 using (Database.DisableAllTriggersForCurrentThread())
@@ -791,7 +791,7 @@ namespace Raven.Database.Bundles.Replication.Controllers
                 }, HttpStatusCode.NotFound);
             }
 
-            replicationTask.HandleHeartbeat(src);
+            replicationTask.HandleHeartbeat(src, wake: true);
 
             return GetEmptyMessage();
         }

--- a/Raven.Database/Indexing/WorkContext.cs
+++ b/Raven.Database/Indexing/WorkContext.cs
@@ -278,7 +278,7 @@ namespace Raven.Database.Indexing
             }
             ReplicationResetEvent.Set();
         }
-        public AutoResetEvent ReplicationResetEvent = new AutoResetEvent(false);
+        public ManualResetEventSlim ReplicationResetEvent = new ManualResetEventSlim();
         public void AddError(int index, string indexName, string key, Exception exception)
         {
             AddError(index, indexName, key, exception, "Unknown");

--- a/Raven.Tests.Raft/Client/WithFailovers.cs
+++ b/Raven.Tests.Raft/Client/WithFailovers.cs
@@ -27,11 +27,13 @@ namespace Raven.Tests.Raft.Client
             configuration.Replication.ReplicationRequestTimeoutInMilliseconds = 4000;
         }
 
-        [Theory]
+   /*     [Theory]
         [InlineData(3)]
-        [InlineData(5)]
-        public void ReadFromLeaderWriteToLeaderWithFailoversShouldWork(int numberOfNodes)
+        [InlineData(5)]*/
+        [Fact]
+        public void ReadFromLeaderWriteToLeaderWithFailoversShouldWork()
         {
+            int numberOfNodes = 5;
             WithFailoversInternal(numberOfNodes, FailoverBehavior.ReadFromLeaderWriteToLeaderWithFailovers);
         }
 

--- a/Raven.Tryouts/Program.cs
+++ b/Raven.Tryouts/Program.cs
@@ -24,7 +24,7 @@ namespace Raven.Tryouts
                 Console.WriteLine(i);
                 using (var x = new WithFailovers())
                 {
-                    x.ReadFromLeaderWriteToLeaderWithFailoversShouldWork(3);
+                    x.ReadFromLeaderWriteToLeaderWithFailoversShouldWork();
                 }
             }
 


### PR DESCRIPTION
- better checks to see if there is actually new data to replicate before requesting last Etag
- changed the replication event from auto reset event to Manual reset event slim
- propagation timer will now fire every 15 seconds and will only set the replication event if there
