### PR TITLE
RavenDB-5422 always escaping Lucene tokens

### DIFF
--- a/Raven.Abstractions/Util/RavenQuery.cs
+++ b/Raven.Abstractions/Util/RavenQuery.cs
@@ -113,6 +113,12 @@ namespace Raven.Abstractions.Util
                         return "\"AND\"";
                     case "NOT":
                         return "\"NOT\"";
+                    case "TO":
+                        return "\"TO\"";
+                    case "INTERSECT":
+                        return "\"INTERSECT\"";
+                    case "NULL":
+                        return "\"NULL\"";
                     default:
                         return term;
                 }

--- a/Raven.Tests.Issues/Raven.Tests.Issues.csproj
+++ b/Raven.Tests.Issues/Raven.Tests.Issues.csproj
@@ -154,6 +154,7 @@
     <Compile Include="RavenDB-4705.cs" />
     <Compile Include="RavenDB-4904.cs" />
     <Compile Include="RavenDB-5151.cs" />
+    <Compile Include="RavenDB-5422.cs" />
     <Compile Include="RavenDB_4645.cs" />
     <Compile Include="RavenDB_4918.cs" />
     <Compile Include="RavenDb_4706.cs" />

--- a/Raven.Tests.Issues/RavenDB-5422.cs
+++ b/Raven.Tests.Issues/RavenDB-5422.cs
@@ -19,11 +19,18 @@ namespace Raven.Tests.Issues
                     session.Store(new User() { Name = "OR" });
                     session.Store(new User() { Name = "AND" });
                     session.Store(new User() { Name = "NOT" });
+                    session.Store(new User() { Name = "TO" });
+                    session.Store(new User() { Name = "INTERSECT" });
+                    session.Store(new User() { Name = "NULL" });
+                    
                     session.SaveChanges();
                     WaitForIndexing(store);
                     session.Query<User, Users_ByName>().Search(user => user.Name, "OR").Single();
                     session.Query<User, Users_ByName>().Search(user => user.Name, "AND").Single();
                     session.Query<User, Users_ByName>().Search(user => user.Name, "NOT").Single();
+                    session.Query<User, Users_ByName>().Search(user => user.Name, "TO").Single();
+                    session.Query<User, Users_ByName>().Search(user => user.Name, "INTERSECT").Single();
+                    session.Query<User, Users_ByName>().Search(user => user.Name, "NULL").Single();
                 }
             }
         }


### PR DESCRIPTION
Adding test to issues (was missing in the project)
Adding more problematic tokens due to new parser (doesn't apply to 3.0)
