### PR TITLE
RavenDB-25281 [2/3] Corax query engine: entry scan rewrite, new match types

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "10.0.202"
+    "version": "10.0.201"
   }
 }

--- a/src/Corax/Querying/IndexSearcher.Aggregations.cs
+++ b/src/Corax/Querying/IndexSearcher.Aggregations.cs
@@ -16,7 +16,7 @@ namespace Corax.Querying;
 public partial class IndexSearcher
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IAggregationProvider TextualAggregation(in FieldMetadata field, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
+    public IAggregationProvider TextualAggregation(in FieldMetadata field, bool forward = true, in CancellationToken token = default)
     {
         var compactTree = _fieldsTree?.CompactTreeFor(field.FieldName);
         if (compactTree is null)

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -106,7 +106,10 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     private long _dictionaryId;
     private Lookup<Int64LookupKey> _entryIdToLocation;
     public FieldsCache FieldCache;
-    public Planning.PlanCache PlanCache { get; } = new();
+    /// <summary>Query plan cache. When null (default), a fresh instance is created.
+    /// Set externally to share compiled plans across IndexSearcher instances
+    /// (e.g., per-index-instance lifetime via CoraxIndexPersistence).</summary>
+    public Planning.PlanCache PlanCache { get; set; } = new();
     private bool _nullPostingListsTreeLoaded;
     private bool _nonExistingPostingListsTreeLoaded;
 
@@ -157,6 +160,23 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         FieldCache = new FieldsCache(_transaction, _fieldsTree);
     }
     
+    /// <summary>Special term markers and dictionary ID exposed for batch EntryTermsReader construction
+    /// in DirectScanMatch (avoids per-entry GetEntryTermsReader overhead).</summary>
+    public HashSet<long> NullTermsMarkers { get { InitializeSpecialTermsMarkers(); return _nullTermsMarkers; } }
+    public HashSet<long> NonExistingTermsMarkers { get { InitializeSpecialTermsMarkers(); return _nonExistingTermsMarkers; } }
+    public long[] VectorFieldsMarkers { get { InitializeSpecialTermsMarkers(); return _vectorFieldsMarkers; } }
+    public long DictionaryId => _dictionaryId;
+
+    /// <summary>Batch-resolve entry IDs to container locations. Entry IDs should be sorted
+    /// for best B-tree page locality. Unresolvable entries get -1.</summary>
+    public void ResolveEntryLocations(ReadOnlySpan<long> entryIds, Span<long> containerLocations)
+    {
+        for (int i = 0; i < entryIds.Length; i++)
+        {
+            containerLocations[i] = _entryIdToLocation.TryGetValue(entryIds[i], out var loc) ? loc : -1;
+        }
+    }
+
     public EntryTermsReader GetEntryTermsReader(long id, ref Page p, CompactKey key = null)
     {
         if (_entryIdToLocation.TryGetValue(id, out var locLong) == false)
@@ -581,7 +601,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     }
 
 
-    private void InitializeSpecialTermsMarkers()
+    public void InitializeSpecialTermsMarkers()
     {
         if (_nullTermsMarkersLoaded == false)
         {

--- a/src/Corax/Querying/Matches/BoostingMatch.cs
+++ b/src/Corax/Querying/Matches/BoostingMatch.cs
@@ -38,6 +38,10 @@ namespace Corax.Querying.Matches
         public float BoostFactor;
         public BoostingMatch(Querying.IndexSearcher searcher, in IQueryMatch inner, float boostFactor)
         {
+            // Vector search has its own similarity-based ranking that doesn't compose with boost factors.
+            // Multiplying similarity scores by a boost factor would distort the ranking semantics.
+            // If boosted vector search is needed, the boost should be applied at the query result
+            // level (post-scoring), not at the match level.
             PortableExceptions.ThrowIf<NotSupportedException>(inner is VectorSearchMatch, $"Boosting the {nameof(VectorSearchMatch)} is not supported yet.");
             
             _inner = inner;

--- a/src/Corax/Querying/Matches/CompiledQueryMatch.cs
+++ b/src/Corax/Querying/Matches/CompiledQueryMatch.cs
@@ -28,7 +28,28 @@ public class CompiledQueryMatch(
     CancellationToken token)
     : IBitmapQueryMatch, IDisposable
 {
-    private readonly QueryIlEmitter.CompiledExecuteDelegate _compiledDelegate = compiledPlan.CompiledDelegate;
+    private readonly QueryIlEmitter.CompiledExecuteDelegate _compiledDelegate =
+        wantTimings ? compiledPlan.CompiledTimedDelegate : compiledPlan.CompiledDelegate;
+
+    // Sort seek hint — set by the plan builder when WHERE field matches ORDER BY field
+    private string _seekFieldName;
+    private object _seekValue;
+    private bool _seekInclusive;
+
+    public void SetSortHint(string fieldName, object value, bool inclusive)
+    {
+        _seekFieldName = fieldName;
+        _seekValue = value;
+        _seekInclusive = inclusive;
+    }
+
+    public bool TryGetSortHint(out string fieldName, out object value, out bool inclusive)
+    {
+        fieldName = _seekFieldName;
+        value = _seekValue;
+        inclusive = _seekInclusive;
+        return _seekFieldName != null;
+    }
     public readonly IQueryMatch[] ResolvedMatches = resolvedMatches;
     public readonly PostingSource[] PostingSources = postingSources;
     public readonly ITermsProvider[] TermsProviders = termsProviders;
@@ -36,6 +57,24 @@ public class CompiledQueryMatch(
     public readonly double[] DoubleParams = doubleParams;
     public readonly Slice[] SliceParams = sliceParams;
     public readonly long[] FieldRootPages = fieldRootPages;
+
+    /// <summary>Per-execution term counts for OrRange/AndRange ops. Each range op
+    /// stores its index into this array instead of a hardcoded count in the IL.
+    /// Set during resolution — different executions of the same query can have
+    /// different IN term counts without needing different compiled delegates.</summary>
+    public int[] InRangeCounts;
+
+    // Entry scan: predicates + parameters for CompiledQueryHelper.RunEntryScan
+    public ScanPredicateInfo[] ScanPredicateInfos;
+    public long[] ScanLongParams;
+    public double[] ScanDoubleParams;
+    public Slice[] ScanSliceParams;
+    public long[] ScanFieldRootPages;
+
+    // Entry scan telemetry (populated by IL/C# entry scan when it triggers)
+    public long EntryScanEntriesScanned;
+    public long EntryScanEntriesPassed;
+
     private readonly string _explainSource = compiledPlan.ExplainSource;
     public readonly IndexSearcher Searcher = searcher;
     public readonly CancellationToken Token = token;
@@ -72,7 +111,9 @@ public class CompiledQueryMatch(
         }
     }
 
-    public QueryCountConfidence Confidence => _executed ? QueryCountConfidence.High : QueryCountConfidence.Normal;
+    public QueryCountConfidence Confidence => _executed
+        ? (_count < Limit ? QueryCountConfidence.High : QueryCountConfidence.Low)
+        : QueryCountConfidence.Normal;
 
     public bool IsBoosting
     {
@@ -168,7 +209,13 @@ public class CompiledQueryMatch(
         };
 
         if (EntryScanTakenAtOp >= 0)
+        {
             parameters["EntryScanAt"] = EntryScanTakenAtOp.ToString();
+            if (EntryScanEntriesScanned > 0)
+                parameters["EntryScanScanned"] = EntryScanEntriesScanned.ToString();
+            if (EntryScanEntriesPassed > 0)
+                parameters["EntryScanPassed"] = EntryScanEntriesPassed.ToString();
+        }
 
         if (Timings is { Length: > 0 })
         {

--- a/src/Corax/Querying/Matches/DirectScanMatch.cs
+++ b/src/Corax/Querying/Matches/DirectScanMatch.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Planning;
+using Sparrow;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.Containers;
+using Voron.Data.RoaringBitmaps;
+using Corax.Utils;
+using Voron.Impl;
+
+namespace Corax.Querying.Matches;
+
+/// <summary>
+/// Walks a driving tree in sort order, checking residual predicates per entry via
+/// stored field reads. Replaces CompiledQueryMatch + SortingMatch when the cost model
+/// determines that a bounded tree walk + entry scan is cheaper than building a bitmap.
+///
+/// Entry IDs from each tree batch are sorted by container location for sequential page
+/// access, then predicates are checked in that order. A parallel index array tracks
+/// original positions so results are emitted in field-value (sort) order.
+/// </summary>
+public sealed class DirectScanMatch : IQueryMatch, IDisposable
+{
+    private readonly IndexSearcher _searcher;
+    private readonly LowLevelTransaction _llt;
+    private readonly IQueryMatch _drivingMatch;  // TermsProviderMatch or similar that walks the driving tree
+    private readonly int _take;
+    private long _totalMatched;
+
+    // Residual predicate checking
+    private readonly ScanPredicateInfo[] _residualPredicates;
+    private readonly long[] _longParams;
+    private readonly double[] _doubleParams;
+    private readonly Slice[] _sliceParams;
+    private readonly long[] _fieldRootPages;
+
+    // Dedup for multi-value fields
+    private RoaringBitmap _emittedBitmap;
+    private readonly ByteStringContext _allocator;
+
+    // Telemetry (always collected — cheap)
+    private long _treeEntriesScanned;
+    private long _entriesPassedFilter;
+    private long _entriesRejected;
+    private long _treeScanTicks;
+    private long _entryScanTicks;
+    private string _stoppedReason;
+
+    // Diagnostic metadata
+    public string DrivingTreeName;
+    public string DrivingClause;
+    public string SeekBound;
+    public string Direction;
+    public string ResidualDescription;
+    public string Reason;
+
+    public DirectScanMatch(
+        IndexSearcher searcher,
+        IQueryMatch drivingMatch,
+        ScanPredicateInfo[] residualPredicates,
+        long[] longParams,
+        double[] doubleParams,
+        Slice[] sliceParams,
+        long[] fieldRootPages,
+        int take)
+    {
+        _searcher = searcher;
+        _llt = searcher.Transaction.LowLevelTransaction;
+        _drivingMatch = drivingMatch;
+        _residualPredicates = residualPredicates;
+        _longParams = longParams;
+        _doubleParams = doubleParams;
+        _sliceParams = sliceParams;
+        _fieldRootPages = fieldRootPages;
+        _take = take;
+        _allocator = searcher.Allocator;
+        _emittedBitmap = new RoaringBitmap(_allocator);
+    }
+
+    public long Count => _totalMatched;
+    public QueryCountConfidence Confidence => QueryCountConfidence.Low;
+    public bool IsBoosting => false;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
+
+    [SkipLocalsInit]
+    public unsafe int Fill(Span<long> matches)
+    {
+        if (_take > 0 && _totalMatched >= _take)
+            return 0;
+
+        int count = 0;
+        int remaining = _take > 0 ? (int)Math.Min(matches.Length, _take - _totalMatched) : matches.Length;
+        int batchSize = Math.Min(256, remaining * 4);
+        Span<long> batch = stackalloc long[batchSize];
+        Span<int> indices = stackalloc int[batchSize];
+        Span<bool> passed = stackalloc bool[batchSize];
+
+        while (count < remaining)
+        {
+            long t0 = Stopwatch.GetTimestamp();
+            int read = _drivingMatch.Fill(batch);
+            _treeScanTicks += Stopwatch.GetTimestamp() - t0;
+
+            if (read == 0)
+            {
+                _stoppedReason ??= "TreeExhausted";
+                break;
+            }
+            _treeEntriesScanned += read;
+
+            if (_residualPredicates == null || _residualPredicates.Length == 0)
+            {
+                // No residual predicates — all tree entries are matches
+                for (int i = 0; i < read && count < remaining; i++)
+                {
+                    long id = batch[i];
+                    if (_emittedBitmap.Contains(id) == false)
+                    {
+                        _emittedBitmap.Add(id);
+                        matches[count++] = id;
+                    }
+                }
+            }
+            else
+            {
+                // Sort batch by entry ID for page locality, track original indices
+                for (int i = 0; i < read; i++)
+                    indices[i] = i;
+
+                // Simple insertion sort (batch is small, ~256 entries)
+                for (int i = 1; i < read; i++)
+                {
+                    int key = indices[i];
+                    long keyVal = batch[key];
+                    int j = i - 1;
+                    while (j >= 0 && batch[indices[j]] > keyVal)
+                    {
+                        indices[j + 1] = indices[j];
+                        j--;
+                    }
+                    indices[j + 1] = key;
+                }
+
+                // Batch-resolve entry IDs to container locations for sequential page access.
+                // Sort by entry ID first (already done via indices), resolve, then Container.GetAll.
+                passed.Slice(0, read).Clear();
+
+                long t1 = Stopwatch.GetTimestamp();
+
+                // Build sorted entry ID array for batch resolution
+                Span<long> sortedIds = stackalloc long[read];
+                for (int s = 0; s < read; s++)
+                    sortedIds[s] = batch[indices[s]];
+
+                // Batch resolve to container locations
+                Span<long> containerLocs = stackalloc long[read];
+                _searcher.ResolveEntryLocations(sortedIds, containerLocs);
+
+                // Batch fetch entry data via Container.GetAll (sequential page access)
+                Span<UnmanagedSpan> spans = stackalloc UnmanagedSpan[read];
+                Container.GetAll(_llt, containerLocs, spans, -1, _llt.PageLocator);
+
+                // Initialize special term markers (needed for EntryTermsReader)
+                _searcher.InitializeSpecialTermsMarkers();
+
+                for (int s = 0; s < read; s++)
+                {
+                    int origIdx = indices[s];
+                    long entryId = batch[origIdx];
+
+                    if (_emittedBitmap.Contains(entryId))
+                        continue; // dedup
+
+                    if (containerLocs[s] == -1 || spans[s].Address == null)
+                    {
+                        _entriesRejected++;
+                        continue;
+                    }
+
+                    var reader = new EntryTermsReader(_llt,
+                        _searcher.NullTermsMarkers, _searcher.NonExistingTermsMarkers,
+                        spans[s].Address, spans[s].Length, _searcher.DictionaryId, _searcher.VectorFieldsMarkers, null);
+                    if (CheckAllPredicates(ref reader))
+                        passed[origIdx] = true;
+                    else
+                        _entriesRejected++;
+                }
+                _entryScanTicks += Stopwatch.GetTimestamp() - t1;
+
+                // Emit matches in original (field-value) order
+                for (int i = 0; i < read && count < remaining; i++)
+                {
+                    if (passed[i])
+                    {
+                        long id = batch[i];
+                        _emittedBitmap.Add(id);
+                        _entriesPassedFilter++;
+                        matches[count++] = id;
+                    }
+                }
+            }
+        }
+
+        if (_take > 0 && _totalMatched + count >= _take)
+            _stoppedReason ??= $"_take({_take})";
+
+        _totalMatched += count;
+        return count;
+    }
+
+    private bool CheckAllPredicates(ref EntryTermsReader reader)
+    {
+        for (int p = 0; p < _residualPredicates.Length; p++)
+        {
+            ref readonly var pred = ref _residualPredicates[p];
+            reader.Reset();
+
+            if (reader.FindNext(_fieldRootPages[pred.ParamIndex]) == false)
+            {
+                // Field not found in this entry
+                if (pred.CompareOp == ScanCompareOp.NotEqual)
+                    continue; // NOT having the field satisfies NotEquals
+                return false; // All other ops fail when field is missing
+            }
+
+            if (EvaluatePredicate(ref reader, in pred) == false)
+                return false;
+        }
+        return true;
+    }
+
+    private bool EvaluatePredicate(ref EntryTermsReader reader, in ScanPredicateInfo pred)
+    {
+        // StartsWith/EndsWith need to iterate all terms for the field (multi-value support)
+        if (pred.CompareOp == ScanCompareOp.StartsWith)
+            return CompiledQueryHelper.CheckFieldTermStartsWith(ref reader, _fieldRootPages[pred.ParamIndex], _sliceParams[pred.ParamIndex].AsReadOnlySpan());
+        if (pred.CompareOp == ScanCompareOp.EndsWith)
+            return CompiledQueryHelper.CheckFieldTermEndsWith(ref reader, _fieldRootPages[pred.ParamIndex], _sliceParams[pred.ParamIndex].AsReadOnlySpan());
+
+        return pred.ValueType switch
+        {
+            ScanValueType.Long when pred.CompareOp == ScanCompareOp.Between =>
+                CompiledQueryHelper.CompareLongBetween(reader.CurrentLong, _longParams[pred.ParamIndex], _longParams[pred.ParamIndex2]),
+            ScanValueType.Long =>
+                CompiledQueryHelper.CompareLong(reader.CurrentLong, _longParams[pred.ParamIndex], pred.CompareOp),
+            ScanValueType.Double when pred.CompareOp == ScanCompareOp.Between =>
+                CompiledQueryHelper.CompareDoubleBetween(reader.CurrentDouble, _doubleParams[pred.ParamIndex], _doubleParams[pred.ParamIndex2]),
+            ScanValueType.Double =>
+                CompiledQueryHelper.CompareDouble(reader.CurrentDouble, _doubleParams[pred.ParamIndex], pred.CompareOp),
+            ScanValueType.Slice when pred.CompareOp == ScanCompareOp.Between =>
+                CompiledQueryHelper.CompareSliceBetween(reader.Current.Decoded(), _sliceParams[pred.ParamIndex].AsReadOnlySpan(), _sliceParams[pred.ParamIndex2].AsReadOnlySpan()),
+            ScanValueType.Slice =>
+                CompiledQueryHelper.CompareSlice(reader.Current.Decoded(), _sliceParams[pred.ParamIndex].AsReadOnlySpan(), pred.CompareOp),
+            _ => false
+        };
+    }
+
+    public int AndWith(Span<long> buffer, int matches) => throw new NotSupportedException("DirectScanMatch produces final sorted results");
+
+    public void Score(Span<long> matches, Span<float> scores, float boostFactor)
+    {
+        // No scoring — DirectScanMatch is only used for unboosted queries
+    }
+
+    public SkipSortingResult AttemptToSkipSorting() => SkipSortingResult.ResultsNativelySorted;
+
+    public QueryInspectionNode Inspect()
+    {
+        double tickFreq = Stopwatch.Frequency / 1000.0;
+        var parameters = new Dictionary<string, string>();
+
+        if (DrivingTreeName != null) parameters["DrivingTree"] = DrivingTreeName;
+        if (DrivingClause != null) parameters["DrivingClause"] = DrivingClause;
+        if (SeekBound != null) parameters["SeekBound"] = SeekBound;
+        if (Direction != null) parameters["TreeDirection"] = Direction;
+        if (ResidualDescription != null) parameters["ResidualPredicates"] = ResidualDescription;
+        if (Reason != null) parameters["Reason"] = Reason;
+
+        if (_treeScanTicks > 0) parameters["TreeScan_ms"] = (_treeScanTicks / tickFreq).ToString("F3");
+        if (_entryScanTicks > 0) parameters["EntryScans_ms"] = (_entryScanTicks / tickFreq).ToString("F3");
+
+        parameters["TreeEntriesScanned"] = _treeEntriesScanned.ToString();
+        parameters["EntriesPassedFilter"] = _entriesPassedFilter.ToString();
+        parameters["EntriesRejected"] = _entriesRejected.ToString();
+
+        if (_stoppedReason != null) parameters["StoppedAt"] = _stoppedReason;
+
+        return new QueryInspectionNode("DirectScan", parameters: parameters);
+    }
+
+    public void Dispose()
+    {
+        _emittedBitmap.Dispose();
+        (_drivingMatch as IDisposable)?.Dispose();
+    }
+}

--- a/src/Corax/Querying/Matches/SortedDrivingMatch.cs
+++ b/src/Corax/Querying/Matches/SortedDrivingMatch.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Corax.Indexing;
+using Corax.Querying.Matches.Meta;
+using Corax.Utils;
+using Sparrow;
+using Sparrow.Compression;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.Containers;
+using Voron.Data.PostingLists;
+using Voron.Data.RoaringBitmaps;
+using Voron.Impl;
+using Voron.Util;
+using Voron.Util.PFor;
+
+namespace Corax.Querying.Matches;
+
+/// <summary>
+/// Walks an ITermsProvider in term order, decoding each posting list and yielding
+/// entry IDs directly. Unlike TermsProviderMatch (which materializes into a RoaringBitmap,
+/// losing sort order), this yields entries grouped by term — preserving field-value order.
+///
+/// The ITermsProvider enforces range bounds (TermsRangeProvider only yields terms in range).
+/// No separate bitmap phase needed.
+/// </summary>
+public sealed unsafe class SortedDrivingMatch : IQueryMatch, IDisposable
+{
+    private readonly ITermsProvider _provider;
+    private readonly LowLevelTransaction _llt;
+    private readonly ByteStringContext _allocator;
+
+    // Dedup for multi-value fields
+    private RoaringBitmap _emittedBitmap;
+
+    // State for resuming across Fill calls
+    private bool _providerExhausted;
+
+    // Pending entries from a partially-consumed posting list
+    private PostingList.Iterator _pendingLargeIterator;
+    private bool _hasPendingLargeIterator;
+    private FastPForBufferedReader _smallListReader;
+    private bool _hasSmallListReader;
+
+    public SortedDrivingMatch(ITermsProvider provider, LowLevelTransaction llt, ByteStringContext allocator)
+    {
+        _provider = provider;
+        _llt = llt;
+        _allocator = allocator;
+        _emittedBitmap = new RoaringBitmap(allocator);
+    }
+
+    public long Count => -1;
+    public QueryCountConfidence Confidence => QueryCountConfidence.Low;
+    public bool IsBoosting => false;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
+
+    [SkipLocalsInit]
+    public int Fill(Span<long> matches)
+    {
+        if (_providerExhausted && _hasPendingLargeIterator == false && _hasSmallListReader == false)
+            return 0;
+
+        int count = 0;
+        Span<long> entryBuffer = stackalloc long[256];
+
+        // Resume any pending large posting list iterator
+        if (_hasPendingLargeIterator)
+        {
+            count += DrainLargePostingList(matches, entryBuffer);
+            if (count >= matches.Length)
+                return count;
+        }
+
+        // Resume any pending small posting list reader
+        if (_hasSmallListReader)
+        {
+            count += DrainSmallPostingList(matches.Slice(count), entryBuffer);
+            if (count >= matches.Length)
+                return count;
+        }
+
+        // Walk the provider's posting list IDs
+        Span<long> plIds = stackalloc long[256];
+        var pageLocator = _llt.PageLocator;
+
+        int read;
+        while (count < matches.Length && !_providerExhausted)
+        {
+            read = _provider.FillPostingListIds(plIds);
+            if (read == 0)
+            {
+                _providerExhausted = true;
+                break;
+            }
+
+            // Batch-resolve SmallPostingList container items
+            Span<long> smallPlIds = stackalloc long[read];
+            Span<UnmanagedSpan> containerItems = stackalloc UnmanagedSpan[read];
+            int smallCount = 0;
+
+            for (int i = 0; i < read; i++)
+            {
+                long plId = plIds[i];
+                var termType = (TermIdMask)plId & TermIdMask.EnsureIsSingleMask;
+
+                if (termType == TermIdMask.SmallPostingList)
+                {
+                    smallPlIds[smallCount++] = (long)EntryIdEncodings.GetContainerId(plId);
+                }
+            }
+            if (smallCount > 0)
+            {
+                Container.GetAll(_llt, smallPlIds.Slice(0, smallCount), containerItems.Slice(0, smallCount), long.MinValue, pageLocator);
+            }
+
+            int smallIdx = 0;
+            for (int i = 0; i < read && count < matches.Length; i++)
+            {
+                long plId = plIds[i];
+                var termType = (TermIdMask)plId & TermIdMask.EnsureIsSingleMask;
+
+                switch (termType)
+                {
+                    case TermIdMask.Single:
+                    {
+                        long entryId = (long)EntryIdEncodings.GetContainerId(plId);
+                        if (_emittedBitmap.Contains(entryId) == false)
+                        {
+                            _emittedBitmap.Add(entryId);
+                            matches[count++] = entryId;
+                        }
+                        break;
+                    }
+                    case TermIdMask.SmallPostingList:
+                    {
+                        var item = containerItems[smallIdx++];
+                        _ = VariableSizeEncoding.Read<int>(item.Address, out var offset);
+                        if (_smallListReader.WasInitialized == false)
+                            _smallListReader = new FastPForBufferedReader(_llt.Allocator);
+                        _smallListReader.Init(item.Address + offset, item.Length - offset);
+                        _hasSmallListReader = true;
+                        count += DrainSmallPostingList(matches.Slice(count), entryBuffer);
+                        break;
+                    }
+                    case TermIdMask.PostingList:
+                    {
+                        var setStateSpan = Container.GetReadOnly(_llt, EntryIdEncodings.GetContainerId(plId));
+                        ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
+                        var postingList = new PostingList(_llt, Slices.Empty, in setState);
+                        _pendingLargeIterator = postingList.Iterate();
+                        _hasPendingLargeIterator = true;
+                        count += DrainLargePostingList(matches.Slice(count), entryBuffer);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private int DrainSmallPostingList(Span<long> matches, Span<long> entryBuffer)
+    {
+        int count = 0;
+        fixed (long* pBuffer = entryBuffer)
+        {
+            int read;
+            while (count < matches.Length && (read = _smallListReader.Fill(pBuffer, entryBuffer.Length)) > 0)
+            {
+                EntryIdEncodings.DecodeAndDiscardFrequency(entryBuffer, read);
+                for (int j = 0; j < read && count < matches.Length; j++)
+                {
+                    long entryId = entryBuffer[j];
+                    if (_emittedBitmap.Contains(entryId) == false)
+                    {
+                        _emittedBitmap.Add(entryId);
+                        matches[count++] = entryId;
+                    }
+                }
+            }
+        }
+        if (count < matches.Length)
+            _hasSmallListReader = false; // exhausted
+        return count;
+    }
+
+    private int DrainLargePostingList(Span<long> matches, Span<long> entryBuffer)
+    {
+        int count = 0;
+        while (count < matches.Length && _pendingLargeIterator.Fill(entryBuffer, out int read) && read > 0)
+        {
+            EntryIdEncodings.DecodeAndDiscardFrequency(entryBuffer, read);
+            for (int j = 0; j < read && count < matches.Length; j++)
+            {
+                long entryId = entryBuffer[j];
+                if (_emittedBitmap.Contains(entryId) == false)
+                {
+                    _emittedBitmap.Add(entryId);
+                    matches[count++] = entryId;
+                }
+            }
+        }
+        if (count < matches.Length)
+            _hasPendingLargeIterator = false; // exhausted
+        return count;
+    }
+
+    public int AndWith(Span<long> buffer, int matches) => throw new NotSupportedException();
+    public void Score(Span<long> matches, Span<float> scores, float boostFactor) { }
+    public SkipSortingResult AttemptToSkipSorting() => SkipSortingResult.ResultsNativelySorted;
+
+    public QueryInspectionNode Inspect()
+    {
+        return new QueryInspectionNode("SortedDrivingMatch",
+            parameters: new Dictionary<string, string>
+            {
+                ["Provider"] = _provider.Inspect().Operation
+            });
+    }
+
+    public void Dispose()
+    {
+        if (_hasSmallListReader)
+            _smallListReader.Dispose();
+        _emittedBitmap.Dispose();
+    }
+}

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -290,7 +290,7 @@ public sealed unsafe partial class SortingMatch<TInner> : SortingMatch
         }
     }
     
-    private ref struct SortedIndexReader<TDirection>
+    internal unsafe struct SortedIndexReader<TDirection> : IDisposable
         where TDirection : struct, ILookupIterator
     {
         private PostingList.Iterator _postListIt;
@@ -319,7 +319,9 @@ public sealed unsafe partial class SortingMatch<TInner> : SortingMatch
         private bool _nonExistingPostingListRead;
         private bool _nullPostingListRead;
 
-        public SortedIndexReader(LowLevelTransaction llt, IndexSearcher searcher, TDirection it, FieldMetadata metadata, long min, long max, bool nullFirst, bool isForward)
+        public delegate void SeekAction(ref TDirection it);
+
+        public SortedIndexReader(LowLevelTransaction llt, IndexSearcher searcher, TDirection it, FieldMetadata metadata, long min, long max, bool nullFirst, bool isForward, SeekAction seekAction = null)
         {
             _termsIt = it;
             _min = min;
@@ -327,6 +329,7 @@ public sealed unsafe partial class SortingMatch<TInner> : SortingMatch
             _nullFirst = nullFirst;
             _isForward = isForward;
             _termsIt.Reset();
+            seekAction?.Invoke(ref _termsIt);
             _llt = llt;
             _searcher = searcher;
             _postListIt = default;
@@ -523,7 +526,18 @@ public sealed unsafe partial class SortingMatch<TInner> : SortingMatch
         // Multi-value fields produce duplicate entry IDs in the sort index
         // (one per value). Track emitted IDs to skip duplicates.
         using var emittedBitmap = new RoaringBitmap(allocator);
-        var reader = GetReader(bitmapMatch.MinEntryId, bitmapMatch.MaxEntryId);
+
+        // Seek optimization: when the WHERE field matches the ORDER BY field, skip
+        // walking tree terms that can't match by seeking to the boundary value.
+        SortedIndexReader<TDirection>.SeekAction seekAction = null;
+        if (bitmapMatch is CompiledQueryMatch cm &&
+            cm.TryGetSortHint(out var hintField, out var hintValue, out _) &&
+            hintField == entryCmp.GetSortFieldName(match).ToString())
+        {
+            seekAction = BuildSeekAction(hintValue);
+        }
+
+        var reader = GetReader(bitmapMatch.MinEntryId, bitmapMatch.MaxEntryId, seekAction);
 
         while (match._results.Count < maxResults)
         {
@@ -551,27 +565,59 @@ public sealed unsafe partial class SortingMatch<TInner> : SortingMatch
         reader.Dispose();
         sortedIdsScope.Dispose();
 
-        SortedIndexReader<TDirection> GetReader(long min, long max)
+        static SortedIndexReader<TDirection>.SeekAction BuildSeekAction(object value)
+        {
+            if (value is long longVal)
+            {
+                if (typeof(TDirection) == typeof(Lookup<Int64LookupKey>.ForwardIterator) ||
+                    typeof(TDirection) == typeof(Lookup<Int64LookupKey>.BackwardIterator))
+                {
+                    return (ref TDirection it) => it.Seek(new Int64LookupKey(longVal));
+                }
+            }
+            else if (value is double doubleVal)
+            {
+                if (typeof(TDirection) == typeof(Lookup<DoubleLookupKey>.ForwardIterator) ||
+                    typeof(TDirection) == typeof(Lookup<DoubleLookupKey>.BackwardIterator))
+                {
+                    return (ref TDirection it) => it.Seek(new DoubleLookupKey(doubleVal));
+                }
+            }
+            // String seeks are handled in GetReader() below where the CompactTree
+            // and its DictionaryId are available for CompactKey construction.
+            return null;
+        }
+
+        SortedIndexReader<TDirection> GetReader(long min, long max, SortedIndexReader<TDirection>.SeekAction seek = null)
         {
             if (typeof(TDirection) == typeof(Lookup<CompactTree.CompactKeyLookup>.ForwardIterator) ||
                 typeof(TDirection) == typeof(Lookup<CompactTree.CompactKeyLookup>.BackwardIterator))
             {
                 var termsTree = match._searcher.GetTermsFor(entryCmp.GetSortFieldName(match));
-                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.IterateValues<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending);
+                // Build string seek action here where we have the tree's dictionary ID
+                if (seek == null && bitmapMatch is CompiledQueryMatch cm2 &&
+                    cm2.TryGetSortHint(out _, out var seekVal, out _) && seekVal is string strVal)
+                {
+                    var compactKey = llt.AcquireCompactKey();
+                    compactKey.Set(System.Text.Encoding.UTF8.GetBytes(strVal));
+                    compactKey.ChangeDictionary(termsTree.DictionaryId);
+                    seek = (ref TDirection it) => it.Seek(new CompactTree.CompactKeyLookup(compactKey));
+                }
+                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.IterateValues<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending, seek);
             }
 
             if (typeof(TDirection) == typeof(Lookup<Int64LookupKey>.ForwardIterator) ||
                 typeof(TDirection) == typeof(Lookup<Int64LookupKey>.BackwardIterator))
             {
                 var termsTree = match._searcher.GetLongTermsFor(entryCmp.GetSortFieldName(match));
-                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.Iterate<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending);
+                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.Iterate<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending, seek);
             }
 
             if (typeof(TDirection) == typeof(Lookup<DoubleLookupKey>.ForwardIterator) ||
                 typeof(TDirection) == typeof(Lookup<DoubleLookupKey>.BackwardIterator))
             {
                 var termsTree = match._searcher.GetDoubleTermsFor(entryCmp.GetSortFieldName(match));
-                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.Iterate<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending);
+                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.Iterate<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending, seek);
             }
 
             throw new NotSupportedException(typeof(TDirection).FullName);

--- a/src/Corax/Querying/Matches/TermsProviderMatch.cs
+++ b/src/Corax/Querying/Matches/TermsProviderMatch.cs
@@ -17,6 +17,14 @@ public sealed class TermsProviderMatch : IBitmapQueryMatch
 {
     private readonly ITermsProvider _provider;
     private readonly LowLevelTransaction _llt;
+
+    /// <summary>Expose the inner provider for TreeScan dispatch in the compiled pipeline.
+    /// The compiled pipeline calls QueryPrimitives.CtxFillFromTreeScan directly on the provider,
+    /// bypassing the TermsProviderMatch wrapper.</summary>
+    public ITermsProvider Provider => _provider;
+
+    /// <summary>LowLevelTransaction for SortedDrivingMatch construction.</summary>
+    public LowLevelTransaction Llt => _llt;
     private RoaringBitmap _bitmap;
     private RoaringBitmapIterator _iterator;
     private bool _initialized;

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
@@ -20,49 +20,49 @@ public partial class IndexSearcher
     public IQueryMatch StartWithQuery(string field, string startWith, bool isNegated = false, bool hasBoost = false, bool forward = true) => StartWithQuery(FieldMetadataBuilder(field, hasBoost: hasBoost), EncodeAndApplyAnalyzer(default, startWith), isNegated, forward);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch StartWithQuery(in FieldMetadata field, string startWith, bool isNegated = false, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
+    public IQueryMatch StartWithQuery(in FieldMetadata field, string startWith, bool isNegated = false, bool forward = true, in CancellationToken token = default)
     {
         return (forward, isNegated) switch
         {
-            (true, false) => TermsProviderMatchBuilder<StartsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, streamingEnabled, token),
-            (false, false) => TermsProviderMatchBuilder<StartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, streamingEnabled, token),
-            (true, true) => TermsProviderMatchBuilder<NotStartsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, streamingEnabled, token),
-            (false, true) => TermsProviderMatchBuilder<NotStartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, streamingEnabled, token)
+            (true, false) => TermsProviderMatchBuilder<StartsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, token),
+            (false, false) => TermsProviderMatchBuilder<StartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, token),
+            (true, true) => TermsProviderMatchBuilder<NotStartsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, token),
+            (false, true) => TermsProviderMatchBuilder<NotStartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, token)
         };
     }
 
-    public IQueryMatch StartWithQuery(in FieldMetadata field, Slice startWith, bool isNegated = false, bool forward = true, bool streamingEnabled = false, bool validatePostfixLen = false, in CancellationToken token = default)
+    public IQueryMatch StartWithQuery(in FieldMetadata field, Slice startWith, bool isNegated = false, bool forward = true, bool validatePostfixLen = false, in CancellationToken token = default)
     {
         return (forward, isNegated) switch
         {
-            (true, false) => TermsProviderMatchBuilder<StartsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, streamingEnabled, validatePostfixLen, token),
-            (false, false) => TermsProviderMatchBuilder<StartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, streamingEnabled, validatePostfixLen, token),
-            (true, true) => TermsProviderMatchBuilder<NotStartsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, streamingEnabled, validatePostfixLen, token),
-            (false, true) => TermsProviderMatchBuilder<NotStartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, streamingEnabled, validatePostfixLen, token)
-        };
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch EndsWithQuery(in FieldMetadata field, string endsWith, bool isNegated = false, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
-    {
-        return (forward, isNegated) switch
-        {
-            (true, false) => TermsProviderMatchBuilder<EndsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, streamingEnabled, token),
-            (false, false) => TermsProviderMatchBuilder<EndsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, streamingEnabled, token),
-            (true, true) => TermsProviderMatchBuilder<NotEndsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, streamingEnabled, token),
-            (false, true) => TermsProviderMatchBuilder<NotEndsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, streamingEnabled, token)
+            (true, false) => TermsProviderMatchBuilder<StartsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, validatePostfixLen, token),
+            (false, false) => TermsProviderMatchBuilder<StartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, validatePostfixLen, token),
+            (true, true) => TermsProviderMatchBuilder<NotStartsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, validatePostfixLen, token),
+            (false, true) => TermsProviderMatchBuilder<NotStartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, validatePostfixLen, token)
         };
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch EndsWithQuery(in FieldMetadata field, Slice endsWith, bool isNegated = false, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
+    public IQueryMatch EndsWithQuery(in FieldMetadata field, string endsWith, bool isNegated = false, bool forward = true, in CancellationToken token = default)
     {
         return (forward, isNegated) switch
         {
-            (true, false) => TermsProviderMatchBuilder<EndsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, streamingEnabled, validatePostfixLen: false, token: token),
-            (false, false) => TermsProviderMatchBuilder<EndsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, streamingEnabled, validatePostfixLen: false, token: token),
-            (true, true) => TermsProviderMatchBuilder<NotEndsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, streamingEnabled, validatePostfixLen: false, token: token),
-            (false, true) => TermsProviderMatchBuilder<NotEndsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, streamingEnabled, validatePostfixLen: false, token: token)
+            (true, false) => TermsProviderMatchBuilder<EndsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, token),
+            (false, false) => TermsProviderMatchBuilder<EndsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, token),
+            (true, true) => TermsProviderMatchBuilder<NotEndsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, token),
+            (false, true) => TermsProviderMatchBuilder<NotEndsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, token)
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IQueryMatch EndsWithQuery(in FieldMetadata field, Slice endsWith, bool isNegated = false, bool forward = true, in CancellationToken token = default)
+    {
+        return (forward, isNegated) switch
+        {
+            (true, false) => TermsProviderMatchBuilder<EndsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, token: token),
+            (false, false) => TermsProviderMatchBuilder<EndsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, token: token),
+            (true, true) => TermsProviderMatchBuilder<NotEndsWithTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, token: token),
+            (false, true) => TermsProviderMatchBuilder<NotEndsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, token: token)
         };
     }
 
