### PR TITLE
RavenDB-4889 Arena Allocator

### DIFF
--- a/bench/Regression.Benchmark/BlittableJsonBench.cs
+++ b/bench/Regression.Benchmark/BlittableJsonBench.cs
@@ -16,8 +16,7 @@ namespace Regression
         {
             foreach (var name in new[] { "1.json", "2.json", "3.json", "monsters.json" })
             {
-                using (var pool = new UnmanagedBuffersPool("test"))
-                using (var context = new JsonOperationContext(pool))
+                using (var context = new JsonOperationContext())
                 {
                     var resource = "Regression.Benchmark.Data." + name;
 
@@ -42,8 +41,7 @@ namespace Regression
         {
             foreach (var name in new[] { "1.json", "2.json", "3.json", "monsters.json" })
             {
-                using (var pool = new UnmanagedBuffersPool("test"))
-                using (var context = new JsonOperationContext(pool))
+                using (var context = new JsonOperationContext())
                 {
                     var resource = "Regression.Benchmark.Data." + name;
 

--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -33,7 +33,7 @@ namespace Raven.Client.Http
             public DateTime LastServerUpdate;
             public int Usages;
             public int Utilization;
-            public UnmanagedBuffersPool.AllocatedMemoryData Allocation;
+            public AllocatedMemoryData Allocation;
             public HttpCache Cache;
 
             public bool AddRef()

--- a/src/Raven.Client/Http/RequestExecuter.cs
+++ b/src/Raven.Client/Http/RequestExecuter.cs
@@ -25,7 +25,6 @@ namespace Raven.Client.Http
         private static readonly Logger Logger = LoggerSetup.Instance.GetLogger<RequestExecuter>("Client");
 
         private readonly DocumentStore _store;
-        private readonly UnmanagedBuffersPool _pool = new UnmanagedBuffersPool("client/RequestExecuter");
         private readonly JsonOperationContext _context;
 
         public class AggresiveCacheOptions
@@ -64,7 +63,7 @@ namespace Raven.Client.Http
             var handler = new HttpClientHandler();
             _httpClient = new HttpClient(handler);
 
-            _context = new JsonOperationContext(_pool);
+            _context = new JsonOperationContext();
 
             _updateTopologyTimer = new Timer(UpdateTopologyCallback, null, 0, Timeout.Infinite);
         }
@@ -383,7 +382,6 @@ namespace Raven.Client.Http
             _cache.Dispose();
             _authenticator.Dispose();
             _context.Dispose();
-            _pool.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -272,7 +272,7 @@ namespace Raven.Server.Documents
 
             var prefixSlice = GetSliceFromKey(context, prefix);
             // ReSharper disable once LoopCanBeConvertedToQuery
-            foreach (var result in table.SeekByPrimaryKey(prefixSlice))
+            foreach (var result in table.SeekByPrimaryKey(prefixSlice, startsWith:true))
             {
                 var document = TableValueToDocument(context, result);
                 string documentKey = document.Key;
@@ -514,12 +514,10 @@ namespace Raven.Server.Documents
                     $"Key cannot exceed 255 bytes, but the key was {byteCount} bytes. The invalid key is '{key}'.",
                     nameof(key));
 
-            int size;
             var buffer = context.GetNativeTempBuffer(
                 byteCount
-                + sizeof(char) * key.Length // for the lower calls
-                , out size);
-
+                + sizeof(char) * key.Length); // for the lower calls
+            
             fixed (char* pChars = key)
             {
                 var destChars = (char*)buffer;
@@ -530,7 +528,7 @@ namespace Raven.Server.Documents
 
                 var keyBytes = buffer + key.Length * sizeof(char);
 
-                size = Encoding.UTF8.GetBytes(destChars, key.Length, keyBytes, byteCount);
+                var size = Encoding.UTF8.GetBytes(destChars, key.Length, keyBytes, byteCount);
                 return Slice.External(context.Allocator, keyBytes, (ushort)size);
             }
         }
@@ -567,8 +565,7 @@ namespace Raven.Server.Documents
                 + byteCount // lower key
                 + maxKeyLenSize // the size of var int for the len of the key
                 + byteCount // actual key
-                + escapePositionsSize
-                , out lowerSize);
+                + escapePositionsSize);
 
             fixed (char* pChars = str)
             {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -150,8 +150,7 @@ namespace Raven.Server.Documents
             try
             {
                 Environment = new StorageEnvironment(options);
-                _unmanagedBuffersPool = new UnmanagedBuffersPool(_name);
-                ContextPool = new DocumentsContextPool(_unmanagedBuffersPool, _documentDatabase);
+                ContextPool = new DocumentsContextPool(_documentDatabase);
 
                 using (var tx = Environment.WriteTransaction())
                 {

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
@@ -64,8 +64,7 @@ namespace Raven.Server.Documents.Indexes.Auto
 
         public static AutoMapIndexDefinition Load(StorageEnvironment environment)
         {
-            using (var pool = new UnmanagedBuffersPool(nameof(AutoMapIndexDefinition)))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var tx = environment.ReadTransaction())
             {
                 var tree = tx.CreateTree("Definition");

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -200,7 +200,7 @@ namespace Raven.Server.Documents.Indexes
                     DocumentDatabase = documentDatabase;
                     _environment = environment;
                     _unmanagedBuffersPool = new UnmanagedBuffersPool($"Indexes//{IndexId}");
-                    _contextPool = new TransactionContextPool(_unmanagedBuffersPool, _environment);
+                    _contextPool = new TransactionContextPool(_environment);
                     _indexStorage = new IndexStorage(this, _contextPool, documentDatabase);
                     _logger = LoggerSetup.Instance.GetLogger<Index>(documentDatabase.Name);
                     _indexStorage.Initialize(_environment);

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
@@ -101,8 +101,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         public static AutoMapReduceIndexDefinition Load(StorageEnvironment environment)
         {
-            using (var pool = new UnmanagedBuffersPool(nameof(AutoMapReduceIndexDefinition)))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var tx = environment.ReadTransaction())
             {
                 var tree = tx.CreateTree("Definition");

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
     {
         private readonly UnmanagedBuffersPool _buffersPool;
         private Mode _mode;
-        private UnmanagedBuffersPool.AllocatedMemoryData _buffer;
+        private AllocatedMemoryData _buffer;
         private int _bufferPos;
         private ulong _singleValueHash;
 

--- a/src/Raven.Server/Documents/Indexes/Static/StaticMapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticMapIndexDefinition.cs
@@ -70,8 +70,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public static IndexDefinition Load(StorageEnvironment environment)
         {
-            using (var pool = new UnmanagedBuffersPool(nameof(StaticMapIndexDefinition)))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var tx = environment.ReadTransaction())
             {
                 var tree = tx.CreateTree("Definition");

--- a/src/Raven.Server/Documents/TcpHandlers/BulkInsertConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/BulkInsertConnection.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.TcpHandlers
 
         private class BulkInsertDoc
         {
-            public UnmanagedBuffersPool.AllocatedMemoryData Memory;
+            public AllocatedMemoryData Memory;
             public byte* Pointer;
             public int Used;
         }
@@ -370,7 +370,6 @@ namespace Raven.Server.Documents.TcpHandlers
                         buffer.Used = 0;
                         if (buffer.Memory.SizeInBytes >= len)
                             break;
-                        _context.ReturnMemory(buffer.Memory);
                     }
                     while (len > 0)
                     {

--- a/src/Raven.Server/Documents/Transformers/TransformationScope.cs
+++ b/src/Raven.Server/Documents/Transformers/TransformationScope.cs
@@ -122,8 +122,7 @@ namespace Raven.Server.Documents.Transformers
             var charEnumerable = value as IEnumerable<char>;
             if (charEnumerable != null)
             {
-                var charArray = charEnumerable.ToArray();
-                return context.GetLazyString(charArray, 0, charArray.Length);
+                return context.GetLazyString(charEnumerable.ToString());
             }
 
             var inner = new DynamicJsonValue();

--- a/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
+++ b/src/Raven.Server/Documents/Versioning/VersioningStorage.cs
@@ -278,13 +278,11 @@ namespace Raven.Server.Documents.Versioning
                     $"Key cannot exceed 255 bytes, but the key was {byteCount} bytes. The invalid key is '{key}'.",
                     nameof(key));
 
-            int size;
             var buffer = context.GetNativeTempBuffer(
                 byteCount
                 + sizeof(char) * key.Length // for the lower calls
-                + sizeof(char) * 2 // for the record separator
-                , out size);
-
+                + sizeof(char) * 2); // for the record separator
+            
             fixed (char* pChars = key)
             {
                 var destChars = (char*)buffer;
@@ -296,7 +294,7 @@ namespace Raven.Server.Documents.Versioning
 
                 var keyBytes = buffer + sizeof(char) + key.Length * sizeof(char);
 
-                size = Encoding.UTF8.GetBytes(destChars, key.Length + 1, keyBytes, byteCount + 1);
+                var size = Encoding.UTF8.GetBytes(destChars, key.Length + 1, keyBytes, byteCount + 1);
                 return Slice.External(context.Allocator, keyBytes, (ushort)size);
             }
         }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -41,7 +41,6 @@ namespace Raven.Server
 
         private IWebHost _webHost;
         private Task<List<TcpListener>> _tcpListenerTask;
-        private readonly UnmanagedBuffersPool _unmanagedBuffersPool = new UnmanagedBuffersPool("TcpConnectionPool");
         private readonly Logger _tcpLogger;
 
         public RavenServer(RavenConfiguration configuration)
@@ -245,7 +244,7 @@ namespace Raven.Server
                     tcpClient.ReceiveBufferSize = 32 * 1024;
                     tcpClient.SendBufferSize = 4096;
                     stream = tcpClient.GetStream();
-                    context = new JsonOperationContext(_unmanagedBuffersPool);
+                    context = new JsonOperationContext();
                     multiDocumentParser = context.ParseMultiFrom(stream);
                     try
                     {
@@ -373,7 +372,6 @@ namespace Raven.Server
             }
             ServerStore?.Dispose();
             Timer?.Dispose();
-            _unmanagedBuffersPool?.Dispose();
         }
 
         private void CloseTcpListeners(List<TcpListener> listeners)

--- a/src/Raven.Server/ServerWide/Context/DocumentsContextPool.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsContextPool.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.ServerWide.Context
             Debug.Assert(_documentDatabase != null);
 
             if (_contextPool.TryPop(out context) == false)
-                context = new DocumentsOperationContext(_pool, _documentDatabase);
+                context = new DocumentsOperationContext(_documentDatabase);
 
             return new ReturnRequestContext
             {

--- a/src/Raven.Server/ServerWide/Context/DocumentsContextPool.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsContextPool.cs
@@ -17,15 +17,12 @@ namespace Raven.Server.ServerWide.Context
 {
     public class DocumentsContextPool : IDocumentsContextPool
     {
-        private readonly UnmanagedBuffersPool _pool;
-
         private readonly DocumentDatabase _documentDatabase;
 
         private readonly ConcurrentStack<DocumentsOperationContext> _contextPool;
 
-        public DocumentsContextPool(UnmanagedBuffersPool pool, DocumentDatabase documentDatabase)
+        public DocumentsContextPool(DocumentDatabase documentDatabase)
         {
-            _pool = pool;
             _documentDatabase = documentDatabase;
             _contextPool = new ConcurrentStack<DocumentsOperationContext>();
         }

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -10,8 +10,8 @@ namespace Raven.Server.ServerWide.Context
     {
         private readonly DocumentDatabase _documentDatabase;
        
-        public DocumentsOperationContext(UnmanagedBuffersPool pool, DocumentDatabase documentDatabase)
-            : base(pool)
+        public DocumentsOperationContext(DocumentDatabase documentDatabase)
+            : base()
         {
             _documentDatabase = documentDatabase;
         }

--- a/src/Raven.Server/ServerWide/Context/TransactionContextPool.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionContextPool.cs
@@ -18,16 +18,12 @@ namespace Raven.Server.ServerWide.Context
     {
         private readonly StorageEnvironment _storageEnvironment;
 
-        private readonly UnmanagedBuffersPool _pool;
-
         private readonly ConcurrentStack<TransactionOperationContext> _contextPool;
 
-        public TransactionContextPool(UnmanagedBuffersPool pool, StorageEnvironment storageEnvironment)
+        public TransactionContextPool(StorageEnvironment storageEnvironment)
         {
-            _pool = pool;
             _storageEnvironment = storageEnvironment;
             _contextPool = new ConcurrentStack<TransactionOperationContext>();
-
         }
 
         public IDisposable AllocateOperationContext(out JsonOperationContext context)

--- a/src/Raven.Server/ServerWide/Context/TransactionContextPool.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionContextPool.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.ServerWide.Context
         {
             TransactionOperationContext ctx;
             if (_contextPool.TryPop(out ctx) == false)
-                ctx = new TransactionOperationContext(_pool, _storageEnvironment);
+                ctx = new TransactionOperationContext(_storageEnvironment);
 
             context = ctx;
 
@@ -51,7 +51,7 @@ namespace Raven.Server.ServerWide.Context
 
             TransactionOperationContext ctx;
             if (_contextPool.TryPop(out ctx) == false)
-                ctx = new TransactionOperationContext(_pool, _storageEnvironment);
+                ctx = new TransactionOperationContext(_storageEnvironment);
 
             context = ctx;
 

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -13,8 +13,8 @@ namespace Raven.Server.ServerWide.Context
     {
         private readonly StorageEnvironment _environment;
 
-        public TransactionOperationContext(UnmanagedBuffersPool pool, StorageEnvironment environment)
-            : base(pool)
+        public TransactionOperationContext(StorageEnvironment environment)
+            : base()
         {
             _environment = environment;
         }
@@ -38,8 +38,8 @@ namespace Raven.Server.ServerWide.Context
         public readonly ByteStringContext Allocator;
         public TTransaction Transaction;
 
-        protected TransactionOperationContext(UnmanagedBuffersPool pool)
-            : base(pool)
+        protected TransactionOperationContext()
+            : base()
         {
             Allocator = new ByteStringContext();
         }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -100,8 +100,7 @@ namespace Raven.Server.ServerWide
                 throw;
             }
 
-            _pool = new UnmanagedBuffersPool("ServerStore");// 128MB should be more than big enough for the server store
-            ContextPool = new TransactionContextPool(_pool, _env);
+            ContextPool = new TransactionContextPool(_env);
             _timer = new Timer(IdleOperations, null, _frequencyToCheckForIdleDatabases, TimeSpan.FromDays(7));
         }
 
@@ -178,7 +177,6 @@ namespace Raven.Server.ServerWide
 
             ContextPool?.Dispose();
 
-            toDispose.Add(_pool);
             toDispose.Add(_env);
             toDispose.Add(DatabasesLandlord);
 

--- a/src/Raven.Server/Web/System/BuildVersionHandler.cs
+++ b/src/Raven.Server/Web/System/BuildVersionHandler.cs
@@ -22,8 +22,7 @@ namespace Raven.Server.Web.System
 
         private static byte[] GetVersionBuffer()
         {
-            using (var pool = new UnmanagedBuffersPool("build/version"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             {
                 var stream = new MemoryStream();
                 using (var writer = new BlittableJsonTextWriter(context, stream))

--- a/src/Sparrow/Json/AllocatedMemoryData.cs
+++ b/src/Sparrow/Json/AllocatedMemoryData.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+namespace Sparrow.Json
+{
+    
+}

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using NLog;
+
+namespace Sparrow.Json
+{
+    public unsafe class ArenaMemoryAllocator : IDisposable
+    {
+        private byte* _ptrStart;
+        private byte* _ptrCurrent;
+
+        private int _allocated;
+        private int _used;
+
+        private List<IntPtr> _unusedBuffers;
+
+        private bool _isDisposed;
+        private static readonly Logger _log = LogManager.GetLogger(nameof(ArenaMemoryAllocator));
+        
+        public ArenaMemoryAllocator(int initialSize = 1024 * 1024)
+        {
+            _ptrStart = _ptrCurrent = (byte*)Marshal.AllocHGlobal(initialSize).ToPointer();
+            _allocated = initialSize;
+            _used = 0;
+
+            _log.Debug($"ArenaMemoryAllocator was created with initial capacity of {initialSize:#,#;;0} bytes");
+        }
+
+        public AllocatedMemoryData Allocate(int size)
+        {
+            if (_isDisposed)
+                ThrowAlreadyDisposedException();
+
+            if (_used + size > _allocated)
+                GrowArena(size);
+
+            var allocation = new AllocatedMemoryData()
+            {
+                SizeInBytes = size,
+                Address = new IntPtr(_ptrCurrent)
+            };
+
+            _ptrCurrent += size;
+            _used += size;
+
+            _log.Debug($"ArenaMemoryAllocator allocated {size:#,#;;0} bytes");
+
+            return allocation;
+        }
+
+        private void ThrowAlreadyDisposedException()
+        {
+            throw new ObjectDisposedException($"This ArenaMemoryAllocator is already disposed");
+        }
+
+        public void GrowArena(int requestedSize)
+        {
+            while (_used + requestedSize > _allocated)
+            {
+                var newSize = _allocated * 2;
+                if(newSize < _allocated)
+                    throw new OverflowException("Arena size overflowed");
+
+                _log.Debug($"ArenaMemoryAllocator doubled size of buffer from {_allocated:#,#;0} to {newSize:#,#;0}");
+                _allocated = newSize;
+            }
+            
+            var newBuffer = (byte*) Marshal.AllocHGlobal(_allocated).ToPointer();
+            
+            // Save the old buffer pointer to be released at a more convenient time
+            if (_unusedBuffers == null)
+                _unusedBuffers = new List<IntPtr>();
+            _unusedBuffers.Add(new IntPtr(_ptrStart));
+
+            _ptrStart = newBuffer;
+            _ptrCurrent = _ptrStart;
+        }
+
+        public void ResetArena()
+        {
+            // Reset current arena buffer
+            _ptrCurrent = _ptrStart;
+            _used = 0;
+
+            // Free old buffers not being used anymore
+            if (_unusedBuffers != null)
+            {
+                foreach (var unusedBuffer in _unusedBuffers)
+                {
+                    Marshal.FreeHGlobal(unusedBuffer);
+                }
+                _unusedBuffers = null;
+            }
+        }
+
+        ~ArenaMemoryAllocator()
+        {
+            _log.Warn($"ArenaMemoryAllocator wasn't properly disposed");
+
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+                return;
+
+            ResetArena();
+
+            Marshal.FreeHGlobal(new IntPtr(_ptrStart));
+
+            _isDisposed = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    public class AllocatedMemoryData
+    {
+        public IntPtr Address;
+        public int SizeInBytes;
+    }
+}

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -25,7 +25,8 @@ namespace Sparrow.Json
             _allocated = initialSize;
             _used = 0;
 
-            _log.Debug($"ArenaMemoryAllocator was created with initial capacity of {initialSize:#,#;;0} bytes");
+            if (_log.IsDebugEnabled)
+                _log.Debug($"ArenaMemoryAllocator was created with initial capacity of {initialSize:#,#;;0} bytes");
         }
 
         public AllocatedMemoryData Allocate(int size)
@@ -45,7 +46,8 @@ namespace Sparrow.Json
             _ptrCurrent += size;
             _used += size;
 
-            _log.Debug($"ArenaMemoryAllocator allocated {size:#,#;;0} bytes");
+            if (_log.IsDebugEnabled)
+                _log.Debug($"ArenaMemoryAllocator allocated {size:#,#;;0} bytes");
 
             return allocation;
         }
@@ -63,7 +65,8 @@ namespace Sparrow.Json
                 if(newSize < _allocated)
                     throw new OverflowException("Arena size overflowed");
 
-                _log.Debug($"ArenaMemoryAllocator doubled size of buffer from {_allocated:#,#;0} to {newSize:#,#;0}");
+                if (_log.IsDebugEnabled)
+                    _log.Debug($"ArenaMemoryAllocator doubled size of buffer from {_allocated:#,#;0} to {newSize:#,#;0}");
                 _allocated = newSize;
             }
             
@@ -97,7 +100,8 @@ namespace Sparrow.Json
 
         ~ArenaMemoryAllocator()
         {
-            _log.Warn($"ArenaMemoryAllocator wasn't properly disposed");
+            if (_log.IsWarnEnabled)
+                _log.Warn($"ArenaMemoryAllocator wasn't properly disposed");
 
             Dispose();
         }
@@ -106,12 +110,12 @@ namespace Sparrow.Json
         {
             if (_isDisposed)
                 return;
+            _isDisposed = true;
 
             ResetArena();
 
             Marshal.FreeHGlobal(new IntPtr(_ptrStart));
 
-            _isDisposed = true;
             GC.SuppressFinalize(this);
         }
     }

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -16,7 +16,7 @@ namespace Sparrow.Json
         private readonly IJsonParser _reader;
         private readonly JsonParserState _state;
         private readonly UnmanagedWriteBuffer _unmanagedWriteBuffer;
-        private UnmanagedBuffersPool.AllocatedMemoryData _compressionBuffer;
+        private AllocatedMemoryData _compressionBuffer;
         private int _position;
         private WriteToken _writeToken;
         private readonly string _debugTag;
@@ -61,12 +61,6 @@ namespace Sparrow.Json
 
         public void Dispose()
         {
-            if (_compressionBuffer != null)
-            {
-                _context.ReturnMemory(_compressionBuffer);
-                _compressionBuffer = null;
-            }
-
             _unmanagedWriteBuffer.Dispose();
         }
 
@@ -646,9 +640,6 @@ namespace Sparrow.Json
             if (_compressionBuffer == null ||
                 minSize > _compressionBuffer.SizeInBytes)
             {
-                if (_compressionBuffer != null)
-                    _context.ReturnMemory(_compressionBuffer);
-
                 _compressionBuffer = _context.GetMemory(minSize);
             }
             return (byte*)_compressionBuffer.Address;

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -48,7 +48,7 @@ namespace Sparrow.Json
             if (_propertyNameToId.TryGetValue(propName, out prop) == false)
             {
                 var propIndex = _docPropNames.Count;
-                propName = _context.Intern(propName);
+                propName = _context.GetLazyStringForFieldWithCaching(propName);
                 prop = new PropertyName
                 {
                     Comparer = propName,

--- a/src/Sparrow/Json/LazyCompressedStringValue.cs
+++ b/src/Sparrow/Json/LazyCompressedStringValue.cs
@@ -44,8 +44,7 @@ namespace Sparrow.Json
 
         public byte* DecompressToTempBuffer()
         {
-            int bufferSize;
-            var tempBuffer = _context.GetNativeTempBuffer(UncompressedSize, out bufferSize);
+            var tempBuffer = _context.GetNativeTempBuffer(UncompressedSize);
             int uncompressedSize;
 
             if (UncompressedSize > 128)

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -13,7 +13,7 @@ namespace Sparrow.Json
         public readonly int Size;
         public string String;
         public int[] EscapePositions;
-        public UnmanagedBuffersPool.AllocatedMemoryData AllocatedMemoryData;
+        public AllocatedMemoryData AllocatedMemoryData;
         public int? LastFoundAt;
 
         public byte this[int index] => Buffer[index];
@@ -32,7 +32,7 @@ namespace Sparrow.Json
         public int CompareTo(string other)
         {
             var sizeInBytes = Encoding.UTF8.GetMaxByteCount(other.Length);
-            var tmp = Context.GetNativeTempBuffer(sizeInBytes, out sizeInBytes);
+            var tmp = Context.GetNativeTempBuffer(sizeInBytes);
             fixed (char* pOther = other)
             {
                 var tmpSize = Context.Encoding.GetBytes(pOther, other.Length, tmp, sizeInBytes);
@@ -122,11 +122,7 @@ namespace Sparrow.Json
 
         public void Dispose()
         {
-            if (AllocatedMemoryData == null)
-                return;
-
-            Context.ReturnMemory(AllocatedMemoryData);
-            AllocatedMemoryData = null;
+            
         }
 
         public bool Contains(string value)

--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -14,7 +14,7 @@ namespace Sparrow.Json.Parsing
 
         public readonly List<int> EscapePositions = new List<int>();
 
-        private static readonly char[] EscapeChars = { '\b', '\t', '\r', '\n', '\f', '\\', '/', '"', };
+        private static readonly char[] EscapeChars = { '\b', '\t', '\r', '\n', '\f', '\\', '"', };
 
         public int GetEscapePositionsSize()
         {
@@ -56,11 +56,6 @@ namespace Sparrow.Json.Parsing
 
         public void FindEscapePositionsIn(string str)
         {
-            FindEscapePositionsIn(new StringSegment(str,0,str.Length));				
-        }
-
-        public void FindEscapePositionsIn(StringSegment str)
-        {
             EscapePositions.Clear();
             var lastEscape = 0;
             while (true)
@@ -72,32 +67,6 @@ namespace Sparrow.Json.Parsing
                 lastEscape = curEscape + 1;
             }
         }
-
-
-        public void FindEscapePositionsIn(char[] buffer, int start, int count)
-        {
-            EscapePositions.Clear();
-            //TODO: inefficient, need to copy  COMString::IndexOfCharArray
-            var lastEscape = 0;
-            while (true)
-            {
-                var curEscape = -1;
-
-                int offset = start + lastEscape;
-                foreach (var escapeChar in EscapeChars)
-                {
-                    curEscape = Array.IndexOf(buffer, escapeChar, start + offset, count - offset);
-                    if (curEscape != -1)
-                        break;
-                }
-
-                if (curEscape == -1)
-                    break;
-                EscapePositions.Add(curEscape - lastEscape);
-                lastEscape = curEscape + 1;
-            }
-        }
-
 
         public void WriteEscapePositionsTo(byte* buffer)
         {

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -385,7 +385,7 @@ namespace Sparrow.Json.Parsing
             int size = Encoding.UTF8.GetMaxByteCount(str.Length);
             _state.FindEscapePositionsIn(str);
             size += _state.GetEscapePositionsSize();
-            _state.StringBuffer = _ctx.GetNativeTempBuffer(size, out size);
+            _state.StringBuffer = _ctx.GetNativeTempBuffer(size);
             fixed (char* pChars = str)
             {
                 _state.StringSize = Utf8Encoding.GetBytes(pChars, str.Length, _state.StringBuffer, size);

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
@@ -464,7 +464,7 @@ namespace Sparrow.Json.Parsing
                             _currentStrStart++;
                             _escapeMode = false;
                             _charPos++;
-                            if (b != (byte)'u')
+                            if (b != (byte)'u' && b != (byte)'/')
                             {
                                 _state.EscapePositions.Add(_stringBuffer.SizeInBytes - _prevEscapePosition);
                                 _prevEscapePosition = _stringBuffer.SizeInBytes + 1;

--- a/src/Sparrow/Json/UnmanagedBuffersPool.cs
+++ b/src/Sparrow/Json/UnmanagedBuffersPool.cs
@@ -15,13 +15,7 @@ namespace Sparrow.Json
         private readonly ConcurrentStack<AllocatedMemoryData>[] _freeSegments;
 
         private bool _isDisposed;
-
-        public class AllocatedMemoryData
-        {
-            public IntPtr Address;
-            public int SizeInBytes;
-        }
-
+        
         public UnmanagedBuffersPool(string debugTag)
         {
             _debugTag = debugTag;

--- a/test/FastTests/Blittable/ArrayParsingTests.cs
+++ b/test/FastTests/Blittable/ArrayParsingTests.cs
@@ -14,8 +14,7 @@ namespace FastTests.Blittable
         [Fact]
         public async Task CanParseSimpleArray()
         {
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             {
                 var ms = new MemoryStream(Encoding.UTF8.GetBytes("[\"Oren\",\"Arava\"]"));
                 var array = await ctx.ParseArrayToMemoryAsync(ms, "array",BlittableJsonDocumentBuilder.UsageMode.None);

--- a/test/FastTests/Blittable/Benchmark/ProfilerWork.cs
+++ b/test/FastTests/Blittable/Benchmark/ProfilerWork.cs
@@ -22,8 +22,7 @@ namespace FastTests.Blittable.Benchmark
         {
             string directory = @"C:\Users\bumax_000\Downloads\JsonExamples";
             var files = Directory.GetFiles(directory, "*.json");
-            using (var unmanagedPool = new UnmanagedBuffersPool(string.Empty))
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             {
                 foreach (var file in files.OrderBy(x=> new FileInfo(x).Length).Take(take))
                 {

--- a/test/FastTests/Blittable/Benchmark/WriteToStreamBenchmark.cs
+++ b/test/FastTests/Blittable/Benchmark/WriteToStreamBenchmark.cs
@@ -37,8 +37,7 @@ namespace FastTests.Blittable.Benchmark
                 Console.Write(" lines {1:#,#} json - {0:#,#}ms - {2:#,#} ", sp.ElapsedMilliseconds, lines, size);
 
                 size = 0;
-                using (var unmanagedPool = new UnmanagedBuffersPool(string.Empty))
-                using (var blittableContext = new JsonOperationContext(unmanagedPool))
+                using (var blittableContext = new JsonOperationContext())
                 {
                     sp.Restart();
 
@@ -78,8 +77,7 @@ namespace FastTests.Blittable.Benchmark
                     }
                 }
 
-                using (var unmanagedPool = new UnmanagedBuffersPool(string.Empty))
-                using (var blittableContext = new JsonOperationContext(unmanagedPool))
+                using (var blittableContext = new JsonOperationContext())
                 {
                     foreach (var line in jsonCache)
                     {
@@ -113,8 +111,7 @@ namespace FastTests.Blittable.Benchmark
 
         private static unsafe void BlitIndexing(List<BlittableJsonReaderObject> blitCache)
         {
-            using (var unmanagedPool = new UnmanagedBuffersPool(string.Empty))
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             {
                 foreach (var tuple in blitCache)
                 {
@@ -139,8 +136,7 @@ namespace FastTests.Blittable.Benchmark
                 var files = Directory.GetFiles(directory, "*.json").OrderBy(f => new FileInfo(f).Length).Take(size);
 
                 streamWriter.WriteLine("Name,Json Parse Time,Json Size, Json Time, Blit Parse Time,Blit Size, Blit Time");
-                using (var unmanagedPool = new UnmanagedBuffersPool(string.Empty))
-                using (var blittableContext = new JsonOperationContext(unmanagedPool))
+                using (var blittableContext = new JsonOperationContext())
                 {
                     foreach (var jsonFile in files)
                     {

--- a/test/FastTests/Blittable/BlittableJsonEqualityTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonEqualityTests.cs
@@ -9,8 +9,7 @@ namespace FastTests.Blittable
         [Fact]
         public void Equals_even_though_order_of_properties_is_different()
         {
-            using (var pool = new UnmanagedBuffersPool("foo"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             {
                 var json1 = new DynamicJsonValue()
                 {

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableFormatTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableFormatTests.cs
@@ -25,8 +25,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             {
                 var compacted = JObject.Parse(new StreamReader(stream).ReadToEnd()).ToString(Formatting.None);
                 stream.Position = 0;
-                using (var pool = new UnmanagedBuffersPool("test"))
-                using (var context = new JsonOperationContext(pool))
+                using (var context = new JsonOperationContext())
                 {
                     var writer = context.Read(stream, "docs/1");
 
@@ -46,8 +45,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         {
             foreach (var name in new[] { "geo.json", "comments.json", "blog_post.json" })
             {
-                using (var pool = new UnmanagedBuffersPool("test"))
-                using (var context = new JsonOperationContext(pool))
+                using (var context = new JsonOperationContext())
                 {
                     var resource = typeof(BlittableFormatTests).Namespace + ".Jsons." + name;
 

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ConcurrentAccessTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ConcurrentAccessTests.cs
@@ -15,28 +15,26 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void ConcurrentReadsTest()
         {
-            var unmanagedPool = new UnmanagedBuffersPool(string.Empty);
-
             var str = GenerateSimpleEntityForFunctionalityTest2();
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             using (var employee =  blittableContext.Read(new MemoryStream(Encoding.UTF8.GetBytes(str)), "doc1"))
             {
                /* FileStream file = new FileStream(@"c:\Temp\example.txt",FileMode.Create);
                 employee.WriteTo(file);
                 file.Flush();
                 file.Dispose();*/
-                AssertEmployees(employee, unmanagedPool, str);
+                AssertEmployees(employee, str);
             }
         }
 
-        private static unsafe void AssertEmployees(BlittableJsonReaderObject employee, UnmanagedBuffersPool unmanagedPool, string str)
+        private static unsafe void AssertEmployees(BlittableJsonReaderObject employee, string str)
         {
             var basePointer = employee.BasePointer;
             var size = employee.Size;
 
             Parallel.ForEach(Enumerable.Range(0, 100), x =>
             {
-                using (var localCtx = new JsonOperationContext(unmanagedPool))
+                using (var localCtx = new JsonOperationContext())
                 {
                     AssertComplexEmployee(str, new BlittableJsonReaderObject(basePointer, size, localCtx), localCtx);
                 }

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/FunctionalityTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/FunctionalityTests.cs
@@ -21,10 +21,8 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void FunctionalityTest()
         {
-            var unmanagedPool = new UnmanagedBuffersPool(string.Empty);
-
             var str = GenerateSimpleEntityForFunctionalityTest();
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             using (var employee =  blittableContext.Read(new MemoryStream(Encoding.UTF8.GetBytes(str)), "doc1"))
             {
                 dynamic dynamicRavenJObject = new DynamicJsonObject(RavenJObject.Parse(str));
@@ -49,8 +47,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         public void FunctionalityTest2()
         {
             var str = GenerateSimpleEntityForFunctionalityTest2();
-            using (var unmanagedPool = new UnmanagedBuffersPool(string.Empty))
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             using (var employee = blittableContext.Read(new MemoryStream(Encoding.UTF8.GetBytes(str)), "doc1"))
             {
                 AssertComplexEmployee(str, employee, blittableContext);
@@ -60,10 +57,8 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [Fact]
         public void EmptyArrayTest()
         {
-            var unmanagedPool = new UnmanagedBuffersPool(string.Empty);
-
             var str = "{\"Alias\":\"Jimmy\",\"Data\":[],\"Name\":\"Trolo\",\"SubData\":{\"SubArray\":[]}}";
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             using (var employee = blittableContext.Read(new MemoryStream(Encoding.UTF8.GetBytes(str)), "doc1"))
             {
                 dynamic dynamicObject = new DynamicBlittableJson(employee);
@@ -134,9 +129,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             };
             var str = sampleObject.ToJsonString();
 
-            var unmanagedPool = new UnmanagedBuffersPool(string.Empty);
-
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             using (var doc =  blittableContext.Read(new MemoryStream(Encoding.UTF8.GetBytes(str)), "doc1"))
             {
                 dynamic dynamicObject = new DynamicBlittableJson(doc);
@@ -173,8 +166,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                 }
             });
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             using (var r =  ctx.Read(new MemoryStream(Encoding.UTF8.GetBytes(json)), "doc1"))
             {
                 var ms = new MemoryStream();
@@ -193,8 +185,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                 Dogs = true
             });
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             using (var r = ctx.Read(new MemoryStream(Encoding.UTF8.GetBytes(json)), "doc1"))
             {
                 var ms = new MemoryStream();

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/Jsons/escape-str.json
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/Jsons/escape-str.json
@@ -1,5 +1,7 @@
 ﻿{
   "Test\"": "\n",
   "Url": "http: //foo",
-  "TwoEscapes": "\r\n"
+  "TwoEscapes": "\r\n",
+  "Escaping\/Slash": "Should be\/\/OK",
+  "One/slash": "One/Slash2"
 }

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/UnmanageJsonReaderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/UnmanageJsonReaderTests.cs
@@ -16,8 +16,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         [MemberData("Samples")]
         public void CanReadAll(string name)
         {
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             using (var stream = typeof(UnmanageJsonReaderTests).GetTypeInfo().Assembly.GetManifestResourceStream(name))
             using (var parser = new UnmanagedJsonParser(ctx, new JsonParserState(), "test"))
             {

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/VariousPropertyAmountsTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/VariousPropertyAmountsTests.cs
@@ -38,8 +38,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             //var maxValue = short.MaxValue + 1000;
             var str = GetJsonString(maxValue);
 
-            using (var unmanagedPool = new UnmanagedBuffersPool(string.Empty))
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             using (var employee = blittableContext.Read(new MemoryStream(Encoding.UTF8.GetBytes(str)), "doc1"))
             {
 
@@ -63,9 +62,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
             var str = GetJsonString(maxValue);
 
-            var unmanagedPool = new UnmanagedBuffersPool(string.Empty);
-
-            using (var blittableContext = new JsonOperationContext(unmanagedPool))
+            using (var blittableContext = new JsonOperationContext())
             using (var employee = blittableContext.Read(new MemoryStream(Encoding.UTF8.GetBytes(str)), "doc1"))
             {
                 var ms = new MemoryStream();

--- a/test/FastTests/Blittable/BlittableValidationTest.cs
+++ b/test/FastTests/Blittable/BlittableValidationTest.cs
@@ -16,35 +16,30 @@ namespace FastTests.Blittable
 {
     public class BlittableValidationTest : RavenTestBase
     {
-        private BlittableJsonReaderObject InitSimpleBlittable(out int size)
+        private BlittableJsonReaderObject InitSimpleBlittable(JsonOperationContext context, out int size)
         {
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            var obj = RavenJObject.FromObject(new Employee
             {
-                var obj = RavenJObject.FromObject(new Employee
-                {
-                    Id = "1",
-                    FirstName = "Hibernating",
-                    LastName = "Rhinos"
-                });
-                var objString = obj.ToString(Formatting.None);
-                var stream = new MemoryStream();
-                var streamWriter = new StreamWriter(stream);
-                streamWriter.Write(objString);
-                streamWriter.Flush();
-                stream.Position = 0;
-                var reader = context.Read(stream, "docs/1 ");
-                size = reader.Size;
-                return reader;
-            }
+                Id = "1",
+                FirstName = "Hibernating",
+                LastName = "Rhinos"
+            });
+            var objString = obj.ToString(Formatting.None);
+            var stream = new MemoryStream();
+            var streamWriter = new StreamWriter(stream);
+            streamWriter.Write(objString);
+            streamWriter.Flush();
+            stream.Position = 0;
+            var reader = context.Read(stream, "docs/1 ");
+            size = reader.Size;
+            return reader;
         }
 
         [Fact]
         public void WithEscape()
         {
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             {
                 var obj = RavenJObject.FromObject(new Employee
                 {
@@ -219,8 +214,7 @@ namespace FastTests.Blittable
         [Fact]
         public void Complex_Valid_Blittable()
         {
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             {
                 var company = InitCompany();
                 var obj = RavenJObject.FromObject(company);
@@ -238,8 +232,7 @@ namespace FastTests.Blittable
         [Fact]
         public void Empty_Valid_Blittable()
         {
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             {
                 var obj = RavenJObject.FromObject(new Empty());
                 var objString = obj.ToString(Formatting.None);
@@ -342,45 +335,48 @@ namespace FastTests.Blittable
         [Fact]
         public unsafe void Invalid_Names_Offset()
         {
-            int size;
-            var reader = InitSimpleBlittable(out size);
-            var basePointer = reader.BasePointer;
-
-            *(basePointer + size - 7) = 0x11;
-            var message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
-            Assert.Equal(message.Message, "Properties names token not valid");
-
-            *(basePointer + size - 7) = 0x50;
-            message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
-            Assert.Equal(message.Message, "Properties names token not valid");
-
-            *(basePointer + size - 7) = 0x00;
-            var messageArg = Assert.Throws<ArgumentException>(() => reader.BlittableValidation());
-            Assert.Equal(messageArg.Message, "Illegal offset size");
-
-            *(basePointer + size - 7) = 0x10;
-            var listStart = size - 6;
-
-            for (var i = 0; i < 2; i++)
+            using (var context = new JsonOperationContext())
             {
-                var temp = basePointer[listStart + i];
+                int size;
+                var reader = InitSimpleBlittable(context, out size);
+                var basePointer = reader.BasePointer;
 
-                basePointer[listStart + i] = (byte)listStart;
+                *(basePointer + size - 7) = 0x11;
+                var message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
+                Assert.Equal(message.Message, "Properties names token not valid");
+
+                *(basePointer + size - 7) = 0x50;
                 message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
-                Assert.Equal(message.Message, "Properties names offset not valid");
+                Assert.Equal(message.Message, "Properties names token not valid");
 
-                basePointer[listStart + i] = temp;
-            }
+                *(basePointer + size - 7) = 0x00;
+                var messageArg = Assert.Throws<ArgumentException>(() => reader.BlittableValidation());
+                Assert.Equal(messageArg.Message, "Illegal offset size");
 
-            for (var i = 0; i < 1; i++)
-            {
-                var temp = basePointer[listStart + i];
+                *(basePointer + size - 7) = 0x10;
+                var listStart = size - 6;
 
-                basePointer[listStart + i] = basePointer[listStart + i + 1];
-                message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
-                Assert.Equal(message.Message, "Properties names offset not valid");
+                for (var i = 0; i < 2; i++)
+                {
+                    var temp = basePointer[listStart + i];
 
-                basePointer[listStart + i] = temp;
+                    basePointer[listStart + i] = (byte) listStart;
+                    message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
+                    Assert.Equal(message.Message, "Properties names offset not valid");
+
+                    basePointer[listStart + i] = temp;
+                }
+
+                for (var i = 0; i < 1; i++)
+                {
+                    var temp = basePointer[listStart + i];
+
+                    basePointer[listStart + i] = basePointer[listStart + i + 1];
+                    message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
+                    Assert.Equal(message.Message, "Properties names offset not valid");
+
+                    basePointer[listStart + i] = temp;
+                }
             }
         }
 
@@ -439,21 +435,24 @@ namespace FastTests.Blittable
         [Fact]
         public unsafe void Invalid_Root_Token()
         {
-            int size;
-            var reader = InitSimpleBlittable(out size);
-            var basePointer = reader.BasePointer;
+            using (var context = new JsonOperationContext())
+            {
+                int size;
+                var reader = InitSimpleBlittable(context, out size);
+                var basePointer = reader.BasePointer;
 
-            *(basePointer + size - 1) = 0x52;
-            var message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
-            Assert.Equal(message.Message, "Illegal root object");
+                *(basePointer + size - 1) = 0x52;
+                var message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
+                Assert.Equal(message.Message, "Illegal root object");
 
-            *(basePointer + size - 1) = 0x41;
-            var messageArg = Assert.Throws<ArgumentException>(() => reader.BlittableValidation());
-            Assert.Equal(messageArg.Message, "Illegal offset size");
+                *(basePointer + size - 1) = 0x41;
+                var messageArg = Assert.Throws<ArgumentException>(() => reader.BlittableValidation());
+                Assert.Equal(messageArg.Message, "Illegal offset size");
 
-            *(basePointer + size - 1) = 0x11;
-            messageArg = Assert.Throws<ArgumentException>(() => reader.BlittableValidation());
-            Assert.Equal(messageArg.Message, "Illegal offset size");
+                *(basePointer + size - 1) = 0x11;
+                messageArg = Assert.Throws<ArgumentException>(() => reader.BlittableValidation());
+                Assert.Equal(messageArg.Message, "Illegal offset size");
+            }
         }
 
         [Fact]
@@ -476,16 +475,18 @@ namespace FastTests.Blittable
         [Fact]
         public void Simple_Valid_Blittable_Test()
         {
-            int size;
-            var reader = InitSimpleBlittable(out size);
-            reader.BlittableValidation();
+            using (var context = new JsonOperationContext())
+            {
+                int size;
+                var reader = InitSimpleBlittable(context, out size);
+                reader.BlittableValidation();
+            }
         }
 
         [Fact]
         public void Valid_Blittable()
         {
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             {
                 var allTokens = new AllTokensTypes
                 {
@@ -512,8 +513,7 @@ namespace FastTests.Blittable
         [Fact]
         public void Valid_Compressed_String()
         {
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             {
                 var state = new JsonParserState();
                 using (var parser = new UnmanagedJsonParser(ctx, state, "test"))
@@ -555,30 +555,35 @@ namespace FastTests.Blittable
         [Fact]
         public unsafe void Invalid_Props_Offset()
         {
-            int size;
-            var reader = InitSimpleBlittable(out size);
-            var basePointer = reader.BasePointer;
+            using (var context = new JsonOperationContext())
+            {
+                int size;
+                var reader = InitSimpleBlittable(context, out size);
+                var basePointer = reader.BasePointer;
 
-            *(basePointer + size - 2) = 0xbc;
-            var message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
-            Assert.Equal(message.Message, "Properties names offset not valid");
+                *(basePointer + size - 2) = 0xbc;
+                var message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
+                Assert.Equal(message.Message, "Properties names offset not valid");
 
-            *(basePointer + size - 2) = 0x00;
-            message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
-            Assert.Equal(message.Message, "Properties names offset not valid");
-
+                *(basePointer + size - 2) = 0x00;
+                message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
+                Assert.Equal(message.Message, "Properties names offset not valid");
+            }
         }
 
         [Fact]
         public unsafe void Invalid_Root_Metadata_Offset()
         {
-            int size;
-            var reader = InitSimpleBlittable(out size);
-            var basePointer = reader.BasePointer;
+            using (var context = new JsonOperationContext())
+            {
+                int size;
+                var reader = InitSimpleBlittable(context, out size);
+                var basePointer = reader.BasePointer;
 
-            *(basePointer + size - 3) = 0x40;
-            var message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
-            Assert.Equal(message.Message, "Root metadata offset not valid");
+                *(basePointer + size - 3) = 0x40;
+                var message = Assert.Throws<InvalidDataException>(() => reader.BlittableValidation());
+                Assert.Equal(message.Message, "Root metadata offset not valid");
+            }
         }
 
         [Fact]
@@ -591,8 +596,7 @@ namespace FastTests.Blittable
 
             foreach (var name in resources.Where( x => x.StartsWith(resourcePrefix, StringComparison.Ordinal)))
             {
-                using (var pool = new UnmanagedBuffersPool("test"))
-                using (var context = new JsonOperationContext(pool))
+                using (var context = new JsonOperationContext())
                 {                    
                     using (var stream = assembly.GetManifestResourceStream(name))
                     {

--- a/test/FastTests/Blittable/MemoryPoolTests.cs
+++ b/test/FastTests/Blittable/MemoryPoolTests.cs
@@ -14,7 +14,7 @@ namespace FastTests.Blittable
         {
             using (var pool = new UnmanagedBuffersPool(string.Empty))
             {
-                var allocatedMemory = new List<UnmanagedBuffersPool.AllocatedMemoryData>();
+                var allocatedMemory = new List<AllocatedMemoryData>();
                 for (var i = 0; i < 1000; i++)
                 {
                     allocatedMemory.Add(pool.Allocate(i));
@@ -31,7 +31,7 @@ namespace FastTests.Blittable
         {
             using (var pool = new UnmanagedBuffersPool(string.Empty))
             {
-                var allocatedMemory = new global::Sparrow.Collections.ConcurrentSet<UnmanagedBuffersPool.AllocatedMemoryData>();
+                var allocatedMemory = new global::Sparrow.Collections.ConcurrentSet<AllocatedMemoryData>();
                 Parallel.For(0, 100, x =>
                 {
                     for (var i = 0; i < 10; i++)
@@ -52,7 +52,7 @@ namespace FastTests.Blittable
         {
             using (var pool = new UnmanagedBuffersPool(string.Empty))
             {
-                var allocatedMemory = new BlockingCollection<UnmanagedBuffersPool.AllocatedMemoryData>();
+                var allocatedMemory = new BlockingCollection<AllocatedMemoryData>();
                 Task.Run(() =>
                 {
                     for (var i = 0; i < 100; i++)
@@ -64,7 +64,7 @@ namespace FastTests.Blittable
                 
                 while (allocatedMemory.IsCompleted == false)
                 {
-                    UnmanagedBuffersPool.AllocatedMemoryData tuple;
+                    AllocatedMemoryData tuple;
                     if (allocatedMemory.TryTake(out tuple, 100))
                         pool.Return(tuple);
                 }

--- a/test/FastTests/Blittable/MutatingJsonTests.cs
+++ b/test/FastTests/Blittable/MutatingJsonTests.cs
@@ -121,8 +121,7 @@ namespace FastTests.Blittable
 
         private static void AssertEqualAfterRoundTrip(Action<BlittableJsonReaderObject> mutate, string expected, string json = null)
         {
-            using (var pool = new UnmanagedBuffersPool("foo"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             {
                 var stream = new MemoryStream();
                 var streamWriter = new StreamWriter(stream);

--- a/test/FastTests/Blittable/ObjectJsonParsingTests.cs
+++ b/test/FastTests/Blittable/ObjectJsonParsingTests.cs
@@ -14,8 +14,7 @@ namespace FastTests.Blittable
         [Fact]
         public void Zzz()
         {
-            using (var pool = new UnmanagedBuffersPool("foo"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             {
                 var array = new DynamicJsonArray
                 {
@@ -43,8 +42,7 @@ namespace FastTests.Blittable
         {
             var traverser = new BlittableJsonTraverser();
 
-            using (var pool = new UnmanagedBuffersPool("foo"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             {
                 var input = new DynamicJsonValue
                 {
@@ -150,8 +148,7 @@ namespace FastTests.Blittable
 
         private static void AssertEqualAfterRoundTrip(DynamicJsonValue doc, string expected)
         {
-            using (var pool = new UnmanagedBuffersPool("foo"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             {
                 using (var writer = ctx.ReadObject(doc, "foo"))
                 {

--- a/test/FastTests/Blittable/PartialBlittable.cs
+++ b/test/FastTests/Blittable/PartialBlittable.cs
@@ -23,8 +23,7 @@ namespace FastTests.Blittable
         [Fact]
         public void CanSkipWritingPropertyNames()
         {
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var ctx = new JsonOperationContext(pool))
+            using (var ctx = new JsonOperationContext())
             {
                 var buffer = Encoding.UTF8.GetBytes("{\"Name\":\"Oren\"}");
                 var state = new JsonParserState();

--- a/test/FastTests/Blittable/UnmanagedStreamTests.cs
+++ b/test/FastTests/Blittable/UnmanagedStreamTests.cs
@@ -15,8 +15,7 @@ namespace FastTests.Blittable
         [Fact]
         public void EnsureSingleChunk()
         {
-            using (var unmanagedByteArrayPool = new UnmanagedBuffersPool(string.Empty))
-            using (var ctx = new JsonOperationContext(unmanagedByteArrayPool))
+            using (var ctx = new JsonOperationContext())
             {
                 var newStream = ctx.GetStream();
                 var buffer = new byte[1337];
@@ -46,10 +45,10 @@ namespace FastTests.Blittable
         [Fact]
         public void BulkWriteAscendingSizeTest()
         {
-            using (var unmanagedByteArrayPool = new UnmanagedBuffersPool(string.Empty))
-                using(var ctx = new JsonOperationContext(unmanagedByteArrayPool))
+            //using (var unmanagedByteArrayPool = new UnmanagedBuffersPool(string.Empty))
+            using(var ctx = new JsonOperationContext())
             {
-                var allocatedMemory = new List<UnmanagedBuffersPool.AllocatedMemoryData>();
+                var allocatedMemory = new List<AllocatedMemoryData>();
                 var newStream = ctx.GetStream();
                 var totalSize = 0;
                 var rand = new Random();
@@ -76,10 +75,7 @@ namespace FastTests.Blittable
                         Assert.Equal(*((byte*)buffer.Address + curIndex), *((byte*)((byte*)tuple.Address + i)));
                         curIndex++;
                     }
-
-                    unmanagedByteArrayPool.Return(tuple);
                 }
-                unmanagedByteArrayPool.Return(buffer);
             }
         }
 
@@ -89,21 +85,18 @@ namespace FastTests.Blittable
         {
             var size = 3917701;
            
-            using (var unmanagedByteArrayPool = new UnmanagedBuffersPool(string.Empty))
-            using (var ctx = new JsonOperationContext(unmanagedByteArrayPool))
+            using (var ctx = new JsonOperationContext())
             {
                 var data = ctx.GetMemory(size);
-                ctx.ReturnMemory(data);
             }
         }
 
         [Fact]
         public void BulkWriteDescendingSizeTest()
         {
-            using (var unmanagedByteArrayPool = new UnmanagedBuffersPool(string.Empty))
-            using(var ctx = new JsonOperationContext(unmanagedByteArrayPool))
+            using(var ctx = new JsonOperationContext())
             {
-                var allocatedMemory = new List<UnmanagedBuffersPool.AllocatedMemoryData>();
+                var allocatedMemory = new List<AllocatedMemoryData>();
                 var newStream = ctx.GetStream();
                 var rand = new Random();
                 for (var i = 5000; i > 1; i-=500)
@@ -127,20 +120,16 @@ namespace FastTests.Blittable
                         Assert.Equal(*((byte*)buffer.Address + curIndex), *((byte*)((byte*)tuple.Address+ i)));
                         curIndex++;
                     }
-
-                    ctx.ReturnMemory(tuple);
                 }
-                ctx.ReturnMemory(buffer);
             }
         }
 
         [Fact]
         public void SingleByteWritesTest()
         {
-            using (var unmanagedByteArrayPool = new UnmanagedBuffersPool(string.Empty))
-            using (var ctx = new JsonOperationContext(unmanagedByteArrayPool))
+            using (var ctx = new JsonOperationContext())
             {
-                var allocatedMemory = new List<UnmanagedBuffersPool.AllocatedMemoryData>();
+                var allocatedMemory = new List<AllocatedMemoryData>();
                 var newStream = ctx.GetStream();
                 var rand = new Random();
                 for (var i = 1; i < 5000; i+=500)
@@ -182,10 +171,7 @@ namespace FastTests.Blittable
                             Console.WriteLine(e);
                         }
                     }
-
-                    ctx.ReturnMemory(tuple);
                 }
-                ctx.ReturnMemory(buffer);
             }
         }
 

--- a/test/FastTests/Server/Documents/DocumentsCrud.cs
+++ b/test/FastTests/Server/Documents/DocumentsCrud.cs
@@ -16,7 +16,6 @@ namespace FastTests.Server.Documents
     {
         private RavenConfiguration _configuration;
         private DocumentDatabase _documentDatabase;
-        private readonly UnmanagedBuffersPool _unmanagedBuffersPool;
 
         public DocumentsCrud()
         {
@@ -28,8 +27,6 @@ namespace FastTests.Server.Documents
 
             _documentDatabase = new DocumentDatabase("foo", _configuration, new IoMetrics(256, 256));
             _documentDatabase.Initialize();
-
-            _unmanagedBuffersPool = new UnmanagedBuffersPool("test");
         }
 
         [Theory]
@@ -39,7 +36,7 @@ namespace FastTests.Server.Documents
         [InlineData("users/111112222233333333333444444445555556")]
         public void PutAndGetDocumentById(string key)
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -53,7 +50,7 @@ namespace FastTests.Server.Documents
                 ctx.Transaction.Commit();
             }
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -75,7 +72,7 @@ namespace FastTests.Server.Documents
         [InlineData("לכובע שלי שלוש פינות")]
         public void CanDelete(string key)
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -89,7 +86,7 @@ namespace FastTests.Server.Documents
                 ctx.Transaction.Commit();
             }
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -98,7 +95,7 @@ namespace FastTests.Server.Documents
                 ctx.Transaction.Commit();
             }
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -112,7 +109,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void CanQueryByGlobalEtag()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -152,7 +149,7 @@ namespace FastTests.Server.Documents
                 ctx.Transaction.Commit();
             }
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -173,7 +170,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void EtagsArePersisted()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -195,7 +192,7 @@ namespace FastTests.Server.Documents
 
             Restart();
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -219,7 +216,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void EtagsArePersistedWithDeletes()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -242,7 +239,7 @@ namespace FastTests.Server.Documents
 
             Restart();
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
                 using (var doc = ctx.ReadObject(new DynamicJsonValue
@@ -281,7 +278,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void CanQueryByPrefix()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -321,7 +318,7 @@ namespace FastTests.Server.Documents
                 ctx.Transaction.Commit();
             }
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -340,7 +337,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void CanQueryByCollectionEtag()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -381,7 +378,7 @@ namespace FastTests.Server.Documents
                 ctx.Transaction.Commit();
             }
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -400,7 +397,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void WillVerifyEtags_New()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -424,7 +421,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void WillVerifyEtags_Existing()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -448,7 +445,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void WillVerifyEtags_OnDeleteExisting()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -472,7 +469,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void WillVerifyEtags_OnDeleteNotThere()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -485,7 +482,7 @@ namespace FastTests.Server.Documents
         [Fact]
         public void WillVerifyEtags_ShouldBeNew()
         {
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -510,7 +507,7 @@ namespace FastTests.Server.Documents
         public void PutDocumentWithoutId()
         {
             var key = "users/";
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -528,7 +525,7 @@ namespace FastTests.Server.Documents
                 ctx.Transaction.Commit();
             }
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -537,7 +534,7 @@ namespace FastTests.Server.Documents
                 ctx.Transaction.Commit();
             }
 
-            using (var ctx = new DocumentsOperationContext(_unmanagedBuffersPool, _documentDatabase))
+            using (var ctx = new DocumentsOperationContext(_documentDatabase))
             {
                 ctx.OpenWriteTransaction();
 
@@ -559,7 +556,6 @@ namespace FastTests.Server.Documents
         public void Dispose()
         {
             _documentDatabase.Dispose();
-            _unmanagedBuffersPool.Dispose();
         }
     }
 }

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -271,7 +271,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     Storage = FieldStorage.No
                 } }), database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         using (var tx = context.OpenWriteTransaction())
                         {
@@ -961,7 +961,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 var index1 = database.IndexStore.GetIndex(index1Id);
                 var index2 = database.IndexStore.GetIndex(index2Id);
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                using (var context = new DocumentsOperationContext(database))
                 {
                     await index1.Query(new IndexQueryServerSide(), context, OperationCancelToken.None); // last querying time
                     context.Reset();
@@ -981,7 +981,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 SystemTime.UtcDateTime = () => DateTime.UtcNow.Add(database.Configuration.Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdle.AsTimeSpan);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                using (var context = new DocumentsOperationContext(database))
                 {
                     await index1.Query(new IndexQueryServerSide(), context, OperationCancelToken.None); // last querying time
                 }

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapReduceIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapReduceIndexing.cs
@@ -34,7 +34,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 
                 mri.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await mri.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -50,7 +50,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     Assert.Equal(2L, count);
                 }
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await mri.Query(new IndexQueryServerSide()
                     {
@@ -95,7 +95,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 Assert.Equal(numberOfUsers, batchStats.ReduceSuccesses);
                 Assert.Equal(0, batchStats.ReduceErrors);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide
                     {
@@ -133,7 +133,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 // index 10 users
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -145,7 +145,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     Assert.Equal(numberOfUsers, results[0].Data["Count"]);
                 }
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     using (var tx = context.OpenWriteTransaction())
                     {
@@ -158,7 +158,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 // one document deleted
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -175,7 +175,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 // document added again
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -187,7 +187,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     Assert.Equal(numberOfUsers, results[0].Data["Count"]);
                 }
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     using (var tx = context.OpenWriteTransaction())
                     {
@@ -203,7 +203,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 // all documents removed
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -217,7 +217,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 // documents added back
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -364,7 +364,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 mri.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await mri.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -382,7 +382,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     Assert.Equal(41L, result["Age"]);
                 }
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await mri.Query(new IndexQueryServerSide()
                     {
@@ -435,7 +435,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 mri.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await mri.Query(new IndexQueryServerSide()
                     {
@@ -485,7 +485,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
         private static void CreateUsers(DocumentDatabase db, long numberOfUsers, params string[] locations)
         {
-            using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+            using (var context = new DocumentsOperationContext(db))
             {
                 using (var tx = context.OpenWriteTransaction())
                 {
@@ -536,7 +536,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -548,7 +548,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     Assert.Equal(41L, results[0].Data["Age"]);
                 }
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     using (var tx = context.OpenWriteTransaction())
                     {
@@ -572,7 +572,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -611,7 +611,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None);
 
@@ -623,7 +623,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     Assert.Equal(41L, results[0].Data["Age"]);
                 }
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     using (var tx = context.OpenWriteTransaction())
                     {
@@ -647,7 +647,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var queryResult = await index.Query(new IndexQueryServerSide() { SortedFields = new []{ new SortedField("Location") }}, context, OperationCancelToken.None);
 
@@ -694,7 +694,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
                 index.DoIndexingWork(new IndexingStatsScope(new IndexingRunStats()), CancellationToken.None);
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+                using (var context = new DocumentsOperationContext(db))
                 {
                     var results = (await index.Query(new IndexQueryServerSide(), context, OperationCancelToken.None)).Results;
 
@@ -726,7 +726,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
         private static void CreateOrders(DocumentDatabase db, int numberOfOrders, string[] countries = null, string[] employees = null, string[] companies = null)
         {
-            using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), db))
+            using (var context = new DocumentsOperationContext(db))
             {
                 using (var tx = context.OpenWriteTransaction())
                 {

--- a/test/FastTests/Server/Documents/Indexing/Lucene/LazyStringValueReaderTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Lucene/LazyStringValueReaderTests.cs
@@ -9,13 +9,11 @@ namespace FastTests.Server.Documents.Indexing.Lucene
     public class LazyStringValueReaderTests : IDisposable
     {
         private readonly LazyStringReader _sut = new LazyStringReader();
-        private readonly UnmanagedBuffersPool _pool;
         private readonly JsonOperationContext _ctx;
 
         public LazyStringValueReaderTests()
         {
-            _pool = new UnmanagedBuffersPool("foo");
-            _ctx = new JsonOperationContext(_pool);
+            _ctx = new JsonOperationContext();
         }
 
         [Theory]
@@ -76,7 +74,6 @@ namespace FastTests.Server.Documents.Indexing.Lucene
         public void Dispose()
         {
             _ctx.Dispose();
-            _pool.Dispose();
         }
     }
 }

--- a/test/FastTests/Server/Documents/Indexing/Lucene/LuceneDocumentConverterTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Lucene/LuceneDocumentConverterTests.cs
@@ -20,14 +20,12 @@ namespace FastTests.Server.Documents.Indexing.Lucene
     {
         private LuceneDocumentConverter _sut;
 
-        private readonly UnmanagedBuffersPool _pool;
         private readonly JsonOperationContext _ctx;
         private readonly List<BlittableJsonReaderObject> _docs = new List<BlittableJsonReaderObject>();
 
         public LuceneDocumentConverterTests()
         {
-            _pool = new UnmanagedBuffersPool("foo");
-            _ctx = new JsonOperationContext(_pool);
+            _ctx = new JsonOperationContext();
         }
 
         [Fact]
@@ -515,7 +513,6 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             }
 
             _ctx.Dispose();
-            _pool.Dispose();
         }
     }
 }

--- a/test/FastTests/Server/Documents/Indexing/MapReduce/GroupByComplexObjects.cs
+++ b/test/FastTests/Server/Documents/Indexing/MapReduce/GroupByComplexObjects.cs
@@ -43,7 +43,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
                     }
                 }, database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         Put_docs(context, database);
 
@@ -97,7 +97,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
                     }
                 }, database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         Put_docs(context, database);
 
@@ -159,7 +159,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
                     }
                 }, database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         Put_docs(context, database);
 
@@ -221,7 +221,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
                     }
                 }, database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         Put_docs(context, database);
 

--- a/test/FastTests/Server/Documents/Indexing/MapReduce/ReduceKeyProcessorTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/MapReduce/ReduceKeyProcessorTests.cs
@@ -13,7 +13,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
         public void Can_handle_values_of_different_types()
         {
             using (var bufferPool = new UnmanagedBuffersPool("ReduceKeyProcessorTests"))
-            using (var context = new JsonOperationContext(bufferPool))
+            using (var context = new JsonOperationContext())
             {
                 var sut = new ReduceKeyProcessor(10, bufferPool);
 

--- a/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
@@ -34,7 +34,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                     Type = IndexType.Map
                 }, database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         using (var tx = context.OpenWriteTransaction())
                         {
@@ -209,7 +209,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                 }
             };
 
-            using (var context = new JsonOperationContext(new UnmanagedBuffersPool(string.Empty)))
+            using (var context = new JsonOperationContext())
             {
                 var builder = indexDefinition.ToJson();
                 using (var json = context.ReadObject(builder, nameof(IndexDefinition)))

--- a/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapReduceIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapReduceIndexing.cs
@@ -40,7 +40,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                             }"
                 }, database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         using (var tx = context.OpenWriteTransaction())
                         {
@@ -130,7 +130,7 @@ select new
                     }
                 }, database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         using (var tx = context.OpenWriteTransaction())
                         {
@@ -250,7 +250,7 @@ select new
                 };
                 Assert.Equal(2, database.IndexStore.CreateIndex(defTwo));
 
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                using (var context = new DocumentsOperationContext(database))
                 {
                     using (var tx = context.OpenWriteTransaction())
                     {

--- a/test/FastTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
@@ -150,7 +150,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                 var queryResult =
                     await
                         index.Query(new IndexQueryServerSide(),
-                            new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database),
+                            new DocumentsOperationContext(database),
                             OperationCancelToken.None);
 
                 var results = queryResult.Results;
@@ -209,7 +209,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                 }
 
                 queryResult = await index.Query(new IndexQueryServerSide(),
-                            new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database),
+                            new DocumentsOperationContext(database),
                             OperationCancelToken.None);
 
                 results = queryResult.Results;
@@ -262,7 +262,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                             new SortedField("Location"),
                         }
                     },
-                    new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database),
+                    new DocumentsOperationContext(database),
                     OperationCancelToken.None);
 
                 results = queryResult.Results;

--- a/test/FastTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
@@ -51,8 +51,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                 }), database);
 
                 var mapReduceContext = new MapReduceIndexingContext();
-                using (var pool = new UnmanagedBuffersPool("test"))
-                using (var contextPool = new TransactionContextPool(pool, database.DocumentsStorage.Environment))
+                using (var contextPool = new TransactionContextPool(database.DocumentsStorage.Environment))
                 {
                     var indexStorage = new IndexStorage(index, contextPool, database);
 
@@ -86,8 +85,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                 }, database);
 
                 var mapReduceContext = new MapReduceIndexingContext();
-                using (var pool = new UnmanagedBuffersPool("test"))
-                using (var contextPool = new TransactionContextPool(pool, database.DocumentsStorage.Environment))
+                using (var contextPool = new TransactionContextPool(database.DocumentsStorage.Environment))
                 {
                     var indexStorage = new IndexStorage(index, contextPool, database);
                     var reducer = new ReduceMapResultsOfStaticIndex(index._compiled.Reduce, index.Definition, indexStorage, new MetricsCountersManager(), mapReduceContext);

--- a/test/FastTests/Server/Documents/Indexing/Static/DynamicBlittableJsonTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/DynamicBlittableJsonTests.cs
@@ -14,14 +14,12 @@ namespace FastTests.Server.Documents.Indexing.Static
 {
     public class DynamicBlittableJsonTests
     {
-        private readonly UnmanagedBuffersPool _pool;
         private readonly JsonOperationContext _ctx;
         private readonly List<BlittableJsonReaderObject> _docs = new List<BlittableJsonReaderObject>();
 
         public DynamicBlittableJsonTests()
         {
-            _pool = new UnmanagedBuffersPool("foo");
-            _ctx = new JsonOperationContext(_pool);
+            _ctx = new JsonOperationContext();
         }
 
         [Fact]
@@ -95,7 +93,6 @@ namespace FastTests.Server.Documents.Indexing.Static
             }
 
             _ctx.Dispose();
-            _pool.Dispose();
         }
     }
 }

--- a/test/FastTests/Server/Documents/Tombstones/BasicTombstones.cs
+++ b/test/FastTests/Server/Documents/Tombstones/BasicTombstones.cs
@@ -21,7 +21,7 @@ namespace FastTests.Server.Documents.Tombstones
         {
             using (var database = CreateDocumentDatabase())
             {
-                using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                using (var context = new DocumentsOperationContext(database))
                 {
                     PutResult result;
                     using (var tx = context.OpenWriteTransaction())
@@ -80,7 +80,7 @@ namespace FastTests.Server.Documents.Tombstones
                     Storage = FieldStorage.No
                 } }), database))
                 {
-                    using (var context = new DocumentsOperationContext(new UnmanagedBuffersPool(string.Empty), database))
+                    using (var context = new DocumentsOperationContext(database))
                     {
                         using (var tx = context.OpenWriteTransaction())
                         {

--- a/test/FastTests/Server/Json/BlittableJsonTraverserTests.cs
+++ b/test/FastTests/Server/Json/BlittableJsonTraverserTests.cs
@@ -11,15 +11,13 @@ namespace FastTests.Server.Json
 {
     public class BlittableJsonTraverserTests : IDisposable
     {
-        private readonly UnmanagedBuffersPool _pool;
         private readonly JsonOperationContext _ctx;
         private readonly List<BlittableJsonReaderObject> _docs = new List<BlittableJsonReaderObject>();
         private readonly BlittableJsonTraverser _sut = new BlittableJsonTraverser();
 
         public BlittableJsonTraverserTests()
         {
-            _pool = new UnmanagedBuffersPool("foo");
-            _ctx = new JsonOperationContext(_pool);
+            _ctx = new JsonOperationContext();
         }
 
         [Fact]
@@ -258,7 +256,6 @@ namespace FastTests.Server.Json
             }
 
             _ctx.Dispose();
-            _pool.Dispose();
         }
     }
 }

--- a/test/FastTests/Utils/IncludeUtilTests.cs
+++ b/test/FastTests/Utils/IncludeUtilTests.cs
@@ -84,8 +84,7 @@ namespace FastTests.Utils
                 })
             };
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -112,8 +111,7 @@ namespace FastTests.Utils
                 })
             };
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -160,8 +158,7 @@ namespace FastTests.Utils
                 })
             };
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -209,8 +206,7 @@ namespace FastTests.Utils
                 })
             };
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -266,8 +262,7 @@ namespace FastTests.Utils
                 })
             };
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -332,8 +327,7 @@ namespace FastTests.Utils
                 })
             };
 
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -484,8 +478,7 @@ namespace FastTests.Utils
                     }
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -561,8 +554,7 @@ namespace FastTests.Utils
                     }
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -637,8 +629,7 @@ namespace FastTests.Utils
                     }
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -655,8 +646,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = new DynamicJsonArray(new object[] { 1, 2, 3 })
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -673,8 +663,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = new DynamicJsonArray(new object[] { 1, 2, 3 })
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -709,8 +698,7 @@ namespace FastTests.Utils
                     },
                 })
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -745,8 +733,7 @@ namespace FastTests.Utils
                     },
                 })
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -763,8 +750,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = new DynamicJsonArray(new[] { "foo/1", "foo/2", "foo/3" })
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -788,8 +774,7 @@ namespace FastTests.Utils
                     ["ContactInfoId2"] = new DynamicJsonArray(new[] { "foo/1", "foo/2", "foo/3" })
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -812,8 +797,7 @@ namespace FastTests.Utils
                 ["ContactInfoId2"] = new DynamicJsonArray(new object[] { 1.1, 2.2, 3.3 }),
                 ["ContactInfoId3"] = new DynamicJsonArray(new object[] { (long)1, (long)2, (long)3 })
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -841,8 +825,7 @@ namespace FastTests.Utils
                     ["ContactInfoId"] = "contacts/1"
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -863,8 +846,7 @@ namespace FastTests.Utils
                     ["ContactInfoId"] = 1
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -901,8 +883,7 @@ namespace FastTests.Utils
                     ["ContactInfoId"] = 1
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -939,8 +920,7 @@ namespace FastTests.Utils
                     ["ContactInfoId"] = "megadevice"
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -977,8 +957,7 @@ namespace FastTests.Utils
                     ["ContactInfoId"] = "megadevice"
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1023,8 +1002,7 @@ namespace FastTests.Utils
                     }
                 }
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1050,8 +1028,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = "contacts/1"
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1069,8 +1046,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = "contacts/1"
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1090,8 +1066,7 @@ namespace FastTests.Utils
                 ["ContactInfoId2"] = (long)56,
                 ["ContactInfoId3"] = 78.89, //this one is double
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1116,8 +1091,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = 1
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1135,8 +1109,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = 1
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1163,8 +1136,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = 1
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1182,8 +1154,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = 1
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1202,8 +1173,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = 1
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1229,8 +1199,7 @@ namespace FastTests.Utils
                 ["Name"] = "John Doe",
                 ["ContactInfoId"] = 1
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1258,8 +1227,7 @@ namespace FastTests.Utils
                 ["AddressInfoId"] = "addresses/1",
                 ["CarInfoId"] = "cars/1"
             };
-            using (var pool = new UnmanagedBuffersPool("test"))
-            using (var context = new JsonOperationContext(pool))
+            using (var context = new JsonOperationContext())
             using (var reader = context.ReadObject(obj, "foo"))
             {
                 var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/test/SlowTests/Tests/Indexes/LinqIndexesFromClient.cs
+++ b/test/SlowTests/Tests/Indexes/LinqIndexesFromClient.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Tests.Indexes
             var index = IndexAndTransformerCompiler.Compile(indexDefinition);
             var map = index.Maps.Values.First();
 
-            using (var context = new JsonOperationContext(new UnmanagedBuffersPool(string.Empty)))
+            using (var context = new JsonOperationContext())
             {
                 var results = map(new[]
                 {


### PR DESCRIPTION
- Replace usages of UnmanagedBuffersPool with ArenaMemoryAllocator
- Add arena for long lived object in JsonOperationContext
- When resetting JsonOperationContext, reset NativeTempBuffer to null
- Avoid escaping forward slash characters
