### PR TITLE
RavenDB-26584 Fix inverted condition in AI test skip logic

### DIFF
--- a/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
@@ -83,7 +83,7 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
 
     private bool HasSkipReason(IAiConnectorForTesting<TConfig> aiConnectorForTesting)
     {
-        if (string.IsNullOrEmpty(Skip))
+        if (string.IsNullOrEmpty(Skip) == false)
             return true;
 
         if (RavenTestHelper.SkipAiIntegrationTests)


### PR DESCRIPTION
## Summary
- Fix inverted condition in `HasSkipReason()` in `RavenAiIntegrationAttribute.cs` that caused ~55 AI/GenAi tests to fail instead of being skipped when API credentials are missing
- The condition `string.IsNullOrEmpty(Skip)` should be `string.IsNullOrEmpty(Skip) == false` — the old code returned "has skip reason" when Skip was null (meaning no reason existed), preventing env-var and connectivity checks from ever running
- Add missing `[AmazonS3RetryFact]` to `AttachmentsPatchSlowTests.Can_Copy_Remote_Attachment_In_Patch`
- Add `AzureRequired = true` to `GenAiRemoteAttachments` tests that need Azure credentials

## Test plan
- [ ] Run SlowTests AI/GenAi tests without credentials set — verify they SKIP instead of FAIL
- [ ] Run SlowTests AI/GenAi tests WITH credentials set — verify they still RUN correctly
- [ ] Verify S3/Azure remote attachment tests skip when credentials are missing