### PR TITLE
RavenDB-5027 Query should close transaction only but not Reset context for documents which is used for holding TransformerParameters

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -769,7 +769,7 @@ namespace Raven.Server.Documents.Indexes
 
                         if (WillResultBeAcceptable(isStale, query, wait) == false)
                         {
-                            documentsContext.Reset();
+                            documentsContext.CloseTransaction();
                             indexContext.Reset();
 
                             Debug.Assert(query.WaitForNonStaleResultsTimeout != null);
@@ -784,7 +784,7 @@ namespace Raven.Server.Documents.Indexes
                         FillQueryResult(result, isStale, documentsContext, indexContext);
 
                         if (Type.IsMapReduce() && transformer == null)
-                            documentsContext.Reset(); // map reduce don't need to access mapResults storage unless we have a transformer. Possible optimization: if we will know if transformer needs transaction then we may reset this here or not
+                            documentsContext.CloseTransaction(); // map reduce don't need to access mapResults storage unless we have a transformer. Possible optimization: if we will know if transformer needs transaction then we may reset this here or not
 
                         using (var reader = IndexPersistence.OpenIndexReader(indexTx.InnerTransaction))
                         {

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -13,22 +13,21 @@ using Raven.Server.Documents.Queries.Dynamic;
 using Raven.Server.Documents.Queries.MoreLikeThis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
-using Sparrow.Json;
+
 using PatchRequest = Raven.Server.Documents.Patch.PatchRequest;
 
 namespace Raven.Server.Documents.Queries
 {
-    public class QueryRunner : IDisposable
+    public class QueryRunner
     {
         private readonly DocumentDatabase _database;
 
         private readonly DocumentsOperationContext _documentsContext;
-        private IDisposable _allocateOperationContext;
 
-        public QueryRunner(DocumentDatabase database)
+        public QueryRunner(DocumentDatabase database, DocumentsOperationContext documentsContext)
         {
             _database = database;
-            _allocateOperationContext = _database.DocumentsStorage.ContextPool.AllocateOperationContext(out _documentsContext);
+            _documentsContext = documentsContext;
         }
 
         public async Task<DocumentQueryResult> ExecuteQuery(string indexName, IndexQueryServerSide query, StringValues includes, long? existingResultEtag, OperationCancelToken token)
@@ -119,7 +118,7 @@ namespace Raven.Server.Documents.Queries
             RavenTransaction tx = null;
             var operations = 0;
             var results = await index.Query(query, context, token).ConfigureAwait(false);
-            context.Reset();
+            context.CloseTransaction();
 
             if (options.AllowStale == false && results.IsStale)
                 throw new InvalidOperationException("Cannot perform delete operation. Query is stale.");
@@ -192,11 +191,6 @@ namespace Raven.Server.Documents.Queries
                 throw new InvalidOperationException("There is not index with name: " + indexName);
 
             return index;
-        }
-
-        public void Dispose()
-        {
-            _allocateOperationContext.Dispose();
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -70,6 +70,12 @@ namespace Raven.Server.ServerWide.Context
             return Transaction;
         }
 
+        public void CloseTransaction()
+        {
+            Transaction?.Dispose();
+            Transaction = null;
+        }
+
         public IntPtr PinObjectAndGetAddress(object obj)
         {
             var handle = GCHandle.Alloc(obj, GCHandleType.Pinned);
@@ -101,8 +107,7 @@ namespace Raven.Server.ServerWide.Context
         {
             base.Reset();
 
-            Transaction?.Dispose();            
-            Transaction = null;
+            CloseTransaction();
         }        
     }
 }


### PR DESCRIPTION
@ayende 

I think that https://github.com/ayende/ravendb/commit/6074efb7c6fd4ba8f60ce8ee301a837f61a7437c introduced 

``` csharp
Unhandled Exception: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
    at Sparrow.Json.BlittableJsonReaderBase.ReadVariableSizeInt(Byte* buffer, Int32 pos, Byte& offset)
    at Sparrow.Json.BlittableJsonReaderObject.GetPropertyIndex(StringSegment name)
    at Sparrow.Json.BlittableJsonReaderObject.TryGetMember(StringSegment name, Object& result)
    at Sparrow.Json.BlittableJsonReaderObject.TryGet[T](StringSegment name, T& obj)
    at Sparrow.Json.BlittableJsonReaderObject.TryGet[T](String name, T& obj)
    at Raven.Server.Documents.Document.EnsureMetadata()
    at Raven.Server.Json.BlittableJsonTextWriterExtensions.WriteDocuments(BlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable`1 documents, Boolean metadataOnly)
    at Raven.Server.Json.BlittableJsonTextWriterExtensions.WriteQueryResult(BlittableJsonTextWriter writer, JsonOperationContext context, QueryResultBase`1 result, Boolean metadataOnly, Boolean partial)
    at Raven.Server.Json.BlittableJsonTextWriterExtensions.WriteDocumentQueryResult(BlittableJsonTextWriter writer, JsonOperationContext context, DocumentQueryResult result, Boolean metadataOnly)
    at Raven.Server.Documents.Handlers.QueriesHandler.<Query>d__1.MoveNext()
    at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
    at Raven.Server.Documents.Handlers.QueriesHandler.Query(DocumentsOperationContext context, String indexName, OperationCancelToken token)
    at Raven.Server.Documents.Handlers.QueriesHandler.<Get>d__0.MoveNext()
    at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
    at Raven.Server.Documents.Handlers.QueriesHandler.Get()
```

because TransformersParameters were parsed in different DocumentsOperationContext than was used by QueryRunner. Introduced CloseTransaction method instead.
