### PR TITLE
RavenDB-5208 - Index and transformer replication reverts the changes after some time

### DIFF
--- a/Raven.Abstractions/Data/ChangeNotification.cs
+++ b/Raven.Abstractions/Data/ChangeNotification.cs
@@ -139,6 +139,11 @@ namespace Raven.Abstractions.Data
         /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// The transformer version that was changed
+        /// </summary>
+        public int? Version { get; set; }
+
         public override string ToString()
         {
             return string.Format("{0} on {1}", Type, Name);

--- a/Raven.Abstractions/Data/ChangeNotification.cs
+++ b/Raven.Abstractions/Data/ChangeNotification.cs
@@ -112,6 +112,11 @@ namespace Raven.Abstractions.Data
         public string Name { get; set; }
 
         /// <summary>
+        /// The index version that changed
+        /// </summary>
+        public int? Version { get; set; }
+
+        /// <summary>
         /// TODO [ppekrol]
         /// </summary>
         public Etag Etag { get; set; }

--- a/Raven.Abstractions/Data/IndexToAdd.cs
+++ b/Raven.Abstractions/Data/IndexToAdd.cs
@@ -3,6 +3,7 @@
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
+using System;
 using Raven.Abstractions.Indexing;
 
 namespace Raven.Abstractions.Data
@@ -23,5 +24,15 @@ namespace Raven.Abstractions.Data
         /// Priority of an index
         /// </summary>
         public IndexingPriority Priority { get; set; }
+
+        /// <summary>
+        /// Minimum etag before replacement
+        /// </summary>
+        public Etag MinimumEtagBeforeReplace { get; set; }
+
+        /// <summary>
+        /// UTC time of replacement
+        /// </summary>
+        public DateTime? ReplaceTimeUtc { get; set; }
     }
 }

--- a/Raven.Abstractions/Indexing/IndexDefinition.cs
+++ b/Raven.Abstractions/Indexing/IndexDefinition.cs
@@ -38,6 +38,11 @@ namespace Raven.Abstractions.Indexing
         public IndexLockMode LockMode { get; set; }
 
         /// <summary>
+        /// Index version, used in index replication in order to identify if two indexes are indeed the same.
+        /// </summary>
+        public int? IndexVersion { get; set; }
+
+        /// <summary>
         /// Index map function, if there is only one
         /// </summary>
         /// <remarks>

--- a/Raven.Abstractions/Indexing/TransformerDefinition.cs
+++ b/Raven.Abstractions/Indexing/TransformerDefinition.cs
@@ -17,7 +17,12 @@ namespace Raven.Abstractions.Indexing
         /// </summary>
         public string Name { get; set; }
 
-        public TransformerLockMode LockMode { get; set; } 
+        public TransformerLockMode LockMode { get; set; }
+
+        /// <summary>
+        /// Transformer version, used in transformer replication in order to identify if two transformers are indeed the same.
+        /// </summary>
+        public int? TransformerVersion { get; set; }
 
         public bool Equals(TransformerDefinition other)
         {

--- a/Raven.Abstractions/Raven.Abstractions.csproj
+++ b/Raven.Abstractions/Raven.Abstractions.csproj
@@ -427,6 +427,7 @@
     <Compile Include="Spatial\GeoJsonWktConverter.cs" />
     <Compile Include="Spatial\WktSanitizer.cs" />
     <Compile Include="SystemTime.cs" />
+    <Compile Include="Util\InterlockedLock.cs" />
     <Compile Include="Util\AssemblyHelper.cs" />
     <Compile Include="Util\AsyncEnumeratorBridge.cs" />
     <Compile Include="Util\AsyncHelpers.cs" />

--- a/Raven.Abstractions/Util/InterlockedLock.cs
+++ b/Raven.Abstractions/Util/InterlockedLock.cs
@@ -1,0 +1,29 @@
+//-----------------------------------------------------------------------
+// <copyright file="InterlockedLock.cs" company="Hibernating Rhinos LTD">
+//     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+using System.Threading;
+
+namespace Raven.Abstractions.Util
+{
+    public class InterlockedLock
+    {
+        private int lockStatus = 0;
+        private const int Locked = 1;
+        private const int UnLocked = 0;
+
+        public bool TryEnter()
+        {
+            if (Interlocked.CompareExchange(ref lockStatus, Locked, UnLocked) == Locked)
+                return false;
+
+            return true;
+        }
+
+        public void Exit()
+        {
+            Interlocked.Exchange(ref lockStatus, UnLocked);
+        }
+    }
+}

--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -938,7 +938,11 @@ namespace Raven.Database.Actions
             var indexDefinition = IndexDefinitionStorage.GetIndexDefinition(index);
             if (indexDefinition == null)
                 throw new InvalidOperationException("There is no index named: " + index);
+
             DeleteIndex(index);
+
+            //treat it like a new index
+            indexDefinition.IndexVersion = null;
             PutIndex(index, indexDefinition);
         }
 

--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -227,13 +227,13 @@ namespace Raven.Database.Actions
         // the method already handle attempts to create the same index, so we don't have to 
         // worry about this.
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public string PutIndex(string name, IndexDefinition definition)
+        public string PutIndex(string name, IndexDefinition definition, bool isReplication = false)
         {
-            return PutIndexInternal(name, definition);
+            return PutIndexInternal(name, definition, isReplication: isReplication);
         }
 
-        private string PutIndexInternal(string name, IndexDefinition definition, 
-            bool disableIndexBeforePut = false, bool isUpdateBySideSide = false, IndexCreationOptions? creationOptions = null)
+        private string PutIndexInternal(string name, IndexDefinition definition, bool disableIndexBeforePut = false,
+                    bool isUpdateBySideSide = false, IndexCreationOptions? creationOptions = null, bool isReplication = false)
         {
             if (name == null)
                 throw new ArgumentNullException("name");
@@ -244,25 +244,31 @@ namespace Raven.Database.Actions
             var existingIndex = IndexDefinitionStorage.GetIndexDefinition(name);
             if (existingIndex != null)
             {
-                switch (existingIndex.LockMode)
+                var newIndexVersion = definition.IndexVersion;
+                var currentIndexVersion = existingIndex.IndexVersion;
+
+                // whether we update the index definition or not,
+                // we need to update the index version
+                existingIndex.IndexVersion = definition.IndexVersion =
+                    Math.Max(currentIndexVersion ?? 0, newIndexVersion ?? 0);
+
+                switch (isReplication)
                 {
-                    case IndexLockMode.SideBySide:
-                        if (isUpdateBySideSide == false)
+                    case true:
+                        if (newIndexVersion != null && currentIndexVersion != null &&
+                            newIndexVersion <= currentIndexVersion)
                         {
-                            Log.Info("Index {0} not saved because it might be only updated by side-by-side index");
-                            throw new InvalidOperationException("Can not overwrite locked index: " + name + ". This index can be only updated by side-by-side index.");
+                            //this new index is an older version of the current one
+                            return null;
                         }
 
-                        //keep the SideBySide lock mode from the replaced index
-                        definition.LockMode = IndexLockMode.SideBySide;
-
+                        // we need to update the lock mode only if it was updated by another server
+                        existingIndex.LockMode = definition.LockMode;
                         break;
-                    case IndexLockMode.LockedIgnore:
-                        Log.Info("Index {0} not saved because it was lock (with ignore)", name);
-                        return null;
-
-                    case IndexLockMode.LockedError:
-                        throw new InvalidOperationException("Can not overwrite locked index: " + name);
+                    default:
+                        if (CanUpdateIndex(name, definition, isUpdateBySideSide, existingIndex) == false)
+                            return null;
+                        break;
                 }
             }
 
@@ -276,11 +282,27 @@ namespace Raven.Database.Actions
                     // ensure that the code can compile
                     new DynamicViewCompiler(definition.Name, definition, Database.Extensions, IndexDefinitionStorage.IndexDefinitionsPath, Database.Configuration).GenerateInstance();
                     IndexDefinitionStorage.UpdateIndexDefinitionWithoutUpdatingCompiledIndex(definition);
+                    if (isReplication == false)
+                        definition.IndexVersion = (definition.IndexVersion ?? 0) + 1;
                     return null;
                 case IndexCreationOptions.Update:
                     // ensure that the code can compile
                     new DynamicViewCompiler(definition.Name, definition, Database.Extensions, IndexDefinitionStorage.IndexDefinitionsPath, Database.Configuration).GenerateInstance();
                     DeleteIndex(name);
+                    if (isReplication == false)
+                        definition.IndexVersion = (definition.IndexVersion ?? 0) + 1;
+                    break;
+                case IndexCreationOptions.Create:
+                    if (isReplication == false)
+                    {
+                        // we create a new index,
+                        // we need to restore its previous IndexVersion (if it was deleted before)
+                        var deletedIndexVersion = IndexDefinitionStorage.GetDeletedIndexVersion(definition);
+                        var replacingIndexVersion = GetOriginalIndexVersion(definition.Name);
+                        definition.IndexVersion = Math.Max(deletedIndexVersion, replacingIndexVersion);
+                        definition.IndexVersion++;
+                    }
+
                     break;
             }
 
@@ -298,8 +320,45 @@ namespace Raven.Database.Actions
             return name;
         }
 
+        private bool CanUpdateIndex(string name, IndexDefinition definition, bool isUpdateBySideSide, IndexDefinition existingIndex)
+        {
+            switch (existingIndex.LockMode)
+            {
+                case IndexLockMode.SideBySide:
+                    if (isUpdateBySideSide == false)
+                    {
+                        Log.Info("Index {0} not saved because it might be only updated by side-by-side index");
+                        throw new InvalidOperationException("Can not overwrite locked index: " + name + ". This index can be only updated by side-by-side index.");
+                    }
+
+                    //keep the SideBySide lock mode from the replaced index
+                    definition.LockMode = IndexLockMode.SideBySide;
+                    break;
+                case IndexLockMode.LockedIgnore:
+                    Log.Info("Index {0} not saved because it was lock (with ignore)", name);
+                    return false;
+                case IndexLockMode.LockedError:
+                    throw new InvalidOperationException("Can not overwrite locked index: " + name);
+            }
+
+            return true;
+        }
+
+        private int GetOriginalIndexVersion(string name)
+        {
+            if (name.StartsWith(Constants.SideBySideIndexNamePrefix) == false)
+                return 0;
+
+            var originalName = name.Substring(Constants.SideBySideIndexNamePrefix.Length);
+            var existingIndex = IndexDefinitionStorage.GetIndexDefinition(originalName);
+            if (existingIndex == null)
+                return 0;
+
+            return existingIndex.IndexVersion ?? 0;
+        }
+
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public string[] PutIndexes(IndexToAdd[] indexesToAdd)
+        public string[] PutIndexes(IndexToAdd[] indexesToAdd, bool isReplication)
         {
             var createdIndexes = new List<string>();
             var prioritiesList = new List<IndexingPriority>();
@@ -307,7 +366,7 @@ namespace Raven.Database.Actions
             {
                 foreach (var indexToAdd in indexesToAdd)
                 {
-                    var nameToAdd = PutIndexInternal(indexToAdd.Name, indexToAdd.Definition, disableIndexBeforePut: true);
+                    var nameToAdd = PutIndexInternal(indexToAdd.Name, indexToAdd.Definition, disableIndexBeforePut: true, isReplication: isReplication);
                     if (nameToAdd == null)
                         continue;
 
@@ -320,10 +379,16 @@ namespace Raven.Database.Actions
 
                 for (var i = 0; i < createdIndexes.Count; i++)
                 {
-                    var index = createdIndexes[i];
+                    var indexName = createdIndexes[i];
                     var priority = prioritiesList[i];
 
-                    var instance = Database.IndexStorage.GetIndexInstance(index);
+                    var instance = Database.IndexStorage.GetIndexInstance(indexName);
+                    if (instance == null)
+                    {
+                        Log.Warn("Couldn't set index priority because index named: '{0}' doesn't exist", indexName);
+                        continue;
+                    }
+
                     instance.Priority = priority;
                 }
 
@@ -341,7 +406,7 @@ namespace Raven.Database.Actions
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public List<IndexInfo> PutSideBySideIndexes(SideBySideIndexes sideBySideIndexes)
+        public List<IndexInfo> PutSideBySideIndexes(SideBySideIndexes sideBySideIndexes, bool isReplication)
         {
             var createdIndexes = new List<IndexInfo>();
             var prioritiesList = new List<IndexingPriority>();
@@ -377,9 +442,8 @@ namespace Raven.Database.Actions
                         indexToAdd.Definition.LockMode = GetCurrentLockMode(originalIndexName) ?? indexToAdd.Definition.LockMode;
                     }
 
-                    long _;
                     var nameToAdd = PutIndexInternal(indexName, indexToAdd.Definition,
-                        disableIndexBeforePut: true, isUpdateBySideSide: true, creationOptions: creationOptions);
+                        disableIndexBeforePut: true, isUpdateBySideSide: true, creationOptions: creationOptions, isReplication: isReplication);
 
                     if (nameToAdd == null)
                         continue;
@@ -388,7 +452,9 @@ namespace Raven.Database.Actions
                     {
                         Name = indexName,
                         OriginalName = originalIndexName,
-                        IsSideBySide = isSideBySide
+                        IsSideBySide = isSideBySide,
+                        MinimumEtagBeforeReplace = indexToAdd.MinimumEtagBeforeReplace ?? sideBySideIndexes.MinimumEtagBeforeReplace,
+                        ReplaceTimeUtc = indexToAdd.ReplaceTimeUtc ?? sideBySideIndexes.ReplaceTimeUtc
                     });
 
                     prioritiesList.Add(indexToAdd.Priority);
@@ -412,7 +478,7 @@ namespace Raven.Database.Actions
                     instance.Priority = priority;
                 }
 
