### PR TITLE
RavenDB-26418 Fix embedded reparent ghost entries and deduplicate row decoding

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -426,6 +426,37 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     protected readonly record struct CdcEvent(CdcEventType Type, CdcSinkDocumentOp Op, string Checkpoint);
 
     /// <summary>
+    /// Builds the <see cref="CdcEvent"/>(s) for an UPDATE on an embedded table.
+    /// When the join column changed (reparenting), returns two events: a Delete from the
+    /// old parent followed by an Upsert to the new parent.  Otherwise returns a single Upsert.
+    /// Providers call this after decoding both old and new row values.
+    /// </summary>
+    /// <param name="newOp">The op produced by <see cref="CdcSinkDocumentProcessor.ProcessRow(CdcSinkTableProcessor, CdcSinkOperation, object[], JsonOperationContext)"/> for the new row.</param>
+    /// <param name="oldValues">Decoded column values from the row BEFORE the update (same positional layout as <see cref="CdcSinkTableProcessor.SourceColumnNames"/>). May be null if the provider cannot supply old data.</param>
+    protected CdcEvent[] CreateEmbeddedUpdateEvents(CdcSinkDocumentOp newOp, object[] oldValues)
+    {
+        if (oldValues != null && newOp?.Processor is { IsRoot: false } proc)
+        {
+            var oldParentId = proc.GetParentDocumentId(oldValues);
+            if (string.Equals(oldParentId, newOp.DocumentId, StringComparison.Ordinal) == false)
+            {
+                var deleteOp = new CdcSinkDocumentOp
+                {
+                    Type = CdcSinkDocumentOpType.EmbeddedModify,
+                    DocumentId = oldParentId,
+                    Processor = proc,
+                    MappedData = newOp.MappedData,
+                    RawValues = oldValues,
+                    Operation = CdcSinkOperation.Delete,
+                };
+                return [new CdcEvent(CdcEventType.Delete, deleteOp, null), new CdcEvent(CdcEventType.Upsert, newOp, null)];
+            }
+        }
+
+        return [new CdcEvent(CdcEventType.Upsert, newOp, null)];
+    }
+
+    /// <summary>
     /// Returns an async stream of CDC events from the source database.
     /// Each subclass converts provider-specific events into <see cref="CdcEvent"/>:
     /// <list type="bullet">

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -18,6 +18,7 @@ using Raven.Server.Documents.CdcSink.Stats.Performance;
 using Raven.Server.Documents.CdcSink.Test;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Json;
+using Sparrow.Json;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide.Context;
@@ -427,39 +428,41 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
 
     /// <summary>
     /// Builds the <see cref="CdcEvent"/>(s) for an UPDATE on an embedded table.
-    /// When the join column changed (reparenting), returns two events: a Delete from the
-    /// old parent followed by an Upsert to the new parent.  Otherwise returns a single Upsert.
-    /// Providers call this after decoding both old and new row values.
+    /// When the join column changed (reparenting), returns a Delete against the old parent
+    /// plus an Upsert against the new parent. Otherwise <c>Delete</c> is null and only the
+    /// Upsert event is returned. The caller is responsible for returning <paramref name="oldValues"/>
+    /// to the processor pool when <c>Delete</c> is null (when it is non-null, the values array
+    /// lives on as <c>deleteOp.RawValues</c> and is released with the batch).
+    /// Precondition: <paramref name="newOp"/>.Processor.IsRoot must be false.
     /// </summary>
     /// <param name="newOp">The op produced by <see cref="CdcSinkDocumentProcessor.ProcessRow(CdcSinkTableProcessor, CdcSinkOperation, object[], JsonOperationContext)"/> for the new row.</param>
-    /// <param name="oldValues">Decoded column values from the row BEFORE the update (same positional layout as <see cref="CdcSinkTableProcessor.SourceColumnNames"/>). May be null if the provider cannot supply old data.</param>
-    protected CdcEvent[] CreateEmbeddedUpdateEvents(CdcSinkDocumentOp newOp, object[] oldValues)
+    /// <param name="oldValues">Decoded column values from the row BEFORE the update (same positional layout as <see cref="CdcSinkTableProcessor.SourceColumnNames"/>).</param>
+    protected (CdcEvent? Delete, CdcEvent Upsert) CreateEmbeddedUpdateEvents(
+        CdcSinkDocumentOp newOp, object[] oldValues)
     {
-        if (oldValues != null && newOp?.Processor is { IsRoot: false } proc)
+        var upsert = new CdcEvent(CdcEventType.Upsert, newOp, null);
+        var proc = newOp.Processor;
+
+        var oldParentId = proc.GetParentDocumentId(oldValues);
+        if (string.Equals(oldParentId, newOp.DocumentId, StringComparison.Ordinal))
+            return (null, upsert);
+
+        // Reparent: build the delete op with MappedData derived from the OLD row so that
+        // $old in OnDelete patches (and any PK-based array/map matching) reflects the
+        // actual item being removed from the old parent.
+        var oldMappedData = proc.MapColumns(oldValues, StreamingJsonContext);
+        proc.ApplyLinks(oldMappedData, oldValues);
+
+        var deleteOp = new CdcSinkDocumentOp
         {
-            var oldParentId = proc.GetParentDocumentId(oldValues);
-            if (string.Equals(oldParentId, newOp.DocumentId, StringComparison.Ordinal) == false)
-            {
-                // MappedData is shared with newOp: reparenting changes the join (FK) column,
-                // not the PK. The PK values used by MatchesPrimaryKey to find the array element
-                // are identical in old and new rows.
-                var deleteOp = new CdcSinkDocumentOp
-                {
-                    Type = CdcSinkDocumentOpType.EmbeddedModify,
-                    DocumentId = oldParentId,
-                    Processor = proc,
-                    MappedData = newOp.MappedData,
-                    RawValues = oldValues,
-                    Operation = CdcSinkOperation.Delete,
-                };
-                return [new CdcEvent(CdcEventType.Delete, deleteOp, null), new CdcEvent(CdcEventType.Upsert, newOp, null)];
-            }
-
-            // Same parent — no reparent. Return the pooled old-values array since we won't use it.
-            proc.ReturnValues(oldValues);
-        }
-
-        return [new CdcEvent(CdcEventType.Upsert, newOp, null)];
+            Type = CdcSinkDocumentOpType.EmbeddedModify,
+            DocumentId = oldParentId,
+            Processor = proc,
+            MappedData = oldMappedData,
+            RawValues = oldValues,
+            Operation = CdcSinkOperation.Delete,
+        };
+        return (new CdcEvent(CdcEventType.Delete, deleteOp, null), upsert);
     }
 
     /// <summary>

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -440,6 +440,9 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             var oldParentId = proc.GetParentDocumentId(oldValues);
             if (string.Equals(oldParentId, newOp.DocumentId, StringComparison.Ordinal) == false)
             {
+                // MappedData is shared with newOp: reparenting changes the join (FK) column,
+                // not the PK. The PK values used by MatchesPrimaryKey to find the array element
+                // are identical in old and new rows.
                 var deleteOp = new CdcSinkDocumentOp
                 {
                     Type = CdcSinkDocumentOpType.EmbeddedModify,
@@ -451,6 +454,9 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
                 };
                 return [new CdcEvent(CdcEventType.Delete, deleteOp, null), new CdcEvent(CdcEventType.Upsert, newOp, null)];
             }
+
+            // Same parent — no reparent. Return the pooled old-values array since we won't use it.
+            proc.ReturnValues(oldValues);
         }
 
         return [new CdcEvent(CdcEventType.Upsert, newOp, null)];

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -651,11 +651,11 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
 
 
     /// <summary>
-    /// Whether this provider uses SELECT TOP(N) (SQL Server) vs LIMIT N (Postgres/MySQL).
+    /// Builds the SELECT used by initial-load keyset pagination. Default implementation is
+    /// PostgreSQL/MySQL syntax (LIMIT + row-value comparison `(c1,c2) > (@k0,@k1)`).
+    /// SQL Server overrides this because it does not support row-value comparison.
     /// </summary>
