### PR TITLE
RavenDB-4961 Prevent from getting the synchronization process stuck i…

### DIFF
--- a/Raven.Abstractions/FileSystem/SynchronizationDestination.cs
+++ b/Raven.Abstractions/FileSystem/SynchronizationDestination.cs
@@ -68,5 +68,10 @@ namespace Raven.Abstractions.FileSystem
                 return hashCode;
             }
         }
+
+        public override string ToString()
+        {
+            return Url;
+        }
     }
 }

--- a/Raven.Database/FileSystem/Synchronization/SynchronizationTask.cs
+++ b/Raven.Database/FileSystem/Synchronization/SynchronizationTask.cs
@@ -404,7 +404,7 @@ namespace Raven.Database.FileSystem.Synchronization
             var destinationUrl = destinationSyncClient.BaseUrl;
 
             bool enqueued = false;
-            Etag incrementedEtag = Etag.Empty;
+            var maxEtagOfFilteredDoc = Etag.Empty;
 
             foreach (var fileHeader in filteredFilesToSynchronization)
             {
@@ -433,28 +433,34 @@ namespace Raven.Database.FileSystem.Synchronization
 
                 if (work == null)
                 {
-                    Log.Debug("File '{0}' were not synchronized to {1}. {2}", file, destinationUrl, reason.GetDescription());
+                    Log.Debug("File '{0}' was not synchronized to {1}. {2}", file, destinationUrl, reason.GetDescription());
 
-                    if (reason == NoSyncReason.ContainedInDestinationHistory)
+                    switch (reason)
                     {
-                        var etag = Etag.Parse(localMetadata.Value<string>(Constants.MetadataEtagField));
+                        case NoSyncReason.ContainedInDestinationHistory:
+                        case NoSyncReason.DestinationFileConflicted:
+                        case NoSyncReason.NoNeedToDeleteNonExistigFile:
+                            var localEtag = Etag.Parse(localMetadata.Value<string>(Constants.MetadataEtagField));
 
-                        await destinationSyncClient.IncrementLastETagAsync(storage.Id, FileSystemUrl, etag).ConfigureAwait(false);
-                        RemoveSyncingConfiguration(file, destinationUrl);
+                            if (reason == NoSyncReason.ContainedInDestinationHistory)
+                            {
+                                RemoveSyncingConfiguration(file, destinationUrl);
+                            }
+                            else if (reason == NoSyncReason.DestinationFileConflicted)
+                            {
+                                if (needSyncingAgain.Contains(fileHeader, FileHeaderNameEqualityComparer.Instance) == false)
+                                    CreateSyncingConfiguration(fileHeader.Name, fileHeader.Etag, destinationUrl, SynchronizationType.Unknown);
+                            }
+                            else if (reason == NoSyncReason.NoNeedToDeleteNonExistigFile)
+                            {
+                                // after the upgrade to newer build there can be still an existing syncing configuration for it
+                                RemoveSyncingConfiguration(file, destinationUrl);
+                            }
 
-                        if (EtagUtil.IsGreaterThan(etag, incrementedEtag))
-                            incrementedEtag = etag;
-                    }
-                    else if (reason == NoSyncReason.DestinationFileConflicted)
-                    {
-                        if (needSyncingAgain.Contains(fileHeader, FileHeaderNameEqualityComparer.Instance) == false)
-                            CreateSyncingConfiguration(fileHeader.Name, fileHeader.Etag, destinationUrl, SynchronizationType.Unknown);
+                            if (EtagUtil.IsGreaterThan(localEtag, maxEtagOfFilteredDoc))
+                                maxEtagOfFilteredDoc = localEtag;
 
-                        var etag = Etag.Parse(localMetadata.Value<string>(Constants.MetadataEtagField));
-                        await destinationSyncClient.IncrementLastETagAsync(storage.Id, FileSystemUrl, etag).ConfigureAwait(false);
-
-                        if (EtagUtil.IsGreaterThan(etag, incrementedEtag))
-                            incrementedEtag = etag;
+                            break;
                     }
 
                     continue;
@@ -477,8 +483,12 @@ namespace Raven.Database.FileSystem.Synchronization
                 enqueued = true;
             }
 
-            if (enqueued == false && EtagUtil.IsGreaterThan(incrementedEtag, synchronizationInfo.LastSourceFileEtag))
+            if (enqueued == false && EtagUtil.IsGreaterThan(maxEtagOfFilteredDoc, synchronizationInfo.LastSourceFileEtag))
+            {
+                await destinationSyncClient.IncrementLastETagAsync(storage.Id, FileSystemUrl, maxEtagOfFilteredDoc).ConfigureAwait(false);
+
                 return false; // we bumped the last synced etag on a destination server, let it know it need to repeat the operation
+            }
 
             return true;
         }

--- a/Raven.Tests.FileSystem/Issues/RavenDB_4961.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_4961.cs
@@ -1,0 +1,51 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_4961.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Abstractions.Data;
+using Raven.Database.FileSystem.Synchronization;
+using Raven.Tests.FileSystem.Synchronization;
+using Raven.Tests.FileSystem.Synchronization.IO;
+using Xunit;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+    public class RavenDB_4961 : RavenFilesTestWithLogs
+    {
+        [Fact]
+        public async Task Synchronization_to_empty_fs_must_not_get_stuck_after_filtering_out_all_deletions()
+        {
+            var source = NewAsyncClient(0);
+            var destination = NewAsyncClient(1);
+
+            for (int i = 0; i < SynchronizationTask.NumberOfFilesToCheckForSynchronization; i++)
+            {
+                await source.UploadAsync("test.bin-" + i, new RandomStream(1));
+            }
+
+            for (int i = 0; i < SynchronizationTask.NumberOfFilesToCheckForSynchronization; i++)
+            {
+                await source.DeleteAsync("test.bin-" + i);
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                await source.UploadAsync("test.bin-" + (SynchronizationTask.NumberOfFilesToCheckForSynchronization + i), new RandomStream(1));
+            }
+
+            SyncTestUtils.TurnOnSynchronization(source, destination);
+
+            var report = await source.Synchronization.StartAsync();
+
+            Assert.NotEmpty(report[0].Reports);
+            Assert.True(report[0].Reports.All(x => x.Exception == null));
+
+            var lastSynchronization = await destination.Synchronization.GetLastSynchronizationFromAsync(await source.GetServerIdAsync());
+
+            Assert.NotEqual(Etag.Empty, lastSynchronization.LastSourceFileEtag);
+        }
+    }
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Linq" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
@@ -147,6 +148,7 @@
     <Compile Include="Issues\RavenDB_4092.cs" />
     <Compile Include="Issues\RavenDB_4189.cs" />
     <Compile Include="Issues\RavenDB_4690.cs" />
+    <Compile Include="Issues\RavenDB_4961.cs" />
     <Compile Include="Issues\RavenDB_FEI_2.cs" />
     <Compile Include="Issues\RavenDB_3648.cs" />
     <Compile Include="Issues\RavenDB_2889.cs" />


### PR DESCRIPTION
…f all deletions in the synchronization batch are filtered out because we sync to empty file system (so there is nothing to delete there)
