### PR TITLE
RavenDB-4961 Prevent from getting the synchronization process stuck i…

### DIFF
--- a/Raven.Abstractions/FileSystem/SynchronizationDestination.cs
+++ b/Raven.Abstractions/FileSystem/SynchronizationDestination.cs
@@ -83,5 +83,10 @@ namespace Raven.Abstractions.FileSystem
                 return hashCode;
             }
         }
+
+        public override string ToString()
+        {
+            return Url;
+        }
     }
 }

--- a/Raven.Tests.FileSystem/Issues/RavenDB_4961.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_4961.cs
@@ -1,0 +1,51 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_4961.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Abstractions.Data;
+using Raven.Database.FileSystem.Synchronization;
+using Raven.Tests.FileSystem.Synchronization;
+using Raven.Tests.FileSystem.Synchronization.IO;
+using Xunit;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+    public class RavenDB_4961 : RavenFilesTestWithLogs
+    {
+        [Fact]
+        public async Task Synchronization_to_empty_fs_must_not_get_stuck_after_filtering_out_all_deletions()
+        {
+            var source = NewAsyncClient(0);
+            var destination = NewAsyncClient(1);
+
+            for (int i = 0; i < SynchronizationTask.NumberOfFilesToCheckForSynchronization; i++)
+            {
+                await source.UploadAsync("test.bin-" + i, new RandomStream(1));
+            }
+
+            for (int i = 0; i < SynchronizationTask.NumberOfFilesToCheckForSynchronization; i++)
+            {
+                await source.DeleteAsync("test.bin-" + i);
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                await source.UploadAsync("test.bin-" + (SynchronizationTask.NumberOfFilesToCheckForSynchronization + i), new RandomStream(1));
+            }
+
+            SyncTestUtils.TurnOnSynchronization(source, destination);
+
+            var report = await source.Synchronization.StartAsync();
+
+            Assert.NotEmpty(report[0].Reports);
+            Assert.True(report[0].Reports.All(x => x.Exception == null));
+
+            var lastSynchronization = await destination.Synchronization.GetLastSynchronizationFromAsync(await source.GetServerIdAsync());
+
+            Assert.NotEqual(Etag.Empty, lastSynchronization.LastSourceFileEtag);
+        }
+    }
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -87,6 +87,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Linq" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
@@ -177,6 +178,7 @@
     <Compile Include="Issues\RavenDB_4219.cs" />
     <Compile Include="Issues\RavenDB_4189.cs" />
     <Compile Include="Issues\RavenDB_4690.cs" />
+    <Compile Include="Issues\RavenDB_4961.cs" />
     <Compile Include="Issues\RavenDB_FEI_2.cs" />
     <Compile Include="Issues\RavenDB_3648.cs" />
     <Compile Include="Issues\RavenDB_2889.cs" />


### PR DESCRIPTION
…f all deletions in the synchronization batch are filtered out because we sync to empty file system (so there is nothing to delete there)
