### PR TITLE
Minor fixes to scratch buffers handling:

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -17,7 +17,6 @@ namespace Voron.Impl.Scratch
         private class PendingPage
         {
             public long Page;
-            public long NumberOfPages;
             public long ValidAfterTransactionId;
         }
 
@@ -177,7 +176,6 @@ namespace Voron.Impl.Scratch
                 list.AddFirst(new PendingPage
                 {
                     Page = value.PositionInScratchBuffer,
-                    NumberOfPages = value.NumberOfPages,
                     ValidAfterTransactionId = asOfTxId
                 });
 

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -120,9 +120,10 @@ namespace Voron.Impl.Scratch
             return true;
         }
 
-        public long ActivelyUsedBytes(long oldestActiveTransaction)
+        public bool HasActivelyUsedBytes(long oldestActiveTransaction)
         {
-            long result = _allocatedPagesUsedSize;
+            if (_allocatedPagesUsedSize > 0)
+                return true;
 
             var keys = _freePagesByTransaction.Keys;
             var values = _freePagesByTransaction.Values;
@@ -131,10 +132,11 @@ namespace Voron.Impl.Scratch
                 if (keys[i] < oldestActiveTransaction)
                     break;
 
-                result += values[i];
+                if (values[i] > 0)
+                    return true;
             }
 
-            return result * _pageSize;
+            return false;
         }
 
         public void Free(long page, long asOfTxId)


### PR DESCRIPTION
- actively used bytes - changing signature to return bool since there is no need to know the exact value
- when we free a page from the commit (asOfTxId == -1) then we won't reset the scratch file anyway
- removing misleading comment - even if we recycle a scratch someone can be reading from it (but we won't reuse it until there is an active reader)
