### PR TITLE
RavenDB-26507 - tasks die in fallback mode after initial load when so…

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcessStatistics.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcessStatistics.cs
@@ -52,6 +52,9 @@ public class CdcSinkProcessStatistics
 
         LastConsumeErrorTime = SystemTime.UtcNow;
 
+        if (ConsumeErrors < 100)
+            return;
+
         if (ConsumeErrors <= ConsumeSuccesses)
             return;
 

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -112,7 +112,9 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         ["varbinary"]  = 15,  // MYSQL_TYPE_VARCHAR
 
         // Date/time types
-        ["date"]       = 14,  // MYSQL_TYPE_NEWDATE
+        // MYSQL_TYPE_NEWDATE (14) is an internal storage optimization; binlog row
+        // events emit the legacy MYSQL_TYPE_DATE (10) for `DATE` columns.
+        ["date"]       = 10,  // MYSQL_TYPE_DATE
         ["time"]       = 19,  // MYSQL_TYPE_TIME2
         ["datetime"]   = 18,  // MYSQL_TYPE_DATETIME2
         ["timestamp"]  = 17,  // MYSQL_TYPE_TIMESTAMP2

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkProcessStatisticsTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkProcessStatisticsTests.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Documents.CdcSink;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.CdcSink
+{
+
+    public class CdcSinkProcessStatisticsTests : RavenTestBase
+    {
+        public CdcSinkProcessStatisticsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public async Task RecordConsumeError_FirstErrorWithZeroSuccesses_ShouldNotThrow()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var stats = new CdcSinkProcessStatistics(
+                processTag: "CdcSink",
+                processName: "test-stats",
+                notificationCenter: database.NotificationCenter);
+
+            // Currently throws InvalidOperationException with the message
+            //   "Consume error ratio is too high (errors: 1, successes: 0)..."
+            // because RecordConsumeError unconditionally throws when ConsumeErrors > ConsumeSuccesses,
+            // with no minimum-error-count tolerance.
+            var ex = Record.Exception(() => stats.RecordConsumeError("first stream-side error"));
+
+            Assert.Null(ex);
+            Assert.Equal(1, stats.ConsumeErrors);
+            Assert.False(stats.WasLatestConsumeSuccessful);
+            Assert.NotNull(stats.LastConsumeErrorTime);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceMySqlTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceMySqlTests.cs
@@ -215,5 +215,68 @@ namespace SlowTests.Server.Documents.CdcSink
             Assert.NotNull(doc2);
             Assert.Equal("During Stop", doc2.Name);
         }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlRequired = true)]
+        public async Task SchemaChange_FalsePositive_OnStableSchemaWithDateColumn()
+        {
+
+            using var store = GetDocumentStore();
+            using var __ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out _, dataSet: null, includeData: false);
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE items (
+                    id INT PRIMARY KEY AUTO_INCREMENT,
+                    d  DATE
+                )");
+
+            ExecuteMySql(connectionString, "INSERT INTO items (d) VALUES ('2026-01-01')");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-schema-false-positive-date",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Items",
+                        SourceTableName = "items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "d",  Name = "Date" }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+
+            // Initial load arrives — proves the sink is healthy at this point.
+            var firstDoc = await WaitForDocumentAsync<dynamic>(store, "Items/1", timeoutMs: 60_000);
+            Assert.NotNull(firstDoc);
+
+            // Subscribe to ProcessError before the post-init INSERT to catch the bug
+            // deterministically; race it against the document arriving.
+            var errorTask = await WaitForNextProcessError(store, config.Name);
+
+            ExecuteMySql(connectionString, "INSERT INTO items (d) VALUES ('2026-02-02')");
+
+            var docTask = WaitForDocumentAsync<dynamic>(store, "Items/2", timeoutMs: 60_000);
+            var winner = await Task.WhenAny(errorTask, docTask);
+
+            if (winner == errorTask)
+            {
+                var ex = await errorTask;
+                Assert.Fail(
+                    "Schema-change false-positive on stable schema with DATE column. " +
+                    "MySqlDataTypeToBinlogType[\"date\"] disagrees with the binlog wire format. " +
+                    $"Exception: {ex}");
+            }
+
+            Assert.NotNull(await docTask);
+        }
     }
 }


### PR DESCRIPTION
…urce table contains a DATE column

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26507/CdcSink-MariaDB-tasks-die-in-fallback-mode-after-initial-load-when-source-table-contains-a-DATE-column

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
