### PR TITLE
RavenDB-9952 Issue with repeated elections in cluster

### DIFF
--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Logging;
 
 namespace Raven.Server.Rachis
 {
@@ -199,7 +200,7 @@ namespace Raven.Server.Rachis
                             {
                                 alreadyVoted = true;
                             }
-                            else if(votedTerm > rv.Term)
+                            else if(votedTerm >= rv.Term)
                             {
                                 alreadyVoted = true;
                                 whoGotMyVoteIn = "another node in higher term: " + votedTerm;

--- a/src/Raven.Server/Rachis/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/RemoteConnection.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Sparrow;
 using Sparrow.Binary;
+using Sparrow.Collections;
+using Sparrow.Collections.LockFree;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
@@ -28,13 +32,35 @@ namespace Raven.Server.Rachis
             _buffer = JsonOperationContext.ManagedPinnedBuffer.LongLivedInstance();
         }
 
-        public RemoteConnection(string dest, string src, Stream stream)
+        public class RemoteConnectionInfo
+        {
+            public string Caller;
+            public DateTime StartAt;
+            public string Destination;
+            public int Number;
+        }
+
+        private readonly RemoteConnectionInfo _info;
+        private static int _connectionNumber = 0; 
+        public static ConcurrentSet<RemoteConnectionInfo> RemoteConnectionsList = new ConcurrentSet<RemoteConnectionInfo>();
+
+        public RemoteConnection(string dest, string src, Stream stream, [CallerMemberName] string caller = null)
         {
             _destTag = dest;
             _src = src;
             _log = LoggingSource.Instance.GetLogger<RemoteConnection>($"{_src} > {_destTag}");
             _stream = stream;
             _buffer = JsonOperationContext.ManagedPinnedBuffer.LongLivedInstance();
+
+            var number = Interlocked.Increment(ref _connectionNumber);
+            _info = new RemoteConnectionInfo
+            {
+                Caller = caller,
+                Destination = dest,
+                StartAt = DateTime.UtcNow,
+                Number = number
+            };
+            RemoteConnectionsList.Add(_info);
         }
 
         public void Send(JsonOperationContext context, RachisHello helloMsg)
@@ -82,7 +108,7 @@ namespace Raven.Server.Rachis
 
         public void Send(JsonOperationContext context, RequestVoteResponse rvr)
         {
-            if (_log.IsInfoEnabled == true)
+            if (_log.IsInfoEnabled)
             {
                 _log.Info($"Voting {rvr.VoteGranted} for term {rvr.Term} because: {rvr.Message}");
             }
@@ -369,6 +395,7 @@ namespace Raven.Server.Rachis
 
         public void Dispose()
         {
+            RemoteConnectionsList.TryRemove(_info);
             _stream?.Dispose();
             _buffer?.Dispose();
         }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -460,6 +460,11 @@ namespace Raven.Server.ServerWide
 
         private void OnStateChanged(object sender, RachisConsensus.StateTransition state)
         {
+            if (Engine.Log.IsInfoEnabled)
+            {
+                Engine.Log.Info($"State changed: {state.From} -> {state.To} in term {state.CurrentTerm}, because {state.Reason}");
+            }
+
             using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {


### PR DESCRIPTION
- logs add when the state is changed
- list all remote connections
- prevent casting vote from the elector for the current term