### PR TITLE
RavenDB-5241 - Loading documents with a transformer returns null for duplicate IDs

### DIFF
--- a/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
+++ b/Raven.Client.Lightweight/Connection/Async/AsyncServerClient.cs
@@ -813,7 +813,7 @@ namespace Raven.Client.Connection.Async
             ErrorResponseException responseException;
             try
             {
-                var uniqueKeys = new HashSet<string>(keys);
+                var uniqueKeys = new HashSet<string>(keys).ToArray();
 
                 var results = result
                     .Value<RavenJArray>("Results")
@@ -824,11 +824,11 @@ namespace Raven.Client.Connection.Async
                     .Where(x => x != null && x.ContainsKey("@metadata") && x["@metadata"].Value<string>("@id") != null)
                     .ToDictionary(x => x["@metadata"].Value<string>("@id"), x => x, StringComparer.OrdinalIgnoreCase);
 
-                if (results.Count >= uniqueKeys.Count)
+                if (results.Count >= uniqueKeys.Length)
                 {
-                    for (var i = 0; i < uniqueKeys.Count; i++)
+                    for (var i = 0; i < uniqueKeys.Length; i++)
                     {
-                        var key = keys[i];
+                        var key = uniqueKeys[i];
                         if (documents.ContainsKey(key))
                             continue;
 

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -138,6 +138,7 @@
     <Compile Include="1379\RavenDB_1379_Client_Lazy.cs" />
     <Compile Include="1379\RavenDB_1379_Client_Remote.cs" />
     <Compile Include="ActualValueInJsonReaderException.cs" />
+    <Compile Include="RavenDB-5241.cs" />
     <Compile Include="RavenDB-4977.cs" />
     <Compile Include="RavenDB-1279.cs" />
     <Compile Include="RavenDB-4917.cs" />

--- a/Raven.Tests.Issues/RavenDB-5241.cs
+++ b/Raven.Tests.Issues/RavenDB-5241.cs
@@ -1,0 +1,113 @@
+// -----------------------------------------------------------------------
+//  <copyright file="RavenDB-5241.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Linq;
+using Raven.Tests.Common;
+using Raven.Client.Indexes;
+using Xunit;
+
+namespace Raven.Tests.Issues
+{
+    public class RavenDB_5241 : RavenTest
+    {
+        [Fact]
+        public void loading_documents_with_transformer_duplicate_ids()
+        {
+            using (var store = NewRemoteDocumentStore(true))
+            {
+                new TestDocumentTransformer().Execute(store);
+
+                var document1Id = "TestDocuments/1";
+                var document2Id = "TestDocuments/2";
+                using (var session = store.OpenSession())
+                {
+                    var existing1 = session.Load<TestDocument>(document1Id);
+                    if (existing1 == null)
+                        session.Store(new TestDocument { Id = document1Id, Value = 1 });
+
+                    var existing2 = session.Load<TestDocument>(document2Id);
+                    if (existing2 == null)
+                        session.Store(new TestDocument { Id = document2Id, Value = 2 });
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var docs = session.Load<TestDocumentTransformer, TestDocumentTransformer.Output>(
+                        new[] { document1Id, document1Id, document2Id, document1Id, document2Id });
+                    for (int i = 0; i < docs.Length; i++)
+                    {
+                        Assert.NotNull(docs[i]);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void loading_documents_with_transformer_duplicate_ids_and_non_existing_document()
+        {
+            using (var store = NewRemoteDocumentStore(true))
+            {
+                new TestDocumentTransformer().Execute(store);
+
+                var document1Id = "TestDocuments/1";
+                var document2Id = "TestDocuments/2";
+                using (var session = store.OpenSession())
+                {
+                    var existing1 = session.Load<TestDocument>(document1Id);
+                    if (existing1 == null)
+                        session.Store(new TestDocument { Id = document1Id, Value = 1 });
+
+                    var existing2 = session.Load<TestDocument>(document2Id);
+                    if (existing2 == null)
+                        session.Store(new TestDocument { Id = document2Id, Value = 2 });
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var docs = session.Load<TestDocumentTransformer, TestDocumentTransformer.Output>(
+                        new[] { document1Id, document1Id, "no_document", document2Id, document1Id, document2Id });
+                    for (int i = 0; i < docs.Length; i++)
+                    {
+                        if (i == 2)
+                        {
+                            Assert.Null(docs[i]);
+                            continue;
+                        }
+
+                        Assert.NotNull(docs[i]);
+                    }
+                }
+            }
+        }
+
+        public class TestDocument
+        {
+            public string Id { get; set; }
+            public int Value { get; set; }
+        }
+
+        public class TestDocumentTransformer : AbstractTransformerCreationTask<TestDocument>
+        {
+            public class Output
+            {
+                public string ValueFormatted { get; set; }
+            }
+
+            public TestDocumentTransformer()
+            {
+                TransformResults = results =>
+                    from result in results
+                    select new Output
+                    {
+                        ValueFormatted = string.Format("Formatted Value is {0}", result)
+                    };
+            }
+        }
+    }
+}

--- a/Raven.Tests.Issues/RavenDB-5241.cs
+++ b/Raven.Tests.Issues/RavenDB-5241.cs
@@ -40,7 +40,20 @@ namespace Raven.Tests.Issues
                         new[] { document1Id, document1Id, document2Id, document1Id, document2Id });
                     for (int i = 0; i < docs.Length; i++)
                     {
-                        Assert.NotNull(docs[i]);
+                        var output = docs[i];
+                        Assert.NotNull(output);
+                        switch (i)
+                        {
+                            case 0:
+                            case 1:
+                            case 3:
+                                Assert.Equal(1, output.Value);
+                                break;
+                            case 2:
+                            case 4:
+                                Assert.Equal(2, output.Value);
+                                break;
+                        }
                     }
                 }
             }
@@ -74,13 +87,27 @@ namespace Raven.Tests.Issues
                         new[] { document1Id, document1Id, "no_document", document2Id, document1Id, document2Id });
                     for (int i = 0; i < docs.Length; i++)
                     {
+                        var output = docs[i];
                         if (i == 2)
                         {
-                            Assert.Null(docs[i]);
+                            Assert.Null(output);
                             continue;
                         }
 
-                        Assert.NotNull(docs[i]);
+                        Assert.NotNull(output);
+
+                        switch (i)
+                        {
+                            case 0:
+                            case 1:
+                            case 4:
+                                Assert.Equal(1, output.Value);
+                                break;
+                            case 3:
+                            case 5:
+                                Assert.Equal(2, output.Value);
+                                break;
+                        }
                     }
                 }
             }
@@ -96,7 +123,7 @@ namespace Raven.Tests.Issues
         {
             public class Output
             {
-                public string ValueFormatted { get; set; }
+                public int Value { get; set; }
             }
 
             public TestDocumentTransformer()
@@ -105,7 +132,7 @@ namespace Raven.Tests.Issues
                     from result in results
                     select new Output
                     {
-                        ValueFormatted = string.Format("Formatted Value is {0}", result)
+                        Value = result.Value
                     };
             }
         }


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-5241