@@ -81,14 +81,14 @@ public partial class IndexSearcher
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch ExistsQuery(in FieldMetadata field, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
+    public IQueryMatch ExistsQuery(in FieldMetadata field, bool forward = true, in CancellationToken token = default)
     {
         return forward
-            ? TermsProviderMatchBuilder<ExistsTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, default(Slice), streamingEnabled: streamingEnabled, token: token)
-            : TermsProviderMatchBuilder<ExistsTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, default(Slice), streamingEnabled: streamingEnabled, token: token);
+            ? TermsProviderMatchBuilder<ExistsTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, default(Slice), token: token)
+            : TermsProviderMatchBuilder<ExistsTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, default(Slice), token: token);
     }
 
-    public IQueryMatch RegexQuery(in FieldMetadata field, Regex regex, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
+    public IQueryMatch RegexQuery(in FieldMetadata field, Regex regex, bool forward = true, in CancellationToken token = default)
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
         if (terms == null)

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
@@ -14,7 +14,7 @@ namespace Corax.Querying;
 
 public partial class IndexSearcher
 {
-    private IQueryMatch TermsProviderMatchBuilder<TTermsProvider>(in FieldMetadata field, Slice term, bool streamingEnabled = false, bool validatePostfixLen = false, in CancellationToken token = default)
+    private IQueryMatch TermsProviderMatchBuilder<TTermsProvider>(in FieldMetadata field, Slice term, bool validatePostfixLen = false, in CancellationToken token = default)
         where TTermsProvider : struct, ITermsProvider
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
@@ -33,19 +33,11 @@ public partial class IndexSearcher
             termKey = null;
         }
 
-        CompactKey seekKey = null;
-        if (TryRewriteTermWhenPerformingBackwardStreaming<TTermsProvider>(streamingEnabled, term, out var seekTerm))
-        {
-            seekKey = _fieldsTree.Llt.AcquireCompactKey();
-            seekKey.Set(seekTerm.AsReadOnlySpan());
-            seekKey.ChangeDictionary(terms.DictionaryId);
-        }
-
-        ITermsProvider provider = GetMultiTermMatchProvider<TTermsProvider>(field, terms, termKey, seekKey, validatePostfixLen, token);
+        ITermsProvider provider = GetMultiTermMatchProvider<TTermsProvider>(field, terms, termKey, seekTerm: null, validatePostfixLen, token);
         return new TermsProviderMatch(provider, _transaction.LowLevelTransaction, _transaction.Allocator);
     }
 
