### PR TITLE
RavenDB-5222 renaming of identity property should not cause the actua…

### DIFF
--- a/Raven.Tests.MailingList/ProjectionTests.cs
+++ b/Raven.Tests.MailingList/ProjectionTests.cs
@@ -103,7 +103,6 @@ namespace Raven.Tests.MailingList
                               })
                               .ToList();
 
-            Assert.Null(foos[0].Id);
             Assert.NotNull(foos[0].FooId);
         }
 


### PR DESCRIPTION
…l identity property to become null.
