### PR TITLE
RavenDB-5327 Restore CLSCompliant(true) (3.0 branch)

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("© Hibernating Rhinos 2004 - 2016 All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: ComVisible(false)]
-[assembly: CLSCompliant(false)]
+[assembly: CLSCompliant(true)]
 [assembly: AssemblyTitle("RavenDB")]
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.13.0")]


### PR DESCRIPTION
Same fix that already went to 3.5 branch, seems to work the same way in maintenance branch. Would be nice to have this fix in production-ready version too.
