### PR TITLE
RavenDB-6676

### DIFF
--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -16,7 +16,7 @@ namespace Raven.Client.Documents.Replication
     /// <summary>
     /// Data class for replication destination documents
     /// </summary>
-    public class ReplicationNode : IEquatable<ReplicationNode>
+    public class ReplicationNode : IEquatable<ReplicationNode>, IComparable<ReplicationNode>
     {
 
         public string NodeTag;
@@ -113,6 +113,17 @@ namespace Raven.Client.Documents.Replication
                    ((string.Equals(Url, other.Url, StringComparison.OrdinalIgnoreCase) && string.IsNullOrWhiteSpace(ClientVisibleUrl)) ||
                    (!string.IsNullOrWhiteSpace(ClientVisibleUrl) && string.Equals(ClientVisibleUrl, other.ClientVisibleUrl, StringComparison.OrdinalIgnoreCase))) &&
                    DictionaryExtensions.ContentEquals(SpecifiedCollections, other.SpecifiedCollections);
+        }
+
+        public int CompareTo(ReplicationNode other)
+        {
+            var myValue = GetHashCode();
+            var otherValue = GetHashCode();
+            if (myValue > otherValue)
+                return 1;
+            if (otherValue < myValue)
+                return -1;
+            return 0;
         }
 
         public override bool Equals(object obj)

--- a/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Converters/JsonDeserializationClient.cs
@@ -49,7 +49,7 @@ namespace Raven.Client.Json.Converters
         public static readonly Func<BlittableJsonReaderObject, TcpConnectionHeaderResponse> TcpConnectionHeaderResponse = GenerateJsonDeserializationRoutine<TcpConnectionHeaderResponse>();
 
         public static readonly Func<BlittableJsonReaderObject, CreateDatabaseResult> CreateDatabaseResult = GenerateJsonDeserializationRoutine<CreateDatabaseResult>();
-        public static readonly Func<BlittableJsonReaderObject, UpdateTopologyResult> UpdateTopologyResult = GenerateJsonDeserializationRoutine<UpdateTopologyResult>();
+        public static readonly Func<BlittableJsonReaderObject, ModifyDatabaseWatchersResult> ModifyDatabaseWatchersResult = GenerateJsonDeserializationRoutine<ModifyDatabaseWatchersResult>();
         public static readonly Func<BlittableJsonReaderObject, ModifySolverResult> ModifySolverResult = GenerateJsonDeserializationRoutine<ModifySolverResult>();
 
         public static readonly Func<BlittableJsonReaderObject, DisableDatabaseToggleResult> DisableResoureceToggleResult = GenerateJsonDeserializationRoutine<DisableDatabaseToggleResult>();

--- a/src/Raven.Client/Server/DatabaseTopology.cs
+++ b/src/Raven.Client/Server/DatabaseTopology.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Raven.Client.Documents.Replication;
 using Sparrow;
 using Sparrow.Json.Parsing;
@@ -93,55 +94,125 @@ namespace Raven.Client.Documents
         ulong GetTaskKey();
     }
 
+    public class DatabaseMember : ReplicationNode
+    {
+    }
+
     public class DatabaseWatcher : ReplicationNode, IDatabaseTask
     {
     }
 
     public class DatabasePromotable : ReplicationNode, IDatabaseTask
