### PR TITLE
RavenDB-6719

### DIFF
--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -27,6 +27,8 @@ namespace Tests.Infrastructure
 
         protected Logger Log = LoggingSource.Instance.GetLogger<RachisConsensusTestBase>("RachisConsensusTest");
 
+        protected int LongWaitTime = 15000; //under stress the thread pool may take time to schedule the task to complete the set of the TCS
+
         protected async Task<RachisConsensus<CountingStateMachine>> CreateNetworkAndGetLeader(int nodeCount, [CallerMemberName] string caller = null)
         {
             var initialCount = RachisConsensuses.Count;
@@ -259,6 +261,7 @@ namespace Tests.Infrastructure
 
             foreach (var mustBeSuccessfulTask in _mustBeSuccessfulTasks)
             {
+
                 Assert.True(mustBeSuccessfulTask.Wait(250));
             }
         }


### PR DESCRIPTION
Leader:
Fixed majority calculation
Added more details on vote of non confidence
JsonContextPoolBase:
Added CTS for better Dispose behavior (code was throwing index out of range exception before)
CommandTest:
Increased waiting time to 15 sec from 5 since we saw that the threadpool may take 10 sec to schedule a task under load (which does happen with parallel tests runs)