### PR TITLE
IAsyncDocumentQuery enhancements

### DIFF
--- a/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
@@ -839,11 +839,11 @@ namespace Raven.Client.Document
             SetTransformerParameters(queryInputs);
         }
 
-        public void SetTransformerParameters(Dictionary<string, RavenJToken> parameters)
+        public IAsyncDocumentQuery<T> SetTransformerParameters(Dictionary<string, RavenJToken> parameters)
         {
             transformerParameters = parameters;
+            return this;
         }
-
 
         /// <summary>
         /// Register the query as a lazy-count query in the session and return a lazy

--- a/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
@@ -1134,6 +1134,20 @@ namespace Raven.Client.Document
             return AsyncDatabaseCommands.GetFacetsAsync(indexName, q, facets, facetStart, facetPageSize, token);
         }
 
+        public virtual Lazy<Task<FacetResults>> GetFacetsLazyAsync(string facetSetupDoc, int facetStart, int? facetPageSize, CancellationToken token = default(CancellationToken))
+        {
+            var q = GetIndexQuery(true);
+            var lazyFacetsOperation = new LazyFacetsOperation(AsyncIndexQueried, facetSetupDoc, q, start, pageSize);
+            return ((AsyncDocumentSession)theSession).AddLazyOperation(lazyFacetsOperation, (Action<FacetResults>)null);
+        }
+
+        public virtual Lazy<Task<FacetResults>> GetFacetsLazyAsync(List<Facet> facets, int facetStart, int? facetPageSize, CancellationToken token = default(CancellationToken))
+        {
+            var q = GetIndexQuery(true);
+            var lazyFacetsOperation = new LazyFacetsOperation(AsyncIndexQueried, facets, q, start, pageSize);
+            return ((AsyncDocumentSession)theSession).AddLazyOperation(lazyFacetsOperation, (Action<FacetResults>)null);
+        }
+
         /// <summary>
         /// Returns a list of results for a query asynchronously. 
         /// </summary>
@@ -1143,7 +1157,6 @@ namespace Raven.Client.Document
             var tuple = await ProcessEnumerator(currentQueryOperation).WithCancellation(token).ConfigureAwait(false);
             return tuple.Item2;
         }
-
         
         public async Task<T> FirstAsync()
         {

--- a/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AsyncDocumentQuery.cs
@@ -1195,7 +1195,7 @@ namespace Raven.Client.Document
         /// Register the query as a lazy query in the session and return a lazy
         /// instance that will evaluate the query only when needed
         /// </summary>
-        public virtual Lazy<Task<IEnumerable<T>>> LazilyAsync(Action<IEnumerable<T>> onEval)
+        public virtual Lazy<Task<IEnumerable<T>>> LazilyAsync(Action<IEnumerable<T>> onEval = null)
         {
             if (queryOperation == null)
             {

--- a/Raven.Client.Lightweight/Document/AsyncShardedDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AsyncShardedDocumentQuery.cs
@@ -180,7 +180,7 @@ namespace Raven.Client.Document
         }
 
         
-        public override Lazy<Task<IEnumerable<T>>> LazilyAsync(Action<IEnumerable<T>> onEval)
+        public override Lazy<Task<IEnumerable<T>>> LazilyAsync(Action<IEnumerable<T>> onEval = null)
         {
             throw new NotSupportedException("Async lazy requests are not supported for sharded store");
         }

--- a/Raven.Client.Lightweight/Document/AsyncShardedDocumentQuery.cs
+++ b/Raven.Client.Lightweight/Document/AsyncShardedDocumentQuery.cs
@@ -190,6 +190,16 @@ namespace Raven.Client.Document
             throw new NotSupportedException("Async lazy requests are not supported for sharded store");
         }
 
+        public override Lazy<Task<FacetResults>> GetFacetsLazyAsync(List<Facet> facets, int facetStart, int? facetPageSize, CancellationToken token = new CancellationToken())
+        {
+            throw new NotSupportedException("Async lazy requests are not supported for sharded store");
+        }
+
+        public override Lazy<Task<FacetResults>> GetFacetsLazyAsync(string facetSetupDoc, int facetStart, int? facetPageSize, CancellationToken token = new CancellationToken())
+        {
+            throw new NotSupportedException("Async lazy requests are not supported for sharded store");
+        }
+
         public override IDatabaseCommands DatabaseCommands
         {
             get { throw new NotSupportedException("Sharded has more than one DatabaseCommands to operate on."); }

--- a/Raven.Client.Lightweight/IAsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/IAsyncDocumentQuery.cs
@@ -32,7 +32,17 @@ namespace Raven.Client
         ///     Get the facets as per the specified facets with the given start and pageSize
         /// </summary>
         Task<FacetResults> GetFacetsAsync(List<Facet> facets, int facetStart, int? facetPageSize, CancellationToken token = default (CancellationToken));
+        
+        /// <summary>
+        ///     Get the facets lazily as per the specified doc with the given start and pageSize
+        /// </summary>
+        Lazy<Task<FacetResults>> GetFacetsLazyAsync(string facetSetupDoc, int facetStart, int? facetPageSize, CancellationToken token = default(CancellationToken));
 
+        /// <summary>
+        ///     Get the facets lazily as per the specified doc with the given start and pageSize
+        /// </summary>
+        Lazy<Task<FacetResults>> GetFacetsLazyAsync(List<Facet> facets, int facetStart, int? facetPageSize, CancellationToken token = default(CancellationToken));
+        
         /// <summary>
         ///     Create the index query object for this query
         /// </summary>

--- a/Raven.Client.Lightweight/IAsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/IAsyncDocumentQuery.cs
@@ -94,7 +94,7 @@ namespace Raven.Client
         /// <summary>
         ///     Transformer parameters that will be passed to transformer if one is specified.
         /// </summary>
-        void SetTransformerParameters(Dictionary<string, RavenJToken> transformerParameters);
+        IAsyncDocumentQuery<T> SetTransformerParameters(Dictionary<string, RavenJToken> transformerParameters);
 
         /// <summary>
         ///     Ability to use one factory to determine spatial shape that will be used in query.

--- a/Raven.Client.Lightweight/IAsyncDocumentQuery.cs
+++ b/Raven.Client.Lightweight/IAsyncDocumentQuery.cs
@@ -53,7 +53,7 @@ namespace Raven.Client
         ///     instance that will evaluate the query only when needed.
         /// Also provide a function to execute when the value is evaluated
         /// </summary>
-        Lazy<Task<IEnumerable<T>>> LazilyAsync(Action<IEnumerable<T>> onEval);
+        Lazy<Task<IEnumerable<T>>> LazilyAsync(Action<IEnumerable<T>> onEval = null);
 
         /// <summary>
         ///     Gets the query result. Executing this method for the first time will execute the query.


### PR DESCRIPTION
A few enhancements to IAsyncDocumentQuery
- Support for getting facets lazily and asynchronously
- onEval parameter now optional on LazilyAsync method
- return IAsyncDocumentQuery<T> from SetTransformerParameters

Thanks