-    protected virtual bool UsesTopN => false;
-
-    private string BuildBatchQuery(
+    protected virtual string BuildBatchQuery(
         CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns,
         string[] lastKeys, int maxBatchSize)
     {
@@ -665,9 +665,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             ? $" WHERE ({pkCols}) > ({string.Join(", ", pkColumns.Select((_, i) => $"@k{i}"))})"
             : "";
 
-        return UsesTopN
-            ? $"SELECT TOP ({maxBatchSize}) * FROM {table} {where} ORDER BY {pkCols}"
-            : $"SELECT * FROM {table} {where} ORDER BY {pkCols} LIMIT {maxBatchSize}";
+        return $"SELECT * FROM {table} {where} ORDER BY {pkCols} LIMIT {maxBatchSize}";
     }
 
     /// <summary>

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -541,8 +541,13 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                             var newOp = DecodeRow(uTable, row.AfterUpdate.Cells, CdcSinkOperation.Upsert, StreamingJsonContext);
                             if (newOp?.Processor is { IsRoot: false })
                             {
-                                foreach (var evt in CreateEmbeddedUpdateEvents(newOp, DecodeRowInternal(uTable, row.BeforeUpdate.Cells)))
-                                    yield return evt;
+                                var oldValues = DecodeRowInternal(uTable, row.BeforeUpdate.Cells);
+                                var (delete, upsert) = CreateEmbeddedUpdateEvents(newOp, oldValues);
+                                if (delete.HasValue)
+                                    yield return delete.Value;
+                                else
+                                    uTable.Processor.ReturnValues(oldValues); // no reparent — release the unused old-values array
+                                yield return upsert;
                             }
                             else
                             {

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -576,9 +576,9 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
     }
 
     /// <summary>
-    /// Decodes binlog cells into raw column values and returns the processor and values.
+    /// Decodes binlog cells into raw column values and returns the decoded values array.
     /// Used by <see cref="DecodeRow"/> and by the reparent detection path
-    /// (which needs the raw values without calling ProcessRow).
+    /// (which needs the raw values without calling ProcessRow); the processor is available via <paramref name="tableInfo"/>.
     /// </summary>
     private object[] DecodeRowInternal(
         TableInfo tableInfo, IReadOnlyList<object> cells)

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -537,7 +537,18 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                         if (tableMapCache.TryGetValue(updateRows.TableId, out var uTable) == false)
                             break;
                         foreach (var row in updateRows.Rows)
-                            yield return new CdcEvent(CdcEventType.Upsert, DecodeRow(uTable, row.AfterUpdate.Cells, CdcSinkOperation.Upsert, StreamingJsonContext), null);
+                        {
+                            var newOp = DecodeRow(uTable, row.AfterUpdate.Cells, CdcSinkOperation.Upsert, StreamingJsonContext);
+                            if (newOp?.Processor is { IsRoot: false })
+                            {
+                                foreach (var evt in CreateEmbeddedUpdateEvents(newOp, DecodeRowInternal(uTable, row.BeforeUpdate.Cells)))
+                                    yield return evt;
+                            }
+                            else
+                            {
+                                yield return new CdcEvent(CdcEventType.Upsert, newOp, null);
+                            }
+                        }
                         break;
 
                     case DeleteRowsEvent deleteRows:
@@ -559,6 +570,18 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
     private CdcSinkDocumentOp DecodeRow(
         TableInfo tableInfo, IReadOnlyList<object> cells,
         CdcSinkOperation operation, DocumentsOperationContext jsonParsingContext)
+    {
+        var values = DecodeRowInternal(tableInfo, cells);
+        return DocumentProcessor.ProcessRow(tableInfo.Processor, operation, values, jsonParsingContext);
+    }
+
+    /// <summary>
+    /// Decodes binlog cells into raw column values and returns the processor and values.
+    /// Used by <see cref="DecodeRow"/> and by the reparent detection path
+    /// (which needs the raw values without calling ProcessRow).
+    /// </summary>
+    private object[] DecodeRowInternal(
+        TableInfo tableInfo, IReadOnlyList<object> cells)
     {
         var columns = tableInfo.Columns;
         var processor = tableInfo.Processor;
@@ -592,10 +615,8 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             };
         }
 
-        return DocumentProcessor.ProcessRow(processor, operation, values, jsonParsingContext);
+        return values;
     }
-
-
 
     /// <summary>
     /// Normalizes MySQL CLR values from both ADO.NET (initial load) and MySqlCdc (binlog)

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -476,16 +476,19 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                     break;
                 case FullUpdateMessage fullUpdate:
                 {
-                    // REPLICA IDENTITY FULL — old row available for reparent detection
+                    // Per Npgsql: OldRow MUST be consumed before NewRow (sequential replication stream).
+                    var (proc, oldValues) = await DecodeRowInternal(fullUpdate.Relation, fullUpdate.OldRow, ct);
                     var newOp = await DecodeRow(fullUpdate.Relation, fullUpdate.NewRow, CdcSinkOperation.Upsert, StreamingJsonContext, ct);
+
                     if (newOp?.Processor is { IsRoot: false })
                     {
-                        var (_, oldValues) = await DecodeRowInternal(fullUpdate.Relation, fullUpdate.OldRow, ct);
                         foreach (var evt in CreateEmbeddedUpdateEvents(newOp, oldValues))
                             yield return evt;
                     }
                     else
                     {
+                        // Root table FullUpdateMessage — return oldValues to pool (unused) and yield the upsert.
+                        proc.ReturnValues(oldValues);
                         yield return new CdcEvent(CdcEventType.Upsert, newOp, null);
                     }
                     break;

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -482,12 +482,16 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
 
                     if (newOp?.Processor is { IsRoot: false })
                     {
-                        foreach (var evt in CreateEmbeddedUpdateEvents(newOp, oldValues))
-                            yield return evt;
+                        var (delete, upsert) = CreateEmbeddedUpdateEvents(newOp, oldValues);
+                        if (delete.HasValue)
+                            yield return delete.Value;
+                        else
+                            proc.ReturnValues(oldValues); // no reparent — release the unused old-values array
+                        yield return upsert;
                     }
                     else
                     {
-                        // Root table FullUpdateMessage — return oldValues to pool (unused) and yield the upsert.
+                        // Root table FullUpdateMessage — old values unused, return to pool.
                         proc.ReturnValues(oldValues);
                         yield return new CdcEvent(CdcEventType.Upsert, newOp, null);
                     }

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -474,6 +474,22 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                     yield return new CdcEvent(CdcEventType.Upsert,
                         await DecodeRow(insert.Relation, insert.NewRow, CdcSinkOperation.Upsert, StreamingJsonContext, ct), null);
                     break;
+                case FullUpdateMessage fullUpdate:
+                {
+                    // REPLICA IDENTITY FULL — old row available for reparent detection
+                    var newOp = await DecodeRow(fullUpdate.Relation, fullUpdate.NewRow, CdcSinkOperation.Upsert, StreamingJsonContext, ct);
+                    if (newOp?.Processor is { IsRoot: false })
+                    {
+                        var (_, oldValues) = await DecodeRowInternal(fullUpdate.Relation, fullUpdate.OldRow, ct);
+                        foreach (var evt in CreateEmbeddedUpdateEvents(newOp, oldValues))
+                            yield return evt;
+                    }
+                    else
+                    {
+                        yield return new CdcEvent(CdcEventType.Upsert, newOp, null);
+                    }
+                    break;
+                }
                 case UpdateMessage update:
                     yield return new CdcEvent(CdcEventType.Upsert,
                         await DecodeRow(update.Relation, update.NewRow, CdcSinkOperation.Upsert, StreamingJsonContext, ct), null);
@@ -543,6 +559,18 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
     private async Task<CdcSinkDocumentOp> DecodeRow(
         RelationMessage relation, ReplicationTuple row, CdcSinkOperation operation, JsonOperationContext jsonParsingContext, CancellationToken ct = default)
     {
+        var (proc, values) = await DecodeRowInternal(relation, row, ct);
+        return DocumentProcessor.ProcessRow(proc, operation, values, jsonParsingContext);
+    }
+
+    /// <summary>
+    /// Resolves the processor for a relation, decodes a replication tuple into raw column values,
+    /// and returns both. Used by <see cref="DecodeRow"/> and by the reparent detection path
+    /// (which needs the raw values without calling ProcessRow).
+    /// </summary>
+    private async Task<(CdcSinkTableProcessor Processor, object[] Values)> DecodeRowInternal(
+        RelationMessage relation, ReplicationTuple row, CancellationToken ct)
+    {
         var relationId = relation.RelationId;
 
         if ((relationId & RelationIdSentinelBit) == 0)
@@ -582,7 +610,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
             columnIndex++;
         }
 
-        return DocumentProcessor.ProcessRow(proc, operation, values, jsonParsingContext);
+        return (proc, values);
     }
 
     /// <summary>

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -254,7 +254,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 // CDC always emits the matching op=4 with identical LSN and seqval, so the pair
                 // is found regardless of whether the UPDATE changed any PK column (a PK-derived
                 // key would miss when the embedded PK includes the join column).
