### PR TITLE
RavenDB-5340 Once we hit a record with non matching file name we have…

### DIFF
--- a/Raven.Database/FileSystem/Storage/Esent/StorageActionsAccessor.cs
+++ b/Raven.Database/FileSystem/Storage/Esent/StorageActionsAccessor.cs
@@ -353,7 +353,7 @@ namespace Raven.Database.FileSystem.Storage.Esent
                     {
                         var name = Api.RetrieveColumnAsString(session, Usage, tableColumnsCache.UsageColumns["name"]);
                         if (name.Equals(filename, StringComparison.InvariantCultureIgnoreCase) == false)
-                            continue;
+                            break;
 
                         fileInformation.Pages.Add(new PageInformation
                                                       {


### PR DESCRIPTION
… to break the iteration. Otherwise we will seek over all of remaining records what can result in poor performance when there is large number of files in a file system.
