### PR TITLE
RavenDB-5363 * Fixing reduce handling for branch pages that were modi…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -57,8 +57,17 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             ModifiedPages = new HashSet<long>();
             FreedPages = new HashSet<long>();
 
-            Tree.PageModified += page => ModifiedPages.Add(page);
-            Tree.PageFreed += page => FreedPages.Add(page);
+            Tree.PageModified += page =>
+            {
+                ModifiedPages.Add(page);
+                FreedPages.Remove(page);
+            };
+
+            Tree.PageFreed += page =>
+            {
+                FreedPages.Add(page);
+                ModifiedPages.Remove(page);
+            };
         }
 
         public void Delete(long id)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -1,16 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
-using System.Net;
+using System.Linq;
 using System.Threading;
-using Raven.Abstractions.Logging;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
-using Sparrow.Logging;
+using Sparrow.Binary;
 using Sparrow.Json;
+using Sparrow.Logging;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Data.Tables;
@@ -60,7 +61,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 WriteLastEtags(indexContext); // we need to write etags here, because if we filtered everything during map then we will loose last indexed etag information and this will cause an endless indexing loop
                 return false;
             }
-
+            
             _aggregationBatch.Clear();
 
             _reduceResultsSchema.Create(indexContext.Transaction.InnerTransaction, "PageNumberToReduceResult");