-                Dictionary<string, object[]> pendingPreUpdate = null;
+                Dictionary<LsnSeqKey, object[]> pendingPreUpdate = null;
 
                 while (await reader.ReadAsync(ct))
                 {
@@ -271,8 +271,8 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
 
                     if (operation == 3) // pre-update image for embedded table
                     {
-                        pendingPreUpdate ??= new Dictionary<string, object[]>(StringComparer.Ordinal);
-                        pendingPreUpdate[MakeLsnSeqKey(rowLsn, rowSeq)] = values;
+                        pendingPreUpdate ??= new Dictionary<LsnSeqKey, object[]>();
+                        pendingPreUpdate[new LsnSeqKey(rowLsn, rowSeq)] = values;
                         continue;
                     }
 
@@ -282,7 +282,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                     if (operation == 4 && !processor.IsRoot && pendingPreUpdate != null)
                     {
                         // Post-update image — pair with stashed pre-update for reparent detection
-                        if (pendingPreUpdate.Remove(MakeLsnSeqKey(rowLsn, rowSeq), out var oldValues))
+                        if (pendingPreUpdate.Remove(new LsnSeqKey(rowLsn, rowSeq), out var oldValues))
                         {
                             var (delete, upsert) = CreateEmbeddedUpdateEvents(op, oldValues);
                             if (delete.HasValue)
@@ -769,9 +769,35 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
         return ((ReadOnlySpan<byte>)a).SequenceCompareTo(b);
     }
 
-    private static string MakeLsnSeqKey(byte[] lsn, byte[] seqVal)
+    /// <summary>
+    /// Pair key for SQL Server CDC pre-image (op=3) / post-image (op=4) matching. Holds
+    /// references to the byte[] LSN and seqval ADO.NET already allocated for the row, so
+    /// the dictionary lookup is allocation-free per UPDATE row.
+    /// </summary>
+    private readonly struct LsnSeqKey : IEquatable<LsnSeqKey>
     {
-        return string.Concat(Convert.ToHexString(lsn), ":", Convert.ToHexString(seqVal));
+        private readonly byte[] _lsn;
+        private readonly byte[] _seqVal;
+
+        public LsnSeqKey(byte[] lsn, byte[] seqVal)
+        {
+            _lsn = lsn;
+            _seqVal = seqVal;
+        }
+
+        public bool Equals(LsnSeqKey other) =>
+            ((ReadOnlySpan<byte>)_lsn).SequenceEqual(other._lsn) &&
+            ((ReadOnlySpan<byte>)_seqVal).SequenceEqual(other._seqVal);
+
+        public override bool Equals(object obj) => obj is LsnSeqKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hc = new HashCode();
+            hc.AddBytes(_lsn);
+            hc.AddBytes(_seqVal);
+            return hc.ToHashCode();
+        }
     }
 
     private static bool IsAllZero(byte[] bytes)

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -521,17 +521,19 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
             var columnList = string.Join(", ", quotedColumns);
 
             // __$operation values: 1=delete, 2=insert, 3=pre-update image, 4=post-update image.
-            // For embedded tables we keep pre-update images (op 3) so we can detect join column
-            // changes (reparenting). For root tables we still filter them out.
+            // Embedded tables need pre-update images to detect join-column changes (reparenting),
+            // so we use the 'all update old' row-filter option which delivers op=3 alongside op=4.
+            // (The default 'all' option drops op=3 and only returns the post-image — which means
+            // the previous code path here never actually saw a pre-image.) For root tables we
+            // don't need pre-images, so we still use 'all' and skip the extra row.
             var quotedFn = CommandBuilder.QuoteIdentifier($"fn_cdc_get_all_changes_{captureInstance}");
             // GetProcessor throws if the table isn't registered; every configured table is, so proc is always non-null.
             var proc = DocumentProcessor.GetProcessor(tableInfo.Schema, tableInfo.TableName);
-            var filterPreUpdate = proc.IsRoot;
+            var rowFilterOption = proc.IsRoot ? "all" : "all update old";
             var query = $@"
                 SELECT __$start_lsn, __$seqval, __$operation, {columnList}
-                FROM [cdc].{quotedFn}(@from_lsn, @to_lsn, N'all')
-                {(filterPreUpdate ? "WHERE __$operation <> 3" : "")}
-                ORDER BY __$start_lsn, __$seqval";
+                FROM [cdc].{quotedFn}(@from_lsn, @to_lsn, N'{rowFilterOption}')
+                ORDER BY __$start_lsn, __$seqval, __$operation";
 
             var columnsArray = columns.ToArray();
 

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -249,7 +250,10 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 // Query shape: __$start_lsn (0), __$seqval (1), __$operation (2), user columns (3+)
 
                 // For embedded tables, op 3 (pre-update image) is kept so we can detect
-                // reparenting. Stash old values keyed by PK; pair with op 4 (post-update).
+                // reparenting. Stash old values keyed by (__$start_lsn, __$seqval): SQL Server
+                // CDC always emits the matching op=4 with identical LSN and seqval, so the pair
+                // is found regardless of whether the UPDATE changed any PK column (a PK-derived
+                // key would miss when the embedded PK includes the join column).
                 Dictionary<string, object[]> pendingPreUpdate = null;
 
                 while (await reader.ReadAsync(ct))
@@ -268,8 +272,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                     if (operation == 3) // pre-update image for embedded table
                     {
                         pendingPreUpdate ??= new Dictionary<string, object[]>(StringComparer.Ordinal);
-                        var pkKey = processor.GenerateDocumentId(values);
-                        pendingPreUpdate[pkKey] = values;
+                        pendingPreUpdate[MakeLsnSeqKey(rowLsn, rowSeq)] = values;
                         continue;
                     }
 
@@ -279,8 +282,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                     if (operation == 4 && !processor.IsRoot && pendingPreUpdate != null)
                     {
                         // Post-update image — pair with stashed pre-update for reparent detection
-                        var pkKey = processor.GenerateDocumentId(values);
-                        if (pendingPreUpdate.Remove(pkKey, out var oldValues))
+                        if (pendingPreUpdate.Remove(MakeLsnSeqKey(rowLsn, rowSeq), out var oldValues))
                         {
                             var (delete, upsert) = CreateEmbeddedUpdateEvents(op, oldValues);
                             if (delete.HasValue)
@@ -294,6 +296,16 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
 
                     var eventType = cdcOperation == CdcSinkOperation.Delete ? CdcEventType.Delete : CdcEventType.Upsert;
                     buffer.Add((rowLsn, rowSeq, buffer.Count, new CdcEvent(eventType, op, null)));
+                }
+
+                // Defense-in-depth: under correct CDC semantics every op=3 is paired with an
+                // op=4 in the same poll, but if anything is left over (unexpected CDC shape,
+                // mid-stream cancellation), return the rented arrays to the pool.
+                if (pendingPreUpdate is { Count: > 0 })
+                {
+                    foreach (var arr in pendingPreUpdate.Values)
+                        processor.ReturnValues(arr);
+                    pendingPreUpdate.Clear();
                 }
             }
 
@@ -580,7 +592,42 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
 
     protected override DbCommandBuilder CommandBuilder { get; } = new SqlCommandBuilder();
 
-    protected override bool UsesTopN => true;
+    /// <summary>
+    /// SQL Server lacks support for row-value comparison (<c>(c1,c2) &gt; (@k0,@k1)</c>) and uses
+    /// <c>TOP (N)</c> instead of <c>LIMIT N</c>. Expand the keyset-pagination predicate into the
+    /// equivalent lexicographic-OR form, which yields the same logical result on every provider.
+    /// </summary>
+    protected override string BuildBatchQuery(
+        CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns,
+        string[] lastKeys, int maxBatchSize)
+    {
+        var table = $"{CommandBuilder.QuoteIdentifier(tableInfo.Schema)}.{CommandBuilder.QuoteIdentifier(tableInfo.TableName)}";
+        var quotedCols = pkColumns.Select(c => CommandBuilder.QuoteIdentifier(c)).ToArray();
+        var pkColsList = string.Join(", ", quotedCols);
+
+        var where = string.Empty;
+        if (lastKeys != null)
+        {
+            // (c1,c2,c3) > (@k0,@k1,@k2)  ⇔
+            //   c1 > @k0
+            //   OR (c1 = @k0 AND c2 > @k1)
+            //   OR (c1 = @k0 AND c2 = @k1 AND c3 > @k2)
+            var disjuncts = new List<string>(quotedCols.Length);
+            for (int i = 0; i < quotedCols.Length; i++)
+            {
+                var sb = new StringBuilder();
+                for (int j = 0; j < i; j++)
+                {
+                    sb.Append(quotedCols[j]).Append(" = @k").Append(j).Append(" AND ");
+                }
+                sb.Append(quotedCols[i]).Append(" > @k").Append(i);
+                disjuncts.Add(quotedCols.Length == 1 ? sb.ToString() : "(" + sb + ")");
+            }
+            where = " WHERE " + string.Join(" OR ", disjuncts);
+        }
+
+        return $"SELECT TOP ({maxBatchSize}) * FROM {table}{where} ORDER BY {pkColsList}";
+    }
 
     private readonly Dictionary<string, Dictionary<string, string>> _columnTypesCache = new();
 
@@ -718,6 +765,11 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
         if (b == null) return 1;
 
         return ((ReadOnlySpan<byte>)a).SequenceCompareTo(b);
+    }
+
+    private static string MakeLsnSeqKey(byte[] lsn, byte[] seqVal)
+    {
+        return string.Concat(Convert.ToHexString(lsn), ":", Convert.ToHexString(seqVal));
     }
 
     private static bool IsAllZero(byte[] bytes)

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -205,7 +205,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
 
         await VerifyAgentIsRunning(conn, ct);
         bool shouldWait = false;
-        var buffer = new List<(byte[] Lsn, byte[] SeqVal, CdcEvent Event)>();
+        var buffer = new List<(byte[] Lsn, byte[] SeqVal, int Order, CdcEvent Event)>();
 
         while (true)
         {
@@ -283,26 +283,29 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                         if (pendingPreUpdate.Remove(pkKey, out var oldValues))
                         {
                             foreach (var evt in CreateEmbeddedUpdateEvents(op, oldValues))
-                                buffer.Add((rowLsn, rowSeq, evt));
+                                buffer.Add((rowLsn, rowSeq, buffer.Count, evt));
                             continue;
                         }
                     }
 
                     var eventType = cdcOperation == CdcSinkOperation.Delete ? CdcEventType.Delete : CdcEventType.Upsert;