-                CreateIndexReplacementDocuments(sideBySideIndexes, createdIndexes);
+                CreateIndexReplacementDocuments(createdIndexes);
 
                 return createdIndexes;
             }
@@ -429,7 +495,7 @@ namespace Raven.Database.Actions
             }
         }
 
-        private void CreateIndexReplacementDocuments(SideBySideIndexes sideBySideIndexes, List<IndexInfo> createdIndexes)
+        private void CreateIndexReplacementDocuments(List<IndexInfo> createdIndexes)
         {
             Database.TransactionalStorage.Batch(accessor =>
             {
@@ -444,8 +510,8 @@ namespace Raven.Database.Actions
                         RavenJObject.FromObject(new IndexReplaceDocument
                         {
                             IndexToReplace = createdIndex.OriginalName,
-                            MinimumEtagBeforeReplace = sideBySideIndexes.MinimumEtagBeforeReplace,
-                            ReplaceTimeUtc = sideBySideIndexes.ReplaceTimeUtc
+                            MinimumEtagBeforeReplace = createdIndex.MinimumEtagBeforeReplace,
+                            ReplaceTimeUtc = createdIndex.ReplaceTimeUtc
                         }),
                         new RavenJObject(),
                         null);
@@ -471,6 +537,10 @@ namespace Raven.Database.Actions
             public string OriginalName { get; set; }
 
             public bool IsSideBySide { get; set; }
+
+            public Etag MinimumEtagBeforeReplace { get; set; }
+
+            public DateTime? ReplaceTimeUtc { get; set; }
         }
 
         private static void AssertAnalyzersValid(IndexDefinition indexDefinition)
@@ -941,8 +1011,8 @@ namespace Raven.Database.Actions
 
             DeleteIndex(index);
 
-            //treat it like a new index
-            indexDefinition.IndexVersion = null;
+            //treat it like an update to the current index
+            indexDefinition.IndexVersion = (indexDefinition.IndexVersion ?? 0) + 1;
             PutIndex(index, indexDefinition);
         }
 

--- a/Raven.Database/Actions/IndexActions.cs
+++ b/Raven.Database/Actions/IndexActions.cs
@@ -292,6 +292,7 @@ namespace Raven.Database.Actions
             {
                 Name = name,
                 Type = IndexChangeTypes.IndexAdded,
+                Version = definition.IndexVersion
             }));
 
             return name;
@@ -965,7 +966,8 @@ namespace Raven.Database.Actions
                 {
                     TimeOfOriginalDeletion = SystemTime.UtcNow,
                     instance.IndexId,
-                    IndexName = instance.Name
+                    IndexName = instance.Name,
+                    instance.IndexVersion
                 })), UuidType.Tasks));
 
                 // Delete the main record synchronously
@@ -991,6 +993,7 @@ namespace Raven.Database.Actions
                     {
                         Name = instance.Name,
                         Type = indexChangeType,
+                        Version = instance.IndexVersion
                     })
                 );
             }

--- a/Raven.Database/Actions/TransformerActions.cs
+++ b/Raven.Database/Actions/TransformerActions.cs
@@ -54,7 +54,7 @@ namespace Raven.Database.Actions
                                      {
                                          {"name", new RavenJValue(indexName) },
                                          {"definition", RavenJObject.FromObject(definitions)},
-                                         {"lockMode",new RavenJValue(definitions.LockMode.ToString())}
+                                         {"lockMode", new RavenJValue(definitions.LockMode.ToString())}
                                      };
                     }));
 
@@ -65,6 +65,7 @@ namespace Raven.Database.Actions
             return IndexDefinitionStorage.GetTransformerDefinition(name);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public bool DeleteTransform(string name)
         {
             if (!IndexDefinitionStorage.RemoveTransformer(name)) 
@@ -81,7 +82,7 @@ namespace Raven.Database.Actions
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public string PutTransform(string name, TransformerDefinition definition)
+        public string PutTransform(string name, TransformerDefinition definition, bool isReplication = false)
         {
             if (name == null) throw new ArgumentNullException("name");
             if (definition == null) throw new ArgumentNullException("definition");
@@ -91,19 +92,56 @@ namespace Raven.Database.Actions
             var existingDefinition = IndexDefinitionStorage.GetTransformerDefinition(name);
             if (existingDefinition != null)
             {
-                switch (existingDefinition.LockMode)
+                var newTransformerVersion = definition.TransformerVersion;
+                var currentTransformerVersion = existingDefinition.TransformerVersion;
+
+                // whether we update the transformer definition or not,
+                // we need to update the transformer version
+                existingDefinition.TransformerVersion = definition.TransformerVersion =
+                    Math.Max(currentTransformerVersion ?? 0, newTransformerVersion ?? 0);
+
+                switch (isReplication)
                 {
-                    case TransformerLockMode.Unlock:
-                        if (existingDefinition.Equals(definition))
-                            return name; // no op for the same transformer
+                    case true:
+                        if (newTransformerVersion != null && currentTransformerVersion != null &&
+                            newTransformerVersion <= currentTransformerVersion)
+                        {
+                            //this new transformer is an older version of the current one
+                            return null;
+                        }
+
+                        // we need to update the lock mode only if it was updated by another server
+                        existingDefinition.LockMode = definition.LockMode;
                         break;
-                    case TransformerLockMode.LockedIgnore:
-                        Log.Info("Transformer {0} not saved because it was lock (with ignore)", name);
-                        return name;
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        switch (existingDefinition.LockMode)
+                        {
+                            case TransformerLockMode.Unlock:
+                                if (existingDefinition.Equals(definition))
+                                    return name; // no op for the same transformer
+
+                                definition.TransformerVersion++;
+
+                                break;
+                            case TransformerLockMode.LockedIgnore:
+                                Log.Info("Transformer {0} not saved because it was lock (with ignore)", name);
+                                return name;
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
+                        break;
                 }
             }
+            else if (isReplication == false)
+            {
+                // we're creating a new transformer,
+                // we need to take the transformer version of the deleted transformer (if exists)
+                definition.TransformerVersion = GetDeletedTransformerId(definition.Name);
+                definition.TransformerVersion = (definition.TransformerVersion ?? 0) + 1;
+            }
+
+            if (definition.TransformerVersion == null)
+                definition.TransformerVersion = 0;
 
             var generator = IndexDefinitionStorage.CompileTransform(definition);
 
@@ -122,9 +160,27 @@ namespace Raven.Database.Actions
             {
                 Name = name,
                 Type = TransformerChangeTypes.TransformerAdded,
+                Version = definition.TransformerVersion
             }));
 
             return name;
+        }
+
+        private int GetDeletedTransformerId(string transformerName)
+        {
+            var version = 0;
+
+            TransactionalStorage.Batch(action =>
+            {
+                var li = action.Lists.Read(Constants.RavenReplicationTransformerTombstones, transformerName);
+                if (li == null)
+                    return;
+
+                var versionStr = li.Data.Value<string>("TransformerVersion");
+                int.TryParse(versionStr, out version);
+            });
+
+            return version;
         }
     }
 }