-    private IQueryMatch TermsProviderMatchBuilder<TTermsProvider>(in FieldMetadata field, string term, bool streamingEnabled, CancellationToken token)
+    private IQueryMatch TermsProviderMatchBuilder<TTermsProvider>(in FieldMetadata field, string term, CancellationToken token)
         where TTermsProvider : struct, ITermsProvider
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
@@ -56,67 +48,8 @@ public partial class IndexSearcher
         var termKey = _fieldsTree.Llt.AcquireCompactKey();
         termKey.Set(slicedTerm.AsReadOnlySpan());
 
-        CompactKey seekKey = null;
-        if (TryRewriteTermWhenPerformingBackwardStreaming<TTermsProvider>(streamingEnabled, slicedTerm, out var seekTerm))
-        {
-            seekKey = _fieldsTree.Llt.AcquireCompactKey();
-            seekKey.Set(seekTerm.AsReadOnlySpan());
-        }
-
-        ITermsProvider provider = GetMultiTermMatchProvider<TTermsProvider>(field, terms, termKey, seekKey, validatePostfixLen: false, token: token);
+        ITermsProvider provider = GetMultiTermMatchProvider<TTermsProvider>(field, terms, termKey, seekTerm: null, validatePostfixLen: false, token: token);
         return new TermsProviderMatch(provider, _transaction.LowLevelTransaction, _transaction.Allocator);