-                    buffer.Add((rowLsn, rowSeq, new CdcEvent(eventType, op, null)));
+                    buffer.Add((rowLsn, rowSeq, buffer.Count, new CdcEvent(eventType, op, null)));
                 }
             }
 
             if (buffer.Count > 0)
             {
-                // Sort by (LSN, seqval) to preserve cross-table transaction order
+                // Sort by (LSN, seqval, insertion order) to preserve cross-table transaction order.
+                // Insertion order breaks ties when reparent emits two events with the same (LSN, seqval).
                 buffer.Sort((a, b) =>
                 {
                     int cmp = CompareLsn(a.Lsn, b.Lsn);
-                    return cmp != 0 ? cmp : CompareLsn(a.SeqVal, b.SeqVal);
+                    if (cmp != 0) return cmp;
+                    cmp = CompareLsn(a.SeqVal, b.SeqVal);
+                    return cmp != 0 ? cmp : a.Order.CompareTo(b.Order);
                 });
 
-                foreach (var (_, _, evt) in buffer)
+                foreach (var (_, _, _, evt) in buffer)
                     yield return evt;
 
                 yield return new CdcEvent(CdcEventType.TransactionCommit, null, Convert.ToHexString(lsnInfo.MaxLsn));

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -248,12 +248,15 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 var processor = DocumentProcessor.GetProcessor(ci.TableInfo.Schema, ci.TableInfo.TableName);
                 // Query shape: __$start_lsn (0), __$seqval (1), __$operation (2), user columns (3+)
 
+                // For embedded tables, op 3 (pre-update image) is kept so we can detect
+                // reparenting. Stash old values keyed by PK; pair with op 4 (post-update).
+                Dictionary<string, object[]> pendingPreUpdate = null;
+
                 while (await reader.ReadAsync(ct))
                 {
                     var rowLsn = reader[0] as byte[];
                     var rowSeq = reader[1] as byte[];
                     var operation = reader.GetInt32(2);
-                    var cdcOperation = operation == 1 ? CdcSinkOperation.Delete : CdcSinkOperation.Upsert;
 
                     var values = processor.RentValues();
                     for (int i = 0; i < columns.Length; i++)
@@ -262,7 +265,29 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                         values[i] = reader.IsDBNull(ordinal) ? null : ConvertSqlServerValue(reader.GetValue(ordinal));
                     }
 
+                    if (operation == 3) // pre-update image for embedded table
+                    {
+                        pendingPreUpdate ??= new Dictionary<string, object[]>(StringComparer.Ordinal);
+                        var pkKey = processor.GenerateDocumentId(values);
+                        pendingPreUpdate[pkKey] = values;
+                        continue;
+                    }
+
+                    var cdcOperation = operation == 1 ? CdcSinkOperation.Delete : CdcSinkOperation.Upsert;
                     var op = DocumentProcessor.ProcessRow(processor, cdcOperation, values, StreamingJsonContext);
+
+                    if (operation == 4 && !processor.IsRoot && pendingPreUpdate != null)
+                    {
+                        // Post-update image — pair with stashed pre-update for reparent detection
+                        var pkKey = processor.GenerateDocumentId(values);
+                        if (pendingPreUpdate.Remove(pkKey, out var oldValues))
+                        {
+                            foreach (var evt in CreateEmbeddedUpdateEvents(op, oldValues))
+                                buffer.Add((rowLsn, rowSeq, evt));
+                            continue;
+                        }
+                    }
+
                     var eventType = cdcOperation == CdcSinkOperation.Delete ? CdcEventType.Delete : CdcEventType.Upsert;
                     buffer.Add((rowLsn, rowSeq, new CdcEvent(eventType, op, null)));
                 }
@@ -477,12 +502,15 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
             var columnList = string.Join(", ", quotedColumns);
 
             // __$operation values: 1=delete, 2=insert, 3=pre-update image, 4=post-update image.
-            // We filter out pre-update images (3) at the SQL level to avoid transferring rows we'd discard.
+            // For embedded tables we keep pre-update images (op 3) so we can detect join column
+            // changes (reparenting). For root tables we still filter them out.
             var quotedFn = CommandBuilder.QuoteIdentifier($"fn_cdc_get_all_changes_{captureInstance}");
+            var proc = DocumentProcessor.GetProcessor(tableInfo.Schema, tableInfo.TableName);
+            var filterPreUpdate = proc == null || proc.IsRoot;
             var query = $@"
                 SELECT __$start_lsn, __$seqval, __$operation, {columnList}
                 FROM [cdc].{quotedFn}(@from_lsn, @to_lsn, N'all')
-                WHERE __$operation <> 3
+                {(filterPreUpdate ? "WHERE __$operation <> 3" : "")}
                 ORDER BY __$start_lsn, __$seqval";
 
             var columnsArray = columns.ToArray();

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -282,8 +282,12 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                         var pkKey = processor.GenerateDocumentId(values);
                         if (pendingPreUpdate.Remove(pkKey, out var oldValues))
                         {
-                            foreach (var evt in CreateEmbeddedUpdateEvents(op, oldValues))
-                                buffer.Add((rowLsn, rowSeq, buffer.Count, evt));
+                            var (delete, upsert) = CreateEmbeddedUpdateEvents(op, oldValues);
+                            if (delete.HasValue)
+                                buffer.Add((rowLsn, rowSeq, buffer.Count, delete.Value));
+                            else
+                                processor.ReturnValues(oldValues); // no reparent — release the unused old-values array
+                            buffer.Add((rowLsn, rowSeq, buffer.Count, upsert));
                             continue;
                         }
                     }
@@ -508,8 +512,9 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
             // For embedded tables we keep pre-update images (op 3) so we can detect join column
             // changes (reparenting). For root tables we still filter them out.
             var quotedFn = CommandBuilder.QuoteIdentifier($"fn_cdc_get_all_changes_{captureInstance}");
+            // GetProcessor throws if the table isn't registered; every configured table is, so proc is always non-null.
             var proc = DocumentProcessor.GetProcessor(tableInfo.Schema, tableInfo.TableName);
-            var filterPreUpdate = proc == null || proc.IsRoot;
+            var filterPreUpdate = proc.IsRoot;
             var query = $@"
                 SELECT __$start_lsn, __$seqval, __$operation, {columnList}
                 FROM [cdc].{quotedFn}(@from_lsn, @to_lsn, N'all')

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
@@ -3680,9 +3680,13 @@ namespace SlowTests.Server.Documents.CdcSink
 
             // --- Step 3: Simulate UPDATE group_members SET group_id=2 WHERE id=10 ---
             // In real providers, this UPDATE decodes both old and new row values and calls
-            // CreateEmbeddedUpdateEvents, which yields two CdcEvents when the join column
-            // changed: a Delete from the old parent followed by an Upsert to the new parent.
-            // The test constructs both ops directly since it bypasses the provider layer.
+            // CdcSinkProcess.CreateEmbeddedUpdateEvents, which yields two CdcEvents when the
+            // join column changed: a Delete from the old parent followed by an Upsert to the
+            // new parent. The helper itself is protected on CdcSinkProcess and not reachable
+            // from this unit test, so we mirror its body here — keep this in sync with
+            // src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs:CreateEmbeddedUpdateEvents.
+
+            var oldRowValues = new object[] { 10, "2024-01-01", 1 }; // id=10, group_id=1 (OLD)
 
             var upsertToNewParent = docProcessor.ProcessRow(new CdcSinkRow
             {
@@ -3694,20 +3698,32 @@ namespace SlowTests.Server.Documents.CdcSink
             Assert.NotNull(upsertToNewParent);
             Assert.Equal("Groups/2", upsertToNewParent.DocumentId);
 
-            var deleteFromOldParent = new CdcSinkDocumentOp
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext mapCtx))
             {
-                Type = CdcSinkDocumentOpType.EmbeddedModify,
-                DocumentId = "Groups/1", // OLD parent
-                Processor = embProcessor,
-                MappedData = upsertToNewParent.MappedData, // same PK values identify the entry
-                RawValues = new object[] { 10, "2024-01-01", 1 }, // old row with group_id=1
-                Operation = CdcSinkOperation.Delete,
-            };
+                // Build the delete op's MappedData from the OLD row values, exactly like
+                // CreateEmbeddedUpdateEvents does in production. This ensures $old in
+                // OnDelete patches and PK-based array matching see the entry as it lived
+                // on the old parent. Keep mapCtx alive through the merger enqueue —
+                // production keeps the equivalent StreamingJsonContext alive across the
+                // batch.
+                var oldMappedData = embProcessor.MapColumns(oldRowValues, mapCtx);
+                embProcessor.ApplyLinks(oldMappedData, oldRowValues);
 
-            var reparentOps = new List<CdcSinkDocumentOp> { deleteFromOldParent, upsertToNewParent };
-            var reparentCmd = new CdcSinkBatchCommand(database,
-                reparentOps, "test-reparent", null, null, null, null, null, null);
-            await database.TxMerger.Enqueue(reparentCmd);
+                var deleteFromOldParent = new CdcSinkDocumentOp
+                {
+                    Type = CdcSinkDocumentOpType.EmbeddedModify,
+                    DocumentId = "Groups/1", // OLD parent
+                    Processor = embProcessor,
+                    MappedData = oldMappedData,
+                    RawValues = oldRowValues,
+                    Operation = CdcSinkOperation.Delete,
+                };
+
+                var reparentOps = new List<CdcSinkDocumentOp> { deleteFromOldParent, upsertToNewParent };
+                var reparentCmd = new CdcSinkBatchCommand(database,
+                    reparentOps, "test-reparent", null, null, null, null, null, null);
+                await database.TxMerger.Enqueue(reparentCmd);
+            }
 
             // --- Step 4: Assert correct behavior ---
             using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readCtx))

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
@@ -3570,5 +3570,166 @@ namespace SlowTests.Server.Documents.CdcSink
             }
         }
 
