### PR TITLE
RavenDB-5305 Fixing boolean queries and parenthesis queries OCCUR

### DIFF
--- a/Raven.Tests/Querying/CanHandleNestedBooleanQueries.cs
+++ b/Raven.Tests/Querying/CanHandleNestedBooleanQueries.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Lucene.Net.Analysis;
+using Raven.Abstractions.Data;
+using Raven.Client.Document;
+using Raven.Database.Indexing;
+using Raven.Tests.Common;
+using Xunit;
+
+namespace Raven.Tests.Querying
+{
+    public class CanParseNestedBooleanQueries : RavenTest
+    {
+        private static LuceneASTQueryConfiguration config = new LuceneASTQueryConfiguration
+        {
+            Analayzer = new RavenPerFieldAnalyzerWrapper(new KeywordAnalyzer()),
+            DefaultOperator = QueryOperator.Or,
+            FieldName = "foo"
+        };
+
+        [Fact]
+        void CanParseThreeTermsWithDiffrentOperators()
+        {
+            var parser = new LuceneQueryParser();
+            parser.Parse("foo:a AND foo:b foo:c");
+            var query = parser.LuceneAST.ToQuery(config);
+            Assert.Equal(query.ToString(), "+foo:a +foo:b foo:c");
+        }
+
+        [Fact]
+        void CanParseThreeTermsWithDiffrentOperators2()
+        {
+            var parser = new LuceneQueryParser();
+            parser.Parse("foo:a AND foo:b foo:-c");
+            var query = parser.LuceneAST.ToQuery(config);
+            Assert.Equal(query.ToString(), "+foo:a +foo:b foo:c");
+        }
+
+        [Fact]
+        void CanParseParenthesisInsideNextedBooleanQuery()
+        {
+            var parser = new LuceneQueryParser();
+            parser.Parse("foo:a AND foo:(b -d) foo:-c");
+            var query = parser.LuceneAST.ToQuery(config);
+            Assert.Equal(query.ToString(), "+foo:a +(foo:b -foo:d) foo:c");
+        }
+
+        [Fact]
+        void CanParseParenthesisInsideNextedBooleanQuery2()
+        {
+            var parser = new LuceneQueryParser();
+            parser.Parse("foo:a AND (foo:b -d) foo:-c");
+            var query = parser.LuceneAST.ToQuery(config);
+            Assert.Equal(query.ToString(), "+foo:a +(foo:b -foo:d) foo:c");
+        }
+
+        [Fact]
+        void CanParseComplexedBooleanQuery()
+        {
+            var parser = new LuceneQueryParser();
+            parser.Parse("(foo:a foo:b) (foo:b +d) AND (foo:(e -c) OR g)");
+            var query = parser.LuceneAST.ToQuery(config);
+            Assert.Equal(query.ToString(), "(foo:a foo:b) (foo:b +foo:d) +((foo:e -foo:c) foo:g)");
+        }
+    }
+}

--- a/Raven.Tests/Raven.Tests.csproj
+++ b/Raven.Tests/Raven.Tests.csproj
@@ -646,6 +646,7 @@
     <Compile Include="Properties\TestAssemblyInfo.cs" />
     <Compile Include="Queries\CommentsInQueries.cs" />
     <Compile Include="Querying\CachingOfLongQueries.cs" />
+    <Compile Include="Querying\CanHandleNestedBooleanQueries.cs" />
     <Compile Include="Querying\SkipDuplicates.cs" />
     <Compile Include="Replication\IndexReplication.cs" />
     <Compile Include="Replication\TransformerReplication.cs" />


### PR DESCRIPTION
I have ran query related tests but not all tests.
Need to verify this doesn't break anything.
I spent all day doing test verifying this is the right behavior but this might still be wrong...
