### PR TITLE
RavenDB-4817 fixed compilation

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
+++ b/Raven.Client.Lightweight/FileSystem/AsyncFilesServerClient.cs
@@ -658,15 +658,8 @@ namespace Raven.Client.FileSystem
                 streamConsumed = true;
             }, size, metadata, etag);
         }
+
         public Task UploadAsync(string filename, Action<Stream> source, Action prepareStream, long? size, RavenJObject metadata = null, Etag etag = null)
-        {
-            return UploadAsync(filename, s =>
-            {
-                source(s);
-                return new CompletedTask();
-            }, prepareStream, size, metadata, etag);
-        }
-        public Task UploadAsync(string filename, Func<Stream,Task> source, Action prepareStream, long? size, RavenJObject metadata = null, Etag etag = null)
         {
             if (metadata == null)
                 metadata = new RavenJObject();

--- a/Raven.Client.Lightweight/IAdvancedDocumentSessionOperations.cs
+++ b/Raven.Client.Lightweight/IAdvancedDocumentSessionOperations.cs
@@ -174,7 +174,7 @@ namespace Raven.Client
         /// <summary>
         /// SaveChanges will wait for the changes made to be replicates to `replicas` nodes
         /// </summary>
-        void WaitForReplicationAfterSaveChanges(TimeSpan? timeout = null, bool throwOnTimeout = true, int replicas = 1);
+        void WaitForReplicationAfterSaveChanges(TimeSpan? timeout = null, bool throwOnTimeout = true, int replicas = 1, bool majority = false);
 
         /// <summary>
         /// SaveChanges will wait for the indexes to catch up with the saved changes


### PR DESCRIPTION
@ayende I've reverted the https://github.com/ayende/ravendb/commit/ed4da5ac1da347e129446fd79ba32f12f33eac26 AsyncFilesServerClient changes, not sure why they were added (and it did not compile because of that and the interface desync)