+        [RavenFact(RavenTestCategory.Sinks)]
+        public async Task EmbeddedReparent_JoinColumnChange_MustRemoveFromOldParent()
+        {
+            // Scenario: group_members has JoinColumn "group_id". When group_id changes from 1→2,
+            // the member should move from Groups/1.Members[] to Groups/2.Members[].
+            // Bug: the CDC pipeline only emits an Upsert to Groups/2 — the old entry in
+            // Groups/1.Members[] is never removed, creating a phantom +1 in fanout indexes.
+            //
+            // This test uses CdcSinkDocumentProcessor.ProcessRow to generate ops (simulating the
+            // real pipeline), feeds them through CdcSinkBatchCommand, and asserts correct behavior.
+
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            // --- Configuration: "groups" root table with "group_members" embedded array ---
+            var rootConfig = new CdcSinkTableConfig
+            {
+                CollectionName = "Groups",
+                SourceTableSchema = "public",
+                SourceTableName = "groups",
+                Columns = new List<CdcColumnMapping>
+                {
+                    new() { Column = "group_id", Name = "GroupId" },
+                    new() { Column = "name", Name = "Name" }
+                },
+                PrimaryKeyColumns = new List<string> { "group_id" },
+                EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                {
+                    new()
+                    {
+                        SourceTableSchema = "public",
+                        SourceTableName = "group_members",
+                        PropertyName = "Members",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        JoinColumns = new List<string> { "group_id" },
+                        Type = CdcSinkRelationType.Array,
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new() { Column = "id", Name = "MemberId" },
+                            new() { Column = "joined_at", Name = "JoinedAt" }
+                        }
+                    }
+                }
+            };
+
+            var sinkConfig = new CdcSinkConfiguration
+            {
+                Name = "test-reparent",
+                Tables = new List<CdcSinkTableConfig> { rootConfig }
+            };
+            var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
+
+            // Set source column names (simulates what providers do from DB schema metadata)
+            var rootProcessor = docProcessor.GetProcessor("public", "groups");
+            SetSourceColumnNamesFromConfig(rootProcessor, rootConfig.Columns);
+
+            var embProcessor = docProcessor.GetProcessor("public", "group_members");
+            SetSourceColumnNamesFromConfig(embProcessor, rootConfig.EmbeddedTables[0].Columns);
+
+            // --- Step 1: Create parent documents Groups/1 and Groups/2 ---
+            var group1Op = docProcessor.ProcessRow(new CdcSinkRow
+            {
+                TableSchema = "public", TableName = "groups",
+                Operation = CdcSinkOperation.Upsert,
+                Data = new object[] { 1, "Group Alpha" }
+            }, null);
+
+            var group2Op = docProcessor.ProcessRow(new CdcSinkRow
+            {
+                TableSchema = "public", TableName = "groups",
+                Operation = CdcSinkOperation.Upsert,
+                Data = new object[] { 2, "Group Beta" }
+            }, null);
+
+            var putCmd = new CdcSinkBatchCommand(database,
+                new List<CdcSinkDocumentOp> { group1Op, group2Op },
+                "test-reparent", null, null, null, null, null, null);
+            await database.TxMerger.Enqueue(putCmd);
+
+            // --- Step 2: Insert member (id=10) into Groups/1 ---
+            // SourceColumnNames after SetSourceColumnNamesFromConfig: [id, joined_at, group_id]
+            var insertMemberOp = docProcessor.ProcessRow(new CdcSinkRow
+            {
+                TableSchema = "public", TableName = "group_members",
+                Operation = CdcSinkOperation.Upsert,
+                Data = new object[] { 10, "2024-01-01", 1 } // id=10, joined_at, group_id=1
+            }, null);
+
+            Assert.NotNull(insertMemberOp);
+            Assert.Equal(CdcSinkDocumentOpType.EmbeddedModify, insertMemberOp.Type);
+            Assert.Equal("Groups/1", insertMemberOp.DocumentId);
+
+            var insertCmd = new CdcSinkBatchCommand(database,
+                new List<CdcSinkDocumentOp> { insertMemberOp },
+                "test-reparent", null, null, null, null, null, null);
+            await database.TxMerger.Enqueue(insertCmd);
+
+            // Verify member is in Groups/1
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext verifyCtx))
+            using (verifyCtx.OpenReadTransaction())
+            {
+                var g1 = database.DocumentsStorage.Get(verifyCtx, "Groups/1");
+                Assert.NotNull(g1);
+                g1.Data.TryGet("Members", out BlittableJsonReaderArray m1);
+                Assert.NotNull(m1);
+                Assert.Equal(1, m1.Length);
+            }
+
+            // --- Step 3: Simulate UPDATE group_members SET group_id=2 WHERE id=10 ---
+            // In real providers, this UPDATE decodes both old and new row values and calls
+            // CreateEmbeddedUpdateEvents, which yields two CdcEvents when the join column
+            // changed: a Delete from the old parent followed by an Upsert to the new parent.
+            // The test constructs both ops directly since it bypasses the provider layer.
+
+            var upsertToNewParent = docProcessor.ProcessRow(new CdcSinkRow
+            {
+                TableSchema = "public", TableName = "group_members",
+                Operation = CdcSinkOperation.Upsert,
+                Data = new object[] { 10, "2024-01-01", 2 } // id=10, joined_at, group_id=2 (NEW)
+            }, null);
+
+            Assert.NotNull(upsertToNewParent);
+            Assert.Equal("Groups/2", upsertToNewParent.DocumentId);
+
+            var deleteFromOldParent = new CdcSinkDocumentOp
+            {
+                Type = CdcSinkDocumentOpType.EmbeddedModify,
+                DocumentId = "Groups/1", // OLD parent
+                Processor = embProcessor,
+                MappedData = upsertToNewParent.MappedData, // same PK values identify the entry
+                RawValues = new object[] { 10, "2024-01-01", 1 }, // old row with group_id=1
+                Operation = CdcSinkOperation.Delete,
+            };
+
+            var reparentOps = new List<CdcSinkDocumentOp> { deleteFromOldParent, upsertToNewParent };
+            var reparentCmd = new CdcSinkBatchCommand(database,
+                reparentOps, "test-reparent", null, null, null, null, null, null);
+            await database.TxMerger.Enqueue(reparentCmd);
+
+            // --- Step 4: Assert correct behavior ---
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readCtx))
+            using (readCtx.OpenReadTransaction())
+            {
+                var group1 = database.DocumentsStorage.Get(readCtx, "Groups/1");
+                var group2 = database.DocumentsStorage.Get(readCtx, "Groups/2");
+                Assert.NotNull(group1);
+                Assert.NotNull(group2);
+                // Groups/2 must have exactly 1 member (the reparented one)
+                group2.Data.TryGet("Members", out BlittableJsonReaderArray members2);
+                Assert.NotNull(members2);
+                Assert.Equal(1, members2.Length);
+
+                // Groups/1 must have NO members after reparent — the old entry must be removed.
+                group1.Data.TryGet("Members", out BlittableJsonReaderArray members1);
+                Assert.NotNull(members1);
+                Assert.Equal(0, members1.Length);
+
+
+            }
+        }
+
     }
 }

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkIntegrationTestBase.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkIntegrationTestBase.cs
@@ -5,8 +5,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.CdcSink;
+using Raven.Client.Util;
+using Raven.Server.SqlMigration;
+using Sparrow.Collections;
 using Tests.Infrastructure;
 using Xunit;
