### PR TITLE
RavenDB-6719

### DIFF
--- a/src/Raven.Client/Util/Helpers/DevelopmentHelper.cs
+++ b/src/Raven.Client/Util/Helpers/DevelopmentHelper.cs
@@ -6,7 +6,7 @@ namespace Raven.Client.Util.Helpers
     {
         public static void TimeBomb()
         {
-            if (SystemTime.UtcNow > new DateTime(2017, 4, 1))
+            if (SystemTime.UtcNow > new DateTime(2017, 5, 1))
                 throw new NotImplementedException("Development time bomb.");
         }
     }

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -227,10 +227,6 @@ namespace Raven.Server.Rachis
                     {
                         case 0: // new entry
                             _newEntry.Reset();
-                            if (_engine.Log.IsInfoEnabled)
-                            {
-                                _engine.Log.Info($"Leader {_engine.Tag}: Got new entry");
-                            }
                             // release any waiting ambassadors to send immediately
                             var old = Interlocked.Exchange(ref _newEntriesArrived, new TaskCompletionSource<object>());
                             ThreadPool.QueueUserWorkItem(o => ((TaskCompletionSource<object>)o).TrySetResult(null), old);
@@ -238,21 +234,12 @@ namespace Raven.Server.Rachis
                                 goto case 1;
                             break;
                         case 1: // voter responded
-                            if (_engine.Log.IsInfoEnabled && _voters.Count != 0)
-                            {
-                                _engine.Log.Info($"Leader {_engine.Tag}: voter responded");
-                            }
                             _voterResponded.Reset();
                             OnVoterConfirmation();
                             break;
                         case 2: // promotable updated
-                            if (_engine.Log.IsInfoEnabled && _voters.Count != 0)
-                            {
-                                _engine.Log.Info($"Leader {_engine.Tag}: promotable updated");
-                            }
                             _promotableUpdated.Reset();
                             CheckPromotables();
-
                             break;
                         case WaitHandle.WaitTimeout:
                             break;

--- a/src/Raven.Server/Rachis/Negotiation.cs
+++ b/src/Raven.Server/Rachis/Negotiation.cs
@@ -5,7 +5,7 @@
         public long PrevLogIndex { get; set; }
         public long PrevLogTerm { get; set; }
         public long Term { get; set; }
-
+        public bool Truncated { get; set; }
     }
 
     public class LogLengthNegotiationResponse

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -670,6 +670,26 @@ namespace Raven.Server.Rachis
             return lastIndex;
         }
 
+        public unsafe void ClearLogEntriesAndSetLastTrancate(TransactionOperationContext context, long index, long term)
+        {
+            var table = context.Transaction.InnerTransaction.OpenTable(LogsTable, EntriesSlice);
+            while (true)
+            {
+                TableValueReader reader;
+                if (table.SeekOnePrimaryKey(Slices.BeforeAllKeys, out reader) == false)
+                    break;
+
+                table.Delete(reader.Id);
+            }
+            var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
+            byte* ptr;
+            using (state.DirectAdd(LastTruncatedSlice, sizeof(long) * 2, out ptr))
+            {
+                var data = (long*)ptr;
+                data[0] = index;
+                data[1] = term;
+            }
+        }
         public unsafe void TruncateLogBefore(TransactionOperationContext context, long upto)
         {
             long lastIndex;
@@ -743,13 +763,39 @@ namespace Raven.Server.Rachis
                     out key))
             {
                 var lastEntryIndex = GetLastEntryIndex(context);
+                GetLastCommitIndex(context, out var lastCommitIndex, out var lastCommitTerm);
                 var firstIndexInEntriesThatWeHaveNotSeen = 0;
                 foreach (var entry in entries)
                 {
+                    var entryTerm = GetTermFor(context, entry.Index);
+                    if (entryTerm!= null && entry.Term != entryTerm)
+                    {
+                        //rewind entries with mismatched term
+                        lastEntryIndex = Math.Min(entry.Index - 1, lastEntryIndex);
+                        if (Log.IsInfoEnabled)
+                        {
+                            Log.Info($"Got an entry with index={entry.Index} and term={entry.Term} while our term for that index is {entryTerm}," +
+                                     $"will rewind last entry index to {lastEntryIndex}");
+                        }
+                        break;
+                    }
                     if (entry.Index > lastEntryIndex)
                         break;
 
                     firstIndexInEntriesThatWeHaveNotSeen++;
+                }
+                var firstEntry = entries[firstIndexInEntriesThatWeHaveNotSeen];
+                //While we do support the case where we get the same entries, we expect them to have the same index/term up to the commit index.
+                if (firstEntry.Index < lastCommitIndex)
+                {
+                    var message =
+                        $"FATAL ERROR: got an append entries request with index={firstEntry.Index} term={firstEntry.Term} " +
+                        $"while my commit index={lastCommitIndex} with term={lastCommitTerm}, this means something went wrong badly.";
+                    if (Log.IsInfoEnabled)
+                    {
+                        Log.Info(message);
+                    }
+                    throw new InvalidOperationException(message);
                 }
                 var prevIndex = lastEntryIndex;
 
@@ -763,7 +809,8 @@ namespace Raven.Server.Rachis
                     }
 
                     prevIndex = entry.Index;
