### PR TITLE
RavenDB-26046 CDC Sink Studio UI

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/tasks/getOngoingTaskInfoCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/getOngoingTaskInfoCommand.ts
@@ -14,7 +14,8 @@ class getOngoingTaskInfoCommand<T extends Raven.Client.Documents.Operations.Ongo
     Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskQueueEtl |
     Raven.Client.Documents.Operations.OngoingTasks.EmbeddingsGeneration |
     Raven.Client.Documents.Operations.OngoingTasks.GenAi |
-    Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskQueueSink> extends commandBase {
+    Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskQueueSink |
+    Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskCdcSink> extends commandBase {
 
     private readonly db: database | string;
     private readonly nodeTag: string;
@@ -123,6 +124,10 @@ class getOngoingTaskInfoCommand<T extends Raven.Client.Documents.Operations.Ongo
 
     static forQueueSink(db: database | string, taskId: number) {
         return new getOngoingTaskInfoCommand<Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskQueueSink>(db, "QueueSink", null, taskId);
+    }
+
+    static forCdcSink(db: database | string, taskId: number) {
+        return new getOngoingTaskInfoCommand<Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskCdcSink>(db, "CdcSink", null, taskId);
     }
 }
 

--- a/src/Raven.Studio/typescript/commands/database/tasks/saveCdcSinkCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/saveCdcSinkCommand.ts
@@ -1,0 +1,37 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+
+class saveCdcSinkCommand extends commandBase {
+
+    private readonly db: database | string;
+    private readonly payload: Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration;
+
+    constructor(db: database | string, payload: Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration) {
+        super();
+        this.payload = payload;
+        this.db = db;
+    }
+
+    execute(): JQueryPromise<Raven.Client.Documents.Operations.OngoingTasks.ModifyOngoingTaskResult> {
+        return this.save()
+            .fail((response: JQueryXHR) => {
+                this.reportError(`Failed to save CDC Sink task`, response.responseText, response.statusText);
+            })
+            .done(() => {
+                this.reportSuccess(`Saved CDC Sink task`);
+            });
+    }
+
+    private save(): JQueryPromise<Raven.Client.Documents.Operations.OngoingTasks.ModifyOngoingTaskResult> {
+        const args = {
+            id: this.payload.TaskId || undefined,
+        };
+
+        const url = endpoints.databases.ongoingTasks.adminCdcSink + this.urlEncodeArgs(args);
+
+        return this.put(url, JSON.stringify(this.payload), this.db);
+    }
+}
+
+export = saveCdcSinkCommand;

--- a/src/Raven.Studio/typescript/commands/database/tasks/testCdcSinkCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/testCdcSinkCommand.ts
@@ -1,0 +1,26 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+
+class testCdcSinkCommand extends commandBase {
+    constructor(
+        private db: database | string,
+        private payload: Raven.Server.Documents.CdcSink.Test.TestCdcSinkScript
+    ) {
+        super();
+    }
+
+    execute(): JQueryPromise<Raven.Server.Documents.CdcSink.Test.TestCdcSinkScriptResult> {
+        const url = endpoints.databases.cdcSink.adminCdcSinkTest;
+
+        return this.post<Raven.Server.Documents.CdcSink.Test.TestCdcSinkScriptResult>(
+            url,
+            JSON.stringify(this.payload),
+            this.db
+        ).fail((response: JQueryXHR) => {
+            this.reportError(`Failed to test CDC Sink`, response.responseText, response.statusText);
+        });
+    }
+}
+
+export = testCdcSinkCommand;

--- a/src/Raven.Studio/typescript/commands/database/tasks/verifyCdcSinkSourceCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/verifyCdcSinkSourceCommand.ts
@@ -1,0 +1,30 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+
+class verifyCdcSinkSourceCommand extends commandBase {
+    constructor(
+        private db: database | string,
+        private connectionStringName: string
+    ) {
+        super();
+    }
+
+    execute(): JQueryPromise<Raven.Server.Documents.CdcSink.CdcSinkVerificationResult> {
+        const url = endpoints.databases.cdcSink.adminCdcSinkVerify;
+
+        const payload = {
+            ConnectionStringName: this.connectionStringName
+        };
+
+        return this.post<Raven.Server.Documents.CdcSink.CdcSinkVerificationResult>(
+            url,
+            JSON.stringify(payload),
+            this.db
+        ).fail((response: JQueryXHR) => {
+            this.reportError(`Failed to verify CDC Sink source`, response.responseText, response.statusText);
+        });
+    }
+}
+
+export = verifyCdcSinkSourceCommand;

--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -60,6 +60,7 @@ class appUrl {
         editAmazonSqsEtl: (taskId?: number) => ko.pureComputed(() => appUrl.forEditAmazonSqsEtl(appUrl.currentDatabase(), taskId)),
         editKafkaSink: (taskId?: number) => ko.pureComputed(() => appUrl.forEditKafkaSink(appUrl.currentDatabase(), taskId)),
         editRabbitMqSink: (taskId?: number) => ko.pureComputed(() => appUrl.forEditRabbitMqSink(appUrl.currentDatabase(), taskId)),
+        editCdcSink: (taskId?: number) => ko.pureComputed(() => appUrl.forEditCdcSink(appUrl.currentDatabase(), taskId)),
         query: (indexName?: string) => ko.pureComputed(() => appUrl.forQuery(appUrl.currentDatabase(), indexName)),
         terms: (indexName?: string) => ko.pureComputed(() => appUrl.forTerms(indexName, appUrl.currentDatabase())),
         addNewOngoingTask: (isAiOnly: boolean) => ko.pureComputed(() => appUrl.forAddNewOngoingTasks(appUrl.currentDatabase(), isAiOnly)),
@@ -89,6 +90,7 @@ class appUrl {
         editAmazonSqsEtlTaskUrl: ko.pureComputed(() => appUrl.forEditAmazonSqsEtl(appUrl.currentDatabase())),
         editKafkaSinkTaskUrl: ko.pureComputed(() => appUrl.forEditKafkaSink(appUrl.currentDatabase())),
         editRabbitMqSinkTaskUrl: ko.pureComputed(() => appUrl.forEditRabbitMqSink(appUrl.currentDatabase())),
+        editCdcSinkTaskUrl: ko.pureComputed(() => appUrl.forEditCdcSink(appUrl.currentDatabase())),
         csvImportUrl: ko.pureComputed(() => appUrl.forCsvImport(appUrl.currentDatabase())),
         status: ko.pureComputed(() => appUrl.forStatus(appUrl.currentDatabase())),
 
@@ -724,6 +726,12 @@ class appUrl {
         const databasePart = appUrl.getEncodedDbPart(db);
         const taskPart = taskId ? "&taskId=" + taskId : "";
         return "#databases/tasks/editRabbitMqSinkTask?" + databasePart + taskPart;
+    }
+
+    static forEditCdcSink(db: database | string, taskId?: number): string {
+        const databasePart = appUrl.getEncodedDbPart(db);
+        const taskPart = taskId ? "&taskId=" + taskId : "";
+        return "#databases/tasks/editCdcSinkTask?" + databasePart + taskPart;
     }
 
     static forEditEmbeddingsGeneration(db: database | string, taskId?: number): string {

--- a/src/Raven.Studio/typescript/common/shell/menu/items/tasks.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/tasks.ts
@@ -3,6 +3,7 @@ import intermediateMenuItem = require("common/shell/menu/intermediateMenuItem");
 import leafMenuItem = require("common/shell/menu/leafMenuItem");
 import BackupsPage = require("components/pages/database/tasks/backups/BackupsPage");
 import CreateSampleData = require("components/pages/database/tasks/createSampleData/CreateSampleData");
+import EditCdcSinkTask = require("components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/EditCdcSinkTask");
 import EditGenAiTask = require("components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask");
 import OngoingTasksPage = require("components/pages/database/tasks/ongoingTasks/OngoingTasksPage");
 import AddNewOngoingTask = require("components/pages/database/tasks/ongoingTasks/AddNewOngoingTask");
@@ -399,6 +400,19 @@ function getTasksMenuItem(appUrls: computedAppUrls) {
             search: {
                 overrideTitle: "Add New RabbitMQ Sink Task",
                 alternativeTitles: ["Create RabbitMQ Sink Task"],
+            }
+        }),
+        new leafMenuItem({
+            route: 'databases/tasks/editCdcSinkTask',
+            moduleId: reactUtils.bridgeToReact(EditCdcSinkTask.default, "nonShardedView"),
+            title: 'CDC Sink Task',
+            nav: false,
+            css: "icon-plus",
+            dynamicHash: appUrls.editCdcSinkTaskUrl,
+            itemRouteToHighlight: 'databases/tasks/ongoingTasks',
+            search: {
+                overrideTitle: "Add New CDC Sink Task",
+                alternativeTitles: ["Create CDC Sink Task", "Change Data Capture"],
             }
         }),
     ];

--- a/src/Raven.Studio/typescript/components/models/tasks.ts
+++ b/src/Raven.Studio/typescript/components/models/tasks.ts
@@ -165,6 +165,11 @@ export type OngoingTaskKafkaSinkSharedInfo = OngoingTaskQueueSinkSharedInfo;
 
 export type OngoingTaskRabbitMqSinkSharedInfo = OngoingTaskQueueSinkSharedInfo;
 
+export interface OngoingTaskCdcSinkSharedInfo extends OngoingTaskSharedInfo {
+    connectionStringName: string;
+    factoryName: string;
+}
+
 export interface OngoingTaskQueueEtlSharedInfo extends OngoingTaskSharedInfo {
     connectionStringName: string;
     url: string;
@@ -342,6 +347,11 @@ export type OngoingTaskKafkaSinkInfo = OngoingTaskInfo<
 export type OngoingTaskRabbitMqSinkInfo = OngoingTaskInfo<
     OngoingTaskRabbitMqSinkSharedInfo,
     OngoingTaskNodeInfo<OngoingTaskRabbitMqSinkNodeInfoDetails>
+>;
+
+export type OngoingTaskCdcSinkInfo = OngoingTaskInfo<
+    OngoingTaskCdcSinkSharedInfo,
+    OngoingTaskNodeInfo<OngoingTaskNodeInfoDetails>
 >;
 
 export type OngoingTaskSubscriptionInfo = OngoingTaskInfo<

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
@@ -22,6 +22,7 @@ import {
     OngoingTaskSnowflakeEtlInfo,
     OngoingTaskSqlEtlInfo,
     OngoingTaskGenAiInfo,
+    OngoingTaskCdcSinkInfo,
 } from "components/models/tasks";
 import { RavenEtlPanel } from "./panels/RavenEtlPanel";
 import { SqlEtlPanel } from "./panels/SqlEtlPanel";
@@ -53,6 +54,7 @@ import { OngoingTasksFilterCriteria } from "./partials/OngoingTasksFilter";
 import OngoingTaskOperationConfirm from "../shared/OngoingTaskOperationConfirm";
 import { KafkaSinkPanel } from "components/pages/database/tasks/ongoingTasks/panels/KafkaSinkPanel";
 import { RabbitMqSinkPanel } from "components/pages/database/tasks/ongoingTasks/panels/RabbitMqSinkPanel";
+import { CdcSinkPanel } from "components/pages/database/tasks/ongoingTasks/panels/CdcSinkPanel";
 import { CounterBadge } from "components/common/CounterBadge";
 import { getLicenseLimitReachStatus } from "components/utils/licenseLimitsUtils";
 import { useAppSelector } from "components/store";
@@ -204,6 +206,7 @@ export function OngoingTasksPage({ isAiOnly = false }: OngoingTasksPageProps) {
         amazonSqsEtls,
         kafkaSinks,
         rabbitMqSinks,
+        cdcSinks,
         elasticSearchEtls,
         embeddingsGenerations,
         genAiTasks,
@@ -230,7 +233,7 @@ export function OngoingTasksPage({ isAiOnly = false }: OngoingTasksPageProps) {
         ...amazonSqsEtls,
     ];
 
-    const sinks = [...kafkaSinks, ...rabbitMqSinks];
+    const sinks = [...kafkaSinks, ...rabbitMqSinks, ...cdcSinks];
 
     useEffect(() => {
         throttledUpdateLicenseLimitsUsage();
@@ -690,6 +693,9 @@ export function OngoingTasksPage({ isAiOnly = false }: OngoingTasksPageProps) {
                                         {rabbitMqSinks.map((x) => (
                                             <RabbitMqSinkPanel {...sharedPanelProps} key={taskKey(x.shared)} data={x} />
                                         ))}
+                                        {cdcSinks.map((x) => (
+                                            <CdcSinkPanel {...sharedPanelProps} key={taskKey(x.shared)} data={x} />
+                                        ))}
                                     </div>
                                 )}
                             </>
@@ -784,6 +790,7 @@ function getFilteredTasks(state: OngoingTasksState, filter: OngoingTasksFilterCr
         rabbitMqSinks: filteredTasks.filter(
             (x) => x.shared.taskType === "RabbitQueueSink"
         ) as OngoingTaskRabbitMqSinkInfo[],
+        cdcSinks: filteredTasks.filter((x) => x.shared.taskType === "CdcSink") as OngoingTaskCdcSinkInfo[],
         elasticSearchEtls: filteredTasks.filter(
             (x) => x.shared.taskType === "ElasticSearchEtl"
         ) as OngoingTaskElasticSearchEtlInfo[],

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/EditCdcSinkTask.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/EditCdcSinkTask.tsx
@@ -1,0 +1,120 @@
+import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import { useServices } from "components/hooks/useServices";
+import { useAppSelector } from "components/store";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { tryHandleSubmit } from "components/utils/common";
+import { useAppUrls } from "components/hooks/useAppUrls";
+import { useEventsCollector } from "components/hooks/useEventsCollector";
+import { useDirtyFlag } from "components/hooks/useDirtyFlag";
+import { Icon } from "components/common/Icon";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import { editCdcSinkTaskUtils } from "./utils";
+import { editCdcSinkTaskResolver } from "./validation";
+import { CdcSinkFormData } from "./types";
+import CdcSinkService from "./services/cdcSinkService";
+import CdcSinkBasicFields from "./partials/CdcSinkBasicFields";
+import CdcSinkSchemaExplorer from "./partials/CdcSinkSchemaExplorer";
+import CdcSinkTableList from "./partials/CdcSinkTableList";
+import CdcSinkTableEditor from "./partials/CdcSinkTableEditor";
+import getOngoingTaskInfoCommand from "commands/database/tasks/getOngoingTaskInfoCommand";
+import { useState } from "react";
+import router from "plugins/router";
+
+interface QueryParams {
+    taskId: string;
+}
+
+export default function EditCdcSinkTask({ queryParams }: ReactQueryParamsProps<QueryParams>) {
+    const { tasksService } = useServices();
+    const { reportEvent } = useEventsCollector();
+
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const { appUrl } = useAppUrls();
+
+    const taskId = queryParams?.taskId ? parseInt(queryParams.taskId) : null;
+    const isEditMode = taskId != null;
+
+    const [editingTableIndex, setEditingTableIndex] = useState<number | null>(null);
+
+    const getDefaultValues = async (): Promise<CdcSinkFormData> => {
+        if (taskId) {
+            const result = await getOngoingTaskInfoCommand.forCdcSink(databaseName, taskId).execute();
+            return editCdcSinkTaskUtils.getDefaultValues(result.Configuration);
+        }
+        return editCdcSinkTaskUtils.getDefaultValues();
+    };
+
+    const form = useForm<CdcSinkFormData>({
+        mode: "all",
+        resolver: editCdcSinkTaskResolver as any,
+        defaultValues: getDefaultValues,
+    });
+
+    const { setIsDirty } = useDirtyFlag(form.formState.isDirty);
+    const { handleSubmit, reset, formState } = form;
+
+    const navigateToOngoingTasks = () => {
+        router.navigate(appUrl.forOngoingTasks(databaseName));
+    };
+
+    const handleSave: SubmitHandler<CdcSinkFormData> = (data) => {
+        return tryHandleSubmit(async () => {
+            reportEvent("cdc-sink", "save");
+
+            const dto = editCdcSinkTaskUtils.mapToDto(data, taskId);
+            await CdcSinkService.save(databaseName, dto);
+
+            reset(data);
+            setIsDirty(false);
+            navigateToOngoingTasks();
+        });
+    };
+
+    return (
+        <FormProvider {...form}>
+            <form onSubmit={handleSubmit(handleSave)}>
+                <div className="content-margin">
+                    <div className="d-flex justify-content-between align-items-center mb-4">
+                        <h2>
+                            <Icon icon="sql-etl" />
+                            {isEditMode ? "Edit CDC Sink Task" : "New CDC Sink Task"}
+                        </h2>
+                        <div className="d-flex gap-2">
+                            <button type="button" className="btn btn-secondary" onClick={navigateToOngoingTasks}>
+                                Cancel
+                            </button>
+                            <ButtonWithSpinner
+                                type="submit"
+                                variant="primary"
+                                icon="save"
+                                isSpinning={formState.isSubmitting}
+                                disabled={!formState.isDirty || formState.isSubmitting}
+                            >
+                                Save
+                            </ButtonWithSpinner>
+                        </div>
+                    </div>
+
+                    <CdcSinkBasicFields />
+
+                    <hr />
+
+                    <CdcSinkSchemaExplorer />
+
+                    <hr />
+
+                    {editingTableIndex != null ? (
+                        <CdcSinkTableEditor
+                            tableIndex={editingTableIndex}
+                            onClose={() => setEditingTableIndex(null)}
+                        />
+                    ) : (
+                        <CdcSinkTableList
+                            onEditTable={(index) => setEditingTableIndex(index)}
+                        />
+                    )}
+                </div>
+            </form>
+        </FormProvider>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/CdcSinkBasicFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/CdcSinkBasicFields.tsx
@@ -1,0 +1,171 @@
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import { FormInput, FormSwitch, FormGroup, FormLabel, FormSelect } from "components/common/Form";
+import RichAlert from "components/common/RichAlert";
+import { SelectOption } from "components/common/select/Select";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { clusterSelectors } from "components/common/shell/clusterSlice";
+import useBoolean from "components/hooks/useBoolean";
+import { useServices } from "components/hooks/useServices";
+import { useAppSelector } from "components/store";
+import EditConnectionStrings from "components/pages/database/settings/connectionStrings/EditConnectionStrings";
+import { sortBy } from "lodash";
+import { useAsync, useAsyncCallback } from "react-async-hook";
+import { useFormContext, useWatch } from "react-hook-form";
+import { CdcSinkFormData } from "../types";
+import CdcSinkService from "../services/cdcSinkService";
+import InputGroup from "react-bootstrap/InputGroup";
+import { Icon } from "components/common/Icon";
+import { useState } from "react";
+
+export default function CdcSinkBasicFields() {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const nodes = useAppSelector(clusterSelectors.allNodes);
+
+    const { value: isNewConnectionStringOpen, toggle: toggleIsNewConnectionStringOpen } = useBoolean(false);
+
+    const { tasksService } = useServices();
+    const { control, setValue } = useFormContext<CdcSinkFormData>();
+    const formValues = useWatch({ control });
+
+    const [verifyResult, setVerifyResult] =
+        useState<Raven.Server.Documents.CdcSink.CdcSinkVerificationResult | null>(null);
+
+    const asyncGetConnectionStringsOptions = useAsync(async () => {
+        const result = await tasksService.getConnectionStrings(databaseName);
+
+        const connectionStrings = Object.keys(result.SqlConnectionStrings ?? {});
+
+        return sortBy(connectionStrings, (x) => x.toUpperCase()).map(
+            (x) => ({ value: x, label: x }) satisfies SelectOption
+        );
+    }, []);
+
+    const handleConnectionStringSave = async (connectionName: string) => {
+        await asyncGetConnectionStringsOptions.execute();
+        setValue("connectionStringName", connectionName, {
+            shouldValidate: true,
+            shouldTouch: true,
+            shouldDirty: true,
+        });
+        toggleIsNewConnectionStringOpen();
+    };
+
+    const asyncVerifySource = useAsyncCallback(async () => {
+        if (!formValues.connectionStringName) {
+            return;
+        }
+        const result = await CdcSinkService.verify(databaseName, formValues.connectionStringName);
+        setVerifyResult(result);
+    });
+
+    const possibleMentorOptions: SelectOption[] = nodes
+        .filter((x) => x.type === "Member")
+        .map((x) => ({ value: x.nodeTag, label: `Node ${x.nodeTag}` }));
+
+    return (
+        <div>
+            <h3>Basic Configuration</h3>
+
+            <FormGroup>
+                <FormLabel>Task Name</FormLabel>
+                <FormInput type="text" control={control} name="name" placeholder="CDC Sink task name" />
+            </FormGroup>
+
+            <FormGroup>
+                <FormSwitch control={control} name="disabled">
+                    Disable Task
+                </FormSwitch>
+            </FormGroup>
+
+            <FormGroup>
+                <FormLabel>Connection String</FormLabel>
+                <InputGroup>
+                    <FormSelect
+                        control={control}
+                        name="connectionStringName"
+                        options={asyncGetConnectionStringsOptions.result ?? []}
+                        isLoading={asyncGetConnectionStringsOptions.loading}
+                    />
+                    <InputGroup.Text>
+                        <ButtonWithSpinner
+                            variant="link"
+                            className="text-reset px-0"
+                            icon="plus"
+                            isSpinning={asyncGetConnectionStringsOptions.loading}
+                            onClick={toggleIsNewConnectionStringOpen}
+                        >
+                            Create new SQL connection string
+                        </ButtonWithSpinner>
+                    </InputGroup.Text>
+                    {isNewConnectionStringOpen && (
+                        <EditConnectionStrings
+                            initialConnection={{ type: "Sql" }}
+                            afterSave={handleConnectionStringSave}
+                            afterClose={toggleIsNewConnectionStringOpen}
+                        />
+                    )}
+                </InputGroup>
+            </FormGroup>
+
+            <FormGroup>
+                <FormSwitch control={control} name="isSetResponsibleNode">
+                    Set Responsible Node
+                </FormSwitch>
+            </FormGroup>
+
+            {formValues.isSetResponsibleNode && (
+                <FormGroup>
+                    <FormLabel>Responsible Node</FormLabel>
+                    {possibleMentorOptions.length === 0 ? (
+                        <RichAlert variant="warning">
+                            No nodes are currently available for selection.
+                        </RichAlert>
+                    ) : (
+                        <FormSelect control={control} name="responsibleNode" options={possibleMentorOptions} />
+                    )}
+                </FormGroup>
+            )}
+
+            <FormGroup>
+                <ButtonWithSpinner
+                    variant="secondary"
+                    icon="check"
+                    isSpinning={asyncVerifySource.loading}
+                    onClick={asyncVerifySource.execute}
+                    disabled={!formValues.connectionStringName}
+                >
+                    Verify Source
+                </ButtonWithSpinner>
+
+                {verifyResult && (
+                    <div className="mt-2">
+                        {verifyResult.Success ? (
+                            <RichAlert variant="success">
+                                <Icon icon="check" /> Connection verified successfully.
+                                {!verifyResult.HasPermissionToSetup && (
+                                    <div className="mt-1 text-warning">
+                                        <Icon icon="warning" /> User does not have permission to setup CDC.
+                                    </div>
+                                )}
+                            </RichAlert>
+                        ) : (
+                            <RichAlert variant="danger">
+                                <Icon icon="cancel" /> Verification failed.
+                                {verifyResult.Errors?.map((error, i) => (
+                                    <div key={i} className="mt-1">{error}</div>
+                                ))}
+                            </RichAlert>
+                        )}
+                        {verifyResult.Warnings?.length > 0 && (
+                            <RichAlert variant="warning" className="mt-1">
+                                {verifyResult.Warnings.map((warning, i) => (
+                                    <div key={i}>{warning}</div>
+                                ))}
+                            </RichAlert>
+                        )}
+                    </div>
+                )}
+            </FormGroup>
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/CdcSinkSchemaExplorer.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/CdcSinkSchemaExplorer.tsx
@@ -1,0 +1,210 @@
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import RichAlert from "components/common/RichAlert";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { useAppSelector } from "components/store";
+import { useAsyncCallback } from "react-async-hook";
+import { useFormContext, useWatch } from "react-hook-form";
+import { CdcSinkFormData, CdcSinkTableFormData } from "../types";
+import CdcSinkService from "../services/cdcSinkService";
+import { Icon } from "components/common/Icon";
+import { useState } from "react";
+import getConnectionStringsCommand from "commands/database/settings/getConnectionStringsCommand";
+
+type SqlTableSchema = Raven.Server.SqlMigration.Schema.SqlTableSchema;
+type MigrationProvider = Raven.Server.SqlMigration.MigrationProvider;
+
+function factoryNameToProvider(factoryName: string): MigrationProvider {
+    switch (factoryName) {
+        case "Npgsql":
+            return "NpgSQL";
+        case "Microsoft.Data.SqlClient":
+        case "System.Data.SqlClient":
+            return "MsSQL";
+        case "MySql.Data.MySqlClient":
+            return "MySQL_MySql_Data";
+        case "MySqlConnector.MySqlConnectorFactory":
+            return "MySQL_MySqlConnector";
+        case "Oracle.ManagedDataAccess.Client":
+            return "Oracle";
+        default:
+            return "NpgSQL";
+    }
+}
+
+export default function CdcSinkSchemaExplorer() {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+
+    const { control, setValue, getValues } = useFormContext<CdcSinkFormData>();
+    const formValues = useWatch({ control });
+
+    const [discoveredTables, setDiscoveredTables] = useState<SqlTableSchema[]>([]);
+    const [selectedTables, setSelectedTables] = useState<Set<string>>(new Set());
+
+    const asyncFetchSchema = useAsyncCallback(async () => {
+        const connName = formValues.connectionStringName;
+        if (!connName) {
+            return;
+        }
+
+        // Fetch the connection string details to determine the provider
+        const connectionStrings = await new getConnectionStringsCommand(databaseName).execute();
+        const sqlCs = connectionStrings.SqlConnectionStrings?.[connName];
+        if (!sqlCs) {
+            throw new Error(`SQL connection string '${connName}' not found`);
+        }
+
+        const provider = factoryNameToProvider(sqlCs.FactoryName);
+
+        const result = await CdcSinkService.fetchSchema(databaseName, {
+            ConnectionString: sqlCs.ConnectionString,
+            Provider: provider,
+            Schemas: [],
+        });
+        setDiscoveredTables(result.Tables ?? []);
+        setSelectedTables(new Set());
+    });
+
+    const getTableKey = (table: SqlTableSchema) => `${table.Schema ?? ""}.${table.TableName}`;
+
+    const isTableAlreadyConfigured = (table: SqlTableSchema): boolean => {
+        const tables = formValues.tables ?? [];
+        return tables.some(
+            (t) => t.sourceTableSchema === (table.Schema ?? "") && t.sourceTableName === table.TableName
+        );
+    };
+
+    const toggleTableSelection = (table: SqlTableSchema) => {
+        const key = getTableKey(table);
+        setSelectedTables((prev) => {
+            const next = new Set(prev);
+            if (next.has(key)) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+            return next;
+        });
+    };
+
+    const handleAddSelectedTables = () => {
+        const existingTables = getValues("tables") ?? [];
+
+        const newTables: CdcSinkTableFormData[] = discoveredTables
+            .filter((t) => selectedTables.has(getTableKey(t)) && !isTableAlreadyConfigured(t))
+            .map((t) => {
+                const columns = (t.Columns ?? []).map((col) => ({
+                    column: col.Name,
+                    name: col.Name,
+                    type: "Default" as const,
+                }));
+                return {
+                    name: t.TableName,
+                    sourceTableSchema: t.Schema ?? "",
+                    sourceTableName: t.TableName,
+                    columns,
+                    primaryKeyColumns: t.PrimaryKeyColumns ?? [],
+                    patch: "",
+                    onDelete: null as CdcSinkTableFormData["onDelete"],
+                    disabled: false,
+                    embeddedTables: [] as CdcSinkTableFormData["embeddedTables"],
+                    linkedTables: [] as CdcSinkTableFormData["linkedTables"],
+                };
+            });
+
+        if (newTables.length > 0) {
+            setValue("tables", [...existingTables, ...newTables], {
+                shouldValidate: true,
+                shouldDirty: true,
+            });
+            setSelectedTables(new Set());
+        }
+    };
+
+    const selectedCount = selectedTables.size;
+    const hasConnectionString = !!formValues.connectionStringName;
+
+    return (
+        <div>
+            <h3>
+                <Icon icon="table" /> Schema Explorer
+            </h3>
+
+            <div className="mb-3">
+                <ButtonWithSpinner
+                    variant="secondary"
+                    icon="search"
+                    isSpinning={asyncFetchSchema.loading}
+                    onClick={asyncFetchSchema.execute}
+                    disabled={!hasConnectionString}
+                >
+                    Discover Tables
+                </ButtonWithSpinner>
+                {!hasConnectionString && (
+                    <small className="text-muted ms-2">Select a connection string first</small>
+                )}
+            </div>
+
+            {asyncFetchSchema.error && (
+                <RichAlert variant="danger" className="mb-3">
+                    Failed to fetch schema: {asyncFetchSchema.error.message}
+                </RichAlert>
+            )}
+
+            {discoveredTables.length > 0 && (
+                <div className="mb-3">
+                    <div className="border rounded p-3" style={{ maxHeight: "400px", overflowY: "auto" }}>
+                        {discoveredTables.map((table) => {
+                            const key = getTableKey(table);
+                            const alreadyConfigured = isTableAlreadyConfigured(table);
+                            const isSelected = selectedTables.has(key);
+
+                            return (
+                                <div key={key} className="d-flex align-items-start mb-2 p-2 border-bottom">
+                                    <input
+                                        type="checkbox"
+                                        className="form-check-input mt-1 me-2"
+                                        checked={alreadyConfigured || isSelected}
+                                        disabled={alreadyConfigured}
+                                        onChange={() => toggleTableSelection(table)}
+                                    />
+                                    <div className="flex-grow-1">
+                                        <div className="fw-bold">
+                                            {table.Schema ? `${table.Schema}.` : ""}
+                                            {table.TableName}
+                                            {alreadyConfigured && (
+                                                <span className="badge bg-secondary ms-2">Already configured</span>
+                                            )}
+                                        </div>
+                                        <div className="text-muted small">
+                                            {table.Columns?.length ?? 0} columns
+                                            {table.PrimaryKeyColumns?.length > 0 && (
+                                                <span>
+                                                    {" "} | PK: {table.PrimaryKeyColumns.join(", ")}
+                                                </span>
+                                            )}
+                                        </div>
+                                        <div className="small text-muted">
+                                            {table.Columns?.map((c) => c.Name).join(", ")}
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+
+                    <div className="mt-2">
+                        <button
+                            type="button"
+                            className="btn btn-primary"
+                            disabled={selectedCount === 0}
+                            onClick={handleAddSelectedTables}
+                        >
+                            <Icon icon="plus" />
+                            Add {selectedCount} Selected Table{selectedCount !== 1 ? "s" : ""}
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/CdcSinkTableEditor.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/CdcSinkTableEditor.tsx
@@ -1,0 +1,542 @@
+import { useFormContext, useFieldArray, useWatch } from "react-hook-form";
+import { FormInput, FormGroup, FormLabel, FormSwitch, FormAceEditor } from "components/common/Form";
+import { Icon } from "components/common/Icon";
+import { CdcSinkFormData, CdcSinkEmbeddedTableFormData, CdcSinkLinkedTableFormData, CdcSinkColumnType } from "../types";
+import { useState } from "react";
+
+interface CdcSinkTableEditorProps {
+    tableIndex: number;
+    onClose: () => void;
+}
+
+export default function CdcSinkTableEditor({ tableIndex, onClose }: CdcSinkTableEditorProps) {
+    const { control, register, setValue, getValues } = useFormContext<CdcSinkFormData>();
+    const prefix = `tables.${tableIndex}` as const;
+
+    const tableValues = useWatch({ control, name: `tables.${tableIndex}` });
+
+    return (
+        <div>
+            <div className="d-flex justify-content-between align-items-center mb-3">
+                <h3>
+                    <Icon icon="edit" /> Edit Table: {tableValues?.name || "(unnamed)"}
+                </h3>
+                <button type="button" className="btn btn-secondary" onClick={onClose}>
+                    <Icon icon="arrow-left" /> Back to Table List
+                </button>
+            </div>
+
+            <div className="card mb-3">
+                <div className="card-body">
+                    <h4>General</h4>
+
+                    <FormGroup>
+                        <FormLabel>Collection Name</FormLabel>
+                        <FormInput
+                            type="text"
+                            control={control}
+                            name={`tables.${tableIndex}.name`}
+                            placeholder="RavenDB collection name"
+                        />
+                    </FormGroup>
+
+                    <div className="row">
+                        <div className="col-6">
+                            <FormGroup>
+                                <FormLabel>Source Schema</FormLabel>
+                                <FormInput
+                                    type="text"
+                                    control={control}
+                                    name={`tables.${tableIndex}.sourceTableSchema`}
+                                    placeholder="dbo"
+                                />
+                            </FormGroup>
+                        </div>
+                        <div className="col-6">
+                            <FormGroup>
+                                <FormLabel>Source Table Name</FormLabel>
+                                <FormInput
+                                    type="text"
+                                    control={control}
+                                    name={`tables.${tableIndex}.sourceTableName`}
+                                    placeholder="SQL table name"
+                                />
+                            </FormGroup>
+                        </div>
+                    </div>
+
+                    <FormGroup>
+                        <FormSwitch control={control} name={`tables.${tableIndex}.disabled`}>
+                            Disable this table
+                        </FormSwitch>
+                    </FormGroup>
+                </div>
+            </div>
+
+            <CdcSinkColumnMapping tableIndex={tableIndex} />
+
+            <CdcSinkPrimaryKeyColumns tableIndex={tableIndex} />
+
+            <div className="card mb-3">
+                <div className="card-body">
+                    <h4>Patch Script</h4>
+                    <FormGroup>
+                        <FormAceEditor
+                            control={control}
+                            name={`tables.${tableIndex}.patch`}
+                            mode="javascript"
+                            height="150px"
+                        />
+                    </FormGroup>
+                </div>
+            </div>
+
+            <CdcSinkOnDeleteSection tableIndex={tableIndex} />
+
+            <CdcSinkEmbeddedTablesSection tableIndex={tableIndex} />
+
+            <CdcSinkLinkedTablesSection tableIndex={tableIndex} />
+        </div>
+    );
+}
+
+function CdcSinkColumnMapping({ tableIndex }: { tableIndex: number }) {
+    const { control, getValues, setValue } = useFormContext<CdcSinkFormData>();
+    const columns = useWatch({ control, name: `tables.${tableIndex}.columns` }) ?? [];
+    const [newSqlColumn, setNewSqlColumn] = useState("");
+    const [newTargetName, setNewTargetName] = useState("");
+    const [newType, setNewType] = useState<CdcSinkColumnType>("Default");
+
+    const handleAdd = () => {
+        if (!newSqlColumn) return;
+        const current = getValues(`tables.${tableIndex}.columns`) ?? [];
+        setValue(
+            `tables.${tableIndex}.columns`,
+            [...current, { column: newSqlColumn, name: newTargetName || newSqlColumn, type: newType }],
+            { shouldDirty: true, shouldValidate: true }
+        );
+        setNewSqlColumn("");
+        setNewTargetName("");
+        setNewType("Default");
+    };
+
+    const handleRemove = (index: number) => {
+        const current = [...(getValues(`tables.${tableIndex}.columns`) ?? [])];
+        current.splice(index, 1);
+        setValue(`tables.${tableIndex}.columns`, current, { shouldDirty: true, shouldValidate: true });
+    };
+
+    return (
+        <div className="card mb-3">
+            <div className="card-body">
+                <h4>Column Mapping</h4>
+                <table className="table table-sm">
+                    <thead>
+                        <tr>
+                            <th>SQL Column</th>
+                            <th>Target Name</th>
+                            <th style={{ width: "140px" }}>Type</th>
+                            <th style={{ width: "60px" }}></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {columns.map((col, idx) => (
+                            <tr key={idx}>
+                                <td>{col.column}</td>
+                                <td>{col.name}</td>
+                                <td>{col.type}</td>
+                                <td>
+                                    <button
+                                        type="button"
+                                        className="btn btn-sm btn-outline-danger"
+                                        onClick={() => handleRemove(idx)}
+                                    >
+                                        <Icon icon="trash" />
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                        <tr>
+                            <td>
+                                <input
+                                    type="text"
+                                    className="form-control form-control-sm"
+                                    placeholder="SQL column name"
+                                    value={newSqlColumn}
+                                    onChange={(e) => setNewSqlColumn(e.target.value)}
+                                />
+                            </td>
+                            <td>
+                                <input
+                                    type="text"
+                                    className="form-control form-control-sm"
+                                    placeholder="Target name (defaults to column name)"
+                                    value={newTargetName}
+                                    onChange={(e) => setNewTargetName(e.target.value)}
+                                />
+                            </td>
+                            <td>
+                                <select
+                                    className="form-select form-select-sm"
+                                    value={newType}
+                                    onChange={(e) => setNewType(e.target.value as CdcSinkColumnType)}
+                                >
+                                    <option value="Default">Default</option>
+                                    <option value="Json">Json</option>
+                                    <option value="Attachment">Attachment</option>
+                                </select>
+                            </td>
+                            <td>
+                                <button
+                                    type="button"
+                                    className="btn btn-sm btn-secondary"
+                                    onClick={handleAdd}
+                                    disabled={!newSqlColumn}
+                                >
+                                    <Icon icon="plus" />
+                                </button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}
+
+function CdcSinkPrimaryKeyColumns({ tableIndex }: { tableIndex: number }) {
+    const { control, getValues, setValue } = useFormContext<CdcSinkFormData>();
+    const primaryKeyColumns = useWatch({ control, name: `tables.${tableIndex}.primaryKeyColumns` }) ?? [];
+    const [newColumn, setNewColumn] = useState("");
+
+    const handleAdd = () => {
+        if (!newColumn) return;
+        const current = getValues(`tables.${tableIndex}.primaryKeyColumns`) ?? [];
+        if (!current.includes(newColumn)) {
+            setValue(`tables.${tableIndex}.primaryKeyColumns`, [...current, newColumn], {
+                shouldDirty: true,
+                shouldValidate: true,
+            });
+        }
+        setNewColumn("");
+    };
+
+    const handleRemove = (col: string) => {
+        const current = getValues(`tables.${tableIndex}.primaryKeyColumns`) ?? [];
+        setValue(
+            `tables.${tableIndex}.primaryKeyColumns`,
+            current.filter((c) => c !== col),
+            { shouldDirty: true, shouldValidate: true }
+        );
+    };
+
+    return (
+        <div className="card mb-3">
+            <div className="card-body">
+                <h4>Primary Key Columns</h4>
+                <div className="d-flex flex-wrap gap-2 mb-2">
+                    {primaryKeyColumns.map((col) => (
+                        <span key={col} className="badge bg-primary d-flex align-items-center gap-1">
+                            {col}
+                            <button
+                                type="button"
+                                className="btn-close btn-close-white btn-sm"
+                                onClick={() => handleRemove(col)}
+                            />
+                        </span>
+                    ))}
+                </div>
+                <div className="d-flex gap-2">
+                    <input
+                        type="text"
+                        className="form-control form-control-sm"
+                        placeholder="Column name"
+                        value={newColumn}
+                        onChange={(e) => setNewColumn(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                e.preventDefault();
+                                handleAdd();
+                            }
+                        }}
+                    />
+                    <button type="button" className="btn btn-sm btn-secondary" onClick={handleAdd} disabled={!newColumn}>
+                        <Icon icon="plus" /> Add
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function CdcSinkOnDeleteSection({ tableIndex }: { tableIndex: number }) {
+    const { control, setValue, getValues } = useFormContext<CdcSinkFormData>();
+    const onDelete = useWatch({ control, name: `tables.${tableIndex}.onDelete` });
+    const hasOnDelete = onDelete != null;
+
+    const toggleOnDelete = () => {
+        if (hasOnDelete) {
+            setValue(`tables.${tableIndex}.onDelete`, null, { shouldDirty: true });
+        } else {
+            setValue(`tables.${tableIndex}.onDelete`, { patch: "", ignoreDeletes: false }, { shouldDirty: true });
+        }
+    };
+
+    return (
+        <div className="card mb-3">
+            <div className="card-body">
+                <h4>On Delete</h4>
+                <FormGroup>
+                    <div className="form-check form-switch">
+                        <input
+                            type="checkbox"
+                            className="form-check-input"
+                            checked={hasOnDelete}
+                            onChange={toggleOnDelete}
+                            id={`onDelete-toggle-${tableIndex}`}
+                        />
+                        <label className="form-check-label" htmlFor={`onDelete-toggle-${tableIndex}`}>
+                            Configure delete behavior
+                        </label>
+                    </div>
+                </FormGroup>
+                {hasOnDelete && (
+                    <>
+                        <FormGroup>
+                            <FormSwitch control={control} name={`tables.${tableIndex}.onDelete.ignoreDeletes`}>
+                                Ignore deletes
+                            </FormSwitch>
+                        </FormGroup>
+                        <FormGroup>
+                            <FormLabel>Delete Patch Script</FormLabel>
+                            <FormAceEditor
+                                control={control}
+                                name={`tables.${tableIndex}.onDelete.patch`}
+                                mode="javascript"
+                                height="120px"
+                            />
+                        </FormGroup>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function CdcSinkEmbeddedTablesSection({ tableIndex }: { tableIndex: number }) {
+    const { control } = useFormContext<CdcSinkFormData>();
+    const { fields, append, remove } = useFieldArray({
+        control,
+        name: `tables.${tableIndex}.embeddedTables`,
+    });
+
+    const handleAddEmbeddedTable = () => {
+        const newTable: CdcSinkEmbeddedTableFormData = {
+            sourceTableSchema: "",
+            sourceTableName: "",
+            propertyName: "",
+            type: "Array",
+            joinColumns: [],
+            primaryKeyColumns: [],
+            columns: [],
+            patch: "",
+            onDelete: null,
+            caseSensitiveKeys: false,
+            embeddedTables: [],
+        };
+        append(newTable);
+    };
+
+    return (
+        <div className="card mb-3">
+            <div className="card-body">
+                <div className="d-flex justify-content-between align-items-center mb-2">
+                    <h4>Embedded Tables ({fields.length})</h4>
+                    <button type="button" className="btn btn-sm btn-secondary" onClick={handleAddEmbeddedTable}>
+                        <Icon icon="plus" /> Add Embedded Table
+                    </button>
+                </div>
+                {fields.map((field, embIndex) => (
+                    <EmbeddedTableRow
+                        key={field.id}
+                        tableIndex={tableIndex}
+                        embIndex={embIndex}
+                        onRemove={() => remove(embIndex)}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function EmbeddedTableRow({
+    tableIndex,
+    embIndex,
+    onRemove,
+}: {
+    tableIndex: number;
+    embIndex: number;
+    onRemove: () => void;
+}) {
+    const { control } = useFormContext<CdcSinkFormData>();
+    const prefix = `tables.${tableIndex}.embeddedTables.${embIndex}` as const;
+
+    return (
+        <div className="border rounded p-3 mb-2">
+            <div className="d-flex justify-content-between align-items-center mb-2">
+                <strong>Embedded Table #{embIndex + 1}</strong>
+                <button type="button" className="btn btn-sm btn-outline-danger" onClick={onRemove}>
+                    <Icon icon="trash" /> Remove
+                </button>
+            </div>
+            <div className="row">
+                <div className="col-4">
+                    <FormGroup>
+                        <FormLabel>Source Table</FormLabel>
+                        <FormInput
+                            type="text"
+                            control={control}
+                            name={`tables.${tableIndex}.embeddedTables.${embIndex}.sourceTableName`}
+                            placeholder="Table name"
+                        />
+                    </FormGroup>
+                </div>
+                <div className="col-4">
+                    <FormGroup>
+                        <FormLabel>Property Name</FormLabel>
+                        <FormInput
+                            type="text"
+                            control={control}
+                            name={`tables.${tableIndex}.embeddedTables.${embIndex}.propertyName`}
+                            placeholder="Property name"
+                        />
+                    </FormGroup>
+                </div>
+                <div className="col-4">
+                    <FormGroup>
+                        <FormLabel>Type</FormLabel>
+                        <select
+                            className="form-select form-select-sm"
+                            {...control.register(`tables.${tableIndex}.embeddedTables.${embIndex}.type`)}
+                        >
+                            <option value="Array">Array</option>
+                            <option value="Map">Map</option>
+                            <option value="Value">Value</option>
+                        </select>
+                    </FormGroup>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function CdcSinkLinkedTablesSection({ tableIndex }: { tableIndex: number }) {
+    const { control } = useFormContext<CdcSinkFormData>();
+    const { fields, append, remove } = useFieldArray({
+        control,
+        name: `tables.${tableIndex}.linkedTables`,
+    });
+
+    const handleAddLinkedTable = () => {
+        const newTable: CdcSinkLinkedTableFormData = {
+            sourceTableSchema: "",
+            sourceTableName: "",
+            propertyName: "",
+            linkedCollectionName: "",
+            type: "Value",
+            joinColumns: [],
+        };
+        append(newTable);
+    };
+
+    return (
+        <div className="card mb-3">
+            <div className="card-body">
+                <div className="d-flex justify-content-between align-items-center mb-2">
+                    <h4>Linked Tables ({fields.length})</h4>
+                    <button type="button" className="btn btn-sm btn-secondary" onClick={handleAddLinkedTable}>
+                        <Icon icon="plus" /> Add Linked Table
+                    </button>
+                </div>
+                {fields.map((field, linkIndex) => (
+                    <LinkedTableRow
+                        key={field.id}
+                        tableIndex={tableIndex}
+                        linkIndex={linkIndex}
+                        onRemove={() => remove(linkIndex)}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function LinkedTableRow({
+    tableIndex,
+    linkIndex,
+    onRemove,
+}: {
+    tableIndex: number;
+    linkIndex: number;
+    onRemove: () => void;
+}) {
+    const { control } = useFormContext<CdcSinkFormData>();
+
+    return (
+        <div className="border rounded p-3 mb-2">
+            <div className="d-flex justify-content-between align-items-center mb-2">
+                <strong>Linked Table #{linkIndex + 1}</strong>
+                <button type="button" className="btn btn-sm btn-outline-danger" onClick={onRemove}>
+                    <Icon icon="trash" /> Remove
+                </button>
+            </div>
+            <div className="row">
+                <div className="col-3">
+                    <FormGroup>
+                        <FormLabel>Source Table</FormLabel>
+                        <FormInput
+                            type="text"
+                            control={control}
+                            name={`tables.${tableIndex}.linkedTables.${linkIndex}.sourceTableName`}
+                            placeholder="Table name"
+                        />
+                    </FormGroup>
+                </div>
+                <div className="col-3">
+                    <FormGroup>
+                        <FormLabel>Property Name</FormLabel>
+                        <FormInput
+                            type="text"
+                            control={control}
+                            name={`tables.${tableIndex}.linkedTables.${linkIndex}.propertyName`}
+                            placeholder="Property name"
+                        />
+                    </FormGroup>
+                </div>
+                <div className="col-3">
+                    <FormGroup>
+                        <FormLabel>Linked Collection</FormLabel>
+                        <FormInput
+                            type="text"
+                            control={control}
+                            name={`tables.${tableIndex}.linkedTables.${linkIndex}.linkedCollectionName`}
+                            placeholder="Collection name"
+                        />
+                    </FormGroup>
+                </div>
+                <div className="col-3">
+                    <FormGroup>
+                        <FormLabel>Type</FormLabel>
+                        <select
+                            className="form-select form-select-sm"
+                            {...control.register(`tables.${tableIndex}.linkedTables.${linkIndex}.type`)}
+                        >
+                            <option value="Array">Array</option>
+                            <option value="Value">Value</option>
+                        </select>
+                    </FormGroup>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/CdcSinkTableList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/CdcSinkTableList.tsx
@@ -1,0 +1,128 @@
+import { useFieldArray, useFormContext } from "react-hook-form";
+import { CdcSinkFormData, CdcSinkTableFormData } from "../types";
+import { Icon } from "components/common/Icon";
+import { useState } from "react";
+
+interface CdcSinkTableListProps {
+    onEditTable: (index: number) => void;
+}
+
+export default function CdcSinkTableList({ onEditTable }: CdcSinkTableListProps) {
+    const { control } = useFormContext<CdcSinkFormData>();
+    const { fields, append, remove } = useFieldArray({ control, name: "tables" });
+
+    const [confirmRemoveIndex, setConfirmRemoveIndex] = useState<number | null>(null);
+
+    const handleAddManualTable = () => {
+        const newTable: CdcSinkTableFormData = {
+            name: "",
+            sourceTableSchema: "",
+            sourceTableName: "",
+            columns: [],
+            primaryKeyColumns: [],
+            patch: "",
+            onDelete: null,
+            disabled: false,
+            embeddedTables: [],
+            linkedTables: [],
+        };
+        append(newTable);
+        onEditTable(fields.length);
+    };
+
+    const handleRemove = (index: number) => {
+        remove(index);
+        setConfirmRemoveIndex(null);
+    };
+
+    return (
+        <div>
+            <div className="d-flex justify-content-between align-items-center mb-3">
+                <h3>
+                    <Icon icon="table" /> Configured Tables ({fields.length})
+                </h3>
+                <button type="button" className="btn btn-secondary" onClick={handleAddManualTable}>
+                    <Icon icon="plus" /> Add Table Manually
+                </button>
+            </div>
+
+            {fields.length === 0 ? (
+                <div className="text-center p-4 text-muted border rounded">
+                    No tables configured yet. Use Schema Explorer to discover tables, or add a table manually.
+                </div>
+            ) : (
+                <div className="vstack gap-2">
+                    {fields.map((field, index) => {
+                        const table = field as unknown as CdcSinkTableFormData;
+                        const columnCount = table.columns?.length ?? 0;
+                        const embeddedCount = table.embeddedTables?.length ?? 0;
+                        const linkedCount = table.linkedTables?.length ?? 0;
+
+                        return (
+                            <div key={field.id} className="card">
+                                <div className="card-body d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <div className="fw-bold">
+                                            {table.name || "(unnamed collection)"}
+                                        </div>
+                                        <div className="text-muted small">
+                                            Source: {table.sourceTableSchema ? `${table.sourceTableSchema}.` : ""}
+                                            {table.sourceTableName || "(no source table)"}
+                                        </div>
+                                        <div className="text-muted small">
+                                            {columnCount} column{columnCount !== 1 ? "s" : ""}
+                                            {embeddedCount > 0 && (
+                                                <span> | {embeddedCount} embedded</span>
+                                            )}
+                                            {linkedCount > 0 && (
+                                                <span> | {linkedCount} linked</span>
+                                            )}
+                                            {table.disabled && (
+                                                <span className="badge bg-warning ms-2">Disabled</span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div className="d-flex gap-2">
+                                        <button
+                                            type="button"
+                                            className="btn btn-sm btn-secondary"
+                                            onClick={() => onEditTable(index)}
+                                        >
+                                            <Icon icon="edit" /> Edit
+                                        </button>
+                                        {confirmRemoveIndex === index ? (
+                                            <div className="d-flex gap-1">
+                                                <button
+                                                    type="button"
+                                                    className="btn btn-sm btn-danger"
+                                                    onClick={() => handleRemove(index)}
+                                                >
+                                                    Confirm
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    className="btn btn-sm btn-secondary"
+                                                    onClick={() => setConfirmRemoveIndex(null)}
+                                                >
+                                                    Cancel
+                                                </button>
+                                            </div>
+                                        ) : (
+                                            <button
+                                                type="button"
+                                                className="btn btn-sm btn-outline-danger"
+                                                onClick={() => setConfirmRemoveIndex(index)}
+                                            >
+                                                <Icon icon="trash" /> Remove
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/services/cdcSinkService.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/services/cdcSinkService.ts
@@ -1,0 +1,42 @@
+import saveCdcSinkCommand from "commands/database/tasks/saveCdcSinkCommand";
+import verifyCdcSinkSourceCommand from "commands/database/tasks/verifyCdcSinkSourceCommand";
+import testCdcSinkCommand from "commands/database/tasks/testCdcSinkCommand";
+import fetchSqlDatabaseSchemaCommand from "commands/database/tasks/fetchSqlDatabaseSchemaCommand";
+import database from "models/resources/database";
+
+type CdcSinkConfiguration = Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration;
+
+export default class CdcSinkService {
+    static async save(
+        db: database | string,
+        dto: CdcSinkConfiguration
+    ): Promise<Raven.Client.Documents.Operations.OngoingTasks.ModifyOngoingTaskResult> {
+        return new saveCdcSinkCommand(db, dto).execute();
+    }
+
+    static async verify(
+        db: database | string,
+        connectionStringName: string
+    ): Promise<Raven.Server.Documents.CdcSink.CdcSinkVerificationResult> {
+        return new verifyCdcSinkSourceCommand(db, connectionStringName).execute();
+    }
+
+    static async test(
+        db: database | string,
+        dto: CdcSinkConfiguration,
+        message: string
+    ): Promise<Raven.Server.Documents.CdcSink.Test.TestCdcSinkScriptResult> {
+        const payload: Raven.Server.Documents.CdcSink.Test.TestCdcSinkScript = {
+            Configuration: dto,
+            Message: message,
+        };
+        return new testCdcSinkCommand(db, payload).execute();
+    }
+
+    static async fetchSchema(
+        db: database | string,
+        sourceSqlDatabase: Raven.Server.SqlMigration.Model.SourceSqlDatabase
+    ): Promise<Raven.Server.SqlMigration.Schema.DatabaseSchema> {
+        return new fetchSqlDatabaseSchemaCommand(db, sourceSqlDatabase).execute();
+    }
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/types.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/types.ts
@@ -1,0 +1,57 @@
+export type CdcSinkColumnType = "Default" | "Json" | "Attachment";
+
+export interface CdcSinkColumnFormData {
+    column: string;
+    name: string;
+    type: CdcSinkColumnType;
+}
+
+export interface CdcSinkFormData {
+    name: string;
+    connectionStringName: string;
+    isSetResponsibleNode: boolean;
+    responsibleNode: string;
+    disabled: boolean;
+    tables: CdcSinkTableFormData[];
+}
+
+export interface CdcSinkTableFormData {
+    name: string;
+    sourceTableSchema: string;
+    sourceTableName: string;
+    columns: CdcSinkColumnFormData[];
+    primaryKeyColumns: string[];
+    patch: string;
+    onDelete: CdcSinkOnDeleteFormData | null;
+    disabled: boolean;
+    embeddedTables: CdcSinkEmbeddedTableFormData[];
+    linkedTables: CdcSinkLinkedTableFormData[];
+}
+
+export interface CdcSinkEmbeddedTableFormData {
+    sourceTableSchema: string;
+    sourceTableName: string;
+    propertyName: string;
+    type: "Array" | "Map" | "Value";
+    joinColumns: string[];
+    primaryKeyColumns: string[];
+    columns: CdcSinkColumnFormData[];
+    patch: string;
+    onDelete: CdcSinkOnDeleteFormData | null;
+    caseSensitiveKeys: boolean;
+    embeddedTables: CdcSinkEmbeddedTableFormData[];
+}
+
+export interface CdcSinkLinkedTableFormData {
+    sourceTableSchema: string;
+    sourceTableName: string;
+    propertyName: string;
+    linkedCollectionName: string;
+    type: "Array" | "Value";
+    joinColumns: string[];
+}
+
+export interface CdcSinkOnDeleteFormData {
+    patch: string;
+    ignoreDeletes: boolean;
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils.ts
@@ -1,0 +1,176 @@
+import {
+    CdcSinkFormData,
+    CdcSinkTableFormData,
+    CdcSinkEmbeddedTableFormData,
+    CdcSinkLinkedTableFormData,
+    CdcSinkOnDeleteFormData,
+    CdcSinkColumnFormData,
+} from "./types";
+
+type CdcSinkConfiguration = Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration;
+type CdcSinkTableConfig = Raven.Client.Documents.Operations.CdcSink.CdcSinkTableConfig;
+type CdcSinkEmbeddedTableConfig = Raven.Client.Documents.Operations.CdcSink.CdcSinkEmbeddedTableConfig;
+type CdcSinkLinkedTableConfig = Raven.Client.Documents.Operations.CdcSink.CdcSinkLinkedTableConfig;
+type CdcSinkOnDeleteConfig = Raven.Client.Documents.Operations.CdcSink.CdcSinkOnDeleteConfig;
+type CdcColumnMapping = Raven.Client.Documents.Operations.CdcSink.CdcColumnMapping;
+
+function mapOnDeleteFromDto(dto: CdcSinkOnDeleteConfig | null | undefined): CdcSinkOnDeleteFormData | null {
+    if (!dto) {
+        return null;
+    }
+    return {
+        patch: dto.Patch ?? "",
+        ignoreDeletes: dto.IgnoreDeletes ?? false,
+    };
+}
+
+function mapColumnsFromDto(dtoColumns: CdcColumnMapping[] | null | undefined): CdcSinkColumnFormData[] {
+    return (dtoColumns ?? []).map((c) => ({
+        column: c.Column ?? "",
+        name: c.Name ?? "",
+        type: c.Type ?? "Default",
+    }));
+}
+
+function mapEmbeddedTableFromDto(dto: CdcSinkEmbeddedTableConfig): CdcSinkEmbeddedTableFormData {
+    return {
+        sourceTableSchema: dto.SourceTableSchema ?? "",
+        sourceTableName: dto.SourceTableName ?? "",
+        propertyName: dto.PropertyName ?? "",
+        type: dto.Type ?? "Array",
+        joinColumns: dto.JoinColumns ?? [],
+        primaryKeyColumns: dto.PrimaryKeyColumns ?? [],
+        columns: mapColumnsFromDto(dto.Columns),
+        patch: dto.Patch ?? "",
+        onDelete: mapOnDeleteFromDto(dto.OnDelete),
+        caseSensitiveKeys: dto.CaseSensitiveKeys ?? false,
+        embeddedTables: (dto.EmbeddedTables ?? []).map(mapEmbeddedTableFromDto),
+    };
+}
+
+function mapLinkedTableFromDto(dto: CdcSinkLinkedTableConfig): CdcSinkLinkedTableFormData {
+    return {
+        sourceTableSchema: dto.SourceTableSchema ?? "",
+        sourceTableName: dto.SourceTableName ?? "",
+        propertyName: dto.PropertyName ?? "",
+        linkedCollectionName: dto.LinkedCollectionName ?? "",
+        type: (dto.Type === "Array" ? "Array" : "Value") as "Array" | "Value",
+        joinColumns: dto.JoinColumns ?? [],
+    };
+}
+
+function mapTableFromDto(dto: CdcSinkTableConfig): CdcSinkTableFormData {
+    return {
+        name: dto.Name ?? "",
+        sourceTableSchema: dto.SourceTableSchema ?? "",
+        sourceTableName: dto.SourceTableName ?? "",
+        columns: mapColumnsFromDto(dto.Columns),
+        primaryKeyColumns: dto.PrimaryKeyColumns ?? [],
+        patch: dto.Patch ?? "",
+        onDelete: mapOnDeleteFromDto(dto.OnDelete),
+        disabled: dto.Disabled ?? false,
+        embeddedTables: (dto.EmbeddedTables ?? []).map(mapEmbeddedTableFromDto),
+        linkedTables: (dto.LinkedTables ?? []).map(mapLinkedTableFromDto),
+    };
+}
+
+const getDefaultValues = (dto?: CdcSinkConfiguration): CdcSinkFormData => {
+    if (!dto) {
+        return {
+            name: "",
+            connectionStringName: "",
+            isSetResponsibleNode: false,
+            responsibleNode: "",
+            disabled: false,
+            tables: [],
+        };
+    }
+
+    return {
+        name: dto.Name ?? "",
+        connectionStringName: dto.ConnectionStringName ?? "",
+        isSetResponsibleNode: dto.MentorNode != null,
+        responsibleNode: dto.MentorNode ?? "",
+        disabled: dto.Disabled ?? false,
+        tables: (dto.Tables ?? []).map(mapTableFromDto),
+    };
+};
+
+function mapOnDeleteToDto(data: CdcSinkOnDeleteFormData | null): CdcSinkOnDeleteConfig | null {
+    if (!data) {
+        return null;
+    }
+    return {
+        Patch: data.patch || null,
+        IgnoreDeletes: data.ignoreDeletes,
+    };
+}
+
+function mapColumnsToDto(columns: CdcSinkColumnFormData[]): CdcColumnMapping[] {
+    return columns.map((c) => ({
+        Column: c.column,
+        Name: c.name,
+        Type: c.type,
+    }));
+}
+
+function mapEmbeddedTableToDto(data: CdcSinkEmbeddedTableFormData): CdcSinkEmbeddedTableConfig {
+    return {
+        SourceTableSchema: data.sourceTableSchema || null,
+        SourceTableName: data.sourceTableName,
+        PropertyName: data.propertyName,
+        Type: data.type,
+        JoinColumns: data.joinColumns,
+        PrimaryKeyColumns: data.primaryKeyColumns,
+        Columns: mapColumnsToDto(data.columns),
+        Patch: data.patch || null,
+        OnDelete: mapOnDeleteToDto(data.onDelete),
+        CaseSensitiveKeys: data.caseSensitiveKeys,
+        EmbeddedTables: data.embeddedTables.map(mapEmbeddedTableToDto),
+    };
+}
+
+function mapLinkedTableToDto(data: CdcSinkLinkedTableFormData): CdcSinkLinkedTableConfig {
+    return {
+        SourceTableSchema: data.sourceTableSchema || null,
+        SourceTableName: data.sourceTableName,
+        PropertyName: data.propertyName,
+        LinkedCollectionName: data.linkedCollectionName,
+        Type: data.type,
+        JoinColumns: data.joinColumns,
+    };
+}
+
+function mapTableToDto(data: CdcSinkTableFormData): CdcSinkTableConfig {
+    return {
+        Name: data.name,
+        SourceTableSchema: data.sourceTableSchema || null,
+        SourceTableName: data.sourceTableName,
+        Columns: mapColumnsToDto(data.columns),
+        PrimaryKeyColumns: data.primaryKeyColumns,
+        Patch: data.patch || null,
+        OnDelete: mapOnDeleteToDto(data.onDelete),
+        Disabled: data.disabled,
+        EmbeddedTables: data.embeddedTables.map(mapEmbeddedTableToDto),
+        LinkedTables: data.linkedTables.map(mapLinkedTableToDto),
+    };
+}
+
+const mapToDto = (data: CdcSinkFormData, taskId?: number): CdcSinkConfiguration => {
+    return {
+        TaskId: taskId ?? 0,
+        Name: data.name,
+        ConnectionStringName: data.connectionStringName,
+        Disabled: data.disabled,
+        MentorNode: data.isSetResponsibleNode ? data.responsibleNode : null,
+        PinToMentorNode: false,
+        Tables: data.tables.map(mapTableToDto),
+        Postgres: null,
+        SkipInitialLoad: false,
+    };
+};
+
+export const editCdcSinkTaskUtils = {
+    getDefaultValues,
+    mapToDto,
+};

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/validation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/validation.ts
@@ -1,0 +1,75 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+
+const onDeleteSchema = yup
+    .object({
+        patch: yup.string().nullable(),
+        ignoreDeletes: yup.boolean(),
+    })
+    .nullable()
+    .default(null);
+
+const columnMappingSchema = yup.object({
+    column: yup.string().required("SQL column name is required"),
+    name: yup.string().required("Target name is required"),
+    type: yup.string<"Default" | "Json" | "Attachment">().required(),
+});
+
+const embeddedTableSchema: yup.Lazy<any> = yup.lazy(() =>
+    yup.object({
+        sourceTableSchema: yup.string().nullable(),
+        sourceTableName: yup.string().required(),
+        propertyName: yup.string().required(),
+        type: yup.string<"Array" | "Map" | "Value">().required(),
+        joinColumns: yup.array().of(yup.string().required()).min(1, "At least one join column is required"),
+        primaryKeyColumns: yup.array().of(yup.string().required()),
+        columns: yup.array().of(columnMappingSchema),
+        patch: yup.string().nullable(),
+        onDelete: onDeleteSchema,
+        caseSensitiveKeys: yup.boolean(),
+        embeddedTables: yup.array().of(yup.lazy(() => embeddedTableSchema)),
+    })
+);
+
+const linkedTableSchema = yup.object({
+    sourceTableSchema: yup.string().nullable(),
+    sourceTableName: yup.string().required(),
+    propertyName: yup.string().required(),
+    linkedCollectionName: yup.string().required(),
+    type: yup.string<"Array" | "Value">().required(),
+    joinColumns: yup.array().of(yup.string().required()).min(1, "At least one join column is required"),
+});
+
+const tableSchema = yup.object({
+    name: yup.string().required("Collection name is required"),
+    sourceTableSchema: yup.string().nullable(),
+    sourceTableName: yup.string().required("Source table name is required"),
+    columns: yup
+        .array()
+        .of(columnMappingSchema)
+        .min(1, "At least one column mapping is required"),
+    primaryKeyColumns: yup
+        .array()
+        .of(yup.string().required())
+        .min(1, "At least one primary key column is required"),
+    patch: yup.string().nullable(),
+    onDelete: onDeleteSchema,
+    disabled: yup.boolean(),
+    embeddedTables: yup.array().of(embeddedTableSchema),
+    linkedTables: yup.array().of(linkedTableSchema),
+});
+
+const editCdcSinkTaskSchema = yup.object({
+    name: yup.string().required("Task name is required"),
+    connectionStringName: yup.string().required("Connection string is required"),
+    isSetResponsibleNode: yup.boolean(),
+    responsibleNode: yup.string().nullable(),
+    disabled: yup.boolean(),
+    tables: yup
+        .array()
+        .of(tableSchema)
+        .min(1, "At least one table is required"),
+});
+
+export const editCdcSinkTaskResolver = yupResolver(editCdcSinkTaskSchema);
+export type EditCdcSinkTaskFormData = yup.InferType<typeof editCdcSinkTaskSchema>;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/CdcSinkPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/CdcSinkPanel.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import {
+    BaseOngoingTaskPanelProps,
+    OngoingTaskActions,
+    OngoingTaskName,
+    OngoingTaskResponsibleNode,
+    OngoingTaskStatus,
+    useTasksOperations,
+} from "../../shared/shared";
+import { OngoingTaskCdcSinkInfo } from "components/models/tasks";
+import { useAppUrls } from "hooks/useAppUrls";
+import {
+    RichPanel,
+    RichPanelActions,
+    RichPanelDetailItem,
+    RichPanelDetails,
+    RichPanelHeader,
+    RichPanelInfo,
+    RichPanelSelect,
+} from "components/common/RichPanel";
+import Collapse from "react-bootstrap/Collapse";
+import Form from "react-bootstrap/Form";
+import { useAppSelector } from "components/store";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import { Icon } from "components/common/Icon";
+
+type CdcSinkPanelProps = BaseOngoingTaskPanelProps<OngoingTaskCdcSinkInfo>;
+
+function Details(props: CdcSinkPanelProps) {
+    const { data } = props;
+
+    return (
+        <RichPanelDetails>
+            <RichPanelDetailItem label="Connection String">{data.shared.connectionStringName}</RichPanelDetailItem>
+            <RichPanelDetailItem label="Factory Name">{data.shared.factoryName}</RichPanelDetailItem>
+        </RichPanelDetails>
+    );
+}
+
+export function CdcSinkPanel(props: CdcSinkPanelProps) {
+    const { data, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
+
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
+    const { forCurrentDatabase } = useAppUrls();
+
+    const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;
+    const editUrl = forCurrentDatabase.editCdcSink(data.shared.taskId)();
+
+    const { detailsVisible, toggleDetails, onEdit } = useTasksOperations(editUrl, props);
+
+    return (
+        <RichPanel>
+            <RichPanelHeader>
+                <RichPanelInfo>
+                    {canEdit && (
+                        <RichPanelSelect>
+                            <Form.Check
+                                type="checkbox"
+                                onChange={(e) => toggleSelection(e.currentTarget.checked, data.shared)}
+                                checked={isSelected(data.shared.taskId)}
+                            />
+                        </RichPanelSelect>
+                    )}
+                    <OngoingTaskName task={data} canEdit={canEdit} editUrl={editUrl} />
+                </RichPanelInfo>
+                <RichPanelActions>
+                    <span>
+                        <Icon icon="sql-etl" />
+                        CDC Sink
+                    </span>
+                    <OngoingTaskResponsibleNode task={data} />
+                    <OngoingTaskStatus
+                        task={data}
+                        canEdit={canEdit}
+                        onTaskOperation={onTaskOperation}
+                        isTogglingState={isTogglingState(data.shared.taskId)}
+                    />
+                    <OngoingTaskActions
+                        task={data}
+                        canEdit={canEdit}
+                        onEdit={onEdit}
+                        onTaskOperation={onTaskOperation}
+                        toggleDetails={toggleDetails}
+                        isDeleting={isDeleting(data.shared.taskId)}
+                        isDetailsOpen={detailsVisible}
+                    />
+                </RichPanelActions>
+            </RichPanelHeader>
+            <Collapse in={detailsVisible}>
+                <div>
+                    <Details {...props} />
+                </div>
+            </Collapse>
+        </RichPanel>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingTasksReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingTasksReducer.ts
@@ -33,6 +33,7 @@ import {
     OngoingTaskAmazonSqsEtlSharedInfo,
     OngoingTaskEmbeddingsGenerationSharedInfo,
     OngoingTaskGenAiSharedInfo,
+    OngoingTaskCdcSinkSharedInfo,
 } from "components/models/tasks";
 import OngoingTasksResult = Raven.Server.Web.System.OngoingTasksResult;
 import OngoingTask = Raven.Client.Documents.Operations.OngoingTasks.OngoingTask;
@@ -54,6 +55,7 @@ import { produce, Draft } from "immer";
 import OngoingTaskSubscription = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskSubscription;
 import OngoingTaskQueueEtlListView = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskQueueEtl;
 import OngoingTaskQueueSinkListView = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskQueueSink;
+import OngoingTaskCdcSinkListView = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskCdcSink;
 import OngoingTaskBackup = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskBackup;
 import SubscriptionConnectionsDetails = Raven.Server.Documents.TcpHandlers.SubscriptionConnectionsDetails;
 import DatabaseUtils from "components/utils/DatabaseUtils";
@@ -398,6 +400,16 @@ function mapSharedInfo(task: OngoingTask): OngoingTaskSharedInfo {
                     throw new Error("Invalid broker type: " + incoming.BrokerType);
             }
         }
+        case "CdcSink": {
+            const incoming = task as OngoingTaskCdcSinkListView;
+            // noinspection UnnecessaryLocalVariableJS
+            const result: OngoingTaskCdcSinkSharedInfo = {
+                ...commonProps,
+                connectionStringName: incoming.ConnectionStringName,
+                factoryName: incoming.FactoryName,
+            };
+            return result;
+        }
         case "Backup": {
             const incoming = task as OngoingTaskBackup;
             // noinspection UnnecessaryLocalVariableJS
@@ -507,7 +519,9 @@ function mapNodeInfo(task: OngoingTask): OngoingTaskNodeInfoDetails {
                 onGoingBackup: incoming.OnGoingBackup,
             } as OngoingTaskPeriodicBackupNodeInfoDetails;
         }
-        //TODO: sink?
+        case "CdcSink": {
+            return commonProps;
+        }
         case "Replication": {
             const incoming = task as OngoingTaskReplication;
             return {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/shared/OngoingTaskOperationConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/shared/OngoingTaskOperationConfirm.tsx
@@ -252,6 +252,20 @@ function getTaskGroups(type: OngoingTaskOperationConfirmType, tasks: OngoingTask
 }
 
 function getWarningMessage(taskGroups: TaskGroup[]): ReactNode {
+    const allDeleteTasks = taskGroups.find((x) => x.destinationStatus === "Removed")?.tasks ?? [];
+    const cdcSinkDeleteTasks = allDeleteTasks.filter((x) => x.taskType === "CdcSink");
+
+    if (cdcSinkDeleteTasks.length > 0) {
+        return (
+            <small>
+                Deleting {cdcSinkDeleteTasks.length === 1 ? "this CDC Sink task" : "these CDC Sink tasks"} will{" "}
+                <strong>not</strong> remove the associated PostgreSQL replication slot and publication. They will
+                become orphaned and continue consuming disk space on the source database until a database
+                administrator drops them manually.
+            </small>
+        );
+    }
+
     const allDisableTasks = taskGroups.find((x) => x.destinationStatus === "Disabled")?.tasks ?? [];
     const subscriptionDisableTasksCount = allDisableTasks.filter((x) => x.taskType === "Subscription").length;
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
@@ -415,6 +415,7 @@ export function useNewOngoingTasks({ isAiOnly = false }: { isAiOnly?: boolean })
     const hasAmazonSqsEtl = useAppSelector(licenseSelectors.statusValue("HasQueueEtl"));
     const hasKafkaSink = useAppSelector(licenseSelectors.statusValue("HasQueueSink"));
     const hasRabbitMqSink = useAppSelector(licenseSelectors.statusValue("HasQueueSink"));
+    const hasCdcSink = useAppSelector(licenseSelectors.statusValue("HasCdcSink"));
     const hasPeriodicBackups = useAppSelector(licenseSelectors.statusValue("HasPeriodicBackup"));
     const hasGenAi = useAppSelector(licenseSelectors.statusValue("HasGenAi"));
     const hasEmbeddingGeneration = useAppSelector(licenseSelectors.statusValue("HasEmbeddingsGeneration"));
@@ -709,6 +710,18 @@ export function useNewOngoingTasks({ isAiOnly = false }: { isAiOnly?: boolean })
                     licenseBadge: "Enterprise",
                     showLicenseBadge: !hasRabbitMqSink,
                     link: forCurrentDatabase.editRabbitMqSinkTaskUrl(),
+                    accessRequired: "DatabaseAdmin",
+                },
+                {
+                    title: "CDC Sink",
+                    description:
+                        "Capture changes from an external SQL database using Change Data Capture (CDC) and replicate them into RavenDB documents.",
+                    iconName: "sql-etl",
+                    target: "CdcSink",
+                    variant: "Sink",
+                    licenseBadge: "Enterprise",
+                    showLicenseBadge: !hasCdcSink,
+                    link: forCurrentDatabase.editCdcSinkTaskUrl(),
                     accessRequired: "DatabaseAdmin",
                 },
             ],

--- a/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/studioSearch/hooks/useStudioSearchAsyncRegister.ts
+++ b/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/studioSearch/hooks/useStudioSearchAsyncRegister.ts
@@ -107,6 +107,8 @@ export function useStudioSearchAsyncRegister(props: UseStudioSearchAsyncRegister
                         return getUrlFromProvider(appUrl.forEditEmbeddingsGeneration);
                     case "GenAi":
                         return getUrlFromProvider(appUrl.forEditGenAi);
+                    case "CdcSink":
+                        return getUrlFromProvider(appUrl.forEditCdcSink);
                     default:
                         assertUnreachable(taskType);
                 }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskCdcSinkEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskCdcSinkEditModel.ts
@@ -1,0 +1,150 @@
+/// <reference path="../../../../typings/tsd.d.ts"/>
+import ongoingTaskEditModel = require("models/database/tasks/ongoingTaskEditModel");
+import jsonUtil = require("common/jsonUtil");
+import ongoingTaskCdcSinkTableModel = require("models/database/tasks/ongoingTaskCdcSinkTableModel");
+
+class ongoingTaskCdcSinkEditModel extends ongoingTaskEditModel {
+
+    connectionStringName = ko.observable<string>();
+
+    tables = ko.observableArray<ongoingTaskCdcSinkTableModel>([]);
+
+    showEditTableArea: KnockoutComputed<boolean>;
+
+    tableSelectedForEdit = ko.observable<ongoingTaskCdcSinkTableModel>();
+    editedTableSandbox = ko.observable<ongoingTaskCdcSinkTableModel>();
+
+    validationGroup: KnockoutValidationGroup;
+    dirtyFlag: () => DirtyFlag;
+
+    get studioTaskType(): StudioTaskType {
+        return "CdcSink";
+    }
+
+    constructor(dto: Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskCdcSink) {
+        super();
+
+        this.update(dto);
+        this.initializeObservables();
+        this.initValidation();
+    }
+
+    initializeObservables() {
+        super.initializeObservables();
+
+        this.showEditTableArea = ko.pureComputed(() => !!this.editedTableSandbox());
+
+        const innerDirtyFlag = ko.pureComputed(() => !!this.editedTableSandbox() && this.editedTableSandbox().dirtyFlag().isDirty());
+        const tablesCount = ko.pureComputed(() => this.tables().length);
+        const hasAnyDirtyTable = ko.pureComputed(() => {
+            let anyDirty = false;
+            this.tables().forEach(table => {
+                if (table.dirtyFlag().isDirty()) {
+                    anyDirty = true;
+                }
+            });
+            return anyDirty;
+        });
+
+        this.dirtyFlag = new ko.DirtyFlag([
+                innerDirtyFlag,
+                this.taskName,
+                this.taskState,
+                this.mentorNode,
+                this.pinMentorNode,
+                this.manualChooseMentor,
+                this.connectionStringName,
+                tablesCount,
+                hasAnyDirtyTable
+            ],
+            false, jsonUtil.newLineNormalizingHashFunction);
+    }
+
+    private initValidation() {
+        this.initializeMentorValidation();
+
+        this.connectionStringName.extend({
+            required: true
+        });
+
+        this.tables.extend({
+            validation: [
+                {
+                    validator: () => this.tables().length > 0,
+                    message: "At least one table must be configured"
+                }
+            ]
+        });
+
+        this.validationGroup = ko.validatedObservable({
+            connectionStringName: this.connectionStringName,
+            mentorNode: this.mentorNode,
+            tables: this.tables,
+        });
+    }
+
+    update(dto: Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskCdcSink) {
+        super.update(dto);
+        const configuration = dto.Configuration;
+
+        if (configuration) {
+            this.connectionStringName(configuration.ConnectionStringName);
+            this.tables(configuration.Tables.map(x => new ongoingTaskCdcSinkTableModel(x, false)));
+            this.manualChooseMentor(!!configuration.MentorNode);
+            this.pinMentorNode(configuration.PinToMentorNode);
+            this.mentorNode(configuration.MentorNode);
+        }
+    }
+
+    toDto(): Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration {
+        return {
+            Name: this.taskName(),
+            ConnectionStringName: this.connectionStringName(),
+            Disabled: this.taskState() === "Disabled",
+            Tables: this.tables().map(x => x.toDto()),
+            MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
+            PinToMentorNode: this.pinMentorNode(),
+            TaskId: this.taskId,
+            Postgres: null,
+            SkipInitialLoad: false,
+        };
+    }
+
+    deleteTable(table: ongoingTaskCdcSinkTableModel) {
+        this.tables.remove(x => table.name() === x.name());
+
+        if (this.tableSelectedForEdit() === table) {
+            this.editedTableSandbox(null);
+            this.tableSelectedForEdit(null);
+        }
+    }
+
+    editTable(table: ongoingTaskCdcSinkTableModel) {
+        this.tableSelectedForEdit(table);
+        this.editedTableSandbox(new ongoingTaskCdcSinkTableModel(table.toDto(), false));
+    }
+
+    static empty(): ongoingTaskCdcSinkEditModel {
+        return new ongoingTaskCdcSinkEditModel(
+            {
+                TaskName: "",
+                TaskType: "CdcSink",
+                TaskState: "Enabled",
+                TaskConnectionStatus: "Active",
+                Configuration: {
+                    TaskId: null,
+                    PinToMentorNode: false,
+                    MentorNode: null,
+                    Disabled: false,
+                    Tables: [],
+                    ConnectionStringName: null,
+                    Name: null,
+                    SkipInitialLoad: false,
+                },
+                ConnectionStringName: null,
+                FactoryName: null,
+            } as Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskCdcSink);
+    }
+}
+
+export = ongoingTaskCdcSinkEditModel;

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskCdcSinkTableModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskCdcSinkTableModel.ts
@@ -1,0 +1,190 @@
+/// <reference path="../../../../typings/tsd.d.ts"/>
+import jsonUtil = require("common/jsonUtil");
+
+class cdcSinkColumnMapping {
+    sqlColumnName: string;
+    sqlColumnType: string;
+    propertyName: KnockoutObservable<string>;
+    isPrimaryKey: boolean;
+
+    constructor(sqlColumnName: string, sqlColumnType: string, propertyName: string, isPrimaryKey: boolean) {
+        this.sqlColumnName = sqlColumnName;
+        this.sqlColumnType = sqlColumnType;
+        this.propertyName = ko.observable<string>(propertyName);
+        this.isPrimaryKey = isPrimaryKey;
+    }
+}
+
+class ongoingTaskCdcSinkTableModel {
+
+    name = ko.observable<string>();
+    sourceTableSchema = ko.observable<string>();
+    sourceTableName = ko.observable<string>();
+    patch = ko.observable<string>();
+    disabled = ko.observable<boolean>(false);
+
+    isNew = ko.observable<boolean>(true);
+    isSelected = ko.observable<boolean>(false);
+
+    columns = ko.observableArray<cdcSinkColumnMapping>([]);
+    primaryKeyColumns = ko.observableArray<string>([]);
+
+    displayName: KnockoutComputed<string>;
+
+    validationGroup: KnockoutValidationGroup;
+    testValidationGroup: KnockoutValidationGroup;
+
+    dirtyFlag: () => DirtyFlag;
+
+    constructor(dto: Raven.Client.Documents.Operations.CdcSink.CdcSinkTableConfig, isNew: boolean) {
+        this.update(dto, isNew);
+        this.initObservables();
+        this.initValidation();
+
+        this.dirtyFlag = new ko.DirtyFlag([
+                this.name,
+                this.sourceTableSchema,
+                this.sourceTableName,
+                this.patch,
+                this.disabled,
+                this.isSelected,
+            ],
+            false, jsonUtil.newLineNormalizingHashFunction);
+    }
+
+    static empty(name?: string): ongoingTaskCdcSinkTableModel {
+        return new ongoingTaskCdcSinkTableModel(
+            {
+                Name: name || "",
+                SourceTableSchema: "public",
+                SourceTableName: "",
+                Columns: [],
+                PrimaryKeyColumns: [],
+                Patch: "",
+                Disabled: false,
+                EmbeddedTables: [],
+                LinkedTables: [],
+                OnDelete: null,
+            }, true);
+    }
+
+    static fromSchemaTable(tableSchema: Raven.Server.SqlMigration.Schema.SqlTableSchema): ongoingTaskCdcSinkTableModel {
+        const collectionName = ongoingTaskCdcSinkTableModel.tableNameToCollectionName(tableSchema.TableName);
+
+        const columns = tableSchema.Columns.map(col => ({
+            Column: col.Name,
+            Name: col.Name,
+            Type: "Default" as Raven.Client.Documents.Operations.CdcSink.CdcColumnType,
+        }));
+
+        const model = new ongoingTaskCdcSinkTableModel({
+            Name: collectionName,
+            SourceTableSchema: tableSchema.Schema || "public",
+            SourceTableName: tableSchema.TableName,
+            Columns: columns,
+            PrimaryKeyColumns: tableSchema.PrimaryKeyColumns || [],
+            Patch: "",
+            Disabled: false,
+            EmbeddedTables: [],
+            LinkedTables: [],
+            OnDelete: null,
+        }, true);
+
+        model.isSelected(true);
+
+        const columnMappings = tableSchema.Columns.map(col => {
+            const isPk = (tableSchema.PrimaryKeyColumns || []).indexOf(col.Name) >= 0;
+            return new cdcSinkColumnMapping(col.Name, col.Type, col.Name, isPk);
+        });
+        model.columns(columnMappings);
+        model.primaryKeyColumns(tableSchema.PrimaryKeyColumns || []);
+
+        return model;
+    }
+
+    private static tableNameToCollectionName(tableName: string): string {
+        // Convert snake_case to PascalCase and pluralize
+        return tableName.split("_")
+            .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+            .join("");
+    }
+
+    toDto(): Raven.Client.Documents.Operations.CdcSink.CdcSinkTableConfig {
+        const columns: Raven.Client.Documents.Operations.CdcSink.CdcColumnMapping[] = this.columns().map(col => ({
+            Column: col.sqlColumnName,
+            Name: col.propertyName(),
+            Type: "Default" as Raven.Client.Documents.Operations.CdcSink.CdcColumnType,
+        }));
+
+        return {
+            Name: this.name(),
+            SourceTableSchema: this.sourceTableSchema(),
+            SourceTableName: this.sourceTableName(),
+            Columns: columns,
+            PrimaryKeyColumns: this.primaryKeyColumns(),
+            Patch: this.patch(),
+            Disabled: this.disabled(),
+            EmbeddedTables: [],
+            LinkedTables: [],
+            OnDelete: null,
+        };
+    }
+
+    private initObservables() {
+        this.displayName = ko.pureComputed(() => {
+            const schema = this.sourceTableSchema();
+            const table = this.sourceTableName();
+            if (schema && schema !== "public" && schema !== "dbo") {
+                return schema + "." + table;
+            }
+            return table;
+        });
+    }
+
+    private initValidation() {
+        this.name.extend({
+            required: true
+        });
+
+        this.sourceTableName.extend({
+            required: true
+        });
+
+        this.validationGroup = ko.validatedObservable({
+            name: this.name,
+            sourceTableName: this.sourceTableName,
+        });
+
+        this.testValidationGroup = ko.validatedObservable({
+            name: this.name,
+            sourceTableName: this.sourceTableName,
+        });
+    }
+
+    private update(dto: Raven.Client.Documents.Operations.CdcSink.CdcSinkTableConfig, isNew: boolean) {
+        this.name(dto.Name);
+        this.sourceTableSchema(dto.SourceTableSchema);
+        this.sourceTableName(dto.SourceTableName);
+        this.patch(dto.Patch || "");
+        this.disabled(dto.Disabled || false);
+        this.isNew(isNew);
+        this.primaryKeyColumns(dto.PrimaryKeyColumns || []);
+
+        const dtoColumns = dto.Columns || [];
+        if (dtoColumns.length > 0) {
+            const pkCols = dto.PrimaryKeyColumns || [];
+            const mappings = dtoColumns.map(col => {
+                const isPk = pkCols.indexOf(col.Column) >= 0;
+                return new cdcSinkColumnMapping(col.Column, col.Type || "Default", col.Name, isPk);
+            });
+            this.columns(mappings);
+        }
+    }
+
+    hasUpdates(oldItem: this) {
+        const hashFunction = jsonUtil.newLineNormalizingHashFunctionWithIgnoredFields(["__moduleId__", "validationGroup"]);
+        return hashFunction(this) !== hashFunction(oldItem);
+    }
+}
+
+export = ongoingTaskCdcSinkTableModel;

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditCdcSinkTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditCdcSinkTaskInfoHub.tsx
@@ -1,0 +1,65 @@
+import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
+import { licenseSelectors } from "components/common/shell/licenseSlice";
+import { useAppSelector } from "components/store";
+import React from "react";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "hooks/useRavenLink";
+import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
+
+export function EditCdcSinkTaskInfoHub() {
+    const hasCdcSink = useAppSelector(licenseSelectors.statusValue("HasCdcSink"));
+    const featureAvailability = useLimitedFeatureAvailability({
+        defaultFeatureAvailability,
+        overwrites: [
+            {
+                featureName: defaultFeatureAvailability[0].featureName,
+                value: hasCdcSink,
+            },
+        ],
+    });
+
+    const cdcSinkDocsLink = useRavenLink({ hash: "CDC_SINK" });
+
+    return (
+        <AboutViewFloating defaultOpen={hasCdcSink ? null : "licensing"}>
+            <AccordionItemWrapper
+                targetId="about"
+                icon="about"
+                color="info"
+                heading="About this view"
+                description="Get additional info on this feature"
+            >
+                <p>
+                    <strong>CDC Sink</strong> allows you to capture changes from an external SQL database
+                    using Change Data Capture (CDC) and replicate them into RavenDB documents.
+                </p>
+                <p>
+                    Tables from the source database are mapped to RavenDB collections. Column values
+                    become document properties, and you can customize the mapping or add transformation
+                    patches.
+                </p>
+                <hr />
+                <div>
+                    <a href={cdcSinkDocsLink} target="_blank">
+                        <Icon icon="newtab" /> CDC Sink documentation
+                    </a>
+                </div>
+            </AccordionItemWrapper>
+            <FeatureAvailabilitySummaryWrapper
+                isUnlimited={hasCdcSink}
+                data={featureAvailability}
+            />
+        </AboutViewFloating>
+    );
+}
+
+const defaultFeatureAvailability: FeatureAvailabilityData[] = [
+    {
+        featureName: "CDC Sink",
+        featureIcon: "sql-etl",
+        community: { value: false },
+        professional: { value: false },
+        enterprise: { value: true },
+    },
+];

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editCdcSinkTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editCdcSinkTask.ts
@@ -1,0 +1,471 @@
+import app = require("durandal/app");
+import appUrl = require("common/appUrl");
+import viewModelBase = require("viewmodels/viewModelBase");
+import router = require("plugins/router");
+import eventsCollector = require("common/eventsCollector");
+import getConnectionStringsCommand = require("commands/database/settings/getConnectionStringsCommand");
+import aceEditorBindingHandler = require("common/bindingHelpers/aceEditorBindingHandler");
+import jsonUtil = require("common/jsonUtil");
+import popoverUtils = require("common/popoverUtils");
+import ongoingTaskCdcSinkTableModel = require("models/database/tasks/ongoingTaskCdcSinkTableModel");
+import saveCdcSinkCommand = require("commands/database/tasks/saveCdcSinkCommand");
+import ongoingTaskCdcSinkEditModel = require("models/database/tasks/ongoingTaskCdcSinkEditModel");
+import viewHelpers = require("common/helpers/view/viewHelpers");
+import database = require("models/resources/database");
+import testCdcSinkCommand = require("commands/database/tasks/testCdcSinkCommand");
+import getOngoingTaskInfoCommand = require("commands/database/tasks/getOngoingTaskInfoCommand");
+import fetchSqlDatabaseSchemaCommand = require("commands/database/tasks/fetchSqlDatabaseSchemaCommand");
+import verifyCdcSinkSourceCommand = require("commands/database/tasks/verifyCdcSinkSourceCommand");
+import patchDebugActions = require("viewmodels/database/patch/patchDebugActions");
+import licenseModel = require("models/auth/licenseModel");
+import EditCdcSinkTaskInfoHub = require("./EditCdcSinkTaskInfoHub");
+import typeUtils = require("common/typeUtils");
+
+class cdcSinkTaskTestMode {
+    db: KnockoutObservable<database>;
+    configurationProvider: () => Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration;
+
+    messageText = ko.observable("{}");
+
+    validationGroup: KnockoutValidationGroup;
+    validateParent: () => boolean;
+
+    testAlreadyExecuted = ko.observable<boolean>(false);
+
+    spinners = {
+        test: ko.observable<boolean>(false)
+    };
+
+    actions = new patchDebugActions();
+    debugOutput = ko.observableArray<string>([]);
+
+    constructor(db: KnockoutObservable<database>,
+                validateParent: () => boolean,
+                configurationProvider: () => Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration) {
+        this.db = db;
+        this.validateParent = validateParent;
+        this.configurationProvider = configurationProvider;
+
+        this.actions.showDocumentsInModified(true);
+    }
+
+    initObservables() {
+        this.messageText.extend({
+            required: true,
+            aceValidation: true
+        });
+
+        this.validationGroup = ko.validatedObservable({
+            messageText: this.messageText
+        });
+    }
+
+    runTest() {
+        const testValid = viewHelpers.isValid(this.validationGroup, true);
+        const parentValid = this.validateParent();
+
+        if (testValid && parentValid) {
+            this.spinners.test(true);
+
+            const dto: Raven.Server.Documents.CdcSink.Test.TestCdcSinkScript = {
+                Configuration: this.configurationProvider(),
+                Message: this.messageText()
+            };
+
+            eventsCollector.default.reportEvent("cdc-sink", "test-script");
+
+            new testCdcSinkCommand(this.db(), dto)
+                .execute()
+                .done(simulationResult => {
+                    this.actions.fill(simulationResult.Actions);
+                    this.debugOutput(simulationResult.DebugOutput);
+                    this.testAlreadyExecuted(true);
+                })
+                .fail(() => {
+                    this.actions.reset();
+                })
+                .always(() => this.spinners.test(false));
+        }
+    }
+}
+
+class editCdcSinkTask extends viewModelBase {
+
+    view = require("views/database/tasks/editCdcSinkTask.html");
+    taskResponsibleNodeSectionView = require("views/partial/taskResponsibleNodeSection.html");
+    pinResponsibleNodeTextScriptView = require("views/partial/pinResponsibleNodeTextScript.html");
+
+    patchDebugActionsLoadedView = require("views/database/patch/patchDebugActionsLoaded.html");
+    patchDebugActionsModifiedView = require("views/database/patch/patchDebugActionsModified.html");
+    patchDebugActionsDeletedView = require("views/database/patch/patchDebugActionsDeleted.html");
+
+    hasCdcSink = licenseModel.getStatusValue("HasCdcSink");
+
+    static readonly tableNamePrefix = "Table_";
+
+    enableTestArea = ko.observable<boolean>(false);
+    test: cdcSinkTaskTestMode;
+
+    infoHubView: ReactInKnockout<typeof EditCdcSinkTaskInfoHub.EditCdcSinkTaskInfoHub>;
+
+    editedCdcSink = ko.observable<ongoingTaskCdcSinkEditModel>();
+
+    isAddingNewCdcSinkTask = ko.observable<boolean>(true);
+
+    sqlConnectionStringsDetails = ko.observableArray<Raven.Client.Documents.Operations.ETL.SQL.SqlConnectionString>([]);
+
+    possibleMentors = ko.observableArray<string>([]);
+
+    // Schema discovery
+    schemaFetched = ko.observable<boolean>(false);
+    discoveredTables = ko.observableArray<ongoingTaskCdcSinkTableModel>([]);
+    selectedDiscoveredTable = ko.observable<ongoingTaskCdcSinkTableModel>();
+
+    // Verify source
+    verifyResult = ko.observable<Raven.Server.Documents.CdcSink.CdcSinkVerificationResult>();
+
+    spinners = {
+        test: ko.observable<boolean>(false),
+        save: ko.observable<boolean>(false),
+        fetchSchema: ko.observable<boolean>(false),
+        verify: ko.observable<boolean>(false)
+    };
+
+    fullErrorDetailsVisible = ko.observable<boolean>(false);
+
+    isSharded = ko.pureComputed(() => {
+        const db = this.activeDatabase();
+        return db ? db.isSharded() : false;
+    });
+
+    selectedConnectionStringDetails = ko.pureComputed(() => {
+        const name = this.editedCdcSink() ? this.editedCdcSink().connectionStringName() : null;
+        if (!name) {
+            return null;
+        }
+        return this.sqlConnectionStringsDetails().find(x => x.Name === name) || null;
+    });
+
+    canFetchSchema = ko.pureComputed(() => {
+        return !!this.selectedConnectionStringDetails() && !this.spinners.fetchSchema();
+    });
+
+    canVerifySource = ko.pureComputed(() => {
+        const name = this.editedCdcSink() ? this.editedCdcSink().connectionStringName() : null;
+        return !!name && !this.spinners.verify();
+    });
+
+    selectedTablesCount = ko.pureComputed(() => {
+        return this.discoveredTables().filter(t => t.isSelected()).length;
+    });
+
+    constructor() {
+        super();
+
+        aceEditorBindingHandler.install();
+        this.bindToCurrentInstance("useConnectionString", "removeTable",
+            "cancelEditedTable", "saveEditedTable", "toggleTestArea", "setState",
+            "fetchSchema", "verifySource", "applySelectedTables", "toggleTableSelection",
+            "selectDiscoveredTableForPreview");
+
+        this.infoHubView = ko.pureComputed(() => ({
+            component: EditCdcSinkTaskInfoHub.EditCdcSinkTaskInfoHub
+        }));
+    }
+
+    activate(args: any) {
+        super.activate(args);
+        const deferred = $.Deferred<void>();
+
+        this.loadPossibleMentors();
+
+        if (args.taskId) {
+            this.isAddingNewCdcSinkTask(false);
+
+            getOngoingTaskInfoCommand.forCdcSink(this.activeDatabase(), args.taskId)
+                .execute()
+                .done((result: Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskCdcSink) => {
+                    this.editedCdcSink(new ongoingTaskCdcSinkEditModel(result));
+                    deferred.resolve();
+                })
+                .fail(() => {
+                    deferred.reject();
+                    router.navigate(appUrl.forOngoingTasks(this.activeDatabase()));
+                });
+        } else {
+            this.isAddingNewCdcSinkTask(true);
+            this.editedCdcSink(ongoingTaskCdcSinkEditModel.empty());
+            this.editedCdcSink().editedTableSandbox(ongoingTaskCdcSinkTableModel.empty(this.findNameForNewTable()));
+            deferred.resolve();
+        }
+
+        return $.when<any>(this.getAllConnectionStrings(), deferred)
+            .done(() => {
+                this.initObservables();
+            });
+    }
+
+    private loadPossibleMentors() {
+        const db = this.activeDatabase();
+        const members = db.nodes()
+            .filter(x => x.type === "Member")
+            .map(x => x.tag);
+
+        this.possibleMentors(members);
+    }
+
+    private getAllConnectionStrings() {
+        return new getConnectionStringsCommand(this.activeDatabase())
+            .execute()
+            .done((result: Raven.Client.Documents.Operations.ConnectionStrings.GetConnectionStringsResult) => {
+                const sqlStrings = Object.values(result.SqlConnectionStrings);
+                this.sqlConnectionStringsDetails(typeUtils.sortBy(sqlStrings, x => x.Name.toUpperCase()));
+            });
+    }
+
+    private initObservables() {
+        const dtoProvider = () => {
+            const dto = this.editedCdcSink().toDto();
+
+            if (!dto.Name) {
+                dto.Name = "Test CDC Sink Task";
+            }
+            return dto;
+        };
+
+        this.test = new cdcSinkTaskTestMode(this.activeDatabase, () => {
+            return this.isValid(this.editedCdcSink().editedTableSandbox().testValidationGroup);
+        }, dtoProvider);
+
+        this.test.initObservables();
+
+        this.dirtyFlag = new ko.DirtyFlag([
+            this.editedCdcSink().dirtyFlag().isDirty
+        ], false, jsonUtil.newLineNormalizingHashFunction);
+    }
+
+    useConnectionString(connectionStringToUse: string) {
+        this.editedCdcSink().connectionStringName(connectionStringToUse);
+        // Reset schema state when connection string changes
+        this.schemaFetched(false);
+        this.discoveredTables([]);
+        this.selectedDiscoveredTable(null);
+        this.verifyResult(null);
+    }
+
+    private factoryNameToProvider(factoryName: string): Raven.Server.SqlMigration.MigrationProvider {
+        if (!factoryName) {
+            return "MsSQL";
+        }
+
+        switch (factoryName) {
+            case "Npgsql":
+                return "NpgSQL";
+            case "Microsoft.Data.SqlClient":
+            case "System.Data.SqlClient":
+                return "MsSQL";
+            case "MySql.Data.MySqlClient":
+                return "MySQL_MySql_Data";
+            case "MySqlConnector.MySqlConnectorFactory":
+                return "MySQL_MySqlConnector";
+            case "Oracle.ManagedDataAccess.Client":
+                return "Oracle";
+            default:
+                return "MsSQL";
+        }
+    }
+
+    fetchSchema() {
+        const connDetails = this.selectedConnectionStringDetails();
+        if (!connDetails) {
+            return;
+        }
+
+        this.spinners.fetchSchema(true);
+        eventsCollector.default.reportEvent("cdc-sink", "fetch-schema");
+
+        const sourceSqlDb: Raven.Server.SqlMigration.Model.SourceSqlDatabase = {
+            ConnectionString: connDetails.ConnectionString,
+            Provider: this.factoryNameToProvider(connDetails.FactoryName),
+            Schemas: []
+        };
+
+        new fetchSqlDatabaseSchemaCommand(this.activeDatabase(), sourceSqlDb)
+            .execute()
+            .done((schema: Raven.Server.SqlMigration.Schema.DatabaseSchema) => {
+                const tables = schema.Tables.map(t => ongoingTaskCdcSinkTableModel.fromSchemaTable(t));
+
+                // If we already have configured tables, mark matching ones as selected
+                const existingTables = this.editedCdcSink().tables();
+                tables.forEach(discovered => {
+                    const existing = existingTables.find(e =>
+                        e.sourceTableName() === discovered.sourceTableName() &&
+                        e.sourceTableSchema() === discovered.sourceTableSchema());
+                    if (existing) {
+                        discovered.isSelected(true);
+                        discovered.name(existing.name());
+                        discovered.patch(existing.patch());
+                    }
+                });
+
+                this.discoveredTables(tables);
+                this.schemaFetched(true);
+
+                if (tables.length > 0) {
+                    this.selectDiscoveredTableForPreview(tables[0]);
+                }
+            })
+            .always(() => this.spinners.fetchSchema(false));
+    }
+
+    verifySource() {
+        const connName = this.editedCdcSink().connectionStringName();
+        if (!connName) {
+            return;
+        }
+
+        this.spinners.verify(true);
+        eventsCollector.default.reportEvent("cdc-sink", "verify-source");
+
+        new verifyCdcSinkSourceCommand(this.activeDatabase(), connName)
+            .execute()
+            .done((result: Raven.Server.Documents.CdcSink.CdcSinkVerificationResult) => {
+                this.verifyResult(result);
+            })
+            .always(() => this.spinners.verify(false));
+    }
+
+    toggleTableSelection(table: ongoingTaskCdcSinkTableModel) {
+        table.isSelected(!table.isSelected());
+    }
+
+    selectDiscoveredTableForPreview(table: ongoingTaskCdcSinkTableModel) {
+        this.selectedDiscoveredTable(table);
+    }
+
+    applySelectedTables() {
+        const selected = this.discoveredTables().filter(t => t.isSelected());
+
+        // Replace existing tables with the selected discovered tables
+        const newTables: ongoingTaskCdcSinkTableModel[] = [];
+
+        selected.forEach(discovered => {
+            const tableDto = discovered.toDto();
+            const model = new ongoingTaskCdcSinkTableModel(tableDto, true);
+            model.columns(discovered.columns());
+            model.primaryKeyColumns(discovered.primaryKeyColumns());
+            model.dirtyFlag().forceDirty();
+            newTables.push(model);
+        });
+
+        newTables.sort((a, b) => a.name().toLowerCase().localeCompare(b.name().toLowerCase()));
+        this.editedCdcSink().tables(newTables);
+    }
+
+    saveCdcSink() {
+        let hasAnyErrors = false;
+        this.spinners.save(true);
+        const editedSink = this.editedCdcSink();
+
+        if (editedSink.showEditTableArea()) {
+            if (!this.isValid(editedSink.editedTableSandbox().validationGroup)) {
+                hasAnyErrors = true;
+            } else {
+                this.saveEditedTable();
+            }
+        }
+
+        if (!this.isValid(editedSink.validationGroup)) {
+            hasAnyErrors = true;
+        }
+
+        if (hasAnyErrors) {
+            this.spinners.save(false);
+            return false;
+        }
+
+        eventsCollector.default.reportEvent("cdc-sink", "save");
+
+        const dto = editedSink.toDto();
+        new saveCdcSinkCommand(this.activeDatabase(), dto)
+            .execute()
+            .done(() => {
+                this.dirtyFlag().reset();
+                this.goToOngoingTasksView();
+            })
+            .always(() => this.spinners.save(false));
+    }
+
+    addNewTable() {
+        this.editedCdcSink().tableSelectedForEdit(null);
+        this.editedCdcSink().editedTableSandbox(ongoingTaskCdcSinkTableModel.empty(this.findNameForNewTable()));
+    }
+
+    cancelEditedTable() {
+        this.editedCdcSink().editedTableSandbox(null);
+        this.editedCdcSink().tableSelectedForEdit(null);
+        this.enableTestArea(false);
+    }
+
+    saveEditedTable() {
+        this.enableTestArea(false);
+        const table = this.editedCdcSink().editedTableSandbox();
+        if (!this.isValid(table.validationGroup)) {
+            return;
+        }
+
+        if (table.isNew()) {
+            const newTableItem = new ongoingTaskCdcSinkTableModel(table.toDto(), true);
+            newTableItem.name(table.name());
+            newTableItem.dirtyFlag().forceDirty();
+            this.editedCdcSink().tables.push(newTableItem);
+        } else {
+            const oldItem = this.editedCdcSink().tableSelectedForEdit();
+            const newItem = new ongoingTaskCdcSinkTableModel(table.toDto(), false);
+
+            if (oldItem.dirtyFlag().isDirty() || newItem.hasUpdates(oldItem)) {
+                newItem.dirtyFlag().forceDirty();
+            }
+
+            this.editedCdcSink().tables.replace(oldItem, newItem);
+        }
+
+        this.editedCdcSink().tables.sort((a, b) => a.name().toLowerCase().localeCompare(b.name().toLowerCase()));
+        this.editedCdcSink().editedTableSandbox(null);
+        this.editedCdcSink().tableSelectedForEdit(null);
+    }
+
+    private findNameForNewTable() {
+        const tablesWithPrefix = this.editedCdcSink().tables().filter(table => {
+            return table.name().startsWith(editCdcSinkTask.tableNamePrefix);
+        });
+
+        const maxNumber = _.max(tablesWithPrefix
+            .map(x => x.name().substring(editCdcSinkTask.tableNamePrefix.length))
+            .map(x => _.toInteger(x))) || 0;
+
+        return editCdcSinkTask.tableNamePrefix + (maxNumber + 1);
+    }
+
+    cancelOperation() {
+        this.goToOngoingTasksView();
+    }
+
+    private goToOngoingTasksView() {
+        router.navigate(appUrl.forOngoingTasks(this.activeDatabase()));
+    }
+
+    removeTable(model: ongoingTaskCdcSinkTableModel) {
+        this.editedCdcSink().deleteTable(model);
+    }
+
+    toggleTestArea() {
+        this.enableTestArea(!this.enableTestArea());
+    }
+
+    setState(state: Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskState): void {
+        this.editedCdcSink().taskState(state);
+    }
+}
+
+export = editCdcSinkTask;

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/ongoingTasksWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/ongoingTasksWidget.ts
@@ -96,6 +96,11 @@ class ongoingTasksWidget extends websocketBasedWidget<Raven.Server.Dashboard.Clu
             icon: "icon-rabbitmq-sink",
             colorClass: "rabbitmq-sink",
         },
+        "CdcSink": {
+            nameForUI: "CDC Sink",
+            icon: "icon-sql-etl",
+            colorClass: "sql-etl",
+        },
         "Backup": {
             nameForUI: "Backup",
             icon: "icon-backups",

--- a/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
+++ b/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
@@ -39,6 +39,7 @@ interface computedAppUrls {
     editAmazonSqsEtl: (taskId?: number, taskName?: string) => KnockoutComputed<string>;
     editKafkaSink: (taskId?: number, taskName?: string) => KnockoutComputed<string>;
     editRabbitMqSink: (taskId?: number, taskName?: string) => KnockoutComputed<string>;
+    editCdcSink: (taskId?: number, taskName?: string) => KnockoutComputed<string>;
     editEmbeddingsGeneration: (taskId?: number, taskName?: string) => KnockoutComputed<string>;
     editGenAi: (taskId?: number, taskName?: string) => KnockoutComputed<string>;
     query: (indexName?: string) => KnockoutComputed<string>;
@@ -68,6 +69,7 @@ interface computedAppUrls {
     editAmazonSqsEtlTaskUrl: KnockoutComputed<string>;
     editKafkaSinkTaskUrl: KnockoutComputed<string>;
     editRabbitMqSinkTaskUrl: KnockoutComputed<string>;
+    editCdcSinkTaskUrl: KnockoutComputed<string>;
     editEmbeddingsGenerationTaskUrl: KnockoutComputed<string>;
     editGenAiTaskUrl: KnockoutComputed<string>;
     csvImportUrl: KnockoutComputed<string>;

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -939,6 +939,25 @@ type StudioEtlType = "Raven" | "Sql" | "Snowflake" | "Olap" | "ElasticSearch" | 
 
 type StudioQueueSinkType = "KafkaQueueSink" | "RabbitQueueSink";
 
+declare module Raven.Client.Documents.Operations.OngoingTasks {
+    interface OngoingTaskCdcSink extends Raven.Client.Documents.Operations.OngoingTasks.OngoingTask {
+        Configuration: Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration;
+        ConnectionStringName: string;
+        FactoryName: string;
+    }
+}
+
+declare module Raven.Server.Documents.CdcSink.Test {
+    interface TestCdcSinkScript {
+        Configuration: Raven.Client.Documents.Operations.CdcSink.CdcSinkConfiguration;
+        Message: string;
+    }
+    interface TestCdcSinkScriptResult {
+        Actions: any;
+        DebugOutput: Array<string>;
+    }
+}
+
 type FilterOngoingTaskType = Raven.Client.Documents.Operations.ETL.EtlType  | Raven.Client.Documents.Operations.ETL.Queue.QueueBrokerType | "Subscription" | "Replication";
 
 type TaskDestinationType = "Collection" | "Table" | "Queue" | "Topic" | "Index";

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editCdcSinkTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editCdcSinkTask.html
@@ -1,0 +1,481 @@
+<div class="content-margin edit-cdc-sink-task edit-ongoing-task" data-bind="css: { 'test-mode': enableTestArea }">
+    <div class="align-items-center justify-content-between d-flex gap-2 margin-bottom-md padding-top-xs">
+        <div class="flex-horizontal gap-2">
+            <i class="icon-sql"></i>
+            <h2 data-bind="text: $root.isAddingNewCdcSinkTask() ? `New CDC Sink` : `Edit CDC Sink`" class="mb-0"></h2>
+            <span class="badge license-restricted-badge enterprise" data-bind="if: !hasCdcSink">Enterprise</span>
+        </div>
+        <div class="flex-end margin-right-xs" data-bind="react: infoHubView"></div>
+    </div>
+    <div class="row flex-row">
+        <div class="col-xs-12 col-lg-6 flex-vertical">
+            <form class="flex-form" data-bind="submit: saveCdcSink" autocomplete="off">
+                <div class="flex-header">
+                    <button type="submit" class="btn btn-primary" data-bind="disable: $root.spinners.save() || !$root.dirtyFlag().isDirty(), css: { 'btn-spinner': $root.spinners.save }">
+                        <i class="icon-save"></i><span>Save</span>
+                    </button>
+                    <button data-bind="click: cancelOperation" class="btn btn-default" title="Return to Ongoing Tasks View">
+                        <i class="icon-cancel"></i><span>Cancel</span>
+                    </button>
+                </div>
+                <div class="panel" data-bind="css: { 'pe-none item-disabled': !hasCdcSink }">
+                    <div class="panel-body" data-bind="with: editedCdcSink">
+                        <div class="form-group margin-top">
+                            <label for="taskName" class="control-label">Task Name</label>
+                            <div class="flex-grow">
+                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the CDC Sink task (optional)" data-bind="textInput: taskName">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label">Task State</label>
+                            <div class="flex-grow">
+                                <button type="button" class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown" aria-expanded="false">
+                                    <span data-bind="text: stateText()"></span>
+                                    <span class="caret"></span>
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li><a href="#" data-bind="click: _.partial($root.setState, 'Enabled')"><span>Enabled</span></a></li>
+                                    <li><a href="#" data-bind="click: _.partial($root.setState, 'Disabled')"><span>Disabled</span></a></li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label">&nbsp;</label>
+                            <div class="toggle" data-placement="right" data-toggle="tooltip"
+                                 data-bind="attr: { title: $root.isSharded() ? 'Not supported in sharded databases' : 'Toggle on to set a responsible node for the task' }"
+                                 data-animation="true">
+                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.isSharded()">
+                                <label for="responsibleNode">Set responsible node</label>
+                            </div>
+                        </div>
+                        <div data-bind="compose: $root.taskResponsibleNodeSectionView"></div>
+                        <div class="form-group" data-bind="validationOptions: { insertMessages: false }, validationElement: connectionStringName">
+                            <label class="control-label">Connection String</label>
+                            <div class="flex-grow">
+                                <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown"
+                                        data-bind="disable: $root.sqlConnectionStringsDetails().length === 0,
+                                                   attr: { 'title': $root.sqlConnectionStringsDetails().length === 0 ? 'No SQL connection strings were defined' : 'Select a SQL connection string' }">
+                                    <span data-bind="text: connectionStringName() || 'Select a SQL connection string'"></span>
+                                    <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
+                                </button>
+                                <ul class="dropdown-menu"
+                                    data-bind="foreach: $root.sqlConnectionStringsDetails">
+                                    <li data-bind="click: _.partial($root.useConnectionString, $data.Name)">
+                                        <a href="#">
+                                            <div class="row">
+                                                <strong class="col-xs-6" data-bind="text: $data.Name"></strong>
+                                            </div>
+                                        </a>
+                                    </li>
+                                </ul>
+                                <span class="help-block" data-bind="validationMessage: connectionStringName"></span>
+                            </div>
+                        </div>
+                        <div class="panel-addon" data-bind="visible: $root.sqlConnectionStringsDetails().length === 0">
+                            <div class="padding bg-warning text-warning small">
+                                <i class="icon-warning"></i>&nbsp;&nbsp;No SQL connection strings have been defined yet
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Schema Discovery and Verify Source Buttons -->
+                    <div class="panel-body" data-bind="visible: editedCdcSink() && editedCdcSink().connectionStringName()">
+                        <div class="flex-horizontal gap-2 margin-bottom">
+                            <button type="button" class="btn btn-info"
+                                    data-bind="click: fetchSchema, disable: !canFetchSchema(), css: { 'btn-spinner': spinners.fetchSchema }">
+                                <i class="icon-table"></i>
+                                <span>Fetch Schema</span>
+                            </button>
+                            <button type="button" class="btn btn-default"
+                                    data-bind="click: verifySource, disable: !canVerifySource(), css: { 'btn-spinner': spinners.verify }">
+                                <i class="icon-check"></i>
+                                <span>Verify Source</span>
+                            </button>
+                        </div>
+
+                        <!-- Verify Result -->
+                        <div data-bind="if: verifyResult">
+                            <div data-bind="with: verifyResult">
+                                <div data-bind="if: Success" class="bg-success padding padding-sm small margin-bottom">
+                                    <i class="icon-check"></i>&nbsp;Source database verification passed successfully.
+                                </div>
+                                <div data-bind="if: !Success">
+                                    <div class="bg-danger padding padding-sm small margin-bottom">
+                                        <i class="icon-danger"></i>&nbsp;Source database verification failed.
+                                    </div>
+                                    <div data-bind="if: Errors && Errors.length > 0">
+                                        <ul class="text-danger small margin-bottom">
+                                            <!-- ko foreach: Errors -->
+                                            <li data-bind="text: $data"></li>
+                                            <!-- /ko -->
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div data-bind="if: Warnings && Warnings.length > 0">
+                                    <ul class="text-warning small margin-bottom">
+                                        <!-- ko foreach: Warnings -->
+                                        <li data-bind="text: $data"></li>
+                                        <!-- /ko -->
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Schema Discovery Panel -->
+                <div data-bind="visible: schemaFetched">
+                    <div class="flex-header">
+                        <div class="flex-row margin-top">
+                            <h3>Discovered Tables <span class="badge" data-bind="text: discoveredTables().length"></span></h3>
+                            <button type="button" class="btn btn-success pull-right"
+                                    data-bind="click: applySelectedTables, disable: selectedTablesCount() === 0"
+                                    title="Apply selected tables to the task configuration">
+                                <i class="icon-check"></i>
+                                <span>Apply Selected (<span data-bind="text: selectedTablesCount"></span>)</span>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="scroll" style="max-height: 400px; overflow-y: auto;" data-bind="css: { 'pe-none item-disabled': !hasCdcSink }">
+                        <div class="etl-list">
+                            <div data-bind="if: discoveredTables().length === 0">
+                                <div class="text-center text-muted padding">
+                                    <i class="icon-lg icon-empty-set"></i>
+                                    <h4 class="margin-top margin-top-sm">No tables were discovered in the source database.</h4>
+                                </div>
+                            </div>
+                            <div data-bind="foreach: discoveredTables">
+                                <div class="panel panel-hover item"
+                                     data-bind="css: { active: $data === $root.selectedDiscoveredTable() },
+                                                click: $root.selectDiscoveredTableForPreview">
+                                    <div class="padding padding-sm">
+                                        <div class="flex-horizontal">
+                                            <div class="checkbox margin-right" style="margin-top: 0; margin-bottom: 0;">
+                                                <input type="checkbox" data-bind="checked: isSelected, click: function() { return true; }, clickBubble: false" />
+                                                <label data-bind="click: _.partial($root.toggleTableSelection, $data), clickBubble: false"></label>
+                                            </div>
+                                            <div class="flex-grow info">
+                                                <div class="transformer-name">
+                                                    <span data-bind="text: displayName"></span>
+                                                    <span class="text-muted small margin-left" data-bind="text: '-> ' + name()"></span>
+                                                </div>
+                                                <div class="small text-muted">
+                                                    <span data-bind="text: columns().length + ' columns'"></span>
+                                                    <!-- ko if: primaryKeyColumns().length > 0 -->
+                                                    <span class="margin-left">
+                                                        PK: <span data-bind="text: primaryKeyColumns().join(', ')"></span>
+                                                    </span>
+                                                    <!-- /ko -->
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Configured Tables (when schema not fetched or after apply) -->
+                <div data-bind="visible: !schemaFetched()">
+                    <div class="flex-header" data-bind="css: { 'pe-none item-disabled': !hasCdcSink }">
+                        <div class="flex-row margin-top">
+                            <h3>Tables</h3>
+                            <button type="button" id="addNewTable" data-bind="click: addNewTable, disable: editedCdcSink().showEditTableArea" class="btn btn-info pull-right">
+                                <i class="icon-plus"></i><span>Add Table</span>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="scroll" data-bind="css: { 'pe-none item-disabled': !hasCdcSink }">
+                        <div class="etl-list" id="tablesList" data-bind="with: editedCdcSink">
+                            <div data-bind="if: tables().length === 0 && !editedTableSandbox()">
+                                <div class="text-center text-muted">
+                                    <i class="icon-lg icon-empty-set"></i>
+                                    <h3 class="margin-top margin-top-sm"
+                                        data-bind="css: { 'text-danger': !tables.isValid() && tables.isModified() }">No tables have been configured.
+                                    </h3>
+                                </div>
+                            </div>
+                            <div data-bind="foreach: tables">
+                                <div class="panel panel-hover item" data-bind="css: { active: $data === $parent.tableSelectedForEdit() }">
+                                    <div class="padding padding-sm">
+                                        <div class="flex-horizontal">
+                                            <div class="flex-grow info">
+                                                <div class="transformer-name" title="Collection name">
+                                                    <span data-bind="text: name"></span>
+                                                    <span class="text-warning" data-bind="visible: dirtyFlag().isDirty">*</span>
+                                                </div>
+                                                <div class="queues">
+                                                    Source:
+                                                    <span class="sink-queues" title="Source Table">
+                                                        <span data-bind="text: sourceTableSchema() ? sourceTableSchema() + '.' + sourceTableName() : sourceTableName()"></span>
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <div class="actions">
+                                                <button data-bind="click: $parent.editTable.bind($parent, $data)" class="btn btn-default"><i class="icon-edit" title="Edit table config"></i></button>
+                                                <button data-bind="click: $root.removeTable" class="btn btn-danger"><i class="icon-trash" title="Delete table config"></i></button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Applied Tables (after schema was applied) -->
+                <div data-bind="visible: schemaFetched() && editedCdcSink().tables().length > 0">
+                    <div class="flex-header margin-top">
+                        <h3>Configured Tables <span class="badge" data-bind="text: editedCdcSink().tables().length"></span></h3>
+                    </div>
+                    <div class="scroll" style="max-height: 300px; overflow-y: auto;">
+                        <div class="etl-list" data-bind="with: editedCdcSink">
+                            <div data-bind="foreach: tables">
+                                <div class="panel panel-hover item" data-bind="css: { active: $data === $parent.tableSelectedForEdit() }">
+                                    <div class="padding padding-sm">
+                                        <div class="flex-horizontal">
+                                            <div class="flex-grow info">
+                                                <div class="transformer-name" title="Collection name">
+                                                    <span data-bind="text: name"></span>
+                                                    <span class="text-warning" data-bind="visible: dirtyFlag().isDirty">*</span>
+                                                </div>
+                                                <div class="queues">
+                                                    Source:
+                                                    <span class="sink-queues" title="Source Table">
+                                                        <span data-bind="text: sourceTableSchema() ? sourceTableSchema() + '.' + sourceTableName() : sourceTableName()"></span>
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <div class="actions">
+                                                <button data-bind="click: $parent.editTable.bind($parent, $data)" class="btn btn-default"><i class="icon-edit" title="Edit table config"></i></button>
+                                                <button data-bind="click: $root.removeTable" class="btn btn-danger"><i class="icon-trash" title="Delete table config"></i></button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+        <div class="col-xs-12 col-lg-6 flex-vertical">
+            <!-- Column Mapping Preview for Discovered Table -->
+            <div data-bind="visible: schemaFetched() && selectedDiscoveredTable()">
+                <div class="panel padding" data-bind="with: selectedDiscoveredTable">
+                    <h4>
+                        Column Mapping: <strong data-bind="text: displayName"></strong>
+                        <span class="text-muted small"> -> <span data-bind="text: name"></span></span>
+                    </h4>
+                    <div class="form-group margin-top">
+                        <label><strong>Collection Name:</strong></label>
+                        <input type="text" class="form-control" placeholder="RavenDB collection name"
+                               data-bind="textInput: name" />
+                    </div>
+                    <div data-bind="if: columns().length > 0" class="margin-top">
+                        <table class="table table-condensed table-striped">
+                            <thead>
+                                <tr>
+                                    <th style="width: 30px;"></th>
+                                    <th>SQL Column</th>
+                                    <th>Type</th>
+                                    <th>Property Name</th>
+                                </tr>
+                            </thead>
+                            <tbody data-bind="foreach: columns">
+                                <tr>
+                                    <td>
+                                        <!-- ko if: isPrimaryKey -->
+                                        <i class="icon-key text-warning" title="Primary Key"></i>
+                                        <!-- /ko -->
+                                    </td>
+                                    <td>
+                                        <span data-bind="text: sqlColumnName"></span>
+                                    </td>
+                                    <td>
+                                        <span class="label label-default" data-bind="text: sqlColumnType"></span>
+                                    </td>
+                                    <td>
+                                        <input type="text" class="form-control input-sm"
+                                               data-bind="textInput: propertyName"
+                                               placeholder="Property name" />
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div data-bind="if: columns().length === 0" class="text-muted text-center padding">
+                        No columns discovered for this table.
+                    </div>
+                </div>
+            </div>
+
+            <!-- Table Edit Area (manual mode) -->
+            <div data-bind="with: editedCdcSink()">
+                <div class="flex-grow" data-bind="if: showEditTableArea">
+                    <div id="editTransform" class="panel padding" data-bind="css: { 'pe-none item-disabled': !$root.hasCdcSink }">
+                        <div data-bind="with: editedTableSandbox">
+                            <div class="flex-horizontal margin-bottom" data-bind="validationElement: name">
+                                <label class="control-label"><strong>Collection Name:</strong></label>
+                                <div class="flex-grow margin-left">
+                                    <input type="text" class="form-control" placeholder="Enter RavenDB collection name (e.g. Orders)" autocomplete="off"
+                                           data-bind="textInput: name, disable: $root.enableTestArea() || !isNew()" />
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-4">
+                                    <div class="form-group" data-bind="validationElement: sourceTableName">
+                                        <label><strong>Source Schema:</strong></label>
+                                        <input type="text" class="form-control" placeholder="public" autocomplete="off"
+                                               data-bind="textInput: sourceTableSchema" />
+                                    </div>
+                                </div>
+                                <div class="col-xs-8">
+                                    <div class="form-group" data-bind="validationElement: sourceTableName">
+                                        <label><strong>Source Table:</strong></label>
+                                        <input type="text" class="form-control" placeholder="Enter SQL table name (e.g. orders)" autocomplete="off"
+                                               data-bind="textInput: sourceTableName" />
+                                        <div data-bind="validationOptions: { errorsAsTitle: false }, validationElement: sourceTableName">
+                                            <div class="help-block" data-bind="validationMessage: sourceTableName"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Column Mappings in edit mode -->
+                            <div data-bind="if: columns().length > 0">
+                                <label><strong>Column Mappings:</strong></label>
+                                <table class="table table-condensed table-striped margin-bottom">
+                                    <thead>
+                                        <tr>
+                                            <th style="width: 30px;"></th>
+                                            <th>SQL Column</th>
+                                            <th>Type</th>
+                                            <th>Property Name</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody data-bind="foreach: columns">
+                                        <tr>
+                                            <td>
+                                                <!-- ko if: isPrimaryKey -->
+                                                <i class="icon-key text-warning" title="Primary Key"></i>
+                                                <!-- /ko -->
+                                            </td>
+                                            <td><span data-bind="text: sqlColumnName"></span></td>
+                                            <td><span class="label label-default" data-bind="text: sqlColumnType"></span></td>
+                                            <td>
+                                                <input type="text" class="form-control input-sm"
+                                                       data-bind="textInput: propertyName" />
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <label><strong>JavaScript Patch (optional):</strong></label>
+                            <small class="text-muted d-block margin-bottom-sm">Access all CDC row columns via <code>$row</code>. Example: <code>this.FullAddress = $row.ShipAddress + ', ' + $row.ShipCity;</code></small>
+                            <div data-bind="validationElement: patch">
+                                <pre class="form-control editor"
+                                     data-bind="aceEditor: { code: patch, fontSize: '14px', lang: 'ace/mode/javascript' }, validationOptions: { errorsAsTitle: false }, validationElement: patch" style="height: 200px;"></pre>
+                            </div>
+                            <div class="flex-horizontal margin-top">
+                                <div data-bind="visible: !$root.enableTestArea()">
+                                    <button class="btn btn-success" data-bind="click: $root.saveEditedTable, attr: { title : (isNew() ? 'Add' : 'Update') + ' this table' }">
+                                        <i class="icon-tick"></i> <span data-bind="text: isNew() ? 'Add' : 'Update'"></span>
+                                    </button>
+                                    <button title="Cancel" class="btn btn-default" data-bind="click: $root.cancelEditedTable"><i class="icon-cancel"></i> <span>Cancel</span></button>
+                                </div>
+                                <div class="flex-separator"></div>
+                                <button type="button" class="btn btn-info" data-bind="click: $root.toggleTestArea, visible: !$root.enableTestArea()" title="Click to open the test area">
+                                    <i class="icon-rocket"></i> <span>Test patch</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="js-test-area" data-bind="collapse: $root.enableTestArea()">
+                        <div class="panel" data-bind="css: { 'pe-none item-disabled': !$root.hasCdcSink }">
+                            <div class="panel-body flex-form" data-bind="with: $root.test">
+                                <label>
+                                    <strong>CDC Message: </strong> <br /><small class="text-muted">(JSON format - represents the raw CDC row data)</small>
+                                </label>
+                                <div data-bind="validationElement: messageText" style="height: 200px" class="margin-bottom">
+                                    <pre id="docEditor" class="form-control"
+                                         data-bind="aceEditor: { code: messageText, fontSize:'16px', lang: 'ace/mode/json' }, validationElement: messageText, validationOptions: { errorsAsTitle: false },"></pre>
+                                    <div data-bind="validationOptions: { errorsAsTitle: false }, validationElement: messageText">
+                                        <div class="help-block" data-bind="validationMessage: messageText"></div>
+                                    </div>
+                                </div>
+                                <div class="flex-horizontal">
+                                    <div class="flex-separator"></div>
+                                    <button type="button" class="btn btn-primary margin-right margin-right-sm" data-bind="click: runTest, css: { 'btn-spinner': spinners.test }, disable: spinners.test()">
+                                        <i class="icon-rocket"></i>
+                                        <span>Test</span>
+                                    </button>
+                                    <button type="button" class="btn btn-info" data-bind="click: $root.toggleTestArea">
+                                        <i class="icon-cancel"></i> <span>Close Test Area</span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="test-container flex-grow flex-vertical" data-bind="with: test">
+        <div class="absolute-center text-center" data-bind="visible: !testAlreadyExecuted()">
+            <i class="icon-info icon-xl"></i>
+            Enter <strong>CDC Message</strong> used for test and click <strong>Test</strong> button
+        </div>
+        <div class="tabs" data-bind="css: { 'pe-none item-disabled': !$root.hasCdcSink }">
+            <ul class="nav nav-tabs" role="tablist">
+                <li role="presentation" data-bind="visible: testAlreadyExecuted" class="active">
+                    <a href="#testResultsModified" role="tab" data-toggle="tab">
+                        <i class="icon-export"></i><span>Put</span>
+                        <span class="label label-primary margin-left-xxs" data-bind="text: actions.modifiedCount() || ''"></span>
+                    </a>
+                </li>
+                <li role="presentation" data-bind="visible: testAlreadyExecuted">
+                    <a href="#testResultsLoaded" role="tab" data-toggle="tab">
+                        <i class="icon-import"></i><span>Loaded</span>
+                        <span class="label label-primary margin-left-xxs" data-bind="text: actions.loadedCount() || ''"></span>
+                    </a>
+                </li>
+                <li role="presentation" data-bind="visible: testAlreadyExecuted">
+                    <a href="#testResultsDeleted" role="tab" data-toggle="tab">
+                        <i class="icon-trash"></i><span>Deleted</span>
+                        <span class="label label-primary margin-left-xxs" data-bind="text: actions.deletedCount() || ''"></span>
+                    </a>
+                </li>
+                <li role="presentation" data-bind="visible: debugOutput().length">
+                    <a href="#debugOutput" role="tab" data-toggle="tab">
+                        <i class="icon-administrator-js-console"></i><span>Debug output</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="tab-content flex-grow" data-bind="css: { 'pe-none item-disabled': !$root.hasCdcSink }">
+            <div role="tabpanel" class="tab-pane fade in active margin-bottom" id="testResultsModified">
+                <div data-bind="with: actions">
+                    <div data-bind="compose: $root.patchDebugActionsModifiedView"></div>
+                </div>
+            </div>
+            <div role="tabpanel" class="tab-pane fade margin-bottom" id="testResultsLoaded">
+                <div data-bind="with: actions">
+                    <div data-bind="compose: $root.patchDebugActionsLoadedView"></div>
+                </div>
+            </div>
+            <div role="tabpanel" class="tab-pane fade margin-bottom" id="testResultsDeleted">
+                <div data-bind="with: actions">
+                    <div data-bind="compose: $root.patchDebugActionsDeletedView"></div>
+                </div>
+            </div>
+            <div role="tabpanel" class="tab-pane fade" id="debugOutput">
+                <pre class="absolute-fill" data-bind="text: debugOutput().join('\r\n')"></pre>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="backdrop" data-bind="click: $root.toggleTestArea"></div>


### PR DESCRIPTION
## Summary
- Add Studio frontend for the CDC Sink feature: task editor, schema explorer, task panel, and all supporting commands/models
- Based on the server-side PR (#4698) — this PR only contains Studio changes

## Test plan
- [ ] Create a new CDC Sink task in the Studio and verify the editor loads correctly
- [ ] Test schema explorer with a PostgreSQL and SQL Server source
- [ ] Verify table configuration, column mapping, and embedded table setup
- [ ] Confirm the task appears in the ongoing tasks list with correct status
- [ ] Test enable/disable/delete operations from the task panel