### PR TITLE
RavenDB-4986 - alerts document should be empty on startup

### DIFF
--- a/Raven.Tests/Storage/GeneralStorage.cs
+++ b/Raven.Tests/Storage/GeneralStorage.cs
@@ -268,6 +268,20 @@ namespace Raven.Tests.Storage
             });
         }
 
-        
+        [Fact]
+        public void check_alerts_document()
+        {
+            db.TransactionalStorage.Batch(actions =>
+            {
+                Assert.DoesNotThrow(() =>
+                {
+                    var doc = actions.Documents.DocumentByKey(Constants.RavenAlerts);
+                    if (doc == null)
+                        return;
+
+                    throw new InvalidOperationException("Alerts document data: " + doc.DataAsJson);
+                });
+            });
+        }
     }
 }


### PR DESCRIPTION
if not, we'll see its content
