### PR TITLE
Removed parameter exportFolder from CalculateExportFile.

### DIFF
--- a/Raven.Abstractions/Connection/CompressedContent.cs
+++ b/Raven.Abstractions/Connection/CompressedContent.cs
@@ -3,10 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Raven.Abstractions.Connection
@@ -84,10 +82,7 @@ namespace Raven.Abstractions.Connection
 
                 await originalContent.CopyToAsync(compressedStream).ConfigureAwait(false);
 
-                if (compressedStream != null)
-                {
-                    compressedStream.Dispose();
-                }
+                compressedStream.Dispose();
             }
         }
 

--- a/Raven.Database/Impl/Generators/JsonCodeGenerator.cs
+++ b/Raven.Database/Impl/Generators/JsonCodeGenerator.cs
@@ -1,15 +1,11 @@
 using Raven.Abstractions.Data;
-using Raven.Abstractions.Extensions;
 using Raven.Imports.Newtonsoft.Json.Linq;
 using Raven.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Dynamic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Raven.Database.Impl.Generators
 {
@@ -134,8 +130,6 @@ namespace Raven.Database.Impl.Generators
             public ClassType( string name, IDictionary<string, FieldType> properties = null ) : base ( name, false )
             {
                 this.Properties = new ReadOnlyDictionary<string, FieldType>(properties);
-                if (this.Properties == null)
-                    this.Properties = NoProperties;
             }
 
             public static bool operator ==(ClassType a, ClassType b)

--- a/Raven.Database/Indexing/LuceneAST.cs
+++ b/Raven.Database/Indexing/LuceneAST.cs
@@ -1,19 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.DirectoryServices.ActiveDirectory;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Tokenattributes;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Raven.Abstractions.Data;
 using Raven.Database.Indexing.LuceneIntegration;
-using Raven.Database.Util;
 
 namespace Raven.Database.Indexing
 {
@@ -319,7 +315,7 @@ This edge-case has a very slim chance of happening, but still we should not igno
             //This is probably wrong, need to check what happens with analyzed unqouted terms.
             if (Type == TermType.UnQuoted && !string.IsNullOrEmpty(Similarity))
             {
-                var similarity = string.IsNullOrEmpty(Similarity) ? (float)0.5 : float.Parse(Similarity);
+                var similarity = float.Parse(Similarity);
 
                 return new FuzzyQuery(new Term(configuration.FieldName, terms.FirstOrDefault()), similarity, 0) { Boost = boost };
             }

--- a/Raven.Database/Smuggler/SmugglerCounterApi.cs
+++ b/Raven.Database/Smuggler/SmugglerCounterApi.cs
@@ -76,7 +76,7 @@ namespace Raven.Database.Smuggler
             if (Options.Incremental)
             {
                 ShowProgress("Starting incremental export..");
-                exportFolder = CalculateExportFile(exportOptions, exportFolder);
+                exportFolder = CalculateExportFile(exportOptions);
             }
             else
             {
@@ -149,7 +149,7 @@ namespace Raven.Database.Smuggler
             }
         }
 
-        private static string CalculateExportFile(SmugglerExportOptions<CounterConnectionStringOptions> exportOptions, string exportFolder)
+        private static string CalculateExportFile(SmugglerExportOptions<CounterConnectionStringOptions> exportOptions)
         {
             if (Directory.Exists(exportOptions.ToFile) == false)
             {
@@ -158,7 +158,7 @@ namespace Raven.Database.Smuggler
                 else
                     Directory.CreateDirectory(exportOptions.ToFile);
             }
-            exportFolder = exportOptions.ToFile;
+            var exportFolder = exportOptions.ToFile;
 
             exportOptions.ToFile = Path.Combine(exportOptions.ToFile, SystemTime.UtcNow.ToString("yyyy-MM-dd-HH-mm-0", CultureInfo.InvariantCulture) + CounterIncrementalDump);
             if (File.Exists(exportOptions.ToFile))


### PR DESCRIPTION
Removed parameter exportFolder because it is always rewritten before being used. Using local variable is better for this code.
