### PR TITLE
RavenDB-4970

### DIFF
--- a/Raven.Abstractions/Extensions/ExpressionExtensions.cs
+++ b/Raven.Abstractions/Extensions/ExpressionExtensions.cs
@@ -10,7 +10,10 @@ using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
+using Mono.CSharp;
 using Raven.Imports.Newtonsoft.Json.Utilities;
+using Expression = System.Linq.Expressions.Expression;
+using LambdaExpression = System.Linq.Expressions.LambdaExpression;
 
 namespace Raven.Abstractions.Extensions
 {
@@ -37,9 +40,9 @@ namespace Raven.Abstractions.Extensions
                     {
                         type = type.GetElementType().GetProperty(normalizedProperty).PropertyType;
                     }
-                    else
+                    else if(type.IsGenericType)
                     {
-                        type = type.GetGenericArguments()[0].GetProperty(normalizedProperty).PropertyType;
+                       type = type.GetGenericArguments()[0].GetProperty(normalizedProperty).PropertyType;
                     }
                 }
                 else

--- a/Raven.Tests/Issues/RavenDB_4970.cs
+++ b/Raven.Tests/Issues/RavenDB_4970.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Tests.Helpers;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_4970 : RavenTestBase
+    {
+        [Fact]
+        public void AsyncLoadWithIncludeWithSelect()
+        {
+            using (var store = NewDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Image("images/1"));
+                    session.Store(new Image("images/2"));
+                    session.Store(new Image("images/3"));
+                    session.Store(new TestProduct
+                    {
+                        Id = "products/1",
+                        Title = "Test",
+                        MainImageId = "images/3",
+                        Images = new Dictionary<int, TestImage>
+                        {
+                            {
+                                1, new TestImage("images/1", 1)
+                            },
+                            {
+                                2, new TestImage("images/2", 2)
+                            }
+                        }
+                    });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var product = session
+                        .Include<TestProduct>(p => p.MainImageId)
+                        .Include<TestProduct>(p => p.Images.Select(i => i.Value.ImageId))
+                        .LoadAsync<TestProduct>("products/1")
+                        .Result;
+
+                    Assert.NotNull(product);
+                }
+            }
+        }
+    }
+
+
+    public class TestProduct
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public string MainImageId { get; set; }
+        public Dictionary<int, TestImage> Images { get; set; }
+    }
+
+    public class TestImage
+    {
+        public TestImage(string imageId, int index)
+        {
+            ImageId = imageId;
+            Index = index;
+        }
+
+        public string ImageId { get; set; }
+        public int Index { get; set; }
+    }
+
+    public class Image
+    {
+        public string Id { get; set; }
+        public string Url { get; set; }
+
+        public Image(string id)
+        {
+            Id = id;
+        }
+    }
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -298,6 +298,7 @@
     <Compile Include="Issues\RavenDB-3691.cs" />
     <Compile Include="Issues\RavenDB-4580.cs" />
     <Compile Include="Issues\RavenDB_3435.cs" />
+    <Compile Include="Issues\RavenDB_4970.cs" />
     <Compile Include="Json\JsonCodeGeneratorTests.cs" />
     <Compile Include="LicenseValidatorTest.cs" />
     <Compile Include="Linq\GroupByAndDocumentId.cs" />


### PR DESCRIPTION
- fix ExtractTypeFromPath to throw OutOfBoundsException when try to get generic arguments from none   generic object
- add test
