### PR TITLE
RavenDB-4885

### DIFF
--- a/Raven.Studio.Html5/App/models/dto.ts
+++ b/Raven.Studio.Html5/App/models/dto.ts
@@ -1536,6 +1536,7 @@ interface nodeConnectionInfoDto {
 
 interface clusterConfigurationDto {
     EnableReplication: boolean;
+    DisableReplicationStateChecks: boolean;
     DatabaseSettings?: dictionary<string>;
 }
 

--- a/Raven.Studio.Html5/App/viewmodels/manage/globalConfig/globalConfigDatabaseSettings.ts
+++ b/Raven.Studio.Html5/App/viewmodels/manage/globalConfig/globalConfigDatabaseSettings.ts
@@ -44,7 +44,8 @@ class globalConfigDatabaseSettings extends viewModelBase {
         });
 
         new saveClusterConfigurationCommand({
-                    EnableReplication: this.loadedClusterConfigurationDto().EnableReplication,
+            EnableReplication: this.loadedClusterConfigurationDto().EnableReplication,
+                    DisableReplicationStateChecks: this.loadedClusterConfigurationDto().DisableReplicationStateChecks,
                     DatabaseSettings: customSettings
                 },
                 appUrl.getSystemDatabase())

--- a/Raven.Studio.Html5/App/views/manage/cluster.html
+++ b/Raven.Studio.Html5/App/views/manage/cluster.html
@@ -47,11 +47,9 @@
                             <li><a href="#" data-bind="click: initializeNewCluster">Secede from cluster - rude step down into a single node cluster</a></li>
                             <li><a href="#" data-bind="click: addAnotherServerToCluster.bind($root, true)">Kidnap node into cluster - force a node to the current cluster</a></li>
                             <li><a href="#" data-bind="click: removeClustering.bind($root)">Remove cluster entirely and perform cleanup.</a></li>
+                            <li data-bind="visible: !isReplicationCheckEnabled()"><a href="#" data-bind="click: toggleReplicationChecks.bind($root)">Allow out of date leaders.</a></li>
+                            <li data-bind="visible: isReplicationCheckEnabled()"><a href="#" data-bind="click: toggleReplicationChecks.bind($root)">Prevent out of date leaders.</a></li>
                         </ul>
-                        <button class="btn btn-default" data-bind="click: function () { toggleReplicationChecks(); return true; }, attr: { title: isReplicationCheckEnabled() ?  'will not enforce replication state':'Will enforce replication state' }">
-                            <i class="fa fa-fw fa-umbrella" data-bind="style: { color: isReplicationCheckEnabled() ?  'red':'green' }"></i>
-                            <span data-bind="text: isReplicationCheckEnabled() ? 'Disable replication checks':'Enable replication checks'"></span>
-                        </button>
                     </div>
                 </div>
                 <div class="panel-body">

--- a/Raven.Studio.Html5/App/views/manage/cluster.html
+++ b/Raven.Studio.Html5/App/views/manage/cluster.html
@@ -47,7 +47,7 @@
                             <li><a href="#" data-bind="click: initializeNewCluster">Secede from cluster - rude step down into a single node cluster</a></li>
                             <li><a href="#" data-bind="click: addAnotherServerToCluster.bind($root, true)">Kidnap node into cluster - force a node to the current cluster</a></li>
                             <li><a href="#" data-bind="click: removeClustering.bind($root)">Remove cluster entirely and perform cleanup.</a></li>
-                            <li data-bind="visible: !isReplicationCheckEnabled()"><a href="#" data-bind="click: toggleReplicationChecks.bind($root)">Allow out of date leaders.</a></li>
+                            <li data-bind="visible: !isReplicationCheckEnabled()"><a href="#" data-bind="click: toggleReplicationChecks.bind($root)">Disable replication state sync.</a></li>
                             <li data-bind="visible: isReplicationCheckEnabled()"><a href="#" data-bind="click: toggleReplicationChecks.bind($root)">Prevent out of date leaders.</a></li>
                         </ul>
                     </div>

--- a/Raven.Studio.Html5/App/views/manage/cluster.html
+++ b/Raven.Studio.Html5/App/views/manage/cluster.html
@@ -48,6 +48,10 @@
                             <li><a href="#" data-bind="click: addAnotherServerToCluster.bind($root, true)">Kidnap node into cluster - force a node to the current cluster</a></li>
                             <li><a href="#" data-bind="click: removeClustering.bind($root)">Remove cluster entirely and perform cleanup.</a></li>
                         </ul>
+                        <button class="btn btn-default" data-bind="click: function () { toggleReplicationChecks(); return true; }, attr: { title: isReplicationCheckEnabled() ?  'will not enforce replication state':'Will enforce replication state' }">
+                            <i class="fa fa-fw fa-umbrella" data-bind="style: { color: isReplicationCheckEnabled() ?  'red':'green' }"></i>
+                            <span data-bind="text: isReplicationCheckEnabled() ? 'Disable replication checks':'Enable replication checks'"></span>
+                        </button>
                     </div>
                 </div>
                 <div class="panel-body">


### PR DESCRIPTION
Allowing admins to toggle the Replication state checks.
Note that this reside in the ClusterConfiguration document and as such is been managed by raft.
Since this is somewhat of an emergency operation, if this fails I’ll check the state of the configuration against the local value and if it is the same except for the replication state checks i'll overwrite the local configuration.