+using DisposableAction = Raven.Client.Util.DisposableAction;
 
 namespace SlowTests.Server.Documents.CdcSink
 {
@@ -16,9 +20,45 @@ namespace SlowTests.Server.Documents.CdcSink
         {
         }
 
-        protected AddCdcSinkOperationResult AddCdcSink(IDocumentStore store, CdcSinkConfiguration config)
+        // Tracks sinks created via AddCdcSink so WithSqlDatabase's dispose can stop them
+        // BEFORE it attempts pg_drop_replication_slot. Without this, the Raven-side CDC
+        // loop keeps the wal_sender alive, the slot stays `active`, and the drop silently
+        // fails — orphaning the slot and eventually saturating max_replication_slots.
+        private readonly ConcurrentSet<(IDocumentStore Store, string Name)> _createdSinks = new();
+
+        protected new AddCdcSinkOperationResult AddCdcSink(IDocumentStore store, CdcSinkConfiguration config)
         {
-            return store.Maintenance.Send(new AddCdcSinkOperation(config));
+            var result = store.Maintenance.Send(new AddCdcSinkOperation(config));
+            _createdSinks.Add((store, config.Name));
+            return result;
+        }
+
+        internal override DisposableAction WithSqlDatabase(MigrationProvider provider, out string connectionString, out string schemaName, string dataSet = "northwind", bool includeData = true)
+        {
+            var baseDispose = base.WithSqlDatabase(provider, out connectionString, out schemaName, dataSet, includeData);
+            return new DisposableAction(() =>
+            {
+                StopTrackedSinks();
+                baseDispose.Dispose();
+            });
+        }
+
+        private void StopTrackedSinks()
+        {
+            foreach (var (store, name) in _createdSinks)
+            {
+                try
+                {
+                    var db = AsyncHelpers.RunSync(() => Databases.GetDocumentDatabaseInstanceFor(store));
+                    var proc = db.CdcSinkLoader.Processes.FirstOrDefault(p => p.Name == name);
+                    proc?.Stop("test teardown");
+                }
+                catch
+                {
+                    // best effort — the store or database may already be disposed
+                }
+            }
+            _createdSinks.Clear();
         }
 
         /// <summary>

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkIntegrationTestBase.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkIntegrationTestBase.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.CdcSink;
-using Raven.Client.Util;
 using Raven.Server.SqlMigration;
 using Sparrow.Collections;
 using Tests.Infrastructure;
@@ -26,7 +25,7 @@ namespace SlowTests.Server.Documents.CdcSink
         // fails — orphaning the slot and eventually saturating max_replication_slots.
         private readonly ConcurrentSet<(IDocumentStore Store, string Name)> _createdSinks = new();
 
-        protected new AddCdcSinkOperationResult AddCdcSink(IDocumentStore store, CdcSinkConfiguration config)
+        protected AddCdcSinkOperationResult AddCdcSink(IDocumentStore store, CdcSinkConfiguration config)
         {
             var result = store.Maintenance.Send(new AddCdcSinkOperation(config));
             _createdSinks.Add((store, config.Name));

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkIntegrationTestBase.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkIntegrationTestBase.cs
@@ -38,8 +38,14 @@ namespace SlowTests.Server.Documents.CdcSink
             var baseDispose = base.WithSqlDatabase(provider, out connectionString, out schemaName, dataSet, includeData);
             return new DisposableAction(() =>
             {
-                StopTrackedSinks();
-                baseDispose.Dispose();
+                try
+                {
+                    StopTrackedSinks();
+                }
+                finally
+                {
+                    baseDispose.Dispose();
+                }
             });
         }
 

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
@@ -1476,6 +1476,115 @@ namespace SlowTests.Server.Documents.CdcSink
             }
         }
 
+        /// <summary>
+        /// UPDATE that changes only the FK (join column) on an embedded table whose own PK is
+        /// unchanged. MySQL binlog UpdateRowsEvent carries both BeforeUpdate and AfterUpdate
+        /// row images (binlog_row_image=FULL is the server default), so
+        /// CdcSinkProcess.CreateEmbeddedUpdateEvents must produce a Delete against the old
+        /// parent and an Upsert against the new parent in the same transaction.
+        /// </summary>
+        [RavenFact(RavenTestCategory.Sinks, MySqlRequired = true)]
+        public async Task EmbeddedArray_Reparent_OnJoinColumnChange()
+        {
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE orders (
+                    id INT PRIMARY KEY,
+                    customer_name VARCHAR(200) NOT NULL
+                )");
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE order_lines (
+                    id INT PRIMARY KEY,
+                    order_id INT NOT NULL,
+                    product VARCHAR(200) NOT NULL,
+                    quantity INT NOT NULL,
+                    FOREIGN KEY (order_id) REFERENCES orders(id)
+                )");
+
+            ExecuteMySql(connectionString, "INSERT INTO orders (id, customer_name) VALUES (1, 'Alice')");
+            ExecuteMySql(connectionString, "INSERT INTO orders (id, customer_name) VALUES (2, 'Bob')");
+            ExecuteMySql(connectionString, "INSERT INTO order_lines (id, order_id, product, quantity) VALUES (10, 1, 'Apples', 7)");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-embedded-reparent",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = schemaName,
+                        SourceTableName = "orders",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "customer_name", Name = "CustomerName" }
+                        },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = schemaName,
+                                SourceTableName = "order_lines",
+                                PropertyName = "Lines",
+                                Type = CdcSinkRelationType.Array,
+                                JoinColumns = new List<string> { "order_id" },
+                                PrimaryKeyColumns = new List<string> { "id" },
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "id", Name = "LineId" },
+                                    new CdcColumnMapping { Column = "product", Name = "Product" },
+                                    new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+
+            // Initial load materializes the row in Orders/1.Lines.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                return order1?.Lines?.Count ?? 0;
+            }, 1, timeout: 60_000);
+
+            // Reparenting UPDATE: changes only the join column.
+            ExecuteMySql(connectionString, "UPDATE order_lines SET order_id = 2 WHERE id = 10");
+
+            // Orders/1.Lines must lose the row.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                return order1?.Lines?.Count ?? 0;
+            }, 0, timeout: 60_000);
+
+            // Orders/2.Lines must gain the row.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order2 = await session.LoadAsync<Order>("Orders/2");
+                return order2?.Lines?.Count ?? 0;
+            }, 1, timeout: 60_000);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order2 = await session.LoadAsync<Order>("Orders/2");
+                Assert.Single(order2.Lines);
+                Assert.Equal("Apples", order2.Lines[0].Product);
+            }
+        }
+
         [RavenFact(RavenTestCategory.Sinks, MySqlRequired = true)]
         public async Task EmbeddedArray_AddAndRemoveInSameTransaction()
         {

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresIntegrationTests.cs
@@ -948,6 +948,108 @@ namespace SlowTests.Server.Documents.CdcSink
             }
         }
 
+        /// <summary>
+        /// UPDATE that changes only the FK (join column) on an embedded table whose own PK is
+        /// unchanged. Postgres delivers a FullUpdateMessage (REPLICA IDENTITY FULL) with both
+        /// OldRow and NewRow; CdcSinkProcess.CreateEmbeddedUpdateEvents must produce a Delete
+        /// against the old parent and an Upsert against the new parent in the same transaction.
+        /// </summary>
+        [RavenFact(RavenTestCategory.Sinks, NpgSqlRequired = true)]
+        public async Task EmbeddedArray_Reparent_OnJoinColumnChange()
+        {
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.NpgSQL, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteNpgSql(connectionString, @"
+                CREATE TABLE orders (id SERIAL PRIMARY KEY, customer_name VARCHAR(200) NOT NULL);
+                CREATE TABLE order_lines (
+                    id SERIAL PRIMARY KEY,
+                    order_id INT NOT NULL REFERENCES orders(id),
+                    product VARCHAR(200) NOT NULL,
+                    quantity INT NOT NULL
+                );
+                ALTER TABLE order_lines REPLICA IDENTITY FULL;
+                INSERT INTO orders (id, customer_name) VALUES (1, 'Alice');
+                INSERT INTO orders (id, customer_name) VALUES (2, 'Bob');
+                INSERT INTO order_lines (id, order_id, product, quantity) VALUES (10, 1, 'Apples', 7);");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-embedded-reparent",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = "public",
+                        SourceTableName = "orders",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "customer_name", Name = "CustomerName" }
+                        },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = "public",
+                                SourceTableName = "order_lines",
+                                PropertyName = "Lines",
+                                Type = CdcSinkRelationType.Array,
+                                JoinColumns = new List<string> { "order_id" },
+                                PrimaryKeyColumns = new List<string> { "id" },
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "id", Name = "LineId" },
+                                    new CdcColumnMapping { Column = "product", Name = "Product" },
+                                    new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+
+            // Initial load materializes the row in Orders/1.Lines.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                return order1?.Lines?.Count ?? 0;
+            }, 1, timeout: 60_000);
+
+            // Reparenting UPDATE: changes only the join column.
+            ExecuteNpgSql(connectionString, "UPDATE order_lines SET order_id = 2 WHERE id = 10;");
+
+            // Orders/1.Lines must lose the row.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                return order1?.Lines?.Count ?? 0;
+            }, 0, timeout: 60_000);
+
+            // Orders/2.Lines must gain the row.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order2 = await session.LoadAsync<Order>("Orders/2");
+                return order2?.Lines?.Count ?? 0;
+            }, 1, timeout: 60_000);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order2 = await session.LoadAsync<Order>("Orders/2");
+                Assert.Single(order2.Lines);
+                Assert.Equal("Apples", order2.Lines[0].Product);
+            }
+        }
+
         [RavenFact(RavenTestCategory.Sinks, NpgSqlRequired = true)]
         public async Task ThreeWayNesting()
         {

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
@@ -1091,6 +1091,124 @@ namespace SlowTests.Server.Documents.CdcSink
             }
         }
 