--- a/Raven.Database/Bundles/Replication/Tasks/IndexReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/IndexReplicationTask.cs
@@ -1,0 +1,585 @@
+// -----------------------------------------------------------------------
+//  <copyright file="IndexReplicationTask.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Abstractions;
+using Raven.Abstractions.Connection;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Extensions;
+using Raven.Abstractions.Indexing;
+using Raven.Abstractions.Logging;
+using Raven.Abstractions.Replication;
+using Raven.Abstractions.Util;
+using Raven.Bundles.Replication.Impl;
+using Raven.Bundles.Replication.Tasks;
+using Raven.Database.Util;
+using Raven.Json.Linq;
+using Sparrow.Collections;
+
+namespace Raven.Database.Bundles.Replication.Tasks
+{
+    public class IndexReplicationTask : ReplicationTaskBase
+    {
+        private readonly static ILog Log = LogManager.GetCurrentClassLogger();
+
+        private readonly TimeSpan replicationFrequency;
+        private readonly TimeSpan lastQueriedFrequency;
+        private readonly object indexReplicationLock = new object();
+        private Timer indexReplicationTimer;
+        private Timer lastQueriedTimer;
+
+        private readonly ConcurrentDictionary<int, IndexToAdd> sideBySideIndexesToReplicate =
+            new ConcurrentDictionary<int, IndexToAdd>();
+        private readonly ConcurrentDictionary<string, ConcurrentSet<int>> replicatedSideBySideIndexIds =
+            new ConcurrentDictionary<string, ConcurrentSet<int>>();
+        private long sideBySideWorkCounter;
+        private readonly InterlockedLock interlockedLock = new InterlockedLock();
+
+        public TimeSpan TimeToWaitBeforeSendingDeletesOfIndexesToSiblings { get; set; }
+
+        public IndexReplicationTask(DocumentDatabase database, HttpRavenRequestFactory httpRavenRequestFactory, ReplicationTask replication)
+            : base(database, httpRavenRequestFactory, replication)
+        {
+            replicationFrequency = TimeSpan.FromSeconds(database.Configuration.IndexAndTransformerReplicationLatencyInSec); //by default 10 min
+            lastQueriedFrequency = TimeSpan.FromSeconds(database.Configuration.TimeToWaitBeforeRunningIdleIndexes.TotalSeconds / 2);
+            TimeToWaitBeforeSendingDeletesOfIndexesToSiblings = TimeSpan.FromMinutes(1);
+        }
+
+        public void Start()
+        {
+            var indexDefinitions = Database.Indexes.Definitions;
+            var sideBySideIndexes = indexDefinitions.Where(x => x.Name.StartsWith(Constants.SideBySideIndexNamePrefix)).ToList();
+            foreach (var indexDefinition in sideBySideIndexes)
+            {
+                var indexName = indexDefinition.Name;
+                var instance = Database.IndexStorage.GetIndexInstance(indexName);
+                if (instance == null)
+                {
+                    //probably deleted
+                    continue;
+                }
+
+                var indexToAdd = new IndexToAdd
+                {
+                    Name = indexDefinition.Name,
+                    Definition = indexDefinition,
+                    Priority = instance.Priority
+                };
+
+                SetIndexReplaceInfo(indexName, indexToAdd);
+
+                StartReplicatingSideBySideIndexAsync(indexToAdd);
+            }
+
+            Database.Notifications.OnIndexChange += OnIndexChange;
+            Database.Notifications.OnDocumentChange += OnDocumentChange;
+
+            indexReplicationTimer = Database.TimerManager.NewTimer(x => Execute(), TimeSpan.Zero, replicationFrequency);
+            lastQueriedTimer = Database.TimerManager.NewTimer(x => SendLastQueried(), TimeSpan.Zero, lastQueriedFrequency);
+        }
+
+        public void StartReplicatingSideBySideIndexAsync(IndexToAdd indexToAdd)
+        {
+            if (indexToAdd.Name.StartsWith(Constants.SideBySideIndexNamePrefix))
+                indexToAdd.Name = indexToAdd.Name.Substring(Constants.SideBySideIndexNamePrefix.Length);
+
+            sideBySideIndexesToReplicate.TryAdd(indexToAdd.Definition.IndexId, indexToAdd);
+
+            ReplicateSideBySideIndexes();
+        }
+
+        public void ReplicateSideBySideIndexes()
+        {
+            var currentWorkCount = Interlocked.Increment(ref sideBySideWorkCounter);
+
+            if (interlockedLock.TryEnter() == false)
+            {
+                //already replicating side by side indexes
+                return;
+            }
+
+            if (sideBySideIndexesToReplicate.Count == 0)
+            {
+                //nothing to do
+                interlockedLock.Exit();
+                return;
+            }
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    var failedToReplicate = false;
+                    var commonReplicatedIndexIds = new HashSet<int>();
+                    var replicationDestinations = GetReplicationDestinations();
+
+                    foreach (var destination in replicationDestinations)
+                    {
+                        var url = destination.ConnectionStringOptions.Url;
+
+                        var replicatedIndexIds = replicatedSideBySideIndexIds.GetOrAdd(url, new ConcurrentSet<int>());
+                        var indexesToReplicate = sideBySideIndexesToReplicate
+                            .Where(x => replicatedIndexIds.Contains(x.Key) == false).ToList();
+
+                        if (indexesToReplicate.Count == 0)
+                            continue;
+
+                        try
+                        {
+                            ReplicateSideBySideIndexesMultiPut(destination, indexesToReplicate.Select(x => x.Value).ToList());
+                            foreach (var index in indexesToReplicate)
+                            {
+                                replicatedIndexIds.TryAdd(index.Key);
+                            }
+
+                            if (commonReplicatedIndexIds.Count == 0)
+                            {
+                                commonReplicatedIndexIds.UnionWith(replicatedIndexIds);
+                            }
+                            else
+                            {
+                                commonReplicatedIndexIds.IntersectWith(replicatedIndexIds);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            failedToReplicate = true;
+                            Log.ErrorException("Failed to replicate side by side index to " + destination, e);
+                        }
+                    }
+
+                    if (failedToReplicate)
+                        return;
+
+                    //since we replicated the side by side indexes for all destinations,
+                    //there won't be any need to replicate them again
+                    foreach (var indexId in commonReplicatedIndexIds)
+                    {
+                        IndexToAdd _;
+                        sideBySideIndexesToReplicate.TryRemove(indexId, out _);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.ErrorException("Failed to replicate side by side indexes", e);
+                }
+                finally
+                {
+                    interlockedLock.Exit();
+
+                    var newCount = Interlocked.Read(ref sideBySideWorkCounter);
+                    if (currentWorkCount != newCount)
+                    {
+                        //handling a race condition where we get a new side by side index to replicate
+                        //and exiting while thinking that this index will be handled
+                        ReplicateSideBySideIndexes();
+                    }
+                }
+            }, Database.WorkContext.CancellationToken);
+        }
+
+        private void OnDocumentChange(DocumentDatabase db, DocumentChangeNotification notification, RavenJObject doc)
+        {
+            var docId = notification.Id;
+            if (docId == null)
+                return;
+
+            if (docId.StartsWith(Constants.IndexReplacePrefix, StringComparison.OrdinalIgnoreCase) == false)
+                return;
+
+            if (notification.Type != DocumentChangeTypes.Put)
+                return;
+
+            var replaceIndexName = docId.Substring(Constants.IndexReplacePrefix.Length);
+            var instance = Database.IndexStorage.GetIndexInstance(replaceIndexName);
+            if (instance == null)
+                return;
+
+            var indexDefinition = Database.Indexes.GetIndexDefinition(replaceIndexName);
+            if (indexDefinition == null)
+                return;
+
+            var indexToAdd = new IndexToAdd
+            {
+                Name = replaceIndexName,
+                Definition = indexDefinition,
+                Priority = instance.Priority,
+            };
+
+            SetIndexReplaceInfo(replaceIndexName, indexToAdd);
+
+            StartReplicatingSideBySideIndexAsync(indexToAdd);
+        }
+
+        private void SetIndexReplaceInfo(string indexName, IndexToAdd indexToAdd)
+        {
+            var key = Constants.IndexReplacePrefix + indexName;
+            var replaceDoc = Database.Documents.Get(key, null);
+            if (replaceDoc == null)
+                return;
+
+            try
+            {
+                var indexReplaceInformation = replaceDoc.DataAsJson.JsonDeserialization<IndexReplaceDocument>();
+                indexToAdd.MinimumEtagBeforeReplace = indexReplaceInformation.MinimumEtagBeforeReplace;
+                indexToAdd.ReplaceTimeUtc = indexReplaceInformation.ReplaceTimeUtc;
+            }
+            catch (Exception)
+            {
+                //the index was already replaced or the document was deleted
+                //anyway, we'll try to replicate this index with default settings
+            }
+        }
+
+        public bool Execute(Func<ReplicationDestination, bool> shouldSkipDestinationPredicate = null)
+        {
+            if (Database.Disposed)
+                return false;
+
+            if (Monitor.TryEnter(indexReplicationLock) == false)
+                return false;
+
+            if (sideBySideIndexesToReplicate.Count > 0)
+            {
+                //we do replicate side by side indexes on creation
+                //this handles the case when we aren't able to connect to a certain destination
+                //we need to retry until we succeed
+                ReplicateSideBySideIndexes();
+            }
+
+            try
+            {
+                using (CultureHelper.EnsureInvariantCulture())
+                {
+                    shouldSkipDestinationPredicate = shouldSkipDestinationPredicate ?? (x => x.SkipIndexReplication == false);
+                    var replicationDestinations = GetReplicationDestinations(x => shouldSkipDestinationPredicate(x));
+
+                    foreach (var destination in replicationDestinations)
+                    {
+                        try
+                        {
+                            var now = SystemTime.UtcNow;
+
+                            var indexTombstones = GetTombstones(Constants.RavenReplicationIndexesTombstones, 0, 64,
+                                // we don't send out deletions immediately, we wait for a bit
+                                // to make sure that the user didn't reset the index or delete / create
+                                // things manually
+                                x => (now - x.CreatedAt) >= TimeToWaitBeforeSendingDeletesOfIndexesToSiblings);
+
+                            var replicatedIndexTombstones = new Dictionary<string, int>();
+
+                            ReplicateIndexDeletionIfNeeded(indexTombstones, destination, replicatedIndexTombstones);
+
+                            var indexesToAdd = new List<IndexToAdd>();
+
+                            var indexDefinitions = Database.Indexes.Definitions;
+                            if (indexDefinitions.Length > 0)
+                            {
+                                var replicatedIds = replicatedSideBySideIndexIds.GetOrAdd(destination.ConnectionStringOptions.Url, new ConcurrentSet<int>());
+
+                                var sideBySideIndexNamesToReplicate = indexDefinitions
+                                    .Where(x => replicatedIds.Contains(x.IndexId) == false &&
+                                                x.Name.StartsWith(Constants.SideBySideIndexNamePrefix))
+                                    .Select(x => x.Name).ToList();
+
+                                //filtering system indexes like Raven/DocumentsByEntityName and Raven/ConflictDocuments and side by side indexes
+                                var indexesToReplicate = indexDefinitions.Where(x =>
+                                    x.Name.StartsWith(Constants.SideBySideIndexNamePrefix) == false
+                                    && x.Name.StartsWith("Raven/") == false);
+
+                                foreach (var indexDefinition in indexesToReplicate)
+                                {
+                                    if (sideBySideIndexNamesToReplicate.Contains(Constants.SideBySideIndexNamePrefix + indexDefinition.Name))
+                                    {
+                                        //the side by side index for this index wasn't replicated,
+                                        //no need to replicate the original index yet
+                                        continue;
+                                    }
+
+                                    var instance = Database.IndexStorage.GetIndexInstance(indexDefinition.Name);
+                                    if (instance == null)
+                                    {
+                                        //probably deleted
+                                        continue;
+                                    }
+
+                                    indexesToAdd.Add(new IndexToAdd
+                                    {
+                                        Name = indexDefinition.Name,
+                                        Definition = indexDefinition,
+                                        Priority = instance.Priority
+                                    });
+                                }
+
+                                ReplicateIndexesMultiPut(destination, indexesToAdd);
+                            }
+
+                            Database.TransactionalStorage.Batch(actions =>
+                            {
+                                foreach (var indexTombstone in replicatedIndexTombstones)
+                                {
+                                    if (indexTombstone.Value != replicationDestinations.Count &&
+                                        Database.IndexStorage.HasIndex(indexTombstone.Key) == false)
+                                    {
+                                        continue;
+                                    }
+
+                                    actions.Lists.Remove(Constants.RavenReplicationIndexesTombstones, indexTombstone.Key);
+                                }
+                            });
+                        }
+                        catch (Exception e)
+                        {
+                            Log.ErrorException("Failed to replicate indexes to " + destination, e);
+                        }
+                    }
+
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                Log.ErrorException("Failed to replicate indexes", e);
+
+                return false;
+            }
+            finally
+            {
+                Monitor.Exit(indexReplicationLock);
+            }
+        }
+
+        public void Execute(string indexName)
+        {
+            var definition = Database.IndexDefinitionStorage.GetIndexDefinition(indexName);
+
+            if (definition == null)
+                return;
+
+            if (definition.IsSideBySideIndex)
+                return;
+
+            var destinations = GetReplicationDestinations(x => x.SkipIndexReplication == false);
+
+            var sideBySideIndexes = Database.Indexes.Definitions.Where(x => x.IsSideBySideIndex).ToDictionary(x => x.Name, x => x);
+
+            IndexDefinition sideBySideIndexDefinition;
+            if (sideBySideIndexes.TryGetValue("ReplacementOf/" + definition.Name, out sideBySideIndexDefinition))
+            {
+                foreach (var destination in destinations)
+                {
+                    ReplicateSingleSideBySideIndex(destination, definition, sideBySideIndexDefinition);
+                }
+
+                return;
+            }
+
+            foreach (var destination in destinations)
+            {
+                var instance = Database.IndexStorage.GetIndexInstance(definition.Name);
+                if (instance == null)
+                    continue;
+
+                ReplicateIndexesMultiPut(destination, new List<IndexToAdd>
+                    {
+                        new IndexToAdd
+                        {
+                            Name = definition.Name,
+                            Definition = definition,
+                            Priority = instance.Priority
+                        }
+                    });
+            }
+        }
+
+        private void OnIndexChange(DocumentDatabase documentDatabase, IndexChangeNotification notification)
+        {
+            var indexName = notification.Name;
+            switch (notification.Type)
+            {
+                case IndexChangeTypes.IndexAdded:
+                    //if we created index with the same name as deleted one, we should prevent its deletion replication
+                    Database.TransactionalStorage.Batch(accessor =>
+                        accessor.Lists.Remove(Constants.RavenReplicationIndexesTombstones, indexName));
+                    break;
+                case IndexChangeTypes.IndexRemoved:
+                    var indexDefinition = Database.IndexDefinitionStorage.GetIndexDefinition(indexName);
+                    if (indexDefinition != null)
+                    {
+                        //the side by side index was deleted
+                        IndexToAdd _;
+                        sideBySideIndexesToReplicate.TryRemove(indexDefinition.IndexId, out _);
+                    }
+
+                    //If we don't have any destination to replicate to (we are probably slave node)
+                    //we shouldn't keep a tombstone since we are not going to remove it anytime
+                    //and keeping it prevents us from getting that index created again.
+                    if (GetReplicationDestinations().Count == 0)
+                        return;
+
+                    var metadata = new RavenJObject
+                    {
+                        {Constants.RavenIndexDeleteMarker, true},
+                        {Constants.RavenReplicationSource, Database.TransactionalStorage.Id.ToString()},
+                        {Constants.RavenReplicationVersion, ReplicationHiLo.NextId(Database)},
+                        {"IndexVersion", notification.Version }
+                    };
+
+                    Database.TransactionalStorage.Batch(accessor => accessor.Lists.Set(Constants.RavenReplicationIndexesTombstones, indexName, metadata, UuidType.Indexing));
+                    break;
+            }
+        }
+
+        private void ReplicateIndexesMultiPut(ReplicationStrategy destination, List<IndexToAdd> indexesToAdd)
+        {
+            var serializedIndexDefinitions = RavenJToken.FromObject(indexesToAdd.ToArray());
+            var url = string.Format("{0}/indexes?{1}", destination.ConnectionStringOptions.Url, GetDebugInformation());
+
+            var replicationRequest = HttpRavenRequestFactory.Create(url, "PUT", destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
+            replicationRequest.Write(serializedIndexDefinitions);
+            replicationRequest.ExecuteRequest();
+        }
+
+        private void ReplicateSideBySideIndexesMultiPut(ReplicationStrategy destination, List<IndexToAdd> indexes)
+        {
+            var sideBySideIndexes = new SideBySideIndexes
+            {
+                IndexesToAdd = indexes.ToArray()
+            };
+
+            var serializedIndexDefinitions = RavenJToken.FromObject(sideBySideIndexes);
+            var url = string.Format("{0}/side-by-side-indexes?{1}", destination.ConnectionStringOptions.Url, GetDebugInformation());
+
+            var replicationRequest = HttpRavenRequestFactory.Create(url, "PUT", destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
+            replicationRequest.Write(serializedIndexDefinitions);
+            replicationRequest.ExecuteRequest();
+        }
+
+        private void ReplicateSingleSideBySideIndex(ReplicationStrategy destination, IndexDefinition indexDefinition, IndexDefinition sideBySideIndexDefinition)
+        {
+            var url = string.Format("{0}/replication/side-by-side?{1}", destination.ConnectionStringOptions.Url, GetDebugInformation());
+            IndexReplaceDocument indexReplaceDocument;
+
+            try
+            {
+                indexReplaceDocument = Database.Documents.Get(Constants.IndexReplacePrefix + sideBySideIndexDefinition.Name, null).DataAsJson.JsonDeserialization<IndexReplaceDocument>();
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Cannot get side-by-side index replacement document. Aborting operation. (this exception should not happen and the cause should be investigated)", e);
+                return;
+            }
+
+            var sideBySideReplicationInfo = new SideBySideReplicationInfo
+            {
+                Index = indexDefinition,
+                SideBySideIndex = sideBySideIndexDefinition,
+                OriginDatabaseId = destination.CurrentDatabaseId,
+                IndexReplaceDocument = indexReplaceDocument
+            };
+
+            var replicationRequest = HttpRavenRequestFactory.Create(url, "POST", destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
+            replicationRequest.Write(RavenJObject.FromObject(sideBySideReplicationInfo));
+            replicationRequest.ExecuteRequest();
+        }
+
+        private void ReplicateIndexDeletionIfNeeded(List<JsonDocument> indexTombstones, ReplicationStrategy destination, Dictionary<string, int> replicatedIndexTombstones)
+        {
+            if (indexTombstones.Count == 0)
+                return;
+
+            foreach (var tombstone in indexTombstones)
+            {
+                try
+                {
+                    int value;
+                    //In case the index was recreated under the same name we will increase the destination count for this tombstone 
+                    //As if we sent the delete request but without actually sending the request, ending with a NOOP and deleting the index tombstone.
+                    if (Database.IndexStorage.HasIndex(tombstone.Key))
+                    {
+                        replicatedIndexTombstones.TryGetValue(tombstone.Key, out value);
+                        replicatedIndexTombstones[tombstone.Key] = value + 1;
+                        continue;
+                    }
+
+                    var url = string.Format("{0}/indexes/{1}?{2}", destination.ConnectionStringOptions.Url, Uri.EscapeUriString(tombstone.Key), GetDebugInformation());
+                    var replicationRequest = HttpRavenRequestFactory.Create(url, "DELETE", destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
+                    replicationRequest.Write(RavenJObject.FromObject(EmptyRequestBody));
+                    replicationRequest.ExecuteRequest();
+                    Log.Info("Replicated index deletion (index name = {0})", tombstone.Key);
+
+                    replicatedIndexTombstones.TryGetValue(tombstone.Key, out value);
+                    replicatedIndexTombstones[tombstone.Key] = value + 1;
+                }
+                catch (Exception e)
+                {
+                    Replication.HandleRequestBufferingErrors(e, destination);
+
+                    Log.ErrorException(string.Format("Failed to replicate index deletion (index name = {0})", tombstone.Key), e);
+                }
+            }
+        }
+
+        public void SendLastQueried()
+        {
+            if (Database.Disposed)
+                return;
+
+            try
+            {
+                using (CultureHelper.EnsureInvariantCulture())
+                {
+                    var relevantIndexLastQueries = new Dictionary<string, DateTime>();
+                    var relevantIndexes = Database.Statistics.Indexes.Where(indexStats => indexStats.IsInvalidIndex == false && indexStats.Priority != IndexingPriority.Error && indexStats.Priority != IndexingPriority.Disabled && indexStats.LastQueryTimestamp.HasValue);
+
+                    foreach (var relevantIndex in relevantIndexes)
+                    {
+                        relevantIndexLastQueries[relevantIndex.Name] = relevantIndex.LastQueryTimestamp.GetValueOrDefault();
+                    }
+
+                    if (relevantIndexLastQueries.Count == 0) return;
+
+                    var destinations = GetReplicationDestinations(x => x.SkipIndexReplication == false);
+
+                    foreach (var destination in destinations)
+                    {
+                        try
+                        {
+                            string url = destination.ConnectionStringOptions.Url + "/indexes/last-queried";
+
+                            var replicationRequest = HttpRavenRequestFactory.Create(url, "POST", destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
+                            replicationRequest.Write(RavenJObject.FromObject(relevantIndexLastQueries));
+                            replicationRequest.ExecuteRequest();
+                        }
+                        catch (Exception e)
+                        {
+                            Replication.HandleRequestBufferingErrors(e, destination);
+
+                            Log.WarnException("Could not update last query time of " + destination.ConnectionStringOptions.Url, e);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Log.ErrorException("Failed to send last queried timestamp of indexes", e);
+            }
+        }
+
+        public override void Dispose()
+        {
+            if (indexReplicationTimer != null)
+                indexReplicationTimer.Dispose();
+
+            if (lastQueriedTimer != null)
+                lastQueriedTimer.Dispose();
+        }
+    }
+}

--- a/Raven.Database/Bundles/Replication/Tasks/ReplicationTaskBase.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/ReplicationTaskBase.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ItemsReplicationTaskBase.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Abstractions.Connection;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Replication;
+using Raven.Bundles.Replication.Tasks;
+using Raven.Database.Storage;
+using Raven.Json.Linq;
+
+namespace Raven.Database.Bundles.Replication.Tasks
+{
+    public abstract class ReplicationTaskBase : IDisposable
+    {
+        protected readonly object EmptyRequestBody = new object();
+        protected readonly DocumentDatabase Database;
+        protected readonly HttpRavenRequestFactory HttpRavenRequestFactory;
+        protected readonly ReplicationTask Replication;
+
+        protected ReplicationTaskBase(DocumentDatabase database, HttpRavenRequestFactory httpRavenRequestFactory, ReplicationTask replication)
+        {
+            Database = database;
+            HttpRavenRequestFactory = httpRavenRequestFactory;
+            Replication = replication;
+        }
+
+        protected string GetDebugInformation()
+        {
+            return Constants.IsIndexReplicatedUrlParamName + "=true&from=" + Uri.EscapeDataString(Database.ServerUrl);
+        }
+
+        protected List<JsonDocument> GetTombstones(string tombstoneListName, int start, int take, Func<ListItem, bool> wherePredicate = null)
+        {
+            List<JsonDocument> tombstones = null;
+
+            Database.TransactionalStorage.Batch(actions =>
+            {
+                var getTombstones = actions
+                    .Lists
+                    .Read(tombstoneListName, start, take);
+
+                if (wherePredicate != null)
+                {
+                    getTombstones = getTombstones.Where(wherePredicate);
+                }
+
+                tombstones = getTombstones.Select(x => new JsonDocument
+                {
+                    Etag = x.Etag,
+                    Key = x.Key,
+                    Metadata = x.Data,
+                    DataAsJson = new RavenJObject()
+                }).ToList();
+            });
+
+            return tombstones ?? new List<JsonDocument>();
+        }
+
+        protected List<ReplicationStrategy> GetReplicationDestinations(Predicate<ReplicationDestination> predicate = null)
+        {
+            return Replication.GetReplicationDestinations(predicate).ToList();
+        }
+
+        public abstract void Dispose();
+    }
+}

--- a/Raven.Database/Bundles/Replication/Tasks/TransformerReplicationTask.cs
+++ b/Raven.Database/Bundles/Replication/Tasks/TransformerReplicationTask.cs
@@ -1,0 +1,221 @@
+// -----------------------------------------------------------------------
+//  <copyright file="TransformerReplicationTask.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using Raven.Abstractions;
+using Raven.Abstractions.Connection;
+using Raven.Abstractions.Data;
+using Raven.Abstractions.Indexing;
+using Raven.Abstractions.Logging;
+using Raven.Abstractions.Replication;
+using Raven.Bundles.Replication.Impl;
+using Raven.Bundles.Replication.Tasks;
+using Raven.Database.Util;
+using Raven.Json.Linq;
+
+namespace Raven.Database.Bundles.Replication.Tasks
+{
+    public class TransformerReplicationTask : ReplicationTaskBase
+    {
+        private readonly static ILog Log = LogManager.GetCurrentClassLogger();
+
+        private readonly TimeSpan replicationFrequency;
+        private Timer timer;
+        private readonly object replicationLock = new object();
+
+        public TransformerReplicationTask(DocumentDatabase database, HttpRavenRequestFactory httpRavenRequestFactory, ReplicationTask replication)
+            : base(database, httpRavenRequestFactory, replication)
+        {
+            replicationFrequency = TimeSpan.FromSeconds(database.Configuration.IndexAndTransformerReplicationLatencyInSec); //by default 10 min
+            TimeToWaitBeforeSendingDeletesOfTransformersToSiblings = TimeSpan.FromMinutes(1);
+        }
+
+        public TimeSpan TimeToWaitBeforeSendingDeletesOfTransformersToSiblings { get; set; }
+
+        public void Start()
+        {
+            Database.Notifications.OnTransformerChange += OnTransformerChange;
+
+            timer = Database.TimerManager.NewTimer(x => Execute(), TimeSpan.Zero, replicationFrequency);
+        }
+
+        private void OnTransformerChange(DocumentDatabase documentDatabase, TransformerChangeNotification notification)
+        {
+            var transformerName = notification.Name;
+            switch (notification.Type)
+            {
+                case TransformerChangeTypes.TransformerAdded:
+                    //if created transformer with the same name as deleted one, we should prevent its deletion replication
+                    Database.TransactionalStorage.Batch(accessor =>
+                        accessor.Lists.Remove(Constants.RavenReplicationTransformerTombstones, transformerName));
+
+                    break;
+                case TransformerChangeTypes.TransformerRemoved:
+                    //If we don't have any destination to replicate to (we are probably slave node)
+                    //we shouldn't keep a tombstone since we are not going to remove it anytime
+                    //and keeping it prevents us from getting that transformer created again.
+                    if (GetReplicationDestinations().Count == 0)
+                        return;
+
+                    var metadata = new RavenJObject
+                    {
+                        {Constants.RavenTransformerDeleteMarker, true},
+                        {Constants.RavenReplicationSource, Database.TransactionalStorage.Id.ToString()},
+                        {Constants.RavenReplicationVersion, ReplicationHiLo.NextId(Database)},
+                        {"TransformerVersion", notification.Version }
+                    };
+
+                    Database.TransactionalStorage.Batch(accessor =>
+                        accessor.Lists.Set(Constants.RavenReplicationTransformerTombstones, transformerName, metadata, UuidType.Transformers));
+                    break;
+            }
+        }
+
+        public bool Execute(Func<ReplicationDestination, bool> shouldSkipDestinationPredicate = null)
+        {
+            if (Database.Disposed)
+                return false;
+
+            if (Monitor.TryEnter(replicationLock) == false)
+                return false;
+
+            try
+            {
+                using (CultureHelper.EnsureInvariantCulture())
+                {
+                    shouldSkipDestinationPredicate = shouldSkipDestinationPredicate ?? (x => x.SkipIndexReplication == false);
+                    var replicationDestinations = GetReplicationDestinations(x => shouldSkipDestinationPredicate(x));
+
+                    foreach (var destination in replicationDestinations)
+                    {
+                        var now = SystemTime.UtcNow;
+
+                        var transformerTombstones = GetTombstones(Constants.RavenReplicationTransformerTombstones, 0, 64,
+                            // we don't send out deletions immediately, we wait for a bit
+                            // to make sure that the user didn't reset the index or delete / create
+                            // things manually
+                            x => (now - x.CreatedAt) >= TimeToWaitBeforeSendingDeletesOfTransformersToSiblings);
+                        var replicatedTransformerTombstones = new Dictionary<string, int>();
+
+                        try
+                        {
+                            ReplicateTransformerDeletionIfNeeded(transformerTombstones, destination, replicatedTransformerTombstones);
+
+                            if (Database.Transformers.Definitions.Length > 0)
+                            {
+                                foreach (var definition in Database.Transformers.Definitions)
+                                    ReplicateSingleTransformer(destination, definition);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Log.ErrorException("Failed to replicate transformers to " + destination, e);
+                        }
+
+                        Database.TransactionalStorage.Batch(actions =>
+                        {
+                            foreach (var transformerTombstone in replicatedTransformerTombstones)
+                            {
+                                var transformerExists = Database.Transformers.GetTransformerDefinition(transformerTombstone.Key) != null;
+                                if (transformerTombstone.Value != replicationDestinations.Count &&
+                                    transformerExists == false)
+                                    continue;
+
+                                actions.Lists.Remove(Constants.RavenReplicationTransformerTombstones, transformerTombstone.Key);
+                            }
+                        });
+                    }
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                Log.ErrorException("Failed to replicate transformers", e);
+
+                return false;
+            }
+            finally
+            {
+                Monitor.Exit(replicationLock);
+            }
+        }
+
+        public void Execute(string transformerName)
+        {
+            var definition = Database.IndexDefinitionStorage.GetTransformerDefinition(transformerName);
+
+            if (definition == null)
+                return;
+
+            foreach (var destination in GetReplicationDestinations(x => x.SkipIndexReplication == false))
+            {
+                ReplicateSingleTransformer(destination, definition);
+            }
+        }
+
+        private void ReplicateSingleTransformer(ReplicationStrategy destination, TransformerDefinition definition)
+        {
+            try
+            {
+                var clonedTransformer = definition.Clone();
+                clonedTransformer.TransfomerId = 0;
+
+                var url = destination.ConnectionStringOptions.Url + "/transformers/" + Uri.EscapeUriString(definition.Name) + "?" + GetDebugInformation();
+                var replicationRequest = HttpRavenRequestFactory.Create(url, "PUT", destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
+                replicationRequest.Write(RavenJObject.FromObject(clonedTransformer));
+                replicationRequest.ExecuteRequest();
+            }
+            catch (Exception e)
+            {
+                Replication.HandleRequestBufferingErrors(e, destination);
+
+                Log.WarnException("Could not replicate transformer " + definition.Name + " to " + destination.ConnectionStringOptions.Url, e);
+            }
+        }
+
+        private void ReplicateTransformerDeletionIfNeeded(List<JsonDocument> transformerTombstones, ReplicationStrategy destination, Dictionary<string, int> replicatedTransformerTombstones)
+        {
+            if (transformerTombstones.Count == 0)
+                return;
+
+            foreach (var tombstone in transformerTombstones)
+            {
+                try
+                {
+                    int value;
+                    if (Database.Transformers.GetTransformerDefinition(tombstone.Key) != null) //if in the meantime the transformer was recreated under the same name
+                    {
+                        replicatedTransformerTombstones.TryGetValue(tombstone.Key, out value);
+                        replicatedTransformerTombstones[tombstone.Key] = value + 1;
+                        continue;
+                    }
+
+                    var url = string.Format("{0}/transformers/{1}?{2}", destination.ConnectionStringOptions.Url, Uri.EscapeUriString(tombstone.Key), GetDebugInformation());
+                    var replicationRequest = HttpRavenRequestFactory.Create(url, "DELETE", destination.ConnectionStringOptions, Replication.GetRequestBuffering(destination));
+                    replicationRequest.Write(RavenJObject.FromObject(EmptyRequestBody));
+                    replicationRequest.ExecuteRequest();
+                    Log.Info("Replicated transformer deletion (transformer name = {0})", tombstone.Key);
+                    replicatedTransformerTombstones.TryGetValue(tombstone.Key, out value);
+                    replicatedTransformerTombstones[tombstone.Key] = value + 1;
+                }
+                catch (Exception e)
+                {
+                    Replication.HandleRequestBufferingErrors(e, destination);
+
+                    Log.ErrorException(string.Format("Failed to replicate transformer deletion (transformer name = {0})", tombstone.Key), e);
+                }
+            }
+        }
+
+        public override void Dispose()
+        {
+            if (timer != null)
+                timer.Dispose();
+        }
+    }
+}

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -244,6 +244,9 @@
     <Compile Include="Actions\TaskActions.cs" />
     <Compile Include="Bundles\PeriodicExports\Controllers\NonAdminPeriodicBackupConfigurationController.cs" />
     <Compile Include="Bundles\Replication\Controllers\ReplicationTopologyController.cs" />
+    <Compile Include="Bundles\Replication\Tasks\TransformerReplicationTask.cs" />
+    <Compile Include="Bundles\Replication\Tasks\ReplicationTaskBase.cs" />
+    <Compile Include="Bundles\Replication\Tasks\IndexReplicationTask.cs" />
     <Compile Include="Bundles\Replication\Triggers\RenameConflictDocumentIdIndexTrigger.cs" />
     <Compile Include="Bundles\SqlReplication\SqlReplicationClassifier.cs" />
     <Compile Include="Bundles\Versioning\Data\FileVersioningConfiguration.cs" />

--- a/Raven.Database/Server/Controllers/IndexController.cs
+++ b/Raven.Database/Server/Controllers/IndexController.cs
@@ -83,10 +83,14 @@ namespace Raven.Database.Server.Controllers
                     return GetMessageWithString("Expected json document with 'Map' or 'Maps' property", HttpStatusCode.BadRequest);
             }
 
+            var replicationQueryString = GetQueryStringValue(Constants.IsIndexReplicatedUrlParamName);
+            var isReplication = !string.IsNullOrWhiteSpace(replicationQueryString) &&
+                replicationQueryString.Equals("true", StringComparison.InvariantCultureIgnoreCase);
+
             string[] createdIndexes;
             try
             {
-                createdIndexes = Database.Indexes.PutIndexes(indexesToAdd);
+                createdIndexes = Database.Indexes.PutIndexes(indexesToAdd, isReplication);
             }
             catch (Exception ex)
             {
@@ -140,10 +144,14 @@ namespace Raven.Database.Server.Controllers
                     return GetMessageWithString("Expected json document with 'Map' or 'Maps' property", HttpStatusCode.BadRequest);
             }
 
+            var replicationQueryString = GetQueryStringValue(Constants.IsIndexReplicatedUrlParamName);
+            var isReplication = !string.IsNullOrWhiteSpace(replicationQueryString) &&
+                replicationQueryString.Equals("true", StringComparison.InvariantCultureIgnoreCase);
+
             List<IndexActions.IndexInfo> createdIndexes;
             try
             {
-                createdIndexes = Database.Indexes.PutSideBySideIndexes(sideBySideIndexes);
+                createdIndexes = Database.Indexes.PutSideBySideIndexes(sideBySideIndexes, isReplication);
             }
             catch (Exception ex)
             {
@@ -740,6 +748,7 @@ namespace Raven.Database.Server.Controllers
                 return GetMessageWithString("Cannot find index : " + index, HttpStatusCode.NotFound);
             
             indexDefinition.LockMode = indexLockMode;
+            indexDefinition.IndexVersion = (indexDefinition.IndexVersion ?? 0) + 1;
             Database.IndexDefinitionStorage.UpdateIndexDefinitionWithoutUpdatingCompiledIndex(indexDefinition);
 
             return GetEmptyMessage();

--- a/Raven.Database/Storage/IndexDefinitionStorage.cs
+++ b/Raven.Database/Storage/IndexDefinitionStorage.cs
@@ -437,9 +437,6 @@ namespace Raven.Database.Storage
                 return IndexCreationOptions.Create;
             }
 
-            if (newIndexDef.IndexVersion == null)
-                newIndexDef.IndexVersion = currentIndexDefinition.IndexVersion + 1;
-
             if (currentIndexDefinition.IsTestIndex) // always update test indexes
                 return IndexCreationOptions.Update;
 
@@ -458,15 +455,21 @@ namespace Raven.Database.Storage
 
         private bool CheckIfIndexHasBeenDeleted(IndexDefinition definition)
         {
-            return CheckIfIndexVersionIsEqualOrSmaller(definition, Constants.RavenReplicationIndexesTombstones, definition.Name) ||
-                   CheckIfIndexVersionIsEqualOrSmaller(definition, "Raven/Indexes/PendingDeletion", definition.IndexId.ToString(CultureInfo.InvariantCulture));
-        }
-
-        private bool CheckIfIndexVersionIsEqualOrSmaller(IndexDefinition definition, string listName, string listKey)
-        {
-            var res = false;
             if (definition.IndexVersion == null)
                 return false;
+
+            var currentIndexVersion = definition.IndexVersion.Value;
+
+            int _;
+            return CheckIfIndexVersionIsEqualOrSmaller(Constants.RavenReplicationIndexesTombstones, definition.Name, currentIndexVersion, definition.Name, out _) ||
+                   CheckIfIndexVersionIsEqualOrSmaller("Raven/Indexes/PendingDeletion", definition.IndexId.ToString(CultureInfo.InvariantCulture), currentIndexVersion, definition.Name, out _);
+        }
+
+        private bool CheckIfIndexVersionIsEqualOrSmaller(string listName, string listKey,
+            int currentIndexVersion, string indexName, out int oldIndexVersion)
+        {
+            var res = false;
+            var version = 0;
 
             transactionalStorage.Batch(action =>
             {
@@ -474,26 +477,42 @@ namespace Raven.Database.Storage
                 if (li == null)
                     return;
 
-                int version;
                 var versionStr = li.Data.Value<string>("IndexVersion");
                 //the index that we are trying to add is deleted
                 if (int.TryParse(versionStr, out version))
                 {
-                    if (version >= definition.IndexVersion.Value)
+                    if (version >= currentIndexVersion)
                     {
-                        if (version > definition.IndexVersion.Value)
-                            logger.Error("Trying to add an index ({0}) with a version smaller than the deleted version, this should not happen", definition.Name);
+                        if (version > currentIndexVersion)
+                            logger.Error("Trying to add an index ({0}) with a version smaller " +
+                                         "than the deleted version, this should not happen", indexName);
 
                         res = true;
                     }
                 }
                 else
                 {
-                    logger.Error("Failed to parse index version of index {0}", definition.Name);
+                    logger.Error("Failed to parse index version of index {0}", indexName);
                 }
             });
 
+            oldIndexVersion = version;
             return res;
+        }
+
+        public int GetDeletedIndexVersion(IndexDefinition definition)
+        {
+            var currentIndexVersion = definition.IndexVersion ?? 0;
+            int indexVersionFromTombstones;
+            CheckIfIndexVersionIsEqualOrSmaller(Constants.RavenReplicationIndexesTombstones,
+                definition.Name, currentIndexVersion, definition.Name, out indexVersionFromTombstones);
+
+            int indexVersionFromPendingDeletions;
+            CheckIfIndexVersionIsEqualOrSmaller("Raven/Indexes/PendingDeletion",
+                definition.IndexId.ToString(CultureInfo.InvariantCulture),
+                currentIndexVersion, definition.Name, out indexVersionFromPendingDeletions);
+
+            return Math.Max(indexVersionFromTombstones, indexVersionFromPendingDeletions);
         }
 
         public bool Contains(string indexName)
@@ -567,10 +586,13 @@ namespace Raven.Database.Storage
             int ignoredId;
             if (transformCache.TryRemove(id, out ignoredViewGenerator))
                 transformNameToId.TryRemove(ignoredViewGenerator.Name, out ignoredId);
-            TransformerDefinition ignoredIndexDefinition;
-            transformDefinitions.TryRemove(id, out ignoredIndexDefinition);
+
+            TransformerDefinition _;
+            transformDefinitions.TryRemove(id, out _);
+
             if (configuration.RunInMemory)
                 return;
+
             File.Delete(GetIndexSourcePath(id) + ".transform");
             UpdateTransformerMappingFile();
         }
@@ -604,7 +626,23 @@ namespace Raven.Database.Storage
             index.IsSideBySideIndex = false;
 
             var indexToReplace = GetIndexDefinition(indexToSwapName);
-            index.Name = indexToReplace != null ? indexToReplace.Name : indexToSwapName;
+            if (indexToReplace != null)
+            {
+                // keep the index version of the replaced index
+                index.IndexVersion = (indexToReplace.IndexVersion ?? 0) + 1;
+                index.Name = indexToReplace.Name;
+            }
+            else
+            {
+                index.Name = indexToSwapName;
+
+                int indexVersionFromTombstones;
+                CheckIfIndexVersionIsEqualOrSmaller(Constants.RavenReplicationIndexesTombstones,
+                    indexToSwapName, 0, indexToSwapName, out indexVersionFromTombstones);
+
+                index.IndexVersion = indexVersionFromTombstones + 1;
+            }
+
             CreateAndPersistIndex(index);
             AddIndex(index.IndexId, index);
 

--- a/Raven.Database/Storage/IndexDefinitionStorage.cs
+++ b/Raven.Database/Storage/IndexDefinitionStorage.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -424,9 +425,9 @@ namespace Raven.Database.Storage
             var currentIndexDefinition = GetIndexDefinition(newIndexDef.Name);
             if (currentIndexDefinition == null)
             {
-                if (CheckIfIndexIsBeenDeleted(newIndexDef))
+                if (CheckIfIndexHasBeenDeleted(newIndexDef))
                 {
-                    //index is been deleted ignoring this index
+                    // index has been deleted, ignoring this index
                     return IndexCreationOptions.Noop;
                 }
 
@@ -445,38 +446,53 @@ namespace Raven.Database.Storage
             newIndexDef.IndexId = currentIndexDefinition.IndexId;
             var result = currentIndexDefinition.Equals(newIndexDef);
             if (result)
+            {
+                // index definitions are equal, nothing to do
                 return IndexCreationOptions.Noop;
+            }
 
             // try to compare to find changes which doesn't require removing compiled index
             return currentIndexDefinition.Equals(newIndexDef, ignoreFormatting: true, ignoreMaxIndexOutput: true)
                 ? IndexCreationOptions.UpdateWithoutUpdatingCompiledIndex : IndexCreationOptions.Update;
         }
 
-        private bool CheckIfIndexIsBeenDeleted(IndexDefinition definition)
+        private bool CheckIfIndexHasBeenDeleted(IndexDefinition definition)
         {
-            return CheckIfIndexVersionIsEqual(definition, Constants.RavenReplicationIndexesTombstones)
-                || CheckIfIndexVersionIsEqual(definition, "Raven/Indexes/PendingDeletion");
+            return CheckIfIndexVersionIsEqualOrSmaller(definition, Constants.RavenReplicationIndexesTombstones, definition.Name) ||
+                   CheckIfIndexVersionIsEqualOrSmaller(definition, "Raven/Indexes/PendingDeletion", definition.IndexId.ToString(CultureInfo.InvariantCulture));
         }
 
-        private bool CheckIfIndexVersionIsEqual(IndexDefinition definition, string listName)
+        private bool CheckIfIndexVersionIsEqualOrSmaller(IndexDefinition definition, string listName, string listKey)
         {
-            bool res = false;
-            if (definition.IndexVersion == null) return false;
+            var res = false;
+            if (definition.IndexVersion == null)
+                return false;
+
             transactionalStorage.Batch(action =>
             {
-                var li = action.Lists.Read(listName, definition.Name);
-                if (li == null) return;
+                var li = action.Lists.Read(listName, listKey);
+                if (li == null)
+                    return;
+
                 int version;
-                string versionStr = li.Data.Value<string>("IndexVersion");
-                // The index that we are trying to add is deleted
+                var versionStr = li.Data.Value<string>("IndexVersion");
+                //the index that we are trying to add is deleted
                 if (int.TryParse(versionStr, out version))
                 {
-                    if (version == definition.IndexVersion.Value)
+                    if (version >= definition.IndexVersion.Value)
                     {
+                        if (version > definition.IndexVersion.Value)
+                            logger.Error("Trying to add an index ({0}) with a version smaller than the deleted version, this should not happen", definition.Name);
+
                         res = true;
                     }
                 }
+                else
+                {
+                    logger.Error("Failed to parse index version of index {0}", definition.Name);
+                }
             });
+
             return res;
         }
 

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -138,6 +138,7 @@
     <Compile Include="1379\RavenDB_1379_Client_Lazy.cs" />
     <Compile Include="1379\RavenDB_1379_Client_Remote.cs" />
     <Compile Include="ActualValueInJsonReaderException.cs" />
+    <Compile Include="RavenDB-4977.cs" />
     <Compile Include="RavenDB-1279.cs" />
     <Compile Include="RavenDB-4917.cs" />
     <Compile Include="RavenDB-4877.cs" />

--- a/Raven.Tests.Issues/RavenDB-3460.cs
+++ b/Raven.Tests.Issues/RavenDB-3460.cs
@@ -29,7 +29,7 @@ namespace Raven.Tests.Issues
             }
         }
 
-        [TimeBombedFact(2016,9,1,"Edge-case for special character combination in a query. (This is not a regression, this case was not handled before)")]
+        [TimeBombedFact(2018,9,1,"Edge-case for special character combination in a query. (This is not a regression, this case was not handled before)")]
         public void Can_query_for_special_percentage_character()
         {
             using (var store = NewRemoteDocumentStore())

--- a/Raven.Tests.Issues/RavenDB-4977.cs
+++ b/Raven.Tests.Issues/RavenDB-4977.cs
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------
+//  <copyright file="RavenDB-4977.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Indexes;
+using Raven.Json.Linq;
+using Raven.Tests.Core.Replication;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_4977 : RavenReplicationCoreTest
+    {
+        [Fact]
+        public void can_reset_index()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var index = new Users_By_Name();
+                index.Execute(store);
+
+                store.DatabaseCommands.Put("users/1", null, RavenJObject.FromObject(new User { Name = "Grisha" }), new RavenJObject());
+                WaitForIndexing(store);
+
+                var stats = store.DatabaseCommands.GetStatistics();
+                Assert.Equal(1, stats.Indexes.Length);
+
+                store.DatabaseCommands.ResetIndex(index.IndexName);
+                WaitForIndexing(store);
+
+                stats = store.DatabaseCommands.GetStatistics();
+                Assert.Equal(1, stats.Indexes.Length);
+            }
+        }
+
+        [Fact]
+        public void can_reset_index_with_replication()
+        {
+            using (var store = GetDocumentStore())
+            {
+                SetupReplication(store, new List<RavenJObject> { new RavenJObject { { "Url", "http://localhost:8080" } } });
+                var index = new Users_By_Name();
+                index.Execute(store);
+
+                store.DatabaseCommands.Put("users/1", null, RavenJObject.FromObject(new User { Name = "Grisha" }), new RavenJObject());
+                WaitForIndexing(store);
+
+                var stats = store.DatabaseCommands.GetStatistics();
+                Assert.Equal(1, stats.Indexes.Length);
+
+                store.DatabaseCommands.ResetIndex(index.IndexName);
+                WaitForIndexing(store);
+
+                stats = store.DatabaseCommands.GetStatistics();
+                Assert.Equal(1, stats.Indexes.Length);
+            }
+        }
+
+        public class User
+        {
+            public string Name { get; set; }
+
+            public string Phone { get; set; }
+        }
+
+        public class Users_By_Name : AbstractIndexCreationTask<User>
+        {
+            public override string IndexName
+            {
+                get { return "test"; }
+            }
+
+            public Users_By_Name()
+            {
+                Map = users =>
+                    from user in users
+                    select new
+                    {
+                        user.Name
+                    };
+            }
+        }
+
+        public class Users_By_Name_And_Phone : AbstractIndexCreationTask<User>
+        {
+            public override string IndexName
+            {
+                get { return "test"; }
+            }
+
+            public Users_By_Name_And_Phone()
+            {
+                Map = users =>
+                    from user in users
+                    select new
+                    {
+                        user.Name,
+                        user.Phone
+                    };
+            }
+        }
+    }
+}

--- a/Raven.Tests.Issues/RavenDB_3574.cs
+++ b/Raven.Tests.Issues/RavenDB_3574.cs
@@ -40,7 +40,7 @@ namespace Raven.Tests.Issues
         [Fact]
         public async Task Index_replication_with_index_delete_should_propagate_as_usual()
         {
-            using(var source = CreateStore())
+            using (var source = CreateStore())
             using (var destination = CreateStore())
             {
                 var testIndex = new RavenDB_3232.TestIndex();
@@ -56,17 +56,17 @@ namespace Raven.Tests.Issues
 
                 var sourceReplicationTask = sourceDatabase.StartupTasks.OfType<ReplicationTask>().First();
                 sourceReplicationTask.Pause();
-                sourceReplicationTask.TimeToWaitBeforeSendingDeletesOfIndexesToSiblings = TimeSpan.FromSeconds(0);
+                sourceReplicationTask.IndexReplication.TimeToWaitBeforeSendingDeletesOfIndexesToSiblings = TimeSpan.FromSeconds(0);
 
                 SetupReplication(source.DatabaseCommands, destination);
 
                 WaitForIndexing(source);
-                sourceReplicationTask.ReplicateIndexesAndTransformersTask(null); //replicate index create
+                sourceReplicationTask.IndexReplication.Execute(); //replicate index create
 
                 source.DatabaseCommands.DeleteIndex(testIndex.IndexName);
 
                 shouldRecordRequests = true;
-                sourceReplicationTask.ReplicateIndexesAndTransformersTask(null);
+                sourceReplicationTask.IndexReplication.Execute();
 
 
                 Assert.Equal(1, requestLog.Count(x => x.Method.Method == "DELETE"));
@@ -75,10 +75,10 @@ namespace Raven.Tests.Issues
 
         [Fact]
         public async Task Index_replication_with_side_by_side_indexes_should_not_propagate_replaced_index_tombstones()
-        {				
-            using(var source = CreateStore())
-            using(var destination = CreateStore())			
-            {				
+        {
+            using (var source = CreateStore())
+            using (var destination = CreateStore())
+            {
                 var oldIndexDef = new IndexDefinition
                 {
                     Map = "from person in docs.People\nselect new {\n\tFirstName = person.FirstName\n}"
@@ -96,14 +96,14 @@ namespace Raven.Tests.Issues
                     session.SaveChanges();
                 }
                 var sourceReplicationTask = sourceDatabase.StartupTasks.OfType<ReplicationTask>().First();
-                sourceReplicationTask.TimeToWaitBeforeSendingDeletesOfIndexesToSiblings = TimeSpan.FromSeconds(0);
+                sourceReplicationTask.IndexReplication.TimeToWaitBeforeSendingDeletesOfIndexesToSiblings = TimeSpan.FromSeconds(0);
 
                 sourceReplicationTask.Pause(); //pause replciation task _before_ setting up replication
 
                 SetupReplication(source.DatabaseCommands, destination);
 
                 var mre = new ManualResetEventSlim();
-                
+
                 sourceDatabase.Notifications.OnIndexChange += (database, notification) =>
                 {
                     if (notification.Type == IndexChangeTypes.SideBySideReplace)
@@ -116,10 +116,10 @@ namespace Raven.Tests.Issues
                 sourceDatabase.SpinBackgroundWorkers();
                 WaitForIndexing(source); //now old index should be a tombstone and side-by-side replaced it.
                 mre.Wait();
-                sourceReplicationTask.ReplicateIndexesAndTransformersTask(null);
+                sourceReplicationTask.IndexReplication.Execute();
 
-                Assert.Equal(0,requestLog.Count(x => x.Method.Method == "DELETE"));
+                Assert.Equal(0, requestLog.Count(x => x.Method.Method == "DELETE"));
             }
-        }		
+        }
     }
 }

--- a/Raven.Tests.Issues/RavenDB_3647.cs
+++ b/Raven.Tests.Issues/RavenDB_3647.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Raven.Abstractions.Indexing;
 using Raven.Client.Indexes;
 using Raven.Tests.Common;
@@ -19,12 +15,12 @@ namespace Raven.Tests.Issues
             {
                 store.ExecuteTransformer(new SimpleTransformer());
                 //Checking that we can lock transformer
-                store.DatabaseCommands.SetTransformerLock("SimpleTransformer",TransformerLockMode.LockedIgnore);
+                store.DatabaseCommands.SetTransformerLock("SimpleTransformer", TransformerLockMode.LockedIgnore);
                 var transformerDefinition = store.DatabaseCommands.GetTransformer("SimpleTransformer");
                 var oldTransformResults = transformerDefinition.TransformResults;
                 Assert.Equal(transformerDefinition.LockMode, TransformerLockMode.LockedIgnore);
                 //Checking that we can't change a locked transformer
-                transformerDefinition.TransformResults = newTransformResults;
+                transformerDefinition.TransformResults = NewTransformResults;
                 store.DatabaseCommands.PutTransformer("SimpleTransformer", transformerDefinition);
                 transformerDefinition = store.DatabaseCommands.GetTransformer("SimpleTransformer");
                 Assert.Equal(transformerDefinition.TransformResults, oldTransformResults);
@@ -33,14 +29,42 @@ namespace Raven.Tests.Issues
                 transformerDefinition = store.DatabaseCommands.GetTransformer("SimpleTransformer");
                 Assert.Equal(transformerDefinition.LockMode, TransformerLockMode.Unlock);
                 //checking that the transformer is indeed overridden
-                transformerDefinition.TransformResults = newTransformResults;
+                transformerDefinition.TransformResults = NewTransformResults;
                 store.DatabaseCommands.PutTransformer("SimpleTransformer", transformerDefinition);
                 transformerDefinition = store.DatabaseCommands.GetTransformer("SimpleTransformer");
-                Assert.Equal(transformerDefinition.TransformResults, newTransformResults);
+                Assert.Equal(NewTransformResults, transformerDefinition.TransformResults);
             }
         }
 
-        private const string newTransformResults = "from result in results  select new { Number = result.Number + int.MaxValue };";
+        [Fact]
+        public void CanLockIndexes()
+        {
+            using (var store = NewDocumentStore())
+            {
+                store.ExecuteIndex(new SimpleIndex());
+                //Checking that we can lock index
+                store.DatabaseCommands.SetIndexLock("SimpleIndex", IndexLockMode.LockedIgnore);
+                var indexDefinition = store.DatabaseCommands.GetIndex("SimpleIndex");
+                var map = indexDefinition.Map;
+                Assert.Equal(indexDefinition.LockMode, IndexLockMode.LockedIgnore);
+                //Checking that we can't change a locked index
+                indexDefinition.Map = NewMap;
+                store.DatabaseCommands.PutIndex("SimpleIndex", indexDefinition, true);
+                indexDefinition = store.DatabaseCommands.GetIndex("SimpleIndex");
+                Assert.Equal(indexDefinition.Map, map);
+                //Checking that we can unlock a index
+                store.DatabaseCommands.SetIndexLock("SimpleIndex", IndexLockMode.Unlock);
+                indexDefinition = store.DatabaseCommands.GetIndex("SimpleIndex");
+                Assert.Equal(indexDefinition.LockMode, IndexLockMode.Unlock);
+                //checking that the index is indeed overridden
+                indexDefinition.Map = NewMap;
+                store.DatabaseCommands.PutIndex("SimpleIndex", indexDefinition, true);
+                indexDefinition = store.DatabaseCommands.GetIndex("SimpleIndex");
+                Assert.Equal(NewMap, indexDefinition.Map);
+            }
+        }
+
+        private const string NewTransformResults = "from result in results  select new { Number = result.Number + int.MaxValue };";
 
         public class SimpleTransformer : AbstractTransformerCreationTask<SimpleData>
         {
@@ -50,9 +74,26 @@ namespace Raven.Tests.Issues
                                               select new { Number = result.Number ^ int.MaxValue };
             }
         }
+
         public class SimpleData
         {
+            public string Id { get; set; }
+
             public int Number { get; set; }
+        }
+
+        private const string NewMap = "from doc in docs.SimpleDatas select new { Id = doc.Id, Number = doc.Number };";
+
+        public class SimpleIndex : AbstractIndexCreationTask<SimpleData>
+        {
+            public SimpleIndex()
+            {
+                Map = docs => from doc in docs
+                              select new
+                              {
+                                  doc.Number
+                              };
+            }
         }
     }
 }

--- a/Raven.Tests/Replication/IndexReplication.cs
+++ b/Raven.Tests/Replication/IndexReplication.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Abstractions.Connection;
 using Raven.Abstractions.Data;
+using Raven.Abstractions.Indexing;
 using Raven.Abstractions.Replication;
 using Raven.Bundles.Replication.Tasks;
 using Raven.Client;
@@ -12,12 +13,12 @@ using Raven.Client.Document;
 using Raven.Client.Indexes;
 using Raven.Database.Config;
 using Raven.Json.Linq;
-using Raven.Tests.Helpers;
+using Raven.Tests.Common;
 using Xunit;
 
 namespace Raven.Tests.Replication
 {
-    public class IndexReplication : RavenTestBase
+    public class IndexReplication : ReplicationBase
     {
         protected override void ModifyConfiguration(InMemoryRavenConfiguration configuration)
         {
@@ -29,6 +30,8 @@ namespace Raven.Tests.Replication
             public string Id { get; set; }
 
             public string Name { get; set; }
+
+            public string LastName { get; set; }
         }
 
         public class UserIndex : AbstractIndexCreationTask<User>
@@ -39,6 +42,21 @@ namespace Raven.Tests.Replication
                                select new
                                {
                                    user.Name
+                               };
+            }
+        }
+
+        public class UserIndex_Extended : AbstractIndexCreationTask<User>
+        {
+            public override string IndexName { get { return "UserIndex"; } }
+
+            public UserIndex_Extended()
+            {
+                Map = users => from user in users
+                               select new
+                               {
+                                   user.Name,
+                                   user.LastName
                                };
             }
         }
@@ -140,9 +158,20 @@ namespace Raven.Tests.Replication
                 source.DatabaseCommands.ForDatabase("testDB").PutIndex(anotherUserIndex.IndexName, anotherUserIndex.CreateIndexDefinition());
                 source.DatabaseCommands.ForDatabase("testDB").PutIndex(yetAnotherUserIndex.IndexName, yetAnotherUserIndex.CreateIndexDefinition());
 
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+
+
                 var sourceDB = await sourceServer.Server.GetDatabaseInternal("testDB");
                 var replicationTask = sourceDB.StartupTasks.OfType<ReplicationTask>().First();
-                SpinWait.SpinUntil(() => replicationTask.ReplicateIndexesAndTransformersTask(null));
+                SpinWait.SpinUntil(() => replicationTask.IndexReplication.Execute());
 
                 var expectedIndexNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { userIndex.IndexName, anotherUserIndex.IndexName, yetAnotherUserIndex.IndexName };
                 var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
@@ -199,7 +228,17 @@ namespace Raven.Tests.Replication
 
                 var sourceDB = await sourceServer.Server.GetDatabaseInternal("testDB");
                 var replicationTask = sourceDB.StartupTasks.OfType<ReplicationTask>().First();
-                replicationTask.SendLastQueriedTask(null);
+                replicationTask.IndexReplication.SendLastQueried();
+
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
 
                 var indexNames = new[] { userIndex.IndexName, anotherUserIndex.IndexName, yetAnotherUserIndex.IndexName };
 
@@ -231,13 +270,13 @@ namespace Raven.Tests.Replication
         public void Should_replicate_all_indexes_if_relevant_endpoint_is_hit()
         {
             var requestFactory = new HttpRavenRequestFactory();
-            using (var sourceServer = GetNewServer(8077))
+            using (var sourceServer = GetNewServer(8076))
             using (var source = NewRemoteDocumentStore(ravenDbServer: sourceServer))
-            using (var destinationServer1 = GetNewServer(8078))
+            using (var destinationServer1 = GetNewServer(8077))
             using (var destination1 = NewRemoteDocumentStore(ravenDbServer: destinationServer1))
-            using (var destinationServer2 = GetNewServer())
+            using (var destinationServer2 = GetNewServer(8078))
             using (var destination2 = NewRemoteDocumentStore(ravenDbServer: destinationServer2))
-            using (var destinationServer3 = GetNewServer(8081))
+            using (var destinationServer3 = GetNewServer(8079))
             using (var destination3 = NewRemoteDocumentStore(ravenDbServer: destinationServer3))
             {
                 CreateDatabaseWithReplication(source, "testDB");
@@ -249,6 +288,12 @@ namespace Raven.Tests.Replication
                 source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
                 // ReSharper disable once AccessToDisposedClosure
                 SetupReplication(source, "testDB", store => false, destination1, destination2, destination3);
+
+                // index replication can be triggered if we haven't replicated anything yet, bypassing this
+                source.DatabaseCommands.ForDatabase("testDB").Put("keys/1", null, new RavenJObject(), new RavenJObject());
+                WaitForDocument(destination1.DatabaseCommands.ForDatabase("testDB"), "keys/1");
+                WaitForDocument(destination2.DatabaseCommands.ForDatabase("testDB"), "keys/1");
+                WaitForDocument(destination3.DatabaseCommands.ForDatabase("testDB"), "keys/1");
 
                 //make sure not to replicate the index automatically
                 var userIndex = new UserIndex();
@@ -263,18 +308,35 @@ namespace Raven.Tests.Replication
                 {
                     Url = source.Url
                 });
+
                 replicationRequest.ExecuteRequest();
 
-                var expectedIndexNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { userIndex.IndexName, anotherUserIndex.IndexName, yetAnotherUserIndex.IndexName };
-                var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
-                Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication1));
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+
+                var expectedIndexNames = new List<string> { userIndex.IndexName, anotherUserIndex.IndexName, yetAnotherUserIndex.IndexName };
+                expectedIndexNames.Sort(StringComparer.InvariantCultureIgnoreCase);
+                var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToList();
+                indexStatsAfterReplication1.Sort(StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal(expectedIndexNames, indexStatsAfterReplication1);
 
 
-                var indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
-                Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication3));
+                var indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToList();
+                indexStatsAfterReplication3.Sort(StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal(expectedIndexNames, indexStatsAfterReplication3);
 
-                var indexStatsAfterReplication2 = destination2.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
-                Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication2));
+                var indexStatsAfterReplication2 = destination2.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToList();
+                indexStatsAfterReplication2.Sort(StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal(expectedIndexNames, indexStatsAfterReplication2);
+
+
             }
         }
 
