### PR TITLE
Numerical Comparers Hash

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/Fields/FieldCacheKey.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/Fields/FieldCacheKey.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.Fields
                     {
                         int nameHash = name?.GetHashCode() ?? 0;
                         int fieldHash = (index != null ? (byte)index : -1) << 16 | ((byte)store << 8) | (byte)termVector;
-                        int hash = Hashing.CombineInline(nameHash, fieldHash);
+                        int hash = Hashing.Combine(nameHash, fieldHash);
 
                         if (multipleItemsSameField.Length > 0)
                         {

--- a/src/Sparrow/Collections/FastDictionary.cs
+++ b/src/Sparrow/Collections/FastDictionary.cs
@@ -352,6 +352,7 @@ namespace Sparrow.Collections
 
                 uint nHash;
                 int numProbes = 1;
+                int capacity = _capacity;
                 do
                 {
                     nHash = entries[bucket].Hash;
@@ -361,9 +362,13 @@ namespace Sparrow.Collections
                     bucket = (bucket + numProbes) & _capacityMask;
                     numProbes++;
 
-                    //Debug.Assert(numProbes < 100);
-                    if (numProbes >= _capacity)
+#if DEBUG
+                    if (numProbes >= 100)
+                        throw new InvalidOperationException("The hash function used for this object is not good enough. The distribution is causing clusters and causing huge slowdowns.");
+#else
+                    if (numProbes >= capacity)
                         break;
+#endif                
                 }
                 while (nHash != KUnusedHash);
 
@@ -521,7 +526,7 @@ namespace Sparrow.Collections
             int bucket = hash & _capacityMask;
 
             var entries = _entries;
-
+            int capacity = _capacity;
             uint uhash = (uint)hash;
             int numProbes = 1; // how many times we've probed
 
@@ -535,9 +540,13 @@ namespace Sparrow.Collections
                 bucket = ((bucket + numProbes) & _capacityMask);
                 numProbes++;
 
-                //Debug.Assert(numProbes < 100);
-                if (numProbes >= _capacity)
+#if DEBUG       
+                if (numProbes >= 100)
+                    throw new InvalidOperationException("The hash function used for this object is not good enough. The distribution is causing clusters and causing huge slowdowns.");
+#else
+                if (numProbes >= capacity)
                     break;
+#endif                
             }
             while (nHash != KUnusedHash);
 

--- a/src/Sparrow/Collections/ZFastNodesTable.cs
+++ b/src/Sparrow/Collections/ZFastNodesTable.cs
@@ -721,7 +721,7 @@ namespace Sparrow.Collections
                         uint hash = Hashing.Iterative.XXHash32.CalculateInline((byte*)bitsPtr, words * sizeof(ulong), state, lcp / BitVector.BitsPerByte);
 
                         remainingWord = ((remainingWord) >> shift) << shift;
-                        ulong intermediate = Hashing.CombineInline(remainingWord, ((ulong)remaining) << 32 | (ulong)hash);
+                        ulong intermediate = Hashing.Combine(remainingWord, ((ulong)remaining) << 32 | (ulong)hash);
 
                         hash = (uint)intermediate ^ (uint)(intermediate >> 32);
 

--- a/src/Sparrow/Comparers.cs
+++ b/src/Sparrow/Comparers.cs
@@ -17,7 +17,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(long obj)
         {
-            return unchecked((int)obj ^ (int)(obj >> 32));
+            return Hashing.Combine((int)(obj >> 32), (int)obj);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -41,7 +41,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(ulong obj)
         {
-            return unchecked((int)obj ^ (int)(obj >> 32));
+            return Hashing.Combine((int)(obj >> 32), (int)obj);
         }
     }
 
@@ -56,7 +56,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(long obj)
         {
-            return unchecked((int)obj ^ (int)(obj >> 32));
+            return Hashing.Mix(obj);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -80,7 +80,7 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(ulong obj)
         {
-            return unchecked((int)obj ^ (int)(obj >> 32));
+            return (int) Hashing.Mix(obj);
         }
     }
 

--- a/src/Sparrow/Hashing.cs
+++ b/src/Sparrow/Hashing.cs
@@ -478,40 +478,71 @@ namespace Sparrow
 
         #region Downsampling Hashing
 
-        public static int Combine(int x, int y)
+        public static class HashCombiner
         {
-            return CombineInline(x, y);
+            public static int Combine(int x, int y)
+            {
+                return CombineInline(x, y);
+            }
+
+            public static uint Combine(uint x, uint y)
+            {
+                return CombineInline(x, y);
+            }
+
+            public static long Combine(long x, long y)
+            {
+                return CombineInline(x, y);
+            }
+
+            public static ulong Combine(ulong x, ulong y)
+            {
+                return CombineInline(x, y);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int CombineInline(int x, int y)
+            {
+                // The jit optimizes this to use the ROL instruction on x86
+                // Related GitHub pull request: dotnet/coreclr#1830
+                uint shift5 = ((uint)x << 5) | ((uint)x >> 27);
+                return ((int)shift5 + x) ^ y;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static uint CombineInline(uint x, uint y)
+            {
+                // The jit optimizes this to use the ROL instruction on x86
+                // Related GitHub pull request: dotnet/coreclr#1830
+                uint shift5 = (x << 5) | (x >> 27);
+                return (shift5 + x) ^ y;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static long CombineInline(long x, long y)
+            {
+                // The jit optimizes this to use the ROL instruction on x86
+                // Related GitHub pull request: dotnet/coreclr#1830
+                ulong ux = (ulong)x;
+                ulong shift5 = (ux << 10) | (ux >> 54);
+                return (long) (shift5 + ux) ^ y;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ulong CombineInline(ulong x, ulong y)
+            {
+                // The jit optimizes this to use the ROL instruction on x86
+                // Related GitHub pull request: dotnet/coreclr#1830
+                ulong shift5 = (x << 10) | (x >> 54);
+                return (shift5 + x) ^ y;
+            }
         }
 
-        public static uint Combine(uint x, uint y)
-        {
-            return CombineInline(x, y);
-        }
-
-
-        public static long Combine(long x, long y)
-        {
-            return CombineInline(x, y);
-        }
-
-        public static ulong Combine(ulong x, ulong y)
-        {
-            return CombineInline(x, y);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int CombineInline(int x, int y)
-        {
-            // The jit optimizes this to use the ROL instruction on x86
-            // Related GitHub pull request: dotnet/coreclr#1830
-            uint shift5 = ((uint)x << 5) | ((uint)x >> 27);
-            return ((int)shift5 + x) ^ y;
-        }
 
         private static readonly ulong kMul = 0x9ddfea08eb382d69UL;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong CombineInline(ulong x, ulong y)
+        public static ulong Combine(ulong x, ulong y)
         {
             // This is the Hash128to64 function from Google's CityHash (available
             // under the MIT License).  We use it to reduce multiple 64 bit hashes
@@ -528,7 +559,7 @@ namespace Sparrow
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long CombineInline(long upper, long lower)
+        public static long Combine(long upper, long lower)
         {
             // This is the Hash128to64 function from Google's CityHash (available
             // under the MIT License).  We use it to reduce multiple 64 bit hashes
@@ -544,16 +575,60 @@ namespace Sparrow
             b ^= (b >> 47);
             b *= kMul;
 
-            return (long) b;
+            return (long)b;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint CombineInline(uint x, uint y)
+        public static uint Mix(ulong key)
         {
-            // The jit optimizes this to use the ROL instruction on x86
-            // Related GitHub pull request: dotnet/coreclr#1830
-            uint shift5 = (x << 5) | (x >> 27);
-            return (shift5 + x) ^ y;
+            key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+            key = key ^ (key >> 31);
+            key = key * 21; // key = (key + (key << 2)) + (key << 4);
+            key = key ^ (key >> 11);
+            key = key + (key << 6);
+            key = key ^ (key >> 22);
+            return (uint)key;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Mix(long key)
+        {
+            key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+            key = key ^ (key >> 31);
+            key = key * 21; // key = (key + (key << 2)) + (key << 4);
+            key = key ^ (key >> 11);
+            key = key + (key << 6);
+            key = key ^ (key >> 22);
+            return (int)key;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint Combine(uint upper, uint lower)
+        {
+            ulong key = ((ulong)upper << 32) | lower;
+
+            key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+            key = key ^ (key >> 31);
+            key = key * 21; // key = (key + (key << 2)) + (key << 4);
+            key = key ^ (key >> 11);
+            key = key + (key << 6);
+            key = key ^ (key >> 22);
+            return (uint)key;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine(int upper, int lower)
+        {
+            ulong x = (uint)upper; // Ensure we do not mess up with the sign extend.
+            ulong key = (x << 32) | (uint)lower;
+
+            key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+            key = key ^ (key >> 31);
+            key = key * 21; // key = (key + (key << 2)) + (key << 4);
+            key = key ^ (key >> 11);
+            key = key + (key << 6);
+            key = key ^ (key >> 22);
+            return (int)key;
         }
 
         #endregion

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -223,7 +223,7 @@ namespace Sparrow.Json
             int hash = 0;
             for (int i = 0; i < count; i++)
             {
-                hash = Hashing.CombineInline(hash, properties[i].Property.HashCode);
+                hash = Hashing.HashCombiner.CombineInline(hash, properties[i].Property.HashCode);
             }
 
             Debug.Assert(_cachedSorts.Length == CachedSortsSize && Bits.NextPowerOf2(CachedSortsSize) == CachedSortsSize); 

--- a/src/Sparrow/StringSegment.cs
+++ b/src/Sparrow/StringSegment.cs
@@ -76,7 +76,7 @@ namespace Sparrow
             uint hash = 0;
             for (int i = 0; i < xSize; i++)
             {
-                hash = Hashing.CombineInline(hash, xStr[xStart + i]);
+                hash = Hashing.Combine(hash, xStr[xStart + i]);
             }
 
             return (int)hash;

--- a/test/FastTests/Sparrow/Hashing.cs
+++ b/test/FastTests/Sparrow/Hashing.cs
@@ -292,8 +292,8 @@ namespace FastTests.Sparrow
         [Fact]
         public void Combine()
         {
-            int h1 = Hashing.CombineInline(1991, 13);
-            int h2 = Hashing.CombineInline(1991, 12);
+            int h1 = Hashing.HashCombiner.CombineInline(1991, 13);
+            int h2 = Hashing.HashCombiner.CombineInline(1991, 12);
             Assert.NotEqual(h1, h2);
         }
 


### PR DESCRIPTION
Fixed: Numerical Comparers were using an awful hash function. We changed it to a 64 bits into a 32 bits mixer.