+        /// <summary>
+        /// UPDATE that changes an embedded-table column listed in BOTH JoinColumns and
+        /// PrimaryKeyColumns. SQL Server CDC emits a pre-image (op=3) and post-image (op=4)
+        /// pair sharing the same (__$start_lsn, __$seqval). Reparent detection must pair
+        /// them even though processor.GenerateDocumentId(values) — derived from the embedded
+        /// PrimaryKeyColumns — produces different values for op=3 (old PK) and op=4 (new PK).
+        /// </summary>
+        [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true, MsSqlCdcRequired = true)]
+        public async Task EmbeddedArray_Reparent_WhenJoinColumnIsPartOfEmbeddedPK()
+        {
+            using var store = GetDocumentStore();
+            var schema = CreateTestSchema();
+
+            ExecuteMsSql($@"
+                CREATE TABLE [{schema}].orders (id INT PRIMARY KEY, customer_name NVARCHAR(200) NOT NULL);
+                CREATE TABLE [{schema}].order_lines (
+                    order_id INT NOT NULL REFERENCES [{schema}].orders(id),
+                    line_num INT NOT NULL,
+                    product NVARCHAR(200) NOT NULL,
+                    quantity INT NOT NULL,
+                    PRIMARY KEY (order_id, line_num)
+                );
+                INSERT INTO [{schema}].orders (id, customer_name) VALUES (1, 'Alice');
+                INSERT INTO [{schema}].orders (id, customer_name) VALUES (2, 'Bob');
+                INSERT INTO [{schema}].order_lines (order_id, line_num, product, quantity) VALUES (1, 5, 'Apples', 7);");
+
+            EnableCdcOnTables((schema, "orders"), (schema, "order_lines"));
+
+            var sqlCs = SetupSqlConnectionString(store);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-reparent-pk-includes-join",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = schema,
+                        SourceTableName = "orders",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "customer_name", Name = "CustomerName" }
+                        },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = schema,
+                                SourceTableName = "order_lines",
+                                PropertyName = "Lines",
+                                Type = CdcSinkRelationType.Array,
+                                JoinColumns = new List<string> { "order_id" },
+                                // Composite PK that *includes* the join column. With the pre-fix
+                                // PK-derived dictionary key, op=3 ("OrderLines/1/5") and op=4
+                                // ("OrderLines/2/5") never paired, no Delete from Orders/1 was
+                                // emitted, and Orders/1.Lines kept a ghost entry.
+                                PrimaryKeyColumns = new List<string> { "order_id", "line_num" },
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "order_id", Name = "OrderId" },
+                                    new CdcColumnMapping { Column = "line_num", Name = "LineNum" },
+                                    new CdcColumnMapping { Column = "product", Name = "Product" },
+                                    new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+
+            // Initial load materializes the existing row in Orders/1.Lines.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                return order1?.Lines?.Count ?? 0;
+            }, 1, timeout: 60_000);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                Assert.Single(order1.Lines);
+                Assert.Equal("Apples", order1.Lines[0].Product);
+            }
+
+            // Reparenting UPDATE: changes both the join column *and* a PK column.
+            ExecuteMsSql($"UPDATE [{schema}].order_lines SET order_id = 2 WHERE order_id = 1 AND line_num = 5;");
+
+            // Orders/1.Lines must lose the row (no ghost entry).
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                return order1?.Lines?.Count ?? 0;
+            }, 0, timeout: 60_000);
+
+            // Orders/2.Lines must gain the row.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order2 = await session.LoadAsync<Order>("Orders/2");
+                return order2?.Lines?.Count ?? 0;
+            }, 1, timeout: 60_000);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order2 = await session.LoadAsync<Order>("Orders/2");
+                Assert.Single(order2.Lines);
+                Assert.Equal("Apples", order2.Lines[0].Product);
+                Assert.Equal(5, order2.Lines[0].LineNum);
+            }
+        }
+
         // ─────────────────────────────────────────────────────────────────────
         // Patch Script Tests
         // ─────────────────────────────────────────────────────────────────────

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
@@ -1092,6 +1092,111 @@ namespace SlowTests.Server.Documents.CdcSink
         }
 
         /// <summary>
+        /// UPDATE that changes only the FK (join column), embedded-table PK unchanged.
+        /// SQL Server CDC delivers this as op=3 (pre-image) + op=4 (post-image) sharing the
+        /// same (__$start_lsn, __$seqval). pendingPreUpdate pairs them and
+        /// CreateEmbeddedUpdateEvents emits a Delete from the old parent and an Upsert to
+        /// the new parent.
+        /// </summary>
+        [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true, MsSqlCdcRequired = true)]
+        public async Task EmbeddedArray_Reparent_OnJoinColumnChange()
+        {
+            using var store = GetDocumentStore();
+            var schema = CreateTestSchema();
+
+            ExecuteMsSql($@"
+                CREATE TABLE [{schema}].orders (id INT PRIMARY KEY, customer_name NVARCHAR(200) NOT NULL);
+                CREATE TABLE [{schema}].order_lines (
+                    id INT PRIMARY KEY,
+                    order_id INT NOT NULL REFERENCES [{schema}].orders(id),
+                    product NVARCHAR(200) NOT NULL,
+                    quantity INT NOT NULL
+                );
+                INSERT INTO [{schema}].orders (id, customer_name) VALUES (1, 'Alice');
+                INSERT INTO [{schema}].orders (id, customer_name) VALUES (2, 'Bob');
+                INSERT INTO [{schema}].order_lines (id, order_id, product, quantity) VALUES (10, 1, 'Apples', 7);");
+
+            EnableCdcOnTables((schema, "orders"), (schema, "order_lines"));
+
+            var sqlCs = SetupSqlConnectionString(store);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-reparent-fk-only",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = schema,
+                        SourceTableName = "orders",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "customer_name", Name = "CustomerName" }
+                        },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = schema,
+                                SourceTableName = "order_lines",
+                                PropertyName = "Lines",
+                                Type = CdcSinkRelationType.Array,
+                                JoinColumns = new List<string> { "order_id" },
+                                PrimaryKeyColumns = new List<string> { "id" },
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "id", Name = "LineId" },
+                                    new CdcColumnMapping { Column = "product", Name = "Product" },
+                                    new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+
+            // Initial load materializes the row in Orders/1.Lines.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                return order1?.Lines?.Count ?? 0;
+            }, 1, timeout: 60_000);
+
+            // Reparenting UPDATE: changes only the FK. Embedded PK (id) stays at 10, so SQL
+            // Server CDC delivers op=3+op=4 (not op=1+op=2 like a PK change would).
+            ExecuteMsSql($"UPDATE [{schema}].order_lines SET order_id = 2 WHERE id = 10;");
+
+            // Orders/1.Lines must lose the row.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order1 = await session.LoadAsync<Order>("Orders/1");
+                return order1?.Lines?.Count ?? 0;
+            }, 0, timeout: 60_000);
+
+            // Orders/2.Lines must gain the row.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order2 = await session.LoadAsync<Order>("Orders/2");
+                return order2?.Lines?.Count ?? 0;
+            }, 1, timeout: 60_000);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order2 = await session.LoadAsync<Order>("Orders/2");
+                Assert.Single(order2.Lines);
+                Assert.Equal("Apples", order2.Lines[0].Product);
+            }
+        }
+
+        /// <summary>
         /// UPDATE that changes an embedded-table column listed in BOTH JoinColumns and
         /// PrimaryKeyColumns. SQL Server CDC emits a pre-image (op=3) and post-image (op=4)
         /// pair sharing the same (__$start_lsn, __$seqval). Reparent detection must pair

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -16,6 +16,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.Attachments.Remote;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.CdcSink;
 using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.DataArchival;
@@ -69,7 +70,7 @@ namespace SlowTests.Smuggler
                 .Select(field => field.Name)
                 .ToList();
 
-            Assert.Equal(54, fieldNames.Count);
+            Assert.Equal(55, fieldNames.Count);
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport, RavenArchitecture.AllX64)]
@@ -229,7 +230,30 @@ namespace SlowTests.Smuggler
                         MentorNode = "A",
                         Transforms = new List<Transformation> { new() { Script = "loadToOrders(this)", Collections = new List<string> { "Orders" }, Name = "testScript" } }
                     }));
-                    
+
+                    store1.Maintenance.Send(new AddCdcSinkOperation(new CdcSinkConfiguration
+                    {
+                        Name = "CdcSink",
+                        ConnectionStringName = "connection",
+                        Disabled = false,
+                        MentorNode = "A",
+                        Tables = new List<CdcSinkTableConfig>
+                        {
+                            new CdcSinkTableConfig
+                            {
+                                CollectionName = "Orders",
+                                SourceTableSchema = "dbo",
+                                SourceTableName = "orders",
+                                PrimaryKeyColumns = new List<string> { "id" },
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "id", Name = "Id" },
+                                    new CdcColumnMapping { Column = "name", Name = "Name" }
+                                }
+                            }
+                        }
+                    }));
+
                     //put embedding generation store 1
                     var aiConnectionString = new AiConnectionString { Name = "aiconnection", EmbeddedSettings = new EmbeddedSettings() };
                     aiConnectionString.Identifier = aiConnectionString.GenerateIdentifier();
@@ -363,7 +387,19 @@ namespace SlowTests.Smuggler
                     Assert.Equal("connection", record.SnowflakeEtls.First().ConnectionStringName);
                     Assert.Equal(true, record.SnowflakeEtls.First().AllowEtlOnNonEncryptedChannel);
                     Assert.Equal(true, record.SnowflakeEtls.First().Disabled);
