### PR TITLE
RavenDB-9952 Issue with repeated elections in cluster

### DIFF
--- a/src/Raven.Server/Rachis/Candidate.cs
+++ b/src/Raven.Server/Rachis/Candidate.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Rachis
         private Thread _thread;
         public long RunRealElectionAtTerm { get; private set; }
 
-        private MultipleUseFlag _running = new MultipleUseFlag();
+        private readonly MultipleUseFlag _running = new MultipleUseFlag(true);
         public bool Running => _running.IsRaised();
         public ElectionResult ElectionResult;
 
@@ -155,7 +155,7 @@ namespace Raven.Server.Rachis
                         if (RunRealElectionAtTerm != ElectionTerm &&
                             trialElectionsCount >= majority)
                         {
-                            CastVoteForSelf("Won in the trial eletions");
+                            CastVoteForSelf("Won in the trial elections");
                         }
                     }
                 }

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Rachis
         public string StatusMessage;
         public AmbassadorStatus Status;
         private Thread _thread;
-        private MultipleUseFlag _running = new MultipleUseFlag();
+        private readonly MultipleUseFlag _running = new MultipleUseFlag(true);
         public long TrialElectionWonAtTerm { get; set; }
         public long RealElectionWonAtTerm { get; set; }
         public string Tag => _tag;

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Rachis
         private string _lastSentMsg;
         private Thread _thread;
         private RemoteConnection _connection;
-        private MultipleUseFlag _running = new MultipleUseFlag();
+        private readonly MultipleUseFlag _running = new MultipleUseFlag(true);
 
         public string Tag => _tag;
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -685,7 +685,7 @@ namespace Raven.Server
                 var errors = new List<Exception>();
                 foreach (var ipAddress in GetListenIpAddresses(host))
                 {
-                    if (Logger.IsInfoEnabled)
+                    if (Configuration.Core.TcpServerUrls != null && Logger.IsInfoEnabled)
                         Logger.Info($"RavenDB TCP is configured to use {string.Join(", ", Configuration.Core.TcpServerUrls)} and bind to {ipAddress} at {port}");
 
                     var listener = new TcpListener(ipAddress, status.Port != 0 ? status.Port : port);


### PR DESCRIPTION
- Initialize the running flags with 'true'.
- Dispose the parent first and only then its peers.