@@ -301,6 +363,9 @@ namespace Raven.Tests.Replication
                 // ReSharper disable once AccessToDisposedClosure
                 var destinationDocuments = SetupReplication(source, "testDB", store => false, destination1, destination2, destination3);
 
+                // index and transformer replication is forced if we are replicating for the first time, so replicating one document to bypass this
+                ReplicateOneDummyDocument(source, destination1, destination2, destination3);
+
                 //make sure not to replicate the index automatically
                 var userIndex = new UserIndex();
                 var anotherUserIndex = new AnotherUserIndex();
@@ -318,16 +383,22 @@ namespace Raven.Tests.Replication
                 replicationRequest.Write(RavenJObject.FromObject(destinationDocuments[1]));
                 replicationRequest.ExecuteRequest();
 
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName);
+                WaitForIndexToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName);
+
                 var expectedIndexNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { userIndex.IndexName, anotherUserIndex.IndexName, yetAnotherUserIndex.IndexName };
-                var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
+                var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Where(x => x.Name != ConflictDocumentsIndex);
                 var indexStatsAfterReplication2 = destination2.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
-                var indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
+                var indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Where(x => x.Name != ConflictDocumentsIndex);
 
                 Assert.Equal(0, indexStatsAfterReplication1.Count());
                 Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication2));
                 Assert.Equal(0, indexStatsAfterReplication3.Count());
             }
         }
