### PR TITLE
RavenDB-15162 Add env var to disable dispose checks

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -150,6 +150,7 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public async Task SaveChangesAsync(CancellationToken token = default(CancellationToken))
         {
+            AssertNotDisposed();
             using (AsyncTaskHolder())
             {
                 if (_asyncDocumentIdGeneration != null)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -150,8 +150,7 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public async Task SaveChangesAsync(CancellationToken token = default(CancellationToken))
         {
-            if (DisableDisposeChecks == false)
-                AssertNotDisposed();
+            AssertNotDisposed();
             using (AsyncTaskHolder())
             {
                 if (_asyncDocumentIdGeneration != null)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -150,7 +150,8 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public async Task SaveChangesAsync(CancellationToken token = default(CancellationToken))
         {
-            AssertNotDisposed();
+            if (DisableDisposeChecks == false)
+                AssertNotDisposed();
             using (AsyncTaskHolder())
             {
                 if (_asyncDocumentIdGeneration != null)

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -86,6 +86,7 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         public void SaveChanges()
         {
+            AssertNotDisposed();
             var saveChangesOperation = new BatchOperation(this);
 
             using (var command = saveChangesOperation.CreateRequest())

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -86,7 +86,8 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         public void SaveChanges()
         {
-            AssertNotDisposed();
+            if (DisableDisposeChecks == false)
+                AssertNotDisposed();
             var saveChangesOperation = new BatchOperation(this);
 
             using (var command = saveChangesOperation.CreateRequest())

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -86,8 +86,7 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         public void SaveChanges()
         {
-            if (DisableDisposeChecks == false)
-                AssertNotDisposed();
+            AssertNotDisposed();
             var saveChangesOperation = new BatchOperation(this);
 
             using (var command = saveChangesOperation.CreateRequest())

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1435,6 +1435,9 @@ more responsive application.
         {
             if (_isDisposed)
                 throw new ObjectDisposedException("session");
+
+            if (_documentStore.WasDisposed)
+                throw new ObjectDisposedException("store", "The document store has already been disposed and cannot be used");
         }
 
         private void Dispose(bool isDisposing)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -40,6 +40,8 @@ namespace Raven.Client.Documents.Session
     /// </summary>
     public abstract partial class InMemoryDocumentSessionOperations : IDisposable
     {
+        internal static readonly bool DisableDisposeChecks = string.Equals(Environment.GetEnvironmentVariable("RAVEN_DISABLE_DISPOSE_CHECKS"), "true", StringComparison.OrdinalIgnoreCase);
+
         internal long _asyncTasksCounter;
         internal int _maxDocsCountOnCachedRenewSession = 16 * 1024;
         protected readonly RequestExecutor _requestExecutor;
@@ -1436,7 +1438,7 @@ more responsive application.
             if (_isDisposed)
                 throw new ObjectDisposedException("session");
 
-            if (_documentStore.WasDisposed)
+            if (DisableDisposeChecks == false && _documentStore.WasDisposed)
                 throw new ObjectDisposedException("store", "The document store has already been disposed and cannot be used");
         }
 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -600,6 +600,9 @@ namespace Raven.Client.Http
             SessionInfo sessionInfo = null,
             CancellationToken token = default)
         {
+            if (Disposed)
+                ThrowObjectDisposedException();
+
             var topologyUpdate = _firstTopologyUpdate;
 
             if (topologyUpdate != null && topologyUpdate.Status == TaskStatus.RanToCompletion)
@@ -2057,6 +2060,11 @@ namespace Raven.Client.Http
         internal bool Disposed => _disposeOnceRunner.Disposed;
 
         public static bool HasServerCertificateCustomValidationCallback => _serverCertificateCustomValidationCallback?.Length > 0;
+
+        private static void ThrowObjectDisposedException()
+        {
+            throw new ObjectDisposedException(nameof(RequestExecutor), "The request executor has already been disposed and cannot be used");
+        }
 
         public virtual void Dispose()
         {

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -600,7 +600,7 @@ namespace Raven.Client.Http
             SessionInfo sessionInfo = null,
             CancellationToken token = default)
         {
-            if (Disposed)
+            if (InMemoryDocumentSessionOperations.DisableDisposeChecks == false && Disposed)
                 ThrowObjectDisposedException();
 
             var topologyUpdate = _firstTopologyUpdate;

--- a/test/FastTests/Client/HiLo.cs
+++ b/test/FastTests/Client/HiLo.cs
@@ -529,6 +529,51 @@ namespace FastTests.Client
             }
         }
 
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void SaveChanges_After_Store_Dispose_Should_Throw()
+        {
+            var name = GetDatabaseName();
+            var store = GetDocumentStore(new Options
+            {
+                RunInMemory = false,
+                ModifyDatabaseName = _ => name,
+                DeleteDatabaseOnDispose = false,
+                ModifyDocumentStore = s => s.Conventions = new Raven.Client.Documents.Conventions.DocumentConventions { UseOptimisticConcurrency = true }
+            });
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User());
+                session.SaveChanges();
+            }
+
+            // open a session before dispose
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User());
+
+                store.Dispose();
+
+                session.Store(new User());
+                Assert.Throws<ObjectDisposedException>(() => session.SaveChanges());
+            }
+
+            // verify that reopening the store and saving doesn't cause a concurrency conflict from a corrupted HiLo
+            using (var store2 = GetDocumentStore(new Options
+            {
+                RunInMemory = false,
+                ModifyDatabaseName = _ => name,
+                ModifyDocumentStore = s => s.Conventions = new Raven.Client.Documents.Conventions.DocumentConventions { UseOptimisticConcurrency = true }
+            }))
+            {
+                using (var session = store2.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+            }
+        }
+
         private static async Task<long> GetNextIdAsync(AsyncHiLoIdGenerator idGenerator)
         {
             var nextId = await idGenerator.GetNextIdAsync();


### PR DESCRIPTION
## Summary
- Adds a `RAVEN_DISABLE_DISPOSE_CHECKS` environment variable (static readonly bool) that, when set to `"true"`, disables the store-disposal guard introduced in ravendb/ravendb#22618
- The env var only gates the `_documentStore.WasDisposed` check inside `AssertNotDisposed()` and the `Disposed` check in `RequestExecutor.ExecuteAsync` — the session's own `_isDisposed` guard remains unconditional
- `SaveChanges`/`SaveChangesAsync` always call `AssertNotDisposed()`

## Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-15162

## Test plan
- [x] Existing test `SaveChanges_After_Store_Dispose_Should_Throw` passes (checks throw without env var)
- [x] Solution builds successfully
- [x] FastTests pass (6 pre-existing failures unrelated to this change)
- [ ] Verify that setting `RAVEN_DISABLE_DISPOSE_CHECKS=true` suppresses only the store-disposed `ObjectDisposedException`