### PR TITLE
Removed redundant condition

### DIFF
--- a/Raven.Abstractions/Connection/CompressedContent.cs
+++ b/Raven.Abstractions/Connection/CompressedContent.cs
@@ -3,10 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Raven.Abstractions.Connection
@@ -84,10 +82,7 @@ namespace Raven.Abstractions.Connection
 
                 await originalContent.CopyToAsync(compressedStream).ConfigureAwait(false);
 
-                if (compressedStream != null)
-                {
-                    compressedStream.Dispose();
-                }
+                compressedStream.Dispose();
             }
         }
 


### PR DESCRIPTION
Removed redundant condition.
compressedStream can not be null in this place.