-                    
+
+                    Assert.NotNull(record.CdcSinks);
+                    Assert.Equal(1, record.CdcSinks.Count);
+                    Assert.Equal("CdcSink", record.CdcSinks.First().Name);
+                    Assert.Equal("connection", record.CdcSinks.First().ConnectionStringName);
+                    Assert.Equal(true, record.CdcSinks.First().Disabled);
+                    Assert.Equal(1, record.CdcSinks.First().Tables.Count);
+                    Assert.Equal("Orders", record.CdcSinks.First().Tables.First().CollectionName);
+                    Assert.Equal("orders", record.CdcSinks.First().Tables.First().SourceTableName);
+                    Assert.Equal("dbo", record.CdcSinks.First().Tables.First().SourceTableSchema);
+                    Assert.Equal(new List<string> { "id" }, record.CdcSinks.First().Tables.First().PrimaryKeyColumns);
+                    Assert.Equal(2, record.CdcSinks.First().Tables.First().Columns.Count);
+
                     Assert.Equal(1, record.AiConnectionStrings.Count);
                     Assert.Equal("aiconnection", record.AiConnectionStrings.First().Value.Name);
                     
@@ -1416,7 +1452,30 @@ namespace SlowTests.Smuggler
                     ConnectionStringName = "test",
                     Scripts = new List<QueueSinkScript>(){ new QueueSinkScript(){Script = "from Users", Disabled = false, Name = "QueueSinkScript"}}
                 }));
-                
+
+                store.Maintenance.Send(new AddCdcSinkOperation(new CdcSinkConfiguration
+                {
+                    Name = "CdcSink",
+                    ConnectionStringName = "connection",
+                    Disabled = false,
+                    MentorNode = "A",
+                    Tables = new List<CdcSinkTableConfig>
+                    {
+                        new CdcSinkTableConfig
+                        {
+                            CollectionName = "Orders",
+                            SourceTableSchema = "dbo",
+                            SourceTableName = "orders",
+                            PrimaryKeyColumns = new List<string> { "id" },
+                            Columns = new List<CdcColumnMapping>
+                            {
+                                new CdcColumnMapping { Column = "id", Name = "Id" },
+                                new CdcColumnMapping { Column = "name", Name = "Name" }
+                            }
+                        }
+                    }
+                }));
+
                 using (var context = JsonOperationContext.ShortTermSingleUse())
                 {
                     var schemaDefinitionObj =
@@ -1550,6 +1609,18 @@ namespace SlowTests.Smuggler
                     Assert.False(record.QueueSinks.First().Disabled);
                     Assert.Equal("QueueSink", record.QueueSinks.First().Name);
                     Assert.Equal(1, record.QueueSinks.First().Scripts.Count);
+
+                    Assert.NotNull(record.CdcSinks);
+                    Assert.Equal(1, record.CdcSinks.Count);
+                    Assert.False(record.CdcSinks.First().Disabled);
+                    Assert.Equal("CdcSink", record.CdcSinks.First().Name);
+                    Assert.Equal("connection", record.CdcSinks.First().ConnectionStringName);
+                    Assert.Equal(1, record.CdcSinks.First().Tables.Count);
+                    Assert.Equal("Orders", record.CdcSinks.First().Tables.First().CollectionName);
+                    Assert.Equal("orders", record.CdcSinks.First().Tables.First().SourceTableName);
+                    Assert.Equal("dbo", record.CdcSinks.First().Tables.First().SourceTableSchema);
+                    Assert.Equal(new List<string> { "id" }, record.CdcSinks.First().Tables.First().PrimaryKeyColumns);
+                    Assert.Equal(2, record.CdcSinks.First().Tables.First().Columns.Count);
 
                     Assert.NotNull(record.AiConnectionStrings);
                     Assert.Equal(1, record.AiConnectionStrings.Count);

--- a/test/Tests.Infrastructure/SqlAwareTestBase.cs
+++ b/test/Tests.Infrastructure/SqlAwareTestBase.cs
@@ -4,7 +4,6 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using FastTests;
 using Microsoft.Data.SqlClient;
@@ -14,8 +13,8 @@ using Raven.Server.SqlMigration;
 using Raven.Server.SqlMigration.Model;
 using Raven.Server.SqlMigration.Schema;
 using Tests.Infrastructure.ConnectionString;
-using DisposableAction = Raven.Client.Util.DisposableAction;
 using Xunit;
+using DisposableAction = Raven.Client.Util.DisposableAction;
 
 namespace Tests.Infrastructure
 {
@@ -129,7 +128,7 @@ namespace Tests.Infrastructure
             }
         }
 
-        internal DisposableAction WithSqlDatabase(MigrationProvider provider, out string connectionString, out string schemaName, string dataSet = "northwind", bool includeData = true)
+        internal virtual DisposableAction WithSqlDatabase(MigrationProvider provider, out string connectionString, out string schemaName, string dataSet = "northwind", bool includeData = true)
         {
             switch (provider)
             {
@@ -392,14 +391,25 @@ namespace Tests.Infrastructure
                         dbCommand.ExecuteNonQuery();
 
                         // Drop any logical replication slots for this database.
-                        // PostgreSQL refuses to drop a database that has active slots.
-                        // pg_terminate_backend is asynchronous — the WAL sender may need
-                        // a moment to release the slot after being terminated. Retry briefly.
-                        for (int attempt = 0; attempt < 5; attempt++)
+                        // PostgreSQL refuses to drop a database that has active slots. Terminate
+                        // any wal_sender attached to a slot FIRST, then retry the drop. If the
+                        // sink's replication loop reconnects mid-retry, re-terminate each iteration.
+                        // All pre-DROP steps are best-effort — we must reach DROP DATABASE below
+                        // even if slot cleanup fails, otherwise we'd leak both the slot AND the DB.
+                        try
+                        {
+                            TerminateWalSender(dbCommand, dbName);
+                        }
+                        catch
+                        {
+                            /* best effort */
+                        }
+
+                        for (int attempt = 0; attempt < 10; attempt++)
                         {
                             try
                             {
-                                        dbCommand.Parameters.Clear();
+                                dbCommand.Parameters.Clear();
                                 dbCommand.CommandText = @"
                                     SELECT pg_drop_replication_slot(slot_name)
                                     FROM pg_replication_slots
@@ -410,15 +420,43 @@ namespace Tests.Infrastructure
                             }
                             catch (PostgresException ex) when (ex.SqlState == "55006")
                             {
-                                // 55006 = object_in_use (slot is still active)
-                                Thread.Sleep(500);
+                                // 55006 = object_in_use (slot still active — sink may have reconnected).
+                                // Re-terminate the wal_sender and wait. The outer sibling catch does NOT
+                                // catch exceptions thrown from inside this catch block, so we must swallow
+                                // locally to avoid escaping the retry loop.
+                                try
+                                {
+                                    TerminateWalSender(dbCommand, dbName);
+
+                                }
+                                catch
+                                {
+                                    /* best effort */
+                                }
+                                Thread.Sleep(1000);
                             }
                             catch (PostgresException)
                             {
-                                // Ignore other exceptions, such as "slot does not exist". 
+                                // Ignore other exceptions, such as "slot does not exist".
                                 // We want to make sure the database is dropped, even if we fail to drop the slots.
                                 break;
                             }
+                        }
+
+                        // Warn (don't throw) if anything still remains so CI logs surface leaks.
+                        // Wrapped so a transient error here can't skip DROP DATABASE below.
+                        try
+                        {
+                            dbCommand.Parameters.Clear();
+                            dbCommand.CommandText = "SELECT count(*) FROM pg_replication_slots WHERE database = @dbName";
+                            dbCommand.Parameters.AddWithValue("dbName", dbName);
+                            var remainingSlots = (long)dbCommand.ExecuteScalar();
+                            if (remainingSlots > 0)
+                                Console.Error.WriteLine($"[CDC-TEST-CLEANUP] WARN: {remainingSlots} replication slot(s) still on {dbName} after teardown");
+                        }
+                        catch
+                        {
+                            // diagnostic only — don't block DROP DATABASE
                         }
 
                         dbCommand.Parameters.Clear();
@@ -429,6 +467,17 @@ namespace Tests.Infrastructure
                     con.Close();
                 }
             });
+        }
+
+        private static void TerminateWalSender(NpgsqlCommand dbCommand, string dbName)
+        {
+            dbCommand.Parameters.Clear();
+            dbCommand.CommandText = @"
+                            SELECT pg_terminate_backend(active_pid)
+                            FROM pg_replication_slots
+                            WHERE database = @dbName AND active_pid IS NOT NULL";
+            dbCommand.Parameters.AddWithValue("dbName", dbName);
+            dbCommand.ExecuteNonQuery();
         }
 
         private DisposableAction WithOracleDatabase(out string connectionString, out string databaseName, string dataSet, bool includeData = true)


### PR DESCRIPTION

  - CDC providers now detect join column changes on embedded table UPDATEs and yield a Delete event (old parent) before the Upsert (new parent), removing stale ghost entries from the old parent document
  - Added CreateEmbeddedUpdateEvents helper on CdcSinkProcess base class shared by all three providers (PostgreSQL, MySQL, SQL Server)
  - PostgreSQL: match FullUpdateMessage to access OldRow for reparent detection
  - MySQL: decode BeforeUpdate.Cells for embedded reparent detection
  - SQL Server: include pre-update images (op=3) for embedded tables, stash and pair with post-update (op=4) for reparent detection
  - Extracted DecodeRowInternal in PostgreSQL and MySQL to eliminate duplicate row-decoding logic between DecodeRow and reparent path
  - Added EmbeddedReparent_JoinColumnChange_MustRemoveFromOldParent test
