### PR TITLE
RavenDB-5347-3.0 - Raven .Net Client File session null reference exception when file does not exist

### DIFF
--- a/Raven.Client.Lightweight/FileSystem/AsyncFilesSession.cs
+++ b/Raven.Client.Lightweight/FileSystem/AsyncFilesSession.cs
@@ -96,7 +96,7 @@ namespace Raven.Client.FileSystem
             {
                 IncrementRequestCount();
 
-                var fileHeaders = await Commands.GetAsync(idsOfNotExistingObjects.ToArray());
+                var fileHeaders = await Commands.GetAsync(idsOfNotExistingObjects.ToArray()).ConfigureAwait(false);
                 foreach (var header in fileHeaders)
                 {
                     if (header == null)

--- a/Raven.Tests.FileSystem/Issues/RavenDB_5347.cs
+++ b/Raven.Tests.FileSystem/Issues/RavenDB_5347.cs
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------
+//  <copyright file="RavenDB_5347.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Raven.Tests.FileSystem.Issues
+{
+    public class RavenDB_5347 : RavenFilesTestWithLogs
+    {
+        [Theory]
+        [InlineData("voron")]
+        [InlineData("esent")]
+        public void load_non_existing_file(string storage)
+        {
+            using (var store = NewStore(requestedStorage: storage))
+            {
+                Assert.DoesNotThrow(() =>
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var headers = session.LoadFileAsync(new[] { "filekey/that/is/not/exist" }).Result;
+                        Assert.Equal(1, headers.Length);
+                        Assert.Null(headers[0]);
+                    }
+                });
+            }
+        }
+
+        [Theory]
+        [PropertyData("Storages")]
+        public async Task load_non_existing_file_multiple_files(string storage)
+        {
+            using (var store = NewStore(requestedStorage: storage))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.RegisterUpload("test1.file", CreateUniformFileStream(128));
+                    await session.SaveChangesAsync();
+                }
+
+                Assert.DoesNotThrow(() =>
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var files = session.LoadFileAsync(new[] { "/b/test1.file", "test1.file" }).Result;
+                        Assert.Equal(2, files.Length);
+                        Assert.Null(files[0]);
+                        Assert.NotNull(files[1]);
+                    }
+                });
+
+                Assert.DoesNotThrow(() =>
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+
+                        var files = session.LoadFileAsync(new[] { "test1.file", "/b/test1.file" }).Result;
+                        Assert.Equal(2, files.Length);
+                        Assert.Null(files[1]);
+                        Assert.NotNull(files[0]);
+                    }
+                });
+            }
+        }
+    }
+}

--- a/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
+++ b/Raven.Tests.FileSystem/Raven.Tests.FileSystem.csproj
@@ -138,6 +138,7 @@
     <Compile Include="FileHandling.cs" />
     <Compile Include="FileNamingTests.cs" />
     <Compile Include="Folders.cs" />
+    <Compile Include="Issues\RavenDB_5347.cs" />
     <Compile Include="Issues\RavenDB_3887.cs" />
     <Compile Include="Issues\RavenDB_3920.cs" />
     <Compile Include="Issues\RavenDB_3955.cs" />


### PR DESCRIPTION
http://issues.hibernatingrhinos.com/issue/RavenDB-5347