-    {    
+    {
     }
 
     public class DatabaseTopology
     {
-        public List<string> Members = new List<string>();
-        public List<string> Promotables = new List<string>();
+        public List<DatabaseMember> Members = new List<DatabaseMember>();
+        public List<DatabasePromotable> Promotables = new List<DatabasePromotable>();
         public List<DatabaseWatcher> Watchers = new List<DatabaseWatcher>();
+
+        public class ConnectionChangeStatus
+        {
+            public bool Add;
+            public bool Remove => !Add;
+            public ReplicationNode Node;
+        }
 
         public Dictionary<string,string> NameToUrlMap = new Dictionary<string, string>();
         public bool RelevantFor(string nodeTag)
         {
-            return Members.Contains(nodeTag) ||
-                   Promotables.Contains(nodeTag) ||
+            return Members.Exists(m => m.NodeTag == nodeTag) ||
+                   Promotables.Exists(p => p.NodeTag == nodeTag) ||
                    Watchers.Exists(w => w.NodeTag == nodeTag);
         }
 
         public IEnumerable<ReplicationNode> GetDestinations(string nodeTag, string databaseName)
         {
-            var watchers = Watchers.Where(w => IsItMyTask(w, nodeTag));
-
-            return AllNodes.Where(n => n != nodeTag).Select(n => new ReplicationNode{
-                NodeTag = n,
-                Url = NameToUrlMap[n],
-                Database = databaseName
-            }).Concat(watchers);
+            var list = new List<ReplicationNode>();
+            list.AddRange(Watchers.Where(w => IsItMyTask(w, nodeTag)));
+            list.AddRange(Promotables.Where(p => IsItMyTask(p, nodeTag)));
+            list.AddRange(Members.Where(m => m.NodeTag != nodeTag));
+            list.Sort();
+            return list;
         }
 
-        public bool MyConnectionChanged(DatabaseTopology other, string nodeTag, string databaseName)
+        public void AddMember(string nodeTag, string databaseName)
         {
-            return GetDestinations(nodeTag,databaseName).SequenceEqual(other.GetDestinations(nodeTag, databaseName)) == false;
+            Members.Add(new DatabaseMember
+            {
+                NodeTag = nodeTag,
+                Url = NameToUrlMap[nodeTag],
+                Database = databaseName
+            });
         }
 
+        public (List<ReplicationNode> nodesToAdd, List<ReplicationNode> nodesToRemove) FindConnectionChanges(DatabaseTopology other, string nodeTag, string databaseName)
+        {
+            var oldDestinations = GetDestinations(nodeTag, databaseName);
+            var newDestinations = other.GetDestinations(nodeTag, databaseName);
+
+            var addDestinations = new List<ReplicationNode>();
+            var removeDestinations = new List<ReplicationNode>();
+            
+            // this will work because the destinations are sorted. 
+            using (var oldEnum = oldDestinations.GetEnumerator())
+            using (var newEnum = newDestinations.GetEnumerator())
+            {
+                newEnum.MoveNext();
+                oldEnum.MoveNext();
+                while (oldEnum.Current != null && newEnum.Current != null)
+                {
+                    if (oldEnum.Current.CompareTo(newEnum.Current) > 0)
+                    {
+                        // add new
+                        addDestinations.Add(newEnum.Current);
+                        newEnum.MoveNext();
+                        continue;
+                    }
+                    if (oldEnum.Current.CompareTo(newEnum.Current) < 0)
+                    {
+                        // remove old
+                        removeDestinations.Add(oldEnum.Current);
+                        oldEnum.MoveNext();
+                        continue;
+                    }
+                    newEnum.MoveNext();
+                    oldEnum.MoveNext();
+                }
+
+                // the remaining nodes of the old destinations should be removed
+                while (oldEnum.Current != null)
+                {
+                    removeDestinations.Add(oldEnum.Current);
+                    oldEnum.MoveNext();
+                }
+
+                // the remaining nodes of the new destinations should be added
+                while (newEnum.Current != null)
+                {
+                    addDestinations.Add(newEnum.Current);
+                    newEnum.MoveNext();
+                }
+            }
+            return (addDestinations,removeDestinations);
+        }
+   
         public IEnumerable<string> AllNodes
         {
             get
             {
                 foreach (var member in Members)
                 {
-                    yield return member;
+                    yield return member.NodeTag;
                 }
-                foreach (var member in Promotables)
+                foreach (var promotable in Promotables)
                 {
-                    yield return member;
+                    yield return promotable.NodeTag;
+                }
+                foreach (var watcher in Watchers)
+                {
+                    yield return watcher.NodeTag;
                 }
             }
         }
@@ -150,8 +221,8 @@ namespace Raven.Client.Documents
         {
             return new DynamicJsonValue
             {
-                [nameof(Members)] = new DynamicJsonArray(Members),
-                [nameof(Promotables)] = new DynamicJsonArray(Promotables),
+                [nameof(Members)] = new DynamicJsonArray(Members.Select(m => m.ToJson())),
+                [nameof(Promotables)] = new DynamicJsonArray(Promotables.Select(p => p.ToJson())),
                 [nameof(Watchers)] = new DynamicJsonArray(Watchers.Select(w => w.ToJson())),
                 [nameof(NameToUrlMap)] = DynamicJsonValue.Convert(NameToUrlMap)
             };
@@ -159,13 +230,13 @@ namespace Raven.Client.Documents
 
         public void RemoveFromTopology(string delDbFromNode)
         {
-            Members.Remove(delDbFromNode);
-            Promotables.Remove(delDbFromNode);
+            Promotables.RemoveAll(p=> p.NodeTag == delDbFromNode);
+            Members.RemoveAll(m=> m.NodeTag == delDbFromNode);
         }
 
         public bool IsItMyTask(IDatabaseTask task, string nodeTag)
         {
-            var myPosition = Members.FindIndex(s => s == nodeTag);
+            var myPosition = Members.FindIndex(s => s.NodeTag == nodeTag);
             if (myPosition == -1) //not a member
             {
                 return false;

--- a/src/Raven.Client/Server/Operations/CreateDatabaseResult .cs
+++ b/src/Raven.Client/Server/Operations/CreateDatabaseResult .cs
@@ -27,7 +27,7 @@ namespace Raven.Client.Server.Operations
         public DatabaseTopology Topology { get; set; }
     }
 
-    public class UpdateTopologyResult : CreateDatabaseResult
+    public class ModifyDatabaseWatchersResult : CreateDatabaseResult
     {
     }
 

--- a/src/Raven.Client/Server/Operations/ModifyDatabaseWatchers.cs
+++ b/src/Raven.Client/Server/Operations/ModifyDatabaseWatchers.cs
@@ -13,31 +13,31 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Server.Operations
 {
-    public class UpdateDatabaseTopology : IServerOperation<UpdateTopologyResult>
+    public class ModifyDatabaseWatchers : IServerOperation<ModifyDatabaseWatchersResult>
     {
         private readonly List<DatabaseWatcher> _newWatchers;
         private readonly string _database;
 
-        public UpdateDatabaseTopology(string database, List<DatabaseWatcher> newWatchers = null)
+        public ModifyDatabaseWatchers(string database, List<DatabaseWatcher> newWatchers = null)
         {
             MultiDatabase.AssertValidName(database);
             _database = database;
             _newWatchers = newWatchers;
         }
 
-        public RavenCommand<UpdateTopologyResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        public RavenCommand<ModifyDatabaseWatchersResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new UpdateTopologyCommand(conventions, context, _database, _newWatchers);
+            return new ModifyDatabaseWatchersCommand(conventions, context, _database, _newWatchers);
         }
 
-        private class UpdateTopologyCommand : RavenCommand<UpdateTopologyResult>
+        private class ModifyDatabaseWatchersCommand : RavenCommand<ModifyDatabaseWatchersResult>
         {
             private readonly JsonOperationContext _context;
             private readonly DocumentConventions _conventions;
             private readonly string _databaseName;
             private readonly List<DatabaseWatcher> _newWatchers;
           
-            public UpdateTopologyCommand(
+            public ModifyDatabaseWatchersCommand(
                 DocumentConventions conventions, 
                 JsonOperationContext context, 
                 string database,
@@ -53,7 +53,7 @@ namespace Raven.Client.Server.Operations
 
             public override HttpRequestMessage CreateRequest(ServerNode node, out string url)
             {
-                url = $"{node.Url}/admin/update-topology?name={_databaseName}";
+                url = $"{node.Url}/admin/modify-watchers?name={_databaseName}";
                 
                 var request = new HttpRequestMessage
                 {
@@ -65,7 +65,7 @@ namespace Raven.Client.Server.Operations
                             ["NewWatchers"] = new DynamicJsonArray(_newWatchers?.Select( w=> w.ToJson())),
                         };
 
-                        _context.Write(stream, _context.ReadObject(json, "updated-topology"));
+                        _context.Write(stream, _context.ReadObject(json, "modify-watchers"));
 ;
                     })
                 };
@@ -78,7 +78,7 @@ namespace Raven.Client.Server.Operations
                 if (response == null)
                     ThrowInvalidResponse();
 
-                Result = JsonDeserializationClient.UpdateTopologyResult(response);
+                Result = JsonDeserializationClient.ModifyDatabaseWatchersResult(response);
             }
 
             public override bool IsReadRequest => false;

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -90,7 +90,7 @@ namespace Raven.Server.ServerWide
                 case nameof(SetTransformerLockModeCommand):
                 case nameof(DeleteTransformerCommand):
                 case nameof(EditVersioningCommand):
-                case nameof(UpdateTopologyCommand):
+                case nameof(ModifyDatabaseWatchers):
                 case nameof(ModifyConflictSolverCommand):
                     UpdateDatabase(context, type, cmd, index, leader);
                     break;
@@ -135,8 +135,8 @@ namespace Raven.Server.ServerWide
                     return;
                 }
 
-                databaseRecord.Topology.Members.Remove(remove.NodeTag);
-                databaseRecord.Topology.Promotables.Remove(remove.NodeTag);
+                databaseRecord.Topology.Members.RemoveAll(m => m.NodeTag == remove.NodeTag);
+                databaseRecord.Topology.Promotables.RemoveAll(p=> p.NodeTag == remove.NodeTag);
                
                 databaseRecord.DeletionInProgress.Remove(remove.NodeTag);
 
@@ -206,8 +206,8 @@ namespace Raven.Server.ServerWide
                 }
                 else
                 {
-                    var allNodes = databaseRecord.Topology.Members
-                        .Concat(databaseRecord.Topology.Promotables);
+                    var allNodes = databaseRecord.Topology.Members.Select(m => m.NodeTag)
+                        .Concat(databaseRecord.Topology.Promotables.Select(p=>p.NodeTag));
 
                     foreach (var node in allNodes)
                     {
@@ -634,13 +634,11 @@ namespace Raven.Server.ServerWide
         void UpdateDatabaseRecord(DatabaseRecord record);
     }
 
-    public class UpdateTopologyCommand : IUpdateDatabaseCommand
+    public class ModifyDatabaseWatchers : IUpdateDatabaseCommand
     {
         public string DatabaseName;
         public BlittableJsonReaderObject Value;
         
-       
-
         public void UpdateDatabaseRecord(DatabaseRecord record)
         {
             Value.TryGet("NewWatchers", out BlittableJsonReaderArray watchers);
@@ -720,7 +718,7 @@ namespace Raven.Server.ServerWide
             [nameof(PutTransformerCommand)] = GenerateJsonDeserializationRoutine<PutTransformerCommand>(),
             [nameof(DeleteTransformerCommand)] = GenerateJsonDeserializationRoutine<DeleteTransformerCommand>(),
             [nameof(SetTransformerLockModeCommand)] = GenerateJsonDeserializationRoutine<SetTransformerLockModeCommand>(),
-            [nameof(UpdateTopologyCommand)] = GenerateJsonDeserializationRoutine<UpdateTopologyCommand>(),
+            [nameof(ModifyDatabaseWatchers)] = GenerateJsonDeserializationRoutine<ModifyDatabaseWatchers>(),
             [nameof(ModifyConflictSolverCommand)] = GenerateJsonDeserializationRoutine<ModifyConflictSolverCommand>(),
         };
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -242,16 +242,16 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public async Task<long> UpdateDatabaseTopology(
+        public async Task<long> ModifyDatabaseWatchers(
             JsonOperationContext context, 
             string key, 
             BlittableJsonReaderObject val)
         {
             using (var putCmd = context.ReadObject(new DynamicJsonValue
             {
-                ["Type"] = nameof(UpdateTopologyCommand),
-                [nameof(UpdateTopologyCommand.DatabaseName)] = key,
-                [nameof(UpdateTopologyCommand.Value)] = val,
+                ["Type"] = nameof(ServerWide.ModifyDatabaseWatchers),
+                [nameof(ServerWide.ModifyDatabaseWatchers.DatabaseName)] = key,
+                [nameof(ServerWide.ModifyDatabaseWatchers.Value)] = val,
             }, "update-cmd"))
             {
                 return await SendToLeaderAsync(putCmd);

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -118,6 +118,7 @@ namespace Raven.Server.Web.System
                 {
                     if (databaseRecord.Topology.RelevantFor(node))
                         throw new InvalidOperationException($"Can't add node {node} to {name} topology because it is already part of it");
+                    
                     //TODO:add as promotable 
 
                     databaseRecord.Topology.AddMember(node,name);
@@ -134,7 +135,7 @@ namespace Raven.Server.Web.System
                     var rand = new Random().Next();
                     var newNode = allNodes[rand % allNodes.Count];
                     //TODO:add as promotable 
-                    databaseRecord.Topology.AddMember(node, name);
+                    databaseRecord.Topology.AddMember(newNode, name);
                 }
 
                 var topologyJson = EntityToBlittable.ConvertEntityToBlittable(databaseRecord, DocumentConventions.Default, context);
@@ -197,10 +198,14 @@ namespace Raven.Server.Web.System
 
                 var offset = new Random().Next();
 
+                foreach (var node in allNodes)
+                {
+                    topology.NameToUrlMap[node] = clusterTopology.GetUrlFromTag(node);
+                }
+
                 for (int i = 0; i < Math.Min(allNodes.Length, factor); i++)
                 {
                     var selectedNode = allNodes[(i + offset) % allNodes.Length];
-                    topology.NameToUrlMap[selectedNode] = clusterTopology.GetUrlFromTag(selectedNode);
                     topology.AddMember(selectedNode, name);
                 }
 

--- a/test/FastTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/FastTests/Client/Attachments/AttachmentsReplication.cs
@@ -44,8 +44,7 @@ namespace FastTests.Client.Attachments
                 using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
                 {
                     var result = store1.Operations.Send(new PutAttachmentOperation("users/1", names[0], profileStream, "image/png"));
-                    //TODO: figure out the etag correct behavior
-                //    Assert.Equal(2 + (replicateDocumentFirst ? 2 : 0), result.Etag);
+                    Assert.Equal(2, result.Etag);
                     Assert.Equal(names[0], result.Name);
                     Assert.Equal("users/1", result.DocumentId);
                     Assert.Equal("image/png", result.ContentType);
@@ -54,7 +53,7 @@ namespace FastTests.Client.Attachments
                 using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
                 {
                     var result = store1.Operations.Send(new PutAttachmentOperation("users/1", names[1], backgroundStream, "ImGgE/jPeG"));
-                 //   Assert.Equal(4 + (replicateDocumentFirst ? 2 : 0), result.Etag);
+                    Assert.Equal(4, result.Etag);
                     Assert.Equal(names[1], result.Name);
                     Assert.Equal("users/1", result.DocumentId);
                     Assert.Equal("ImGgE/jPeG", result.ContentType);
@@ -63,7 +62,7 @@ namespace FastTests.Client.Attachments
                 using (var fileStream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 }))
                 {
                     var result = store1.Operations.Send(new PutAttachmentOperation("users/1", names[2], fileStream, null));
-                 //   Assert.Equal(6 + (replicateDocumentFirst ? 2 : 0), result.Etag);
+                    Assert.Equal(6, result.Etag);
                     Assert.Equal(names[2], result.Name);
                     Assert.Equal("users/1", result.DocumentId);
                     Assert.Equal("", result.ContentType);

--- a/test/FastTests/Server/Replication/ReplicationTestsBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestsBase.cs
@@ -27,6 +27,7 @@ using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Sdk;
+using ModifyDatabaseWatchers = Raven.Client.Server.Operations.ModifyDatabaseWatchers;
 
 namespace FastTests.Server.Replication
 {
@@ -310,11 +311,11 @@ namespace FastTests.Server.Replication
         }
 
 
-        protected static async Task<UpdateTopologyResult> UpdateReplicationTopology(
+        protected static async Task<ModifyDatabaseWatchersResult> UpdateReplicationTopology(
             DocumentStore store,
             List<DatabaseWatcher> watchers)
         {
-            var cmd = new UpdateDatabaseTopology(store.DefaultDatabase, watchers);
+            var cmd = new ModifyDatabaseWatchers(store.DefaultDatabase, watchers);
             return await store.Admin.Server.SendAsync(cmd);
         }
 

--- a/test/RachisTests/Cluster.cs
+++ b/test/RachisTests/Cluster.cs
@@ -39,7 +39,7 @@ namespace SlowTests.Server.Rachis
                 var startReplicationFactor = replicationFactor;
                 while (replicationFactor>0)
                 {
-                    var serverTagToBeDeleted = databaseResult.Topology.Members[startReplicationFactor-replicationFactor];
+                    var serverTagToBeDeleted = databaseResult.Topology.Members[startReplicationFactor-replicationFactor].NodeTag;
                     replicationFactor--;
                     deleteResult = store.Admin.Server.Send(new DeleteDatabaseOperation(databaseName, hardDelete: true, fromNode: serverTagToBeDeleted));
                     //The +1 is for NotifyLeaderAboutRemoval


### PR DESCRIPTION
After code review:
* On database record change each node checks which outgoing connection should be
dropped and which should be added.


Following message refers to to whole RavenDB-6676 issue:
* Each node of the database topology replicate to all the other full members.
* Watchers can be added as a master-slave replication.
* raft commands for adding watchers and changing conflict resolution were added.

* Adjusting the replication tests to fit the raft concept.
So in order to setup replication between two databases, we do the following:
1. Create two rafts with single server with single database.
2. Configure each database to be a watcher in the other database topology.