-                    reversedEntryIndex = Bits.SwapBytes(entry.Index);
+                    //In the case where we delete entries reversedEntryIndex will advance forward so we need to keep the origin index.
+                    var originalReversedIndex = reversedEntryIndex = Bits.SwapBytes(entry.Index);
                     TableValueReader reader;
                     if (table.ReadByKey(key, out reader)) // already exists
                     {
@@ -775,7 +822,6 @@ namespace Raven.Server.Rachis
 
                         // we have found a divergence in the log, and we now need to trucate it from this
                         // location forward
-
                         do
                         {
                             table.Delete(reader.Id);
@@ -791,7 +837,7 @@ namespace Raven.Server.Rachis
                     TableValueBuilder tableValueBuilder;
                     using (table.Allocate(out tableValueBuilder))
                     {
-                        tableValueBuilder.Add(reversedEntryIndex);
+                        tableValueBuilder.Add(originalReversedIndex);
                         tableValueBuilder.Add(entry.Term);
                         tableValueBuilder.Add(nested.BasePointer, nested.Size);
                         tableValueBuilder.Add((int)entry.Flags);
@@ -931,6 +977,8 @@ namespace Raven.Server.Rachis
                         case CommitIndexModification.Equal:
                             if (value == commitIndex)
                                 return;
+                            if(value < commitIndex)
+                                throw new TimeoutException($"We are waiting for commit index to be equal to {value} but we are already in commit index = {commitIndex}");
                             break;
                         case CommitIndexModification.GreaterOrEqual:
                             if (value <= commitIndex)

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -13,7 +13,62 @@ namespace Tryouts
     {
         public static void Main(string[] args)
         {
-
+            int failed = 0;
+            var iterations = 1000;
+            var printEveryXIterations = 10;
+            var sw = new Stopwatch();
+            long timeRan = 0;
+            long timeToDispose = 0;
+            long totalTimeToRun = 0;
+            long maxTimeToRun = 0;
+            long minTimeToRun = long.MaxValue;
+            long totalTimeToDispose = 0;
+            long maxTimeToDispose = 0;
+            long minTimeToDispose = long.MaxValue;
+            bool enableLogging = true;
+            int i = 0;
+            for (; i < iterations; i++)
+            {
+                sw.Restart();
+                if (i % printEveryXIterations == 0)
+                {
+                    Console.WriteLine($"starting iteration {i}");
+                }
+                if (enableLogging)
+                {
+                    LoggingSource.Instance.SetupLogMode(LogMode.Information | LogMode.Operations, @"C:\work\4.0\tests\OnNetworkDisconnection" + i);
+                }
+                using (var test = new ElectionTests())
+                {
+                    try
+                    {
+                        test.OnNetworkDisconnectionANewLeaderIsElectedAfterReconnectOldLeaderStepsDownAndRollBackHisLog(3).Wait();
+                        timeRan = sw.ElapsedMilliseconds;
+                    }
+                    catch (Exception e)
+                    {
+                        failed++;
+                        Console.WriteLine($"Failed iteration {i}{Environment.NewLine}error:{e}");
+                        //Console.ReadLine();
+                    }
+                }
+                timeToDispose = sw.ElapsedMilliseconds - timeRan;
+                totalTimeToRun += timeRan;
+                totalTimeToDispose += timeToDispose;
+                if (timeRan > maxTimeToRun)
+                    maxTimeToRun = timeRan;
+                if (timeRan < minTimeToRun)
+                    minTimeToRun = timeRan;
+                if (timeToDispose < minTimeToDispose)
+                    minTimeToDispose = timeToDispose;
+                if (timeToDispose > maxTimeToDispose)
+                    maxTimeToDispose = timeToDispose;
+            }
+            Console.WriteLine($"done with {(double)failed * 100 / iterations}% failure rate{Environment.NewLine}" +
+                              $"Time Ran Avarage={(double)totalTimeToRun / iterations}ms min={minTimeToRun}ms max={maxTimeToRun}ms{Environment.NewLine}" +
+                              $"Time to dispose  Avarage={(double)totalTimeToDispose / iterations}ms min={minTimeToDispose}ms max={maxTimeToDispose}ms"
+            );
+            Console.ReadLine();
         }
     }
 }


### PR DESCRIPTION
Follower changes:
Implemented ReadInstallSnapshotAndIgnoreContent for the case that the follower commit index is greater than the snapshot index please take a look as i'm not sure i implemented it right!
Now will clear the entire entries table when getting a snapshot rather than just truncating entries prior to the snapshot (this was leaving us with old leadership entries)
Now support getting truncated response from leader index negotiation because we might have entries the leader already truncated and in this case we just ask for everything
FollowerAmbassador (Leader->Follower behavior):
Added logging on sent entries because it was a pain not seen which entries the leader sent (it might be enough just to send index and term but it is nice seen the actual command too)
Fixed an issue where we might not have the entries the follower is sending us as midterm indexes and so we would get stuck in an infinite loop
Leader:
Removed useless log entries ,actual LOG entries not raft log :)
RachisConsensus:
Now properly check for duplicate entries and properly delete them
Will throw timeout exception if we are asked to wait for a commit index to be equal some value and we already passed it.