@@ -170,30 +171,36 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             CancellationToken token, MapReduceResultsStore modifiedStore, LowLevelTransaction lowLevelTransaction,
             IndexWriteOperation writer, LazyStringValue reduceKeyHash, Table table)
         {
-            var parentPagesToAggregate = new Dictionary<long, Tree>();
+            var tree = modifiedStore.Tree;
+
+            var branchesToAggregate = new HashSet<long>();
+
+            var parentPagesToAggregate = new HashSet<long>();
 
             foreach (var modifiedPage in modifiedStore.ModifiedPages)
             {
                 token.ThrowIfCancellationRequested();
 
-                if (modifiedStore.FreedPages.Contains(modifiedPage))
-                    continue;
-
                 var page = lowLevelTransaction.GetPage(modifiedPage).ToTreePage();
                 if (page.IsLeaf == false)
+                {
+                    Debug.Assert(page.IsBranch);
+                    branchesToAggregate.Add(modifiedPage);
+
                     continue;
+                }
 
                 if (page.NumberOfEntries == 0)
                 {
-                    if (page.PageNumber != modifiedStore.Tree.State.RootPageNumber)
+                    if (page.PageNumber != tree.State.RootPageNumber)
                     {
                         throw new InvalidOperationException(
-                            $"Encountered empty page which isn't a root. Page #{page.PageNumber} in '{modifiedStore.Tree.Name}' tree.");
+                            $"Encountered empty page which isn't a root. Page #{page.PageNumber} in '{tree.Name}' tree.");
                     }
 
                     writer.DeleteReduceResult(reduceKeyHash, stats);
 
-                    var emptyPageNumber = page.PageNumber;
+                    var emptyPageNumber = Bits.SwapBytes(page.PageNumber);
                     Slice pageNumSlice;
                     using(Slice.External(indexContext.Allocator, (byte*)&emptyPageNumber, sizeof(long),out pageNumSlice))
                         table.DeleteByKey(pageNumSlice);
@@ -201,7 +208,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                     continue;
                 }
 
-                var parentPage = modifiedStore.Tree.GetParentPageOf(page);
+                var parentPage = tree.GetParentPageOf(page);
 
                 stats.RecordReduceAttempts(page.NumberOfEntries);
 
@@ -225,14 +232,14 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         else
                         {
                             StoreAggregationResult(page.PageNumber, page.NumberOfEntries, table, result);
-                            parentPagesToAggregate[parentPage] = modifiedStore.Tree;
+                            parentPagesToAggregate.Add(parentPage);
                         }
                     }
                 }
                 catch (Exception e)
                 {
                     var message =
-                        $"Failed to execute reduce function for reduce key '{modifiedStore.Tree.Name}' on a leaf page #{page} of '{_indexDefinition.Name}' index.";
+                        $"Failed to execute reduce function for reduce key '{tree.Name}' on a leaf page #{page} of '{_indexDefinition.Name}' index.";
 
                     if (_logger.IsInfoEnabled)
                         _logger.Info(message, e);
@@ -251,36 +258,35 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             {
                 foreach (var freedPage in modifiedStore.FreedPages)
                 {
-                    tmp = freedPage;
-                    table.DeleteByKey(pageNumberSlice);
+                    tmp = Bits.SwapBytes(freedPage);
+                    table.DeleteByKey(pageNumberSlice); 
                 }
             }
-            while (parentPagesToAggregate.Count > 0)
+            
+            while (parentPagesToAggregate.Count > 0 || branchesToAggregate.Count > 0)
             {
                 token.ThrowIfCancellationRequested();
 
-                var other = parentPagesToAggregate;
-                parentPagesToAggregate = new Dictionary<long, Tree>();
+                var branchPages = parentPagesToAggregate;
+                parentPagesToAggregate = new HashSet<long>();
 
-                foreach (var kvp in other)
+                foreach (var pageNumber in branchPages)
                 {
-                    var pageNumber = kvp.Key;
-                    var tree = kvp.Value;
                     var page = lowLevelTransaction.GetPage(pageNumber).ToTreePage();
-
-                    if (page.IsBranch == false)
-                    {
-                        throw new InvalidOperationException("Parent page was found that wasn't a branch, error at " +
-                                                            page.PageNumber);
-                    }
-
-                    var parentPage = tree.GetParentPageOf(page);
 
                     int aggregatedEntries = 0;
 
                     try
                     {
-                        using (var result = AggregateBranchPage(page, table, indexContext, token, out aggregatedEntries))
+                        if (page.IsBranch == false)
+                        {
+                            throw new InvalidOperationException("Parent page was found that wasn't a branch, error at " +
+                                                                page.PageNumber);
+                        }
+
+                        var parentPage = tree.GetParentPageOf(page);
+
+                        using (var result = AggregateBranchPage(page, table, indexContext, branchesToAggregate, token, out aggregatedEntries))
                         {
                             if (parentPage == -1)
                             {
@@ -297,7 +303,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                             }
                             else
                             {
-                                parentPagesToAggregate[parentPage] = tree;
+                                parentPagesToAggregate.Add(parentPage);
+
                                 StoreAggregationResult(page.PageNumber, aggregatedEntries, table, result);
                             }
                         }
@@ -305,7 +312,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                     catch (Exception e)
                     {
                         var message =
-                            $"Failed to execute reduce function for reduce key '{modifiedStore.Tree.Name}' on a branch page #{page} of '{_indexDefinition.Name}' index.";
+                            $"Failed to execute reduce function for reduce key '{tree.Name}' on a branch page #{page} of '{_indexDefinition.Name}' index.";
 
                         if (_logger.IsInfoEnabled)
                             _logger.Info(message, e);
@@ -313,6 +320,16 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         stats.RecordReduceErrors(aggregatedEntries);
                         stats.AddReduceError(message + $" Exception: {e}");
                     }
+                    finally
+                    {
+                        branchesToAggregate.Remove(pageNumber);
+                    }
+                }
+
+                if (parentPagesToAggregate.Count == 0 && branchesToAggregate.Count > 0)
+                {
+                    // we still have unaggregated branches which were modified but their children were not modified (branch page splitting) so we missed them
+                    parentPagesToAggregate.Add(branchesToAggregate.First());
                 }
             }
         }
@@ -330,30 +347,56 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             return AggregateBatchResults(_aggregationBatch, indexContext, token);
         }
 
-        private AggregationResult AggregateBranchPage(TreePage page, Table table, TransactionOperationContext indexContext, CancellationToken token, out int aggregatedEntries)
+        private AggregationResult AggregateBranchPage(TreePage page, Table table, TransactionOperationContext indexContext, HashSet<long> remainingBranchesToAggregate, CancellationToken token, out int aggregatedEntries)
         {
             aggregatedEntries = 0;
 
             for (int i = 0; i < page.NumberOfEntries; i++)
             {
-                var childPageNumber = IPAddress.HostToNetworkOrder(page.GetNode(i)->PageNumber);
+                var pageNumber = page.GetNode(i)->PageNumber;
+                var childPageNumber = Bits.SwapBytes(pageNumber);
                 Slice childPageNumberSlice;
                 TableValueReader tvr;
-                using(Slice.External(indexContext.Allocator, (byte*)&childPageNumber, sizeof(long),out childPageNumberSlice))
+                using (Slice.External(indexContext.Allocator, (byte*)&childPageNumber, sizeof(long), out childPageNumberSlice))
+                {
                     tvr = table.ReadByKey(childPageNumberSlice);
-                if (tvr == null)
-                {
-                    throw new InvalidOperationException("Couldn't find pre-computed results for existing page " + childPageNumber);
-                }
-                
-                int size;
-                aggregatedEntries += *(int*)tvr.Read(1, out size);
+                    if (tvr == null)
+                    {
+                        if (remainingBranchesToAggregate.Contains(pageNumber))
+                        {
+                            // we have a modified branch page but its children were not modified (branch page splitting) so we didn't aggregated it yet, let's do it now
 
-                var numberOfResults = *(int*)tvr.Read(2, out size);
+                            try
+                            {
+                                var unaggregatedPage = indexContext.Transaction.InnerTransaction.LowLevelTransaction.GetPage(pageNumber).ToTreePage();
+                                int aggregated;
+                                using (var result = AggregateBranchPage(unaggregatedPage, table, indexContext, remainingBranchesToAggregate, token, out aggregated))
+                                {
+                                    StoreAggregationResult(unaggregatedPage.PageNumber, aggregated, table, result);
+                                }
+                            }
+                            finally
+                            {
+                                remainingBranchesToAggregate.Remove(pageNumber);
+                            }
+                            
+                            tvr = table.ReadByKey(childPageNumberSlice);
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException("Couldn't find pre-computed results for existing page " + pageNumber);
+                        }
+                    }
 
-                for (int j = 0; j < numberOfResults; j++)
-                {
-                    _aggregationBatch.Add(new BlittableJsonReaderObject(tvr.Read(3 + j, out size), size, indexContext));
+                    int size;
+                    aggregatedEntries += *(int*)tvr.Read(1, out size);
+
+                    var numberOfResults = *(int*)tvr.Read(2, out size);
+
+                    for (int j = 0; j < numberOfResults; j++)
+                    {
+                        _aggregationBatch.Add(new BlittableJsonReaderObject(tvr.Read(3 + j, out size), size, indexContext));
+                    }
                 }
             }
 
@@ -376,9 +419,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             return result;
         }
 
-        private static void StoreAggregationResult(long modifiedPage, int aggregatedEntries, Table table, AggregationResult result)
+        private void StoreAggregationResult(long modifiedPage, int aggregatedEntries, Table table, AggregationResult result)
         {
-            var pageNumber = IPAddress.HostToNetworkOrder(modifiedPage);
+            var pageNumber = Bits.SwapBytes(modifiedPage);
             var numberOfOutputs = result.Count;
 
             var tvb = new TableValueBuilder


### PR DESCRIPTION
…fied during page splits. Page splits on branches does not affect children, in result we missed such pages and didn't aggregate them because we collected branches to aggregate using parents of modified leafs.
- Using Bits.SwapBytes instead NetworkToHostOrder, added missing usages on deletes.
- Properly handling modified and freed pages - a page can be freed and modified in the same transaction multiple times.
