### PR TITLE
RavenDB-5325 trim .NET Core dependencies to minimum

### DIFF
--- a/Bundles/Raven.Client.Authorization/project.json
+++ b/Bundles/Raven.Client.Authorization/project.json
@@ -25,8 +25,7 @@
   },
 
   "frameworks": {
-    "netstandard1.6": {
-      "imports": [ "dnxcore50" ],
+    "netstandard1.3": {
       "buildOptions": {
         "define": [ "DNXCORE50", "PORTABLE", "DOTNET" ]
       }

--- a/Bundles/Raven.Client.UniqueConstraints/project.json
+++ b/Bundles/Raven.Client.UniqueConstraints/project.json
@@ -24,13 +24,13 @@
   },
 
   "frameworks": {
-    "netstandard1.6": {
-      "imports": [ "dnxcore50" ],
+    "netstandard1.3": {
       "buildOptions": {
         "define": [ "DNXCORE50", "PORTABLE", "DOTNET" ]
       },
       "dependencies": {
-        "System.Reflection.Extensions": "4.0.1"
+        "System.Reflection.Extensions": "4.0.1",
+        "System.Reflection.TypeExtensions": "4.1.0"
       }
     }
   }

--- a/Imports/Newtonsoft.Json/Src/Newtonsoft.Json/Utilities/TypeExtensions.cs
+++ b/Imports/Newtonsoft.Json/Src/Newtonsoft.Json/Utilities/TypeExtensions.cs
@@ -34,6 +34,17 @@ using System.Linq;
 
 namespace Raven.Imports.Newtonsoft.Json.Utilities
 {
+#if (DNXCORE50)
+    internal enum MemberTypes
+    {
+        Property = 0,
+        Field = 1,
+        Event = 2,
+        Method = 3,
+        Other = 4
+    }
+#endif
+
     internal static class TypeExtensions
     {
 #if NETFX_CORE || PORTABLE
@@ -99,7 +110,7 @@ namespace Raven.Imports.Newtonsoft.Json.Utilities
 
         public static MemberTypes MemberType(this MemberInfo memberInfo)
         {
-            return memberInfo.MemberType;
+            return memberInfo.MemberType();
         }
 
         public static bool ContainsGenericParameters(this Type type)

--- a/Raven.Abstractions/project.json
+++ b/Raven.Abstractions/project.json
@@ -19,14 +19,11 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-
     "Sparrow": "3.5.0"
   },
 
   "frameworks": {
-    "netstandard1.6": {
-      "imports": "dnxcore50",
+    "netstandard1.3": {
       "buildOptions": {
         "define": [ "DNXCORE50", "PORTABLE", "DOTNET" ]
       },
@@ -34,15 +31,24 @@
         "Microsoft.CSharp": "4.0.1",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Collections.Specialized": "4.0.1",
+        "System.Diagnostics.Tools": "4.0.1",
         "Microsoft.Extensions.Configuration": "1.0.0",
         "System.IO.Compression": "4.1.0",
+        "System.IO.FileSystem": "4.0.1",
+        "System.IO.FileSystem.Primitives": "4.0.1",
+        "System.Net.Http": "4.1.0",
+        "System.Net.Primitives": "4.0.11",
         "System.Net.WebHeaderCollection": "4.0.1",
+        "System.Reflection": "4.1.0",
+        "System.Reflection.Extensions": "4.0.1",
         "System.Reflection.TypeExtensions": "4.1.0",
         "System.Security.Cryptography.Csp": "4.0.0",
         "System.Security.Principal": "4.0.1",
         "System.ServiceModel.Primitives": "4.1.0",
+        "System.Text.Encoding.Extensions": "4.0.11",
         "System.Text.RegularExpressions": "4.1.0",
         "System.Threading.Thread": "4.0.0",
+        "System.Threading.Timer": "4.0.1",
         "System.Xml.XDocument": "4.0.11"
       }
     }

--- a/Raven.Client.Lightweight/project.json
+++ b/Raven.Client.Lightweight/project.json
@@ -16,13 +16,11 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-
     "Raven.Abstractions": "3.5.0"
   },
 
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.3": {
       "imports": [ "dnxcore50" ],
       "buildOptions": {
         "define": [ "DNXCORE50", "PORTABLE", "DOTNET" ]
@@ -33,7 +31,6 @@
         "System.Linq.Queryable": "4.0.1",
         "System.Diagnostics.Process": "4.1.0",
         "System.IO.FileSystem.Primitives": "4.0.1",
-        "System.IO.IsolatedStorage": "4.0.1",
         "System.Net.Http": "4.1.0",
         "System.Net.NameResolution": "4.0.0"
       }

--- a/Raven.Sparrow/Sparrow/project.json
+++ b/Raven.Sparrow/Sparrow/project.json
@@ -15,18 +15,20 @@
     }
   },
 
-  "dependencies": {
-    "NETStandard.Library": "1.6.0"
-  },
-
   "frameworks": {
-    "netstandard1.6": {
-      "imports": "dnxcore50",
+    "netstandard1.1": {
       "buildOptions": {
         "define": [ "DNXCORE50" ]
       },
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1"
+        "Microsoft.CSharp": "4.0.1",
+        "System.Collections": "4.0.11",
+        "System.Collections.Concurrent": "4.0.12",
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Globalization": "4.0.11",
+        "System.Linq": "4.1.0",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Threading": "4.0.11"
       }
     }
   }

--- a/Raven.Tests.Core/project.json
+++ b/Raven.Tests.Core/project.json
@@ -26,7 +26,6 @@
 
   "frameworks": {
     "netcoreapp1.0": {
-      "imports": [ "dnxcore50" ],
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",


### PR DESCRIPTION
Went through dependencies trimming them and tried to find the best minimal netstandard dependency for projects. Now nestandard1.3 is the biggest requirement. Added MemberTypes enumeration following Newtonsoft.Json's way of handling minimal dependency.

Now all libs require netstandard1.3 or less.