-    }
-
-    private bool TryRewriteTermWhenPerformingBackwardStreaming<TTermsProvider>(bool streamingEnabled, Slice termSlice, out Slice termForSeek)
-        where TTermsProvider : struct, ITermsProvider
-    {
-        var shouldRewrite = typeof(TTermsProvider) == typeof(StartsWithTermsProvider<Lookup<CompactKeyLookup>.BackwardIterator>);
-
-        if (streamingEnabled == false || shouldRewrite == false || termSlice.Size == 0)
-        {
-            termForSeek = default;
-            return false;
-        }
-
-        var originalTerm = termSlice.AsSpan();
-
-        if (originalTerm[^1] < byte.MaxValue)
-        {
-            Slice.From(Allocator, termSlice.AsSpan(), out termForSeek);
-            //When we have eg startsWith("ab") we have to seek into "ac"
-            termForSeek.AsSpan()[^1]++;
-            return true;
-        }
-
-        if (originalTerm.Length >= 2)
-        {
-            //Lets scan
-            int idX = originalTerm.Length - 2;
-            for (; idX >= 0; idX--)
-            {
-                if (originalTerm[idX] < byte.MaxValue)
-                    break;
-            }
-
-            if (idX == 0 && originalTerm[idX] == byte.MaxValue)
-                goto AfterAllKeys;
-
-            using (Slice.From(Allocator, originalTerm, out Slice temporarySlice))
-            {
-                temporarySlice[idX]++;
-                temporarySlice[idX + 1] = 1;
-
-                //We accept leaking here since it's will be released after query execution.
-                Slice.From(Allocator, temporarySlice.AsSpan().Slice(idX + 1), out termForSeek);
-                return true;
-            }
-        }
-
-        AfterAllKeys:
-        //Super rare case when we have prefix [255][255] prefix that means we can go to the end of tree, isn't?
-        //[255] chain, we can go to the end of the tree then ;-)
-        termForSeek = Slices.AfterAllKeys;
-        return true;
     }
 
     private TTermsProvider GetMultiTermMatchProvider<TTermsProvider>(in FieldMetadata field, CompactTree termTree, CompactKey term, CompactKey seekTerm, bool validatePostfixLen, CancellationToken token)

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Ranges.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Ranges.cs
@@ -15,22 +15,22 @@ namespace Corax.Querying;
 public partial class IndexSearcher
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch BetweenQuery<TValue>(in FieldMetadata field, TValue low, TValue high, UnaryMatchOperation leftSide = UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation rightSide = UnaryMatchOperation.LessThanOrEqual, bool forward = true, bool streamingEnabled = false, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default) {
+    public IQueryMatch BetweenQuery<TValue>(in FieldMetadata field, TValue low, TValue high, UnaryMatchOperation leftSide = UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation rightSide = UnaryMatchOperation.LessThanOrEqual, bool forward = true, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default) {
         if (typeof(TValue) == typeof(long))
         {
             return (leftSide, rightSide) switch
             {
                 // (x, y)
-                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Exclusive, Range.Exclusive>(field, (long)(object)low, (long)(object)high, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Exclusive, Range.Exclusive>(field, (long)(object)low, (long)(object)high, forward, token: token),
 
                 //<x, y)
-                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Inclusive, Range.Exclusive>(field, (long)(object)low, (long)(object)high, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Inclusive, Range.Exclusive>(field, (long)(object)low, (long)(object)high, forward, token: token),
 
                 //<x, y>
-                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Inclusive, Range.Inclusive>(field, (long)(object)low, (long)(object)high, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Inclusive, Range.Inclusive>(field, (long)(object)low, (long)(object)high, forward, token: token),
 
                 //(x, y>
-                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Exclusive, Range.Inclusive>(field, (long)(object)low, (long)(object)high, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Exclusive, Range.Inclusive>(field, (long)(object)low, (long)(object)high, forward, token: token),
                 _ => throw new ArgumentOutOfRangeException($"Unknown operation at {nameof(BetweenQuery)}.")
             };
         }
@@ -40,16 +40,16 @@ public partial class IndexSearcher
             return (leftSide, rightSide) switch
             {
                 // (x, y)
-                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Exclusive, Range.Exclusive>(field, (double)(object)low, (double)(object)high, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Exclusive, Range.Exclusive>(field, (double)(object)low, (double)(object)high, forward, token: token),
 
                 //<x, y)
-                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Inclusive, Range.Exclusive>(field, (double)(object)low, (double)(object)high, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Inclusive, Range.Exclusive>(field, (double)(object)low, (double)(object)high, forward, token: token),
 
                 //<x, y>
-                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Inclusive, Range.Inclusive>(field, (double)(object)low, (double)(object)high, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Inclusive, Range.Inclusive>(field, (double)(object)low, (double)(object)high, forward, token: token),
 
                 //(x, y>
-                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Exclusive, Range.Inclusive>(field, (double)(object)low, (double)(object)high, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Exclusive, Range.Inclusive>(field, (double)(object)low, (double)(object)high, forward, token: token),
                 _ => throw new ArgumentOutOfRangeException($"Unknown operation at {nameof(BetweenQuery)}.")
 
             };
@@ -64,19 +64,19 @@ public partial class IndexSearcher
             {
                 // (x, y)
                 (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Exclusive, Range.Exclusive>(field,
-                    leftValue, rightValue, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                    leftValue, rightValue, forward, token: token),
 
                 //<x, y)
                 (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThan) => RangeBuilder<Range.Inclusive, Range.Exclusive>(field,
-                    leftValue, rightValue, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                    leftValue, rightValue, forward, token: token),
 
                 //<x, y>
                 (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Inclusive, Range.Inclusive>(
-                    field, leftValue, rightValue, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                    field, leftValue, rightValue, forward, token: token),
 
                 //(x, y>
                 (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThanOrEqual) => RangeBuilder<Range.Exclusive, Range.Inclusive>(field,
-                    leftValue, rightValue, forward, streamingEnabled, maxNumberOfTerms, token: token),
+                    leftValue, rightValue, forward, token: token),
                 _ => throw new ArgumentOutOfRangeException($"Unknown operation at {nameof(BetweenQuery)}.")
             };
         }
@@ -85,68 +85,68 @@ public partial class IndexSearcher
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch GreaterThanQuery<TValue>(in FieldMetadata field, TValue value, bool forward = true, bool streamingEnabled = false, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
+    public IQueryMatch GreaterThanQuery<TValue>(in FieldMetadata field, TValue value, bool forward = true, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
     {
-        return GreatBuilder<Range.Exclusive, Range.Inclusive, TValue>(field, value, forward, streamingEnabled, maxNumberOfTerms, token: token);
+        return GreatBuilder<Range.Exclusive, Range.Inclusive, TValue>(field, value, forward, token: token);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch GreaterThanOrEqualsQuery<TValue>(in FieldMetadata field, TValue value, bool forward = true, bool streamingEnabled = false, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
+    public IQueryMatch GreaterThanOrEqualsQuery<TValue>(in FieldMetadata field, TValue value, bool forward = true, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
     {
-        return GreatBuilder<Range.Inclusive, Range.Inclusive, TValue>(field, value, forward, streamingEnabled, maxNumberOfTerms, token: token);
+        return GreatBuilder<Range.Inclusive, Range.Inclusive, TValue>(field, value, forward, token: token);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private IQueryMatch GreatBuilder<TLeftRange, TRightRange, TValue>(in FieldMetadata field, TValue value, bool forward = true, bool streamingEnabled = false, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
+    private IQueryMatch GreatBuilder<TLeftRange, TRightRange, TValue>(in FieldMetadata field, TValue value, bool forward = true, CancellationToken token = default)
         where TLeftRange : struct, Range.Marker
         where TRightRange : struct, Range.Marker
     {
         if (typeof(TValue) == typeof(long))
         {
-            return RangeBuilder<TLeftRange, TRightRange>(field, (long)(object)value, long.MaxValue, forward, streamingEnabled, maxNumberOfTerms, token: token);
+            return RangeBuilder<TLeftRange, TRightRange>(field, (long)(object)value, long.MaxValue, forward, token: token);
         }
 
         if (typeof(TValue) == typeof(double))
-            return RangeBuilder<TLeftRange, TRightRange>(field, (double)(object)value, double.MaxValue, forward, streamingEnabled, maxNumberOfTerms, token: token);
+            return RangeBuilder<TLeftRange, TRightRange>(field, (double)(object)value, double.MaxValue, forward, token: token);
         if (typeof(TValue) == typeof(string))
         {
             var sliceValue = EncodeAndApplyAnalyzer(field, (string)(object)value);
-            return RangeBuilder<TLeftRange, TRightRange>(field, sliceValue, Slices.AfterAllKeys, forward, streamingEnabled, maxNumberOfTerms, token: token);
+            return RangeBuilder<TLeftRange, TRightRange>(field, sliceValue, Slices.AfterAllKeys, forward, token: token);
         }
 
         throw new ArgumentException("Range queries are supporting strings, longs or doubles only");
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch LessThanOrEqualsQuery<TValue>(in FieldMetadata field, TValue value, bool forward = true, bool streamingEnabled = false, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
-        => LessBuilder<Range.Inclusive, Range.Inclusive, TValue>(field, value, forward, streamingEnabled, maxNumberOfTerms, token: token);
+    public IQueryMatch LessThanOrEqualsQuery<TValue>(in FieldMetadata field, TValue value, bool forward = true, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
+        => LessBuilder<Range.Inclusive, Range.Inclusive, TValue>(field, value, forward, token: token);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IQueryMatch LessThanQuery<TValue>(in FieldMetadata field, TValue value, bool forward = true, bool streamingEnabled = false, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
-        => LessBuilder<Range.Inclusive, Range.Exclusive, TValue>(field, value, forward, streamingEnabled, maxNumberOfTerms, token: token);
+    public IQueryMatch LessThanQuery<TValue>(in FieldMetadata field, TValue value, bool forward = true, long maxNumberOfTerms = long.MaxValue, CancellationToken token = default)
+        => LessBuilder<Range.Inclusive, Range.Exclusive, TValue>(field, value, forward, token: token);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private IQueryMatch LessBuilder<TLeftRange, TRightRange, TValue>(in FieldMetadata field, TValue value,
-        bool forward, bool streamingEnabled, long maxNumberOfTerms, CancellationToken token)
+        bool forward, CancellationToken token)
         where TLeftRange : struct, Range.Marker
         where TRightRange : struct, Range.Marker
     {
         if (typeof(TValue) == typeof(long))
-            return RangeBuilder<TLeftRange, TRightRange>(field, long.MinValue, (long)(object)value, forward, streamingEnabled, maxNumberOfTerms, token: token);
+            return RangeBuilder<TLeftRange, TRightRange>(field, long.MinValue, (long)(object)value, forward, token: token);
 
         if (typeof(TValue) == typeof(double))
-            return RangeBuilder<TLeftRange, TRightRange>(field, double.MinValue, (double)(object)value, forward, streamingEnabled, maxNumberOfTerms, token: token);
+            return RangeBuilder<TLeftRange, TRightRange>(field, double.MinValue, (double)(object)value, forward, token: token);
 
         if (typeof(TValue) == typeof(string))
         {
             var sliceValue = EncodeAndApplyAnalyzer(field, (string)(object)value);
-            return RangeBuilder<TLeftRange, TRightRange>(field, Slices.BeforeAllKeys, sliceValue, forward, streamingEnabled, maxNumberOfTerms, token: token);
+            return RangeBuilder<TLeftRange, TRightRange>(field, Slices.BeforeAllKeys, sliceValue, forward, token: token);
         }
 
         throw new ArgumentException("Range queries are supporting strings, longs or doubles only");
     }
 
-    private IQueryMatch RangeBuilder<TLow, THigh>(in FieldMetadata field, Slice low, Slice high, bool forward, bool streamingEnabled, long maxNumberOfTerms, CancellationToken token)
+    public IQueryMatch RangeBuilder<TLow, THigh>(in FieldMetadata field, Slice low, Slice high, bool forward, CancellationToken token)
         where TLow : struct, Range.Marker
         where THigh : struct, Range.Marker
     {
@@ -161,7 +161,7 @@ public partial class IndexSearcher
         return new TermsProviderMatch(provider, _transaction.LowLevelTransaction, _transaction.Allocator);
     }
 
-    private IQueryMatch RangeBuilder<TLow, THigh>(FieldMetadata field, long low, long high, bool forward, bool streamingEnabled, long maxNumberOfTerms, CancellationToken token)
+    private IQueryMatch RangeBuilder<TLow, THigh>(FieldMetadata field, long low, long high, bool forward, CancellationToken token)
         where TLow : struct, Range.Marker
         where THigh : struct, Range.Marker
     {
@@ -177,7 +177,7 @@ public partial class IndexSearcher
         return new TermsProviderMatch(provider, _transaction.LowLevelTransaction, _transaction.Allocator);
     }
 
-    private IQueryMatch RangeBuilder<TLow, THigh>(FieldMetadata field, double low, double high, bool forward, bool streamingEnabled, long maxNumberOfTerms, CancellationToken token)
+    private IQueryMatch RangeBuilder<TLow, THigh>(FieldMetadata field, double low, double high, bool forward, CancellationToken token)
         where TLow : struct, Range.Marker
         where THigh : struct, Range.Marker
     {

--- a/src/Corax/Querying/Planning/ClauseExecution.cs
+++ b/src/Corax/Querying/Planning/ClauseExecution.cs
@@ -14,6 +14,10 @@ public sealed class ClauseExecution
     public SpatialParams Spatial;
     public VectorParams Vector;
 
+    /// <summary>True when a WHEN condition evaluated to false for this execution.
+    /// The clause is stripped from the plan (like empty IN).</summary>
+    public bool WhenEliminated;
+
     /// <summary>Per-execution state for OrGroup subclauses. Parallel to <see cref="ClauseInfo.OrSubClauses"/>.</summary>
     public ClauseExecution[] OrSubExecutions;
 

--- a/src/Corax/Querying/Planning/ClauseInfo.cs
+++ b/src/Corax/Querying/Planning/ClauseInfo.cs
@@ -53,4 +53,8 @@ public sealed class ClauseInfo
     /// <summary>True if this clause is wrapped in boost(). When set, Bindings[^1] is the
     /// boost factor binding and exec.BoostFactor is resolved from it per-execution.</summary>
     public bool HasBoost;
+
+    /// <summary>Index into ClauseTemplate.WhenConditions, or -1 if no WHEN wraps this clause.
+    /// The condition is evaluated per-execution in PopulateClauseValues.</summary>
+    public int WhenConditionIndex = -1;
 }

--- a/src/Corax/Querying/Planning/ClauseTemplate.cs
+++ b/src/Corax/Querying/Planning/ClauseTemplate.cs
@@ -13,4 +13,11 @@ public sealed class ClauseTemplate
     public ClauseInfo[] SpatialClauses;
     /// <summary>Vector clauses separated from the main filter chain (AND queries only).</summary>
     public ClauseInfo[] VectorClauses;
+
+    /// <summary>WHEN condition expressions, indexed by clause position. Null entry = no WHEN.
+    /// Null array = no WHEN clauses in this query. Evaluated during PopulateClauseValues
+    /// to determine which clauses are active for this execution.
+    /// Stored as object[] to avoid Corax depending on Raven.Server AST types
+    /// (actual type: BinaryExpression from Raven.Server.Documents.Queries.AST).</summary>
+    public object[] WhenConditions;
 }

--- a/src/Corax/Querying/Planning/CompiledPlan.cs
+++ b/src/Corax/Querying/Planning/CompiledPlan.cs
@@ -2,8 +2,12 @@ namespace Corax.Querying.Planning;
 
 public sealed class CompiledPlan
 {
-    /// <summary>IL-emitted delegate that executes the posting-list scan plan.</summary>
+    /// <summary>IL-emitted delegate that executes the posting-list scan plan (no timing instrumentation).</summary>
     public QueryIlEmitter.CompiledExecuteDelegate CompiledDelegate { get; init; }
+
+    /// <summary>IL-emitted delegate with per-op timing instrumentation. Compiled lazily on
+    /// first `include timings()` request. Null until then.</summary>
+    public QueryIlEmitter.CompiledExecuteDelegate CompiledTimedDelegate { get; set; }
 
     /* A single query may be represented by different compiled plans, because the shape
      * of the data is different. Consider `WHERE Tag = $tag and Published = $published`.

--- a/src/Corax/Querying/Planning/CompiledQueryHelper.cs
+++ b/src/Corax/Querying/Planning/CompiledQueryHelper.cs
@@ -1,11 +1,16 @@
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Corax.Querying.Matches;
+using Corax.Utils;
+using Voron.Data.RoaringBitmaps;
 
 namespace Corax.Querying.Planning;
 
 /// <summary>
-/// Helper methods called by emitted IL for timing and result tracking.
+/// Helper methods called by emitted IL for timing, result tracking, and
+/// predicate evaluation. Methods are [AggressiveInlining] so the JIT
+/// can inline them into generated delegates.
 /// </summary>
 public static class CompiledQueryHelper
 {
@@ -25,5 +30,206 @@ public static class CompiledQueryHelper
         var resultCounts = ctx.ResultCounts;
         if (resultCounts != null && opIndex < resultCounts.Length)
             resultCounts[opIndex] = ctx.Bitmaps[0].Count;
+    }
+
+    // ── Predicate evaluation helpers ────────────────────────────────────
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CompareLong(long actual, long param, ScanCompareOp op)
+    {
+        return op switch
+        {
+            ScanCompareOp.Equal => actual == param,
+            ScanCompareOp.NotEqual => actual != param,
+            ScanCompareOp.GreaterThan => actual > param,
+            ScanCompareOp.GreaterThanOrEqual => actual >= param,
+            ScanCompareOp.LessThan => actual < param,
+            ScanCompareOp.LessThanOrEqual => actual <= param,
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Unsupported compare op for long")
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CompareLongBetween(long actual, long low, long high)
+        => actual >= low && actual <= high;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CompareDouble(double actual, double param, ScanCompareOp op)
+    {
+        return op switch
+        {
+            ScanCompareOp.Equal => actual == param,
+            ScanCompareOp.NotEqual => actual != param,
+            ScanCompareOp.GreaterThan => actual > param,
+            ScanCompareOp.GreaterThanOrEqual => actual >= param,
+            ScanCompareOp.LessThan => actual < param,
+            ScanCompareOp.LessThanOrEqual => actual <= param,
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Unsupported compare op for double")
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CompareDoubleBetween(double actual, double low, double high)
+        => actual >= low && actual <= high;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CompareSlice(ReadOnlySpan<byte> actual, ReadOnlySpan<byte> param, ScanCompareOp op)
+    {
+        return op switch
+        {
+            ScanCompareOp.Equal => actual.SequenceEqual(param),
+            ScanCompareOp.NotEqual => actual.SequenceEqual(param) == false,
+            ScanCompareOp.GreaterThan => actual.SequenceCompareTo(param) > 0,
+            ScanCompareOp.GreaterThanOrEqual => actual.SequenceCompareTo(param) >= 0,
+            ScanCompareOp.LessThan => actual.SequenceCompareTo(param) < 0,
+            ScanCompareOp.LessThanOrEqual => actual.SequenceCompareTo(param) <= 0,
+            _ => false
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CompareSliceBetween(ReadOnlySpan<byte> actual, ReadOnlySpan<byte> low, ReadOnlySpan<byte> high)
+        => actual.SequenceCompareTo(low) >= 0 && actual.SequenceCompareTo(high) <= 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool SliceStartsWith(ReadOnlySpan<byte> actual, ReadOnlySpan<byte> prefix)
+        => actual.Length >= prefix.Length && actual.Slice(0, prefix.Length).SequenceEqual(prefix);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool SliceEndsWith(ReadOnlySpan<byte> actual, ReadOnlySpan<byte> suffix)
+        => actual.Length >= suffix.Length && actual.Slice(actual.Length - suffix.Length).SequenceEqual(suffix);
+
+    /// <summary>Check StartsWith/EndsWith against ALL terms for a field (multi-value support).
+    /// Returns true if ANY term matches.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CheckFieldTermStartsWith(ref EntryTermsReader reader, long fieldRootPage, ReadOnlySpan<byte> prefix)
+    {
+        reader.Reset();
+        while (reader.FindNext(fieldRootPage))
+        {
+            if (SliceStartsWith(reader.Current.Decoded(), prefix))
+                return true;
+        }
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CheckFieldTermEndsWith(ref EntryTermsReader reader, long fieldRootPage, ReadOnlySpan<byte> suffix)
+    {
+        reader.Reset();
+        while (reader.FindNext(fieldRootPage))
+        {
+            if (SliceEndsWith(reader.Current.Decoded(), suffix))
+                return true;
+        }
+        return false;
+    }
+
+    // ── Entry scan batch method ─────────────────────────────────────────
+
+    /// <summary>Run entry scan on a batch of entry IDs. Reads each entry's stored fields,
+    /// evaluates all predicates, adds passing entries to the target bitmap.
+    /// Called by both the IL entry scan path and DirectScanMatch.</summary>
+    public static unsafe void RunEntryScan(
+        Matches.CompiledQueryMatch ctx,
+        ref RoaringBitmap sourceBitmap,
+        ref RoaringBitmap targetBitmap,
+        ScanPredicateInfo[] predicates,
+        long[] longParams, double[] doubleParams, Voron.Slice[] sliceParams, long[] fieldRootPages)
+    {
+        Span<long> buffer = stackalloc long[256]; // EntryScanBatchSize
+        var iterator = sourceBitmap.GetIterator();
+        Voron.Page lastPage = default;
+        var searcher = ctx.Searcher;
+
+        int read;
+        while ((read = iterator.Fill(ref sourceBitmap, buffer)) > 0)
+        {
+            for (int i = 0; i < read; i++)
+            {
+                long entryId = buffer[i];
+                ctx.EntryScanEntriesScanned++;
+
+                var reader = searcher.GetEntryTermsReader(entryId, ref lastPage);
+                bool passed = true;
+                int rootIdx = 0;
+
+                for (int p = 0; p < predicates.Length && passed; p++)
+                {
+                    ref readonly var pred = ref predicates[p];
+
+                    if (pred.SubPredicates != null)
+                    {
+                        // OR group: pass if any branch passes
+                        bool anyPassed = false;
+                        for (int b = 0; b < pred.SubPredicates.Length; b++)
+                        {
+                            reader.Reset();
+                            if (reader.FindNext(fieldRootPages[rootIdx + b]))
+                            {
+                                if (EvaluateSinglePredicate(ref reader, pred.SubPredicates[b], longParams, doubleParams, sliceParams))
+                                {
+                                    anyPassed = true;
+                                    break;
+                                }
+                            }
+                        }
+                        rootIdx += pred.SubPredicates.Length;
+                        passed = anyPassed;
+                        continue;
+                    }
+
+                    reader.Reset();
+                    bool found = reader.FindNext(fieldRootPages[rootIdx]);
+                    rootIdx++;
+
+                    if (pred.CompareOp == ScanCompareOp.Exists)
+                    {
+                        passed = found;
+                    }
+                    else if (pred.CompareOp == ScanCompareOp.NotEqual)
+                    {
+                        passed = found == false || EvaluateSinglePredicate(ref reader, pred, longParams, doubleParams, sliceParams);
+                    }
+                    else
+                    {
+                        passed = found && EvaluateSinglePredicate(ref reader, pred, longParams, doubleParams, sliceParams);
+                    }
+                }
+
+                if (passed)
+                {
+                    ctx.EntryScanEntriesPassed++;
+                    targetBitmap.Add(entryId);
+                }
+            }
+        }
+        iterator.Dispose();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool EvaluateSinglePredicate(ref EntryTermsReader reader, in ScanPredicateInfo pred,
+        long[] longParams, double[] doubleParams, Voron.Slice[] sliceParams)
+    {
+        return pred.ValueType switch
+        {
+            ScanValueType.Long when pred.CompareOp == ScanCompareOp.Between =>
+                CompareLongBetween(reader.CurrentLong, longParams[pred.ParamIndex], longParams[pred.ParamIndex2]),
+            ScanValueType.Long =>
+                CompareLong(reader.CurrentLong, longParams[pred.ParamIndex], pred.CompareOp),
+            ScanValueType.Double when pred.CompareOp == ScanCompareOp.Between =>
+                CompareDoubleBetween(reader.CurrentDouble, doubleParams[pred.ParamIndex], doubleParams[pred.ParamIndex2]),
+            ScanValueType.Double =>
+                CompareDouble(reader.CurrentDouble, doubleParams[pred.ParamIndex], pred.CompareOp),
+            ScanValueType.Slice when pred.CompareOp == ScanCompareOp.Between =>
+                CompareSliceBetween(reader.Current.Decoded(), sliceParams[pred.ParamIndex].AsReadOnlySpan(), sliceParams[pred.ParamIndex2].AsReadOnlySpan()),
+            ScanValueType.Slice when pred.CompareOp == ScanCompareOp.StartsWith =>
+                SliceStartsWith(reader.Current.Decoded(), sliceParams[pred.ParamIndex].AsReadOnlySpan()),
+            ScanValueType.Slice when pred.CompareOp == ScanCompareOp.EndsWith =>
+                SliceEndsWith(reader.Current.Decoded(), sliceParams[pred.ParamIndex].AsReadOnlySpan()),
+            ScanValueType.Slice =>
+                CompareSlice(reader.Current.Decoded(), sliceParams[pred.ParamIndex].AsReadOnlySpan(), pred.CompareOp),
+            _ => false
+        };
     }
 }

--- a/src/Corax/Querying/Planning/QueryExecution.cs
+++ b/src/Corax/Querying/Planning/QueryExecution.cs
@@ -14,7 +14,6 @@ public class QueryExecution
     public ClauseExecution[] Executions;
     public bool IsAllEntries;
     public bool AllNegated;
-    public bool IsOr;
 
     /// <summary>Typed parameter values for clause resolution. Populated during plan building
     /// from resolved query parameters and literal values. Each clause's PackedParam field
@@ -55,4 +54,9 @@ public class QueryExecution
     /// <summary>Metadata for entry scan predicates. Used by the IL emitter to generate
     /// direct comparison calls. Null if no entry scan is possible.</summary>
     public ScanPredicateInfo[] ScanPredicateInfos;
+
+    /// <summary>Per-execution term counts for OrRange/AndRange ops. Each range op's
+    /// ParamIndex2 is an index into this array. The IL reads the count at runtime,
+    /// so the same compiled delegate handles different IN parameter array sizes.</summary>
+    public int[] InRangeCounts;
 }

--- a/src/Corax/Querying/Planning/QueryILEmitter.cs
+++ b/src/Corax/Querying/Planning/QueryILEmitter.cs
@@ -35,6 +35,8 @@ public static class QueryIlEmitter
         typeof(CompiledQueryHelper).GetMethod(nameof(CompiledQueryHelper.RecordTiming))!;
     private static readonly MethodInfo RecordResultCount =
         typeof(CompiledQueryHelper).GetMethod(nameof(CompiledQueryHelper.RecordResultCount))!;
+    private static readonly MethodInfo RunEntryScanMethod =
+        typeof(CompiledQueryHelper).GetMethod(nameof(CompiledQueryHelper.RunEntryScan))!;
 
     // IQueryMatch
     private static readonly MethodInfo MatchCountGetter = typeof(IQueryMatch).GetProperty(nameof(IQueryMatch.Count))!.GetGetMethod()!;
@@ -46,6 +48,10 @@ public static class QueryIlEmitter
     private static readonly MethodInfo OrWith =
         typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.OrWith),
             [typeof(RoaringBitmap).MakeByRefType()])!;
+    private static readonly MethodInfo LazyOrWith =
+        typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.LazyOrWith),
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public,
+            [typeof(RoaringBitmap).MakeByRefType()])!;
     private static readonly MethodInfo AndNotWith =
         typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.AndNotWith),
             [typeof(RoaringBitmap).MakeByRefType()])!;
@@ -55,7 +61,6 @@ public static class QueryIlEmitter
     private static readonly MethodInfo CountGetter = typeof(RoaringBitmap).GetProperty(nameof(RoaringBitmap.Count))!.GetGetMethod()!;
     private static readonly MethodInfo RepairAfterLazy =
         typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.RepairAfterLazy), Type.EmptyTypes)!;
-    private static readonly MethodInfo BitmapCountGetter = typeof(RoaringBitmap).GetProperty(nameof(RoaringBitmap.Count))!.GetGetMethod()!;
     private static readonly MethodInfo SwapContents =
         typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.SwapContents),
             [typeof(RoaringBitmap).MakeByRefType()])!;
@@ -103,6 +108,12 @@ public static class QueryIlEmitter
         typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.SliceParams));
     private static readonly FieldInfo CtxResolvedMatches =
         typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.ResolvedMatches));
+    private static readonly FieldInfo CtxInRangeCounts =
+        typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.InRangeCounts));
+    private static readonly FieldInfo CtxEntryScanScanned =
+        typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.EntryScanEntriesScanned));
+    private static readonly FieldInfo CtxEntryScanPassed =
+        typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.EntryScanEntriesPassed));
     private static readonly FieldInfo CtxTermsProviders =
         typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.TermsProviders));
 
@@ -153,7 +164,7 @@ public static class QueryIlEmitter
             nameof(QueryPrimitives.ShouldSwitchToEntryScan),
             [typeof(long), typeof(long)])!;
 
-    public static CompiledExecuteDelegate EmitDelegate(QueryExecution plan, out string explainSource)
+    public static CompiledExecuteDelegate EmitDelegate(QueryExecution plan, out string explainSource, bool emitTimings = true)
     {
         var ops = plan.Ops;
         if (ops == null || ops.Length == 0)
@@ -186,6 +197,7 @@ public static class QueryIlEmitter
         var doneLabel = il.DefineLabel();
         var entryScanLabel = il.DefineLabel();
         bool hasEntryScan = false;
+        bool needsLazyRepair = false;
         int entryScanOpIndex = -1;
 
         // stackalloc long[FillBufferSize]
@@ -206,8 +218,9 @@ public static class QueryIlEmitter
         {
             ref PlanOp op = ref ops[i];
 
-            // Timing: record start tick before each op
-            EmitTimingStart(il, startTickLocal);
+            // Timing: record start tick before each op (skipped for untimed delegate)
+            if (emitTimings)
+                EmitTimingStart(il, startTickLocal);
 
             // Resolve dispatch once per op — used by both IL emission and EXPLAIN.
             var (src, fillMethod, andMethod, orMethod, andNotMethod) = op.Dispatch switch
@@ -289,17 +302,16 @@ public static class QueryIlEmitter
                     break;
 
                 case PlanOpKind.OrBitmaps:
+                    // Use LazyOrWith to defer popcount repair. Containers are stolen/merged
+                    // immediately but cardinality is left as -1. A single RepairAfterLazy
+                    // before the done label fixes all lazy cardinalities in one pass.
                     EmitLoadBitmapRef(il, op.BitmapLocal);
                     EmitLoadBitmapRef(il, op.ParamIndex2);
-                    il.Emit(OpCodes.Call, OrWith);
-                    explain.AppendLine($"bitmap[{op.BitmapLocal}].OrWith(bitmap[{op.ParamIndex2}]);");
-
-                    EmitLoadBitmapRef(il, op.BitmapLocal);
-                    il.Emit(OpCodes.Call, CountGetter);
-                    il.Emit(OpCodes.Conv_I8);
-                    EmitLoadLimit(il);
-                    il.Emit(OpCodes.Bge, doneLabel);
-                    explain.AppendLine($"if (bitmap[{op.BitmapLocal}].Count >= limit) return;");
+                    il.Emit(OpCodes.Call, LazyOrWith);
+                    needsLazyRepair = true;
+                    explain.AppendLine($"bitmap[{op.BitmapLocal}].LazyOrWith(bitmap[{op.ParamIndex2}]);");
+                    // Skip Count-based limit check — Count is unreliable with lazy cardinality.
+                    // The limit will be checked after RepairAfterLazy.
                     break;
 
                 case PlanOpKind.SwapBitmaps:
@@ -336,7 +348,7 @@ public static class QueryIlEmitter
                     entryScanOpIndex = i;
 
                     EmitLoadBitmapRef(il, 0);
-                    il.Emit(OpCodes.Call, BitmapCountGetter);
+                    il.Emit(OpCodes.Call, CountGetter);
                     il.Emit(OpCodes.Conv_I8);
                     EmitLoadMatch(il, op.ParamIndex);
                     il.Emit(OpCodes.Callvirt, MatchCountGetter);
@@ -348,13 +360,24 @@ public static class QueryIlEmitter
 
                 case PlanOpKind.OrRange:
                 {
-                    // for (int j = start; j < start+count; j++) Or(ctx, j, bitmapLocal);
-                    // Or on an empty bitmap acts as Fill — no separate Fill needed.
+                    // for (int j = start; j < start + ctx.InRangeCounts[rangeIdx]; j++) Or(ctx, j, bitmapLocal);
+                    // Count is read at runtime from ctx.InRangeCounts so the same compiled
+                    // delegate handles different IN parameter array sizes.
                     int start = op.ParamIndex;
-                    int count = op.ParamIndex2;
+                    int rangeIdx = op.ParamIndex2; // index into InRangeCounts
                     var loopVar = il.DeclareLocal(typeof(int));
+                    var endVar = il.DeclareLocal(typeof(int));
                     var loopCheck = il.DefineLabel();
                     var loopBody = il.DefineLabel();
+
+                    // endVar = start + ctx.InRangeCounts[rangeIdx]
+                    il.Emit(OpCodes.Ldc_I4, start);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, CtxInRangeCounts);
+                    EmitLdcI4(il, rangeIdx);
+                    il.Emit(OpCodes.Ldelem_I4);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Stloc, endVar);
 
                     il.Emit(OpCodes.Ldc_I4, start);
                     il.Emit(OpCodes.Stloc, loopVar);
@@ -374,21 +397,31 @@ public static class QueryIlEmitter
 
                     il.MarkLabel(loopCheck);
                     il.Emit(OpCodes.Ldloc, loopVar);
-                    il.Emit(OpCodes.Ldc_I4, start + count);
+                    il.Emit(OpCodes.Ldloc, endVar);
                     il.Emit(OpCodes.Blt, loopBody);
 
-                    explain.AppendLine($"for (i = {start}..{start + count}) Or(bitmap[{op.BitmapLocal}], {src}[i]);");
+                    explain.AppendLine($"for (i = {start}..{start}+InRangeCounts[{rangeIdx}]) Or(bitmap[{op.BitmapLocal}], {src}[i]);");
                     break;
                 }
 
                 case PlanOpKind.AndRange:
                 {
-                    // Emit a loop: for (int j = start; j < start + count; j++) { And(ctx, j); if empty → done; }
+                    // for (int j = start; j < start + ctx.InRangeCounts[rangeIdx]; j++) { And(ctx, j); if empty → done; }
                     int start = op.ParamIndex;
-                    int count = op.ParamIndex2;
+                    int rangeIdx = op.ParamIndex2; // index into InRangeCounts
                     var loopVar = il.DeclareLocal(typeof(int));
+                    var endVar = il.DeclareLocal(typeof(int));
                     var loopCheck = il.DefineLabel();
                     var loopBody = il.DefineLabel();
+
+                    // endVar = start + ctx.InRangeCounts[rangeIdx]
+                    il.Emit(OpCodes.Ldc_I4, start);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, CtxInRangeCounts);
+                    EmitLdcI4(il, rangeIdx);
+                    il.Emit(OpCodes.Ldelem_I4);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Stloc, endVar);
 
                     il.Emit(OpCodes.Ldc_I4, start);
                     il.Emit(OpCodes.Stloc, loopVar);
@@ -415,10 +448,10 @@ public static class QueryIlEmitter
 
                     il.MarkLabel(loopCheck);
                     il.Emit(OpCodes.Ldloc, loopVar);
-                    il.Emit(OpCodes.Ldc_I4, start + count);
+                    il.Emit(OpCodes.Ldloc, endVar);
                     il.Emit(OpCodes.Blt, loopBody);
 
-                    explain.AppendLine($"AndRange(bitmap[0], {src}[{start}..{start + count}]);");
+                    explain.AppendLine($"AndRange(bitmap[0], {src}[{start}..{start}+InRangeCounts[{rangeIdx}]]);");
                     break;
                 }
 
@@ -428,11 +461,19 @@ public static class QueryIlEmitter
                     break;
             }
 
-            // Timing: record elapsed time and result count after each op
-            EmitTimingEnd(il, i, startTickLocal);
+            // Timing: record elapsed time and result count after each op (skipped for untimed delegate)
+            if (emitTimings)
+                EmitTimingEnd(il, i, startTickLocal);
         }
 
         il.MarkLabel(doneLabel);
+        if (needsLazyRepair)
+        {
+            // Fix lazy cardinalities from LazyOrWith before the bitmap is read.
+            EmitLoadBitmapRef(il, 0);
+            il.Emit(OpCodes.Call, RepairAfterLazy);
+            explain.AppendLine("bitmap[0].RepairAfterLazy();");
+        }
         il.Emit(OpCodes.Ret);
 
         // Entry scan label — if any CheckAndMaybeEntryScan was emitted
@@ -443,7 +484,30 @@ public static class QueryIlEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldc_I4, entryScanOpIndex);
             il.Emit(OpCodes.Stfld, CtxEntryScanTakenAtOp);
-            EmitEntryScan(il, plan, readLocal);
+
+            // Call CompiledQueryHelper.RunEntryScan(ctx, ref bitmap[0], ref bitmap[1],
+            //   ctx.ScanPredicateInfos, ctx.ScanLongParams, ctx.ScanDoubleParams, ctx.ScanSliceParams, ctx.ScanFieldRootPages)
+            il.Emit(OpCodes.Ldarg_0);                  // ctx
+            EmitLoadBitmapRef(il, 0);                   // ref bitmap[0]
+            EmitLoadBitmapRef(il, 1);                   // ref bitmap[1]
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.ScanPredicateInfos))!);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.ScanLongParams))!);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.ScanDoubleParams))!);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.ScanSliceParams))!);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.ScanFieldRootPages))!);
+            il.Emit(OpCodes.Call, RunEntryScanMethod);
+
+            // Swap bitmap[0] and bitmap[1], clear bitmap[1]
+            EmitLoadBitmapRef(il, 0);
+            EmitLoadBitmapRef(il, 1);
+            il.Emit(OpCodes.Call, SwapContents);
+            EmitLoadBitmapRef(il, 1);
+            il.Emit(OpCodes.Call, Clear);
             il.Emit(OpCodes.Ret);
         }
         else
@@ -457,439 +521,6 @@ public static class QueryIlEmitter
 
         explainSource = explain.ToString();
         return (CompiledExecuteDelegate)dm.CreateDelegate(typeof(CompiledExecuteDelegate));
-    }
-
-    /// <summary>Emit the entry scan: iterate bitmap entries, check predicates per entry,
-    /// collect matches into TempBitmap, swap bitmaps.
-    /// The predicate checks are emitted as direct IL — no generic loop, no type switch.
-    /// Each predicate's comparison kind (Numerical/Literal) is baked at emitting time.
-    /// The actual comparison values come from the typed parameter arrays (LongParams, DoubleParams, SliceParams).</summary>
-    private static void EmitEntryScan(ILGenerator il, QueryExecution plan, LocalBuilder readLocal)
-    {
-        var predicates = plan.ScanPredicateInfos;
-        if (predicates == null || predicates.Length == 0)
-        {
-            // No predicates — nothing to scan, bitmap is the result
-            return;
-        }
-
-        // Locals for the entry scan loop
-        var batchLocal = il.DeclareLocal(typeof(Span<long>));        // scan batch buffer
-        var iterLocal = il.DeclareLocal(typeof(RoaringBitmapIterator));
-        var pageLocal = il.DeclareLocal(typeof(Page));               // lastPage
-        var readerLocal = il.DeclareLocal(typeof(EntryTermsReader));
-        var iLocal = il.DeclareLocal(typeof(int));                   // loop index i
-        var entryIdLocal = il.DeclareLocal(typeof(long));
-
-        // PrepareForReading + GetIterator
-        EmitLoadBitmapRef(il, 0);
-        il.Emit(OpCodes.Call, PrepareForReading);
-        EmitLoadBitmapRef(il, 0);
-        il.Emit(OpCodes.Call, GetIterator);
-        il.Emit(OpCodes.Stloc, iterLocal);
-
-        // TempBitmap.Clear()
-        EmitLoadBitmapRef(il, 1);
-        il.Emit(OpCodes.Call, Clear);
-
-        // Allocate scan batch: stackalloc long[EntryScanBatchSize]
-        EmitLdcI4(il, QueryPrimitives.EntryScanBatchSize);
-        il.Emit(OpCodes.Conv_U);
-        il.Emit(OpCodes.Sizeof, typeof(long));
-        il.Emit(OpCodes.Mul_Ovf_Un);
-        il.Emit(OpCodes.Localloc);
-        EmitLdcI4(il, QueryPrimitives.EntryScanBatchSize);
-        il.Emit(OpCodes.Newobj, SpanCtor);
-        il.Emit(OpCodes.Stloc, batchLocal);
-
-        // Outer loop: while ((read = iter.Fill(ref bitmap, batch)) > 0)
-        var outerLoopStart = il.DefineLabel();
-        var outerLoopEnd = il.DefineLabel();
-
-        il.MarkLabel(outerLoopStart);
-        il.Emit(OpCodes.Ldloca, iterLocal);
-        EmitLoadBitmapRef(il, 0);
-        il.Emit(OpCodes.Ldloc, batchLocal);
-        il.Emit(OpCodes.Call, IterFill);
-        il.Emit(OpCodes.Stloc, readLocal);
-        il.Emit(OpCodes.Ldloc, readLocal);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Ble, outerLoopEnd);
-
-        // Inner loop: for (i = 0; i < read; i++)
-        var innerLoopStart = il.DefineLabel();
-        var innerLoopEnd = il.DefineLabel();
-        var nextEntry = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Stloc, iLocal);
-
-        il.MarkLabel(innerLoopStart);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Ldloc, readLocal);
-        il.Emit(OpCodes.Bge, innerLoopEnd);
-
-        // entryId = batch[i]
-        il.Emit(OpCodes.Ldloca, batchLocal);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Call, SpanLongIndexer);
-        il.Emit(OpCodes.Ldind_I8);
-        il.Emit(OpCodes.Stloc, entryIdLocal);
-
-        // reader = searcher.GetEntryTermsReader(entryId, ref lastPage, null)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, CtxSearcher);
-        il.Emit(OpCodes.Ldloc, entryIdLocal);
-        il.Emit(OpCodes.Ldloca, pageLocal);
-        il.Emit(OpCodes.Ldnull);                  // CompactKey key = null
-        il.Emit(OpCodes.Call, GetEntryTermsReader);
-        il.Emit(OpCodes.Stloc, readerLocal);
-
-        // Emit each predicate check — comparison kind baked at emit time.
-        // Numeric: direct field access + comparison instruction (no delegate).
-        // Slice: SequenceCompareTo / SequenceEqual — direct byte comparison.
-        // OR groups: branch on first matching sub-predicate.
-        int fieldRootIndex = 0;
-        for (int p = 0; p < predicates.Length; p++)
-        {
-            ref var pred = ref predicates[p];
-
-            if (pred.OrBranches is { Length: > 0 })
-            {
-                // OR group: succeed on first matching branch
-                var orPassed = il.DefineLabel();
-
-                for (int b = 0; b < pred.OrBranches.Length; b++)
-                {
-                    ref var branch = ref pred.OrBranches[b];
-                    var tryNextBranch = (b < pred.OrBranches.Length - 1)
-                        ? il.DefineLabel()
-                        : nextEntry; // last branch fails → entry fails
-
-                    il.Emit(OpCodes.Ldloca, readerLocal);
-                    il.Emit(OpCodes.Call, ReaderReset);
-
-                    // FindNext(fieldRootPages[fieldRootIndex])
-                    il.Emit(OpCodes.Ldloca, readerLocal);
-                    il.Emit(OpCodes.Ldarg_0);
-                    il.Emit(OpCodes.Ldfld, CtxFieldRootPages); // long[]
-                    EmitLdcI4(il, fieldRootIndex);
-                    il.Emit(OpCodes.Ldelem_I8);                  // long
-                    il.Emit(OpCodes.Call, ReaderFindNext);
-                    il.Emit(OpCodes.Brfalse, tryNextBranch);
-
-                    EmitSingleComparison(il, branch, readerLocal);
-                    il.Emit(OpCodes.Brtrue, orPassed); // match → OR succeeds
-
-                    if (b < pred.OrBranches.Length - 1)
-                        il.MarkLabel(tryNextBranch);
-
-                    fieldRootIndex++;
-                }
-
-                il.MarkLabel(orPassed);
-            }
-            else
-            {
-                // Simple AND predicate
-                il.Emit(OpCodes.Ldloca, readerLocal);
-                il.Emit(OpCodes.Call, ReaderReset);
-
-                il.Emit(OpCodes.Ldloca, readerLocal);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, CtxFieldRootPages); // long[]
-                EmitLdcI4(il, fieldRootIndex);
-                il.Emit(OpCodes.Ldelem_I8);                  // long
-                il.Emit(OpCodes.Call, ReaderFindNext);
-
-                if (pred.CompareOp == ScanCompareOp.NotEqual)
-                {
-                    // NotEquals: field not found → predicate passes (entry doesn't have the value)
-                    var fieldFound = il.DefineLabel();
-                    var predPassed = il.DefineLabel();
-                    il.Emit(OpCodes.Brtrue, fieldFound);
-                    il.Emit(OpCodes.Br, predPassed); // skip comparison, predicate passes
-                    il.MarkLabel(fieldFound);
-                    EmitSingleComparison(il, pred, readerLocal);
-                    il.Emit(OpCodes.Brfalse, nextEntry);
-                    il.MarkLabel(predPassed);
-                }
-                else
-                {
-                    il.Emit(OpCodes.Brfalse, nextEntry); // field not found → predicate fails
-                    EmitSingleComparison(il, pred, readerLocal);
-                    il.Emit(OpCodes.Brfalse, nextEntry);
-                }
-
-                fieldRootIndex++;
-            }
-        }
-
-        // All predicates passed — add to TempBitmap
-        EmitLoadBitmapRef(il, 1);
-        il.Emit(OpCodes.Ldloc, entryIdLocal);
-        il.Emit(OpCodes.Call, BitmapAdd);
-
-        // nextEntry: i++, continue
-        il.MarkLabel(nextEntry);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Add);
-        il.Emit(OpCodes.Stloc, iLocal);
-        il.Emit(OpCodes.Br, innerLoopStart);
-
-        il.MarkLabel(innerLoopEnd);
-        il.Emit(OpCodes.Br, outerLoopStart);
-
-        il.MarkLabel(outerLoopEnd);
-
-        // Dispose iterator
-        il.Emit(OpCodes.Ldloca, iterLocal);
-        il.Emit(OpCodes.Call, IterDispose);
-
-        // Swap bitmaps: Bitmap.SwapContents(ref TempBitmap)
-        EmitLoadBitmapRef(il, 0);
-        EmitLoadBitmapRef(il, 1);
-        il.Emit(OpCodes.Call, SwapContents);
-
-        // Clear the now-unused TempBitmap
-        EmitLoadBitmapRef(il, 1);
-        il.Emit(OpCodes.Call, Clear);
-    }
-
-    /// <summary>Emit a single predicate comparison — dispatches to Long/Double/Slice.</summary>
-    private static void EmitSingleComparison(ILGenerator il, in ScanPredicateInfo pred, LocalBuilder readerLocal)
-    {
-        switch (pred.ValueType)
-        {
-            case ScanValueType.Long:
-                EmitLongComparison(il, pred, readerLocal);
-                break;
-            case ScanValueType.Double:
-                EmitDoubleComparison(il, pred, readerLocal);
-                break;
-            case ScanValueType.Slice:
-                EmitSliceComparison(il, pred, readerLocal);
-                break;
-        }
-    }
-
-    /// <summary>Emit: reader.CurrentLong [op] ctx.LongParams[paramIndex] → bool on stack.
-    /// For Between: reader.CurrentLong >= LongParams[paramIndex] AND reader.CurrentLong &lt;= LongParams[paramIndex2].
-    /// IL Cgt/Clt on longs use signed comparison, so long.MinValue &lt; long.MaxValue holds.
-    /// Between uses Blt/Bgt (signed branch) for the same reason — no overflow concern.</summary>
-    private static void EmitLongComparison(ILGenerator il, in ScanPredicateInfo pred, LocalBuilder readerLocal)
-    {
-        if (pred.CompareOp == ScanCompareOp.Between)
-        {
-            // reader.CurrentLong >= LongParams[p1] AND reader.CurrentLong <= LongParams[p2]
-            var betweenFail = il.DefineLabel();
-            var betweenDone = il.DefineLabel();
-
-            // reader.CurrentLong >= LongParams[p1]
-            il.Emit(OpCodes.Ldloca, readerLocal);
-            il.Emit(OpCodes.Ldfld, ReaderCurrentLong);
-            EmitLoadLongParam(il, pred.ParamIndex);
-            il.Emit(OpCodes.Blt, betweenFail);
-
-            // reader.CurrentLong <= LongParams[p2]
-            il.Emit(OpCodes.Ldloca, readerLocal);
-            il.Emit(OpCodes.Ldfld, ReaderCurrentLong);
-            EmitLoadLongParam(il, pred.ParamIndex2);
-            il.Emit(OpCodes.Bgt, betweenFail);
-
-            il.Emit(OpCodes.Ldc_I4_1);
-            il.Emit(OpCodes.Br, betweenDone);
-            il.MarkLabel(betweenFail);
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.MarkLabel(betweenDone);
-            return;
-        }
-
-        // Load reader.CurrentLong
-        il.Emit(OpCodes.Ldloca, readerLocal);
-        il.Emit(OpCodes.Ldfld, ReaderCurrentLong);
-
-        // Load ctx.LongParams[paramIndex]
-        EmitLoadLongParam(il, pred.ParamIndex);
-
-        // Emit comparison → push 1 or 0
-        EmitCompareOp(il, pred.CompareOp);
-    }
-
-    /// <summary>Emit: reader.CurrentDouble [op] ctx.DoubleParams[paramIndex] → bool on stack.</summary>
-    private static void EmitDoubleComparison(ILGenerator il, in ScanPredicateInfo pred, LocalBuilder readerLocal)
-    {
-        if (pred.CompareOp == ScanCompareOp.Between)
-        {
-            var betweenFail = il.DefineLabel();
-            var betweenDone = il.DefineLabel();
-
-            il.Emit(OpCodes.Ldloca, readerLocal);
-            il.Emit(OpCodes.Ldfld, ReaderCurrentDouble);
-            EmitLoadDoubleParam(il, pred.ParamIndex);
-            il.Emit(OpCodes.Blt_Un, betweenFail);
-
-            il.Emit(OpCodes.Ldloca, readerLocal);
-            il.Emit(OpCodes.Ldfld, ReaderCurrentDouble);
-            EmitLoadDoubleParam(il, pred.ParamIndex2);
-            il.Emit(OpCodes.Bgt_Un, betweenFail);
-
-            il.Emit(OpCodes.Ldc_I4_1);
-            il.Emit(OpCodes.Br, betweenDone);
-            il.MarkLabel(betweenFail);
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.MarkLabel(betweenDone);
-            return;
-        }
-
-        il.Emit(OpCodes.Ldloca, readerLocal);
-        il.Emit(OpCodes.Ldfld, ReaderCurrentDouble);
-        EmitLoadDoubleParam(il, pred.ParamIndex);
-        EmitCompareOp(il, pred.CompareOp);
-    }
-
-    /// <summary>Emit: reader.Current.Decoded() [op] ctx.SliceParams[paramIndex].AsReadOnlySpan() → bool on stack.
-    /// Direct byte comparison — inlined IL, no delegate indirection.
-    /// For Equals: SequenceEqual. For ordered: SequenceCompareTo [op] 0.</summary>
-    private static void EmitSliceComparison(ILGenerator il, in ScanPredicateInfo pred, LocalBuilder readerLocal)
-    {
-        // decoded = reader.Current.Decoded()
-        il.Emit(OpCodes.Ldloca, readerLocal);
-        il.Emit(OpCodes.Ldfld, ReaderCurrent);    // CompactKey
-        il.Emit(OpCodes.Callvirt, CompactKeyDecoded); // ReadOnlySpan<byte>
-
-        // expected = ctx.SliceParams[paramIndex].AsReadOnlySpan()
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, CtxSliceParams);    // Slice[]
-        EmitLdcI4(il, pred.ParamIndex);
-        il.Emit(OpCodes.Ldelema, typeof(Slice)); // ref Slice
-        il.Emit(OpCodes.Call, SliceAsReadOnlySpan); // ReadOnlySpan<byte>
-
-        if (pred.CompareOp == ScanCompareOp.Between)
-        {
-            // Between: decoded >= low AND decoded <= high
-            // Stack has: decoded, low (from the default load above)
-            // Need to do two comparisons
-            var betweenFail = il.DefineLabel();
-            var betweenDone = il.DefineLabel();
-
-            // First: decoded.SequenceCompareTo(low) >= 0
-            il.Emit(OpCodes.Call, SequenceCompareTo);
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.Emit(OpCodes.Blt, betweenFail);
-
-            // Second: decoded.SequenceCompareTo(high) <= 0
-            // Re-load decoded
-            il.Emit(OpCodes.Ldloca, readerLocal);
-            il.Emit(OpCodes.Ldfld, ReaderCurrent);
-            il.Emit(OpCodes.Callvirt, CompactKeyDecoded);
-            // Load high
-            il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldfld, CtxSliceParams);    // Slice[]
-            EmitLdcI4(il, pred.ParamIndex2);
-            il.Emit(OpCodes.Ldelema, typeof(Slice)); // ref Slice
-            il.Emit(OpCodes.Call, SliceAsReadOnlySpan);
-            il.Emit(OpCodes.Call, SequenceCompareTo);
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.Emit(OpCodes.Bgt, betweenFail);
-
-            il.Emit(OpCodes.Ldc_I4_1);
-            il.Emit(OpCodes.Br, betweenDone);
-            il.MarkLabel(betweenFail);
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.MarkLabel(betweenDone);
-        }
-        else if (pred.CompareOp == ScanCompareOp.Equal)
-        {
-            // SequenceEqual — returns bool directly
-            il.Emit(OpCodes.Call, SequenceEqual);
-        }
-        else if (pred.CompareOp == ScanCompareOp.NotEqual)
-        {
-            il.Emit(OpCodes.Call, SequenceEqual);
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.Emit(OpCodes.Ceq); // negate
-        }
-        else
-        {
-            // SequenceCompareTo → int, then compare to 0
-            il.Emit(OpCodes.Call, SequenceCompareTo);
-            il.Emit(OpCodes.Ldc_I4_0);
-            EmitIntCompareOp(il, pred.CompareOp);
-        }
-    }
-
-    /// <summary>Emit int comparison for SequenceCompareTo result vs 0.</summary>
-    private static void EmitIntCompareOp(ILGenerator il, ScanCompareOp op)
-    {
-        switch (op)
-        {
-            case ScanCompareOp.GreaterThan:
-                il.Emit(OpCodes.Cgt);
-                break;
-            case ScanCompareOp.GreaterThanOrEqual:
-                il.Emit(OpCodes.Clt);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ceq); // !(result < 0) = result >= 0
-                break;
-            case ScanCompareOp.LessThan:
-                il.Emit(OpCodes.Clt);
-                break;
-            case ScanCompareOp.LessThanOrEqual:
-                il.Emit(OpCodes.Cgt);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ceq); // !(result > 0) = result <= 0
-                break;
-        }
-    }
-
-    private static void EmitLoadLongParam(ILGenerator il, int index)
-    {
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, CtxLongParams); // long[]
-        EmitLdcI4(il, index);
-        il.Emit(OpCodes.Ldelem_I8);              // long
-    }
-
-    private static void EmitLoadDoubleParam(ILGenerator il, int index)
-    {
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, CtxDoubleParams); // double[]
-        EmitLdcI4(il, index);
-        il.Emit(OpCodes.Ldelem_R8);                // double
-    }
-
-    /// <summary>Emit comparison op. Stack has [value, comparand]. Pushes 1 or 0.</summary>
-    private static void EmitCompareOp(ILGenerator il, ScanCompareOp op)
-    {
-        switch (op)
-        {
-            case ScanCompareOp.Equal:
-                il.Emit(OpCodes.Ceq);
-                break;
-            case ScanCompareOp.NotEqual:
-                il.Emit(OpCodes.Ceq);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ceq); // negate
-                break;
-            case ScanCompareOp.GreaterThan:
-                il.Emit(OpCodes.Cgt);
-                break;
-            case ScanCompareOp.GreaterThanOrEqual:
-                il.Emit(OpCodes.Clt);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ceq); // !(a < b) = a >= b
-                break;
-            case ScanCompareOp.LessThan:
-                il.Emit(OpCodes.Clt);
-                break;
-            case ScanCompareOp.LessThanOrEqual:
-                il.Emit(OpCodes.Cgt);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ceq); // !(a > b) = a <= b
-                break;
-        }
     }
 
     private static void EmitLoadBitmapRef(ILGenerator il, int slot)

--- a/src/Corax/Querying/Planning/ScanCompareOp.cs
+++ b/src/Corax/Querying/Planning/ScanCompareOp.cs
@@ -9,4 +9,10 @@ public enum ScanCompareOp : byte
     LessThan,
     LessThanOrEqual,
     Between,
+    /// <summary>Field exists — reader.FindNext succeeds. No value comparison.</summary>
+    Exists,
+    /// <summary>StartsWith — reader term starts with the param slice. Iterate all terms for multi-value fields.</summary>
+    StartsWith,
+    /// <summary>EndsWith — reader term ends with the param slice.</summary>
+    EndsWith,
 }

--- a/src/Corax/Querying/Planning/ScanPredicateInfo.cs
+++ b/src/Corax/Querying/Planning/ScanPredicateInfo.cs
@@ -3,7 +3,7 @@ namespace Corax.Querying.Planning;
 /// <summary>One entry-scan predicate. Numeric predicates emit an IL-inlined compare
 /// against ctx.LongParams[ParamIndex] / DoubleParams[...]; slice predicates emit
 /// an inline byte-sequence comparison. Between uses both ParamIndex slots.
-/// OrBranches field is non-null only for OR-group predicates.</summary>
+/// SubPredicates field is non-null for OR-group and AND-group predicates.</summary>
 public struct ScanPredicateInfo
 {
     public string FieldName;
@@ -11,5 +11,7 @@ public struct ScanPredicateInfo
     public ScanCompareOp CompareOp;
     public int ParamIndex;
     public int ParamIndex2;
-    public ScanPredicateInfo[] OrBranches;
+    /// <summary>Sub-predicates for OR-group or AND-group compound predicates.
+    /// For OR: pass if ANY sub-predicate passes. For AND: pass if ALL pass.</summary>
+    public ScanPredicateInfo[] SubPredicates;
 }

--- a/src/Corax/Querying/Primitives/QueryPrimitives.cs
+++ b/src/Corax/Querying/Primitives/QueryPrimitives.cs
@@ -98,13 +98,13 @@ public static class QueryPrimitives
     // When the candidate bitmap is small enough, it's cheaper to read each entry's
     // stored fields and check predicates than to decode a full posting list and AND.
     // The threshold is the bitmap count below which we consider entry scan.
-    private const long EntryScanCountThreshold = 32 * 1024;
+    public const long EntryScanCountThreshold = 32 * 1024;
 
     // The multiplier approximates the cost ratio: one entry blob read costs roughly
     // 64x a single posting list decode. Entry scan wins when
     // bitmapCount * 64 < postingListSize, i.e. the posting list is much larger
     // than the candidate set.
-    private const long EntryScanCostMultiplier = 64;
+    public const long EntryScanCostMultiplier = 64;
 
     /// <summary>
     /// Fill a bitmap from a posting list. Walks leaf pages, decodes PFor blocks,


### PR DESCRIPTION
## Summary
**Stack: 2 of 3** — Corax library changes

Major overhaul of the Corax query execution layer:

### Entry scan rewrite — C# replaces IL emission
- `CompiledQueryHelper` with `[AggressiveInlining]` predicate helpers (CompareLong/Double/Slice, Between, StartsWith/EndsWith)
- `RunEntryScan` as a C# method replacing ~460 lines of IL generation in `EmitEntryScan`
- Exists, StartsWith, EndsWith added to `ScanCompareOp`
- `OrBranches` → `SubPredicates` rename for AND/OR reuse

### New match types for alternative execution strategies
- **DirectScanMatch**: tree-walk execution with residual entry-scan predicates and batch EntryTermsReader for page locality
- **SortedDrivingMatch**: walks `ITermsProvider` directly, decoding posting lists inline (Single/SmallPostingList/PostingList)

### Sort hint infrastructure
- Replace `ISortSeekHint` interface with `TryGetSortHint`/`SetSortHint` on `CompiledQueryMatch`
- Extract `SortedIndexReader` from `private ref struct` to `internal unsafe struct`
- `SeekAction` delegate for sort-field seek optimization (long/double/string)

### Planning and execution improvements
- Timed delegate compiled upfront on `CompiledPlan`
- Dynamic IN term counts via `InRangeCounts[]`
- WHEN condition index on `ClauseInfo`
- Entry scan telemetry counters

### MultiTermMatch API cleanup
- Remove unused `streamingEnabled` parameter from all multi-term query methods
- Remove dead `TryRewriteTermWhenPerformingBackwardStreaming`
- Make `RangeBuilder` public for compound field queries

## Stack
- [1/3] RoaringBitmap bugfix
- **→ [2/3] Corax query engine** (this PR)
- [3/3] Server integration: QueryPlanBuilder, compound fields, DirectScan

## Files changed (22 files, +1062 -606)
- `src/Corax/Querying/Planning/` — CompiledQueryHelper, QueryILEmitter, planning structs
- `src/Corax/Querying/Matches/` — CompiledQueryMatch, DirectScanMatch, SortedDrivingMatch, SortingMatch
- `src/Corax/Querying/MultiTermMatches/` — API cleanup (3 files)
- `src/Corax/Querying/IndexSearcher.cs` — batch resolution, plan cache setter

## Test plan
- [ ] `dotnet build src/Corax/Corax.csproj -c Release` compiles clean
- [ ] Existing Corax unit tests pass
- [ ] Entry scan C# path produces identical results to old IL path