### PR TITLE
RavenDB-4919

### DIFF
--- a/Raven.Tests.Raft/Client/Basic.cs
+++ b/Raven.Tests.Raft/Client/Basic.cs
@@ -147,7 +147,7 @@ namespace Raven.Tests.Raft.Client
                 var databaseCommands = nonLeaderDocStore.DatabaseCommands;
                 var clusterAwareRequestExecuter = ((ClusterAwareRequestExecuter)((ServerClient)databaseCommands).RequestExecuter);
                 var nonLeaderUrl = clusterAwareRequestExecuter.LeaderNode.Url.Replace(leader.Configuration.ServerUrl, nonLeader.Configuration.ServerUrl);
-                clusterAwareRequestExecuter.LeaderNode = new OperationMetadata(nonLeaderUrl);
+                clusterAwareRequestExecuter.SetLeaderNodeToKnownLeader(new OperationMetadata(nonLeaderUrl));
                 databaseCommands.Put("keys/" + 1, null, new RavenJObject(), new RavenJObject());
 
                 Assert.NotNull(leaderDocStore.DatabaseCommands.Get("keys/1"));


### PR DESCRIPTION
- removed LeaderNode setter - now you must use explicit functions to set the LeaderNode making it less likely to create race conditions
- made leaderNode volatile so we can always read/write its value from any thread.
- Setting leaderNode will be set through interlocked operation except for when SetLeaderNodeToKnownLeader function is used and it basically means i don't care what is the current value this is the right value.
