### PR TITLE
Enhanced optimisitic concurrency control

### DIFF
--- a/Raven.Client.Lightweight/Shard/BaseShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/BaseShardedDocumentSession.cs
@@ -156,14 +156,14 @@ namespace Raven.Client.Shard
             }
         }
 
-        protected override void StoreEntityInUnitOfWork(string id, object entity, Etag etag, RavenJObject metadata, bool forceConcurrencyCheck)
+        protected override void StoreEntityInUnitOfWork(string id, object entity, Etag etag, RavenJObject metadata, bool forceConcurrencyCheck, bool disableConcurrencyCheck)
         {
             string modifyDocumentId = null;
             if (id != null)
             {
                 modifyDocumentId = ModifyObjectId(id, entity, metadata);
             }
-            base.StoreEntityInUnitOfWork(modifyDocumentId, entity, etag, metadata, forceConcurrencyCheck);
+            base.StoreEntityInUnitOfWork(modifyDocumentId, entity, etag, metadata, forceConcurrencyCheck, disableConcurrencyCheck);
         }
 
         protected string ModifyObjectId(string id, object entity, RavenJObject metadata)

--- a/Raven.Client.Lightweight/Shard/BaseShardedDocumentSession.cs
+++ b/Raven.Client.Lightweight/Shard/BaseShardedDocumentSession.cs
@@ -156,14 +156,14 @@ namespace Raven.Client.Shard
             }
         }
 
-        protected override void StoreEntityInUnitOfWork(string id, object entity, Etag etag, RavenJObject metadata, bool forceConcurrencyCheck, bool disableConcurrencyCheck)
+        protected override void StoreEntityInUnitOfWork(string id, object entity, Etag etag, RavenJObject metadata, ConcurrencyCheckMode concurrencyCheckMode)
         {
             string modifyDocumentId = null;
             if (id != null)
             {
                 modifyDocumentId = ModifyObjectId(id, entity, metadata);
             }
-            base.StoreEntityInUnitOfWork(modifyDocumentId, entity, etag, metadata, forceConcurrencyCheck, disableConcurrencyCheck);
+            base.StoreEntityInUnitOfWork(modifyDocumentId, entity, etag, metadata, concurrencyCheckMode);
         }
 
         protected string ModifyObjectId(string id, object entity, RavenJObject metadata)

--- a/Raven.Tests.Core/Raven.Tests.Core.csproj
+++ b/Raven.Tests.Core/Raven.Tests.Core.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Replication\ManualConflictResolution.cs" />
     <Compile Include="ScriptedPatching\ScriptedPatchTests.cs" />
     <Compile Include="Session\Advanced.cs" />
+    <Compile Include="Session\OptimisticConcurrency.cs" />
     <Compile Include="Shard\Sharding.cs" />
     <Compile Include="Smuggler\SmugglerApiTests.cs" />
     <Compile Include="Utils\Entities\Camera.cs" />

--- a/Raven.Tests.Core/Session/Advanced.cs
+++ b/Raven.Tests.Core/Session/Advanced.cs
@@ -200,38 +200,6 @@ namespace Raven.Tests.Core.Session
         }
 
         [Fact]
-        public void CanUseOptmisticConcurrency()
-        {
-            const string entityId = "users/1";
-
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    Assert.False(session.Advanced.UseOptimisticConcurrency);
-                    session.Advanced.UseOptimisticConcurrency = true;
-
-                    session.Store(new User { Id = entityId, Name = "User1" });
-                    session.SaveChanges();
-
-                    using (var otherSession = store.OpenSession())
-                    {
-                        var otherUser = otherSession.Load<User>(entityId);
-                        otherUser.Name = "OtherName";
-                        otherSession.Store(otherUser);
-                        otherSession.SaveChanges();
-                    }
-
-                    var user = session.Load<User>("users/1");
-                    user.Name = "Name";
-                    session.Store(user);
-                    var e = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
-                    Assert.Equal("PUT attempted on document '" + entityId + "' using a non current etag", e.Message);
-                }
-            }
-        }
-
-        [Fact]
         public void CanGetDocumentUrl()
         {
             using (var store = GetDocumentStore())

--- a/Raven.Tests.Core/Session/OptimisticConcurrency.cs
+++ b/Raven.Tests.Core/Session/OptimisticConcurrency.cs
@@ -1,0 +1,200 @@
+﻿using System.Threading.Tasks;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Exceptions;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+
+namespace Raven.Tests.Core.Session
+{
+    public class OptimisticConcurrency : RavenCoreTestBase
+    {
+#if DNXCORE50
+        public Advanced(TestServerFixture fixture)
+            : base(fixture)
+        {
+
+        }
+#endif
+        [Fact]
+        public void CanUseOptmisticConcurrency()
+        {
+            const string entityId = "users/1";
+
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    Assert.False(session.Advanced.UseOptimisticConcurrency);
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    session.Store(new User { Id = entityId, Name = "User1" });
+                    session.SaveChanges();
+
+                    using (var otherSession = store.OpenSession())
+                    {
+                        var otherUser = otherSession.Load<User>(entityId);
+                        otherUser.Name = "OtherName";
+                        otherSession.Store(otherUser);
+                        otherSession.SaveChanges();
+                    }
+
+                    var user = session.Load<User>("users/1");
+                    user.Name = "Name";
+                    session.Store(user);
+                    var e = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+                    Assert.Equal("PUT attempted on document '" + entityId + "' using a non current etag", e.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanBypassOptmisticConcurrencyCheckByExplicitlyProvidingAnEtagOfNull()
+        {
+            const string entityId = "users/1";
+
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    session.Store(new User { Id = entityId, Name = "User1" });
+                    session.SaveChanges();
+
+                    using (var otherSession = store.OpenSession())
+                    {
+                        var otherUser = otherSession.Load<User>(entityId);
+                        otherUser.Name = "OtherName";
+                        otherSession.Store(otherUser);
+                        otherSession.SaveChanges();
+                    }
+
+                    var user = session.Load<User>("users/1");
+                    user.Name = "Name";
+                    session.Store(user, (Etag)null);
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        [Fact]
+        public void CanBypassOptmisticConcurrencyCheckByExplicitlyProvidingAnEtagOfNullToStore()
+        {
+            const string entityId = "users/1";
+
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    session.Store(new User { Id = entityId, Name = "User1" });
+                    session.SaveChanges();
+
+                    using (var otherSession = store.OpenSession())
+                    {
+                        var otherUser = otherSession.Load<User>(entityId);
+                        otherUser.Name = "OtherName";
+                        otherSession.Store(otherUser);
+                        otherSession.SaveChanges();
+                    }
+
+                    var user = session.Load<User>("users/1");
+                    user.Name = "Name";
+                    session.Store(user, (Etag)null);
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        [Fact]
+        public void CanBypassOptmisticConcurrencyCheckByExplicitlyProvidingAnEtagAndAnIdOfNullToStore()
+        {
+            const string entityId = "users/1";
+
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    session.Store(new User { Id = entityId, Name = "User1" });
+                    session.SaveChanges();
+
+                    using (var otherSession = store.OpenSession())
+                    {
+                        var otherUser = otherSession.Load<User>(entityId);
+                        otherUser.Name = "OtherName";
+                        otherSession.Store(otherUser);
+                        otherSession.SaveChanges();
+                    }
+
+                    var user = session.Load<User>("users/1");
+                    user.Name = "Name";
+                    session.Store(user, (Etag)null);
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanBypassOptmisticConcurrencyCheckByExplicitlyProvidingAnEtagOfNullToStoreAsync()
+        {
+            const string entityId = "users/1";
+
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    await session.StoreAsync(new User { Id = entityId, Name = "User1" });
+                    await session.SaveChangesAsync();
+
+                    using (var otherSession = store.OpenSession())
+                    {
+                        var otherUser = otherSession.Load<User>(entityId);
+                        otherUser.Name = "OtherName";
+                        otherSession.Store(otherUser);
+                        otherSession.SaveChanges();
+                    }
+
+                    var user = await session.LoadAsync<User>("users/1");
+                    user.Name = "Name";
+                    await session.StoreAsync(user, null, entityId);
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanBypassOptmisticConcurrencyCheckByExplicitlyProvidingAnEtagAndAnIdOfNullToStoreAsync()
+        {
+            const string entityId = "users/1";
+
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    await session.StoreAsync(new User { Id = entityId, Name = "User1" });
+                    await session.SaveChangesAsync();
+
+                    using (var otherSession = store.OpenSession())
+                    {
+                        var otherUser = otherSession.Load<User>(entityId);
+                        otherUser.Name = "OtherName";
+                        otherSession.Store(otherUser);
+                        otherSession.SaveChanges();
+                    }
+
+                    var user = await session.LoadAsync<User>("users/1");
+                    user.Name = "Name";
+                    await session.StoreAsync(user, null, entityId);
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
As discussed on the maling list:

```
// normal behaviour depending on UseOptimisticConcurrency 
session.Store(entity);

// forces optimistic concurrency check
session.Store(entity, etag:someEtagl);

// NEW: disables optimistic concurrency check even if UseOptimisticConcurrency is set
session.Store(entity, etag:null);
```

...the same for the overloads with id and etag as well as the async version