+
+        private const string ConflictDocumentsIndex = "Raven/ConflictDocuments";
 
         [Fact]
         public void Replicate_all_indexes_should_respect_disable_indexing_flag()
@@ -368,10 +439,13 @@ namespace Raven.Tests.Replication
                 });
                 replicationRequest.ExecuteRequest();
 
-                var expectedIndexNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { userIndex.IndexName, anotherUserIndex.IndexName, yetAnotherUserIndex.IndexName };
-                var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
-                Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication1));
+                Assert.True(WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName));
+                Assert.True(WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), anotherUserIndex.IndexName));
+                Assert.True(WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), yetAnotherUserIndex.IndexName));
 
+                var expectedIndexNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { userIndex.IndexName, anotherUserIndex.IndexName, yetAnotherUserIndex.IndexName };
+                var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToList();
+                Assert.Equal(expectedIndexNames, indexStatsAfterReplication1);
 
                 var indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name);
                 Assert.True(expectedIndexNames.SetEquals(indexStatsAfterReplication3));
@@ -416,6 +490,9 @@ namespace Raven.Tests.Replication
                 });
                 replicationRequest.ExecuteRequest();
 
+                WaitForIndexToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+
                 var indexStatsAfterReplication = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes;
                 Assert.True(indexStatsAfterReplication.Any(index => index.Name.Equals(userIndex.IndexName, StringComparison.InvariantCultureIgnoreCase)));
 
@@ -448,6 +525,8 @@ namespace Raven.Tests.Replication
 
                 //this should fire http request to index replication endpoint -> so the index is replicated
                 userIndex.Execute(source.DatabaseCommands.ForDatabase("testDB"), source.Conventions);
+
+                WaitForIndexToReplicate(destination.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
 
                 var indexStatsAfterReplication = destination.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes;
                 Assert.True(indexStatsAfterReplication.Any(index => index.Name.Equals(userIndex.IndexName, StringComparison.InvariantCultureIgnoreCase)));
@@ -494,11 +573,9 @@ namespace Raven.Tests.Replication
                 CreateDatabaseWithReplication(source, "testDB");
                 CreateDatabaseWithReplication(destination, "testDB");
 
-                //turn-off automatic index replication - precaution
-                source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
-                SetupReplication(source, "testDB", destination);
-
                 var userIndex = new UserIndex();
+
+                SetupReplication(source, "testDB", destination);
 
                 var indexStatsBeforeReplication = destination.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes;
                 Assert.False(indexStatsBeforeReplication.Any(index => index.Name.Equals(userIndex.IndexName, StringComparison.InvariantCultureIgnoreCase)));
@@ -506,13 +583,15 @@ namespace Raven.Tests.Replication
                 //make sure not to replicate the index automatically
                 source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
 
-                
+
                 var replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?indexName={1}", source.Url, userIndex.IndexName);
                 var replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
                 {
                     Url = source.Url
                 });
                 replicationRequest.ExecuteRequest();
+
+                WaitForIndexToReplicate(destination.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
 
                 var indexStatsAfterReplication = destination.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes;
                 Assert.True(indexStatsAfterReplication.Any(index => index.Name.Equals(userIndex.IndexName, StringComparison.InvariantCultureIgnoreCase)));
@@ -549,8 +628,8 @@ namespace Raven.Tests.Replication
 
                 var sourceDB = await sourceServer.Server.GetDatabaseInternal("testDB");
                 var replicationTask = sourceDB.StartupTasks.OfType<ReplicationTask>().First();
-                replicationTask.TimeToWaitBeforeSendingDeletesOfIndexesToSiblings = TimeSpan.Zero;
-                SpinWait.SpinUntil(() => replicationTask.ReplicateIndexesAndTransformersTask(null));
+                replicationTask.IndexReplication.TimeToWaitBeforeSendingDeletesOfIndexesToSiblings = TimeSpan.Zero;
+                SpinWait.SpinUntil(() => replicationTask.IndexReplication.Execute());
 
                 var expectedIndexNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { userIndex.IndexName };
                 var indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
@@ -566,17 +645,260 @@ namespace Raven.Tests.Replication
 
                 //the index is now replicated on all servers.
                 //now delete the index and verify that deletion is replicated
-                SpinWait.SpinUntil(() => replicationTask.ReplicateIndexesAndTransformersTask(null));
+                SpinWait.SpinUntil(() => replicationTask.IndexReplication.Execute());
+
+                WaitForIndexDeletionToReplicate(destination1.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexDeletionToReplicate(destination2.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
+                WaitForIndexDeletionToReplicate(destination3.DatabaseCommands.ForDatabase("testDB"), userIndex.IndexName);
 
 
-                indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+                indexStatsAfterReplication1 = destination1.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Where(x => x.Name != ConflictDocumentsIndex).Select(x => x.Name).ToArray();
                 Assert.Empty(indexStatsAfterReplication1);
 
-                indexStatsAfterReplication2 = destination2.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+                indexStatsAfterReplication2 = destination2.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Where(x => x.Name != ConflictDocumentsIndex).Select(x => x.Name).ToArray();
                 Assert.Empty(indexStatsAfterReplication2);
 
-                indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Select(x => x.Name).ToArray();
+                indexStatsAfterReplication3 = destination3.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Where(x => x.Name != ConflictDocumentsIndex).Select(x => x.Name).ToArray();
                 Assert.Empty(indexStatsAfterReplication3);
+            }
+        }
+
+        [Fact]
+        public void should_replicate_only_updated_indexes()
+        {
+            var requestFactory = new HttpRavenRequestFactory();
+            using (var sourceServer = GetNewServer(8077))
+            using (var source = NewRemoteDocumentStore(ravenDbServer: sourceServer, fiddler: true))
+            using (var destinationServer = GetNewServer(8078))
+            using (var destination = NewRemoteDocumentStore(ravenDbServer: destinationServer, fiddler: true))
+            {
+                CreateDatabaseWithReplication(source, "testDB");
+                CreateDatabaseWithReplication(destination, "testDB");
+
+                source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+                destination.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+
+                SetupReplication(source, "testDB", store => false, destination);
+                SetupReplication(destination, "testDB", store => false, source);
+
+                for (var i = 0; i < 30; i++)
+                {
+                    //just for starting the initial index and transformer replication
+                    source.DatabaseCommands.ForDatabase("testDB").Put("test" + i, Etag.Empty, new RavenJObject(), new RavenJObject());
+                    destination.DatabaseCommands.ForDatabase("testDB").Put("test" + (i + 50), Etag.Empty, new RavenJObject(), new RavenJObject());
+                }
+
+                WaitForDocument(destination.DatabaseCommands.ForDatabase("testDB"), "test29");
+                WaitForDocument(source.DatabaseCommands.ForDatabase("testDB"), "test79");
+
+                var userIndex = new UserIndex();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+
+                //replicating indexes from the source
+                var replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", source.Url);
+                var replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                var updatedUserIndex = new UserIndex_Extended();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, updatedUserIndex.CreateIndexDefinition(), true);
+
+                var index = source.DatabaseCommands.ForDatabase("testDB").GetIndex(userIndex.IndexName);
+                Assert.True(updatedUserIndex.CreateIndexDefinition().Map.Equals(index.Map));
+
+                //replicating indexes from the destination
+                replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", destination.Url);
+                replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
+                {
+                    Url = destination.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                //the new index shouldn't be overwritten
+                index = source.DatabaseCommands.ForDatabase("testDB").GetIndex(userIndex.IndexName);
+                Assert.True(updatedUserIndex.CreateIndexDefinition().Map.Equals(index.Map));
+            }
+        }
+
+        [Fact]
+        public void can_update_index_lock_mode()
+        {
+            var requestFactory = new HttpRavenRequestFactory();
+            using (var sourceServer = GetNewServer(8077))
+            using (var source = NewRemoteDocumentStore(ravenDbServer: sourceServer, fiddler: true))
+            using (var destinationServer = GetNewServer(8078))
+            using (var destination = NewRemoteDocumentStore(ravenDbServer: destinationServer, fiddler: true))
+            {
+                CreateDatabaseWithReplication(source, "testDB");
+                CreateDatabaseWithReplication(destination, "testDB");
+
+                source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+                destination.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+
+                SetupReplication(source, "testDB", store => false, destination);
+                SetupReplication(destination, "testDB", store => false, source);
+
+                for (var i = 0; i < 30; i++)
+                {
+                    //just for starting the initial index and transformer replication
+                    source.DatabaseCommands.ForDatabase("testDB").Put("test" + i, Etag.Empty, new RavenJObject(), new RavenJObject());
+                    destination.DatabaseCommands.ForDatabase("testDB").Put("test" + (i + 50), Etag.Empty, new RavenJObject(), new RavenJObject());
+                }
+
+                WaitForDocument(destination.DatabaseCommands.ForDatabase("testDB"), "test29");
+                WaitForDocument(source.DatabaseCommands.ForDatabase("testDB"), "test79");
+
+                var userIndex = new UserIndex();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+                source.DatabaseCommands.ForDatabase("testDB").SetIndexLock(userIndex.IndexName, IndexLockMode.LockedIgnore);
+
+                //replicating index from the source
+                var replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", source.Url);
+                var replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                var updatedUserIndex = new UserIndex_Extended();
+                source.DatabaseCommands.ForDatabase("testDB").SetIndexLock(updatedUserIndex.IndexName, IndexLockMode.Unlock);
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(updatedUserIndex.IndexName, updatedUserIndex.CreateIndexDefinition(), true);
+
+                var index = source.DatabaseCommands.ForDatabase("testDB").GetIndex(userIndex.IndexName);
+                Assert.True(updatedUserIndex.CreateIndexDefinition().Map.Equals(index.Map));
+
+                //replicating index from the source
+                replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", source.Url);
+                replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                //the index lock mode should change
+                index = destination.DatabaseCommands.ForDatabase("testDB").GetIndex(userIndex.IndexName);
+                Assert.Equal(index.LockMode, IndexLockMode.Unlock);
+                Assert.True(updatedUserIndex.CreateIndexDefinition().Map.Equals(index.Map));
+            }
+        }
+
+        [Fact]
+        public void can_replicate_index_when_lock_mode_is_error()
+        {
+            var requestFactory = new HttpRavenRequestFactory();
+            using (var sourceServer = GetNewServer(8077))
+            using (var source = NewRemoteDocumentStore(ravenDbServer: sourceServer, fiddler: true))
+            using (var destinationServer = GetNewServer(8078))
+            using (var destination = NewRemoteDocumentStore(ravenDbServer: destinationServer, fiddler: true))
+            {
+                CreateDatabaseWithReplication(source, "testDB");
+                CreateDatabaseWithReplication(destination, "testDB");
+
+                source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+                destination.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+
+                SetupReplication(source, "testDB", store => false, destination);
+                SetupReplication(destination, "testDB", store => false, source);
+
+                for (var i = 0; i < 30; i++)
+                {
+                    //just for starting the initial index and transformer replication
+                    source.DatabaseCommands.ForDatabase("testDB").Put("test" + i, Etag.Empty, new RavenJObject(), new RavenJObject());
+                    destination.DatabaseCommands.ForDatabase("testDB").Put("test" + (i + 50), Etag.Empty, new RavenJObject(), new RavenJObject());
+                }
+
+                WaitForDocument(destination.DatabaseCommands.ForDatabase("testDB"), "test29");
+                WaitForDocument(source.DatabaseCommands.ForDatabase("testDB"), "test79");
+
+                var userIndex = new UserIndex();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+
+                //replicating indexes from the source
+                var replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", source.Url);
+                var replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                //only Raven/ByEntityName
+                Assert.Equal(1, destination.DatabaseCommands.GetStatistics().Indexes.Length);
+
+                source.DatabaseCommands.ForDatabase("testDB").SetIndexLock(userIndex.IndexName, IndexLockMode.LockedError);
+
+                var userIndex2 = new AnotherUserIndex();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex2.IndexName, userIndex2.CreateIndexDefinition());
+
+                //replicating indexes from the source
+                replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                //the new index should be replicated
+                Assert.Equal(2, destination.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Length);
+            }
+        }
+
+        [Fact]
+        public void can_replicate_index_when_lock_mode_is_side_by_side()
+        {
+            var requestFactory = new HttpRavenRequestFactory();
+            using (var sourceServer = GetNewServer(8077))
+            using (var source = NewRemoteDocumentStore(ravenDbServer: sourceServer, fiddler: true))
+            using (var destinationServer = GetNewServer(8078))
+            using (var destination = NewRemoteDocumentStore(ravenDbServer: destinationServer, fiddler: true))
+            {
+                CreateDatabaseWithReplication(source, "testDB");
+                CreateDatabaseWithReplication(destination, "testDB");
+
+                source.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+                destination.Conventions.IndexAndTransformerReplicationMode = IndexAndTransformerReplicationMode.None;
+
+                SetupReplication(source, "testDB", store => false, destination);
+                SetupReplication(destination, "testDB", store => false, source);
+
+                for (var i = 0; i < 30; i++)
+                {
+                    //just for starting the initial index and transformer replication
+                    source.DatabaseCommands.ForDatabase("testDB").Put("test" + i, Etag.Empty, new RavenJObject(), new RavenJObject());
+                    destination.DatabaseCommands.ForDatabase("testDB").Put("test" + (i + 50), Etag.Empty, new RavenJObject(), new RavenJObject());
+                }
+
+                WaitForDocument(destination.DatabaseCommands.ForDatabase("testDB"), "test29");
+                WaitForDocument(source.DatabaseCommands.ForDatabase("testDB"), "test79");
+
+                var userIndex = new UserIndex();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex.IndexName, userIndex.CreateIndexDefinition());
+
+                //replicating indexes from the source
+                var replicationRequestUrl = string.Format("{0}/databases/testDB/replication/replicate-indexes?op=replicate-all", source.Url);
+                var replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                //only Raven/ByEntityName
+                Assert.Equal(1, destination.DatabaseCommands.GetStatistics().Indexes.Length);
+
+                source.DatabaseCommands.ForDatabase("testDB").SetIndexLock(userIndex.IndexName, IndexLockMode.SideBySide);
+
+                var userIndex2 = new AnotherUserIndex();
+                source.DatabaseCommands.ForDatabase("testDB").PutIndex(userIndex2.IndexName, userIndex2.CreateIndexDefinition());
+
+                //replicating indexes from the source
+                replicationRequest = requestFactory.Create(replicationRequestUrl, "POST", new RavenConnectionStringOptions
+                {
+                    Url = source.Url
+                });
+                replicationRequest.ExecuteRequest();
+
+                //the new index should be replicated
+                Assert.Equal(2, destination.DatabaseCommands.ForDatabase("testDB").GetStatistics().Indexes.Length);
             }
         }
 
@@ -591,6 +913,24 @@ namespace Raven.Tests.Replication
                     {"Raven/ActiveBundles", "Replication"}
                 }
             });
+        }
+
+        private void ReplicateOneDummyDocument(IDocumentStore source, IDocumentStore destination1, IDocumentStore destination2, IDocumentStore destination3)
+        {
+            string id;
+            using (var session = source.OpenSession("testDB"))
+            {
+                var dummy = new { Id = "" };
+
+                session.Store(dummy);
+                session.SaveChanges();
+
+                id = dummy.Id;
+            }
+
+            WaitForDocument(destination1.DatabaseCommands.ForDatabase("testDB"), id);
+            WaitForDocument(destination2.DatabaseCommands.ForDatabase("testDB"), id);
+            WaitForDocument(destination3.DatabaseCommands.ForDatabase("testDB"), id);
         }
     }
 }


### PR DESCRIPTION
Ported the index replication and transformer from 3.5
Fixed deleted indexes that are automatically re-created

http://issues.hibernatingrhinos.com/issue/RavenDB-4972
http://issues.hibernatingrhinos.com/issue/RavenDB-5208
