### PR TITLE
RavenDB-25281 [3/3] Server integration: compound fields, DirectScan, cost model

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -39,7 +39,8 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         _fieldMappings = fieldsMapping;
         _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings)
         {
-            MaxFacetQueryFilterSizeInBytes = index.Configuration.MaxFacetQueryFilterSize.GetValue(SizeUnit.Bytes)
+            MaxFacetQueryFilterSizeInBytes = index.Configuration.MaxFacetQueryFilterSize.GetValue(SizeUnit.Bytes),
+            PlanCache = (index.IndexPersistence as CoraxIndexPersistence)?.SharedPlanCache ?? new global::Corax.Querying.Planning.PlanCache(),
         };
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -26,6 +26,13 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
     private const bool DisableDictionaryTraining = false; // [DEBUG ONLY]: disable training.
     private readonly RavenLogger _logger;
     private readonly CoraxDocumentConverterBase _converter;
+
+    /// <summary>Shared plan cache across all queries for this index instance.
+    /// Compiled IL delegates and clause templates are reused across transactions,
+    /// amortizing JIT costs. Thread-safe (ConcurrentDictionary + SIMD SoA lookup).
+    /// GC'd when the index instance is replaced (e.g., on index reset/rebuild).</summary>
+    internal readonly global::Corax.Querying.Planning.PlanCache SharedPlanCache = new();
+
     public CoraxIndexPersistence(Index index, IIndexReadOperationFactory indexReadOperationFactory) : base(index, indexReadOperationFactory)
     {
         _logger = RavenLogManager.Instance.GetLoggerForIndex<CoraxIndexPersistence>(index);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -82,6 +82,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             IndexSearcher = new IndexSearcher(readTransaction, _fieldMappings)
             {
                 MaxFacetQueryFilterSizeInBytes = index.Configuration.MaxFacetQueryFilterSize.GetValue(SizeUnit.Bytes),
+                PlanCache = (index.IndexPersistence as CoraxIndexPersistence)?.SharedPlanCache ?? new global::Corax.Querying.Planning.PlanCache(),
             };
             
             if (index is {_forTestingPurposes: {CoraxConfiguration: not null}})
@@ -639,17 +640,59 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
                             innerDisposableMatch = queryMatch as IDisposable;
 
+                            // Compound exact match: WHERE f1 = val AND f2 = val → single compound tree lookup.
+                            // Check before ORDER BY — the compound match is faster regardless of sort.
+                            if (queryPlan != null &&
+                                QueryPlanBuilder.TryCreateCompoundExactMatch(queryPlan, planParams, builderParameters, out var compoundExact))
+                            {
+                                innerDisposableMatch?.Dispose();
+                                innerDisposableMatch = compoundExact as IDisposable;
+                                queryMatch = compoundExact;
+                            }
+
                             orderByFields = QueryPlanBuilder.GetSortMetadata(builderParameters, out bool hasEmptySorts);
                             if (orderByFields != null)
                             {
-                                queryMatch = QueryPlanBuilder.OrderBy(
-                                    builderParameters, queryMatch, orderByFields, hasEmptySorts);
+                                // Compound field optimization: WHERE field1 = 'val' ORDER BY field2
+                                // can be served by a single StartsWith scan on the compound tree.
+                                // Results come back pre-sorted by field2, eliminating the SortingMatch.
+                                if (queryPlan != null &&
+                                    QueryPlanBuilder.TryCreateCompoundFieldMatch(
+                                        queryPlan, orderByFields, planParams, builderParameters, out var compoundMatch))
+                                {
+                                    innerDisposableMatch?.Dispose();
+                                    innerDisposableMatch = compoundMatch as IDisposable;
+                                    queryMatch = QueryPlanBuilder.OrderBy(
+                                        builderParameters, compoundMatch, orderByFields, hasEmptySorts);
+                                }
+                                else if (queryPlan != null &&
+                                    QueryPlanBuilder.TryCreateSimpleFieldDirectScan(
+                                        queryPlan, orderByFields, planParams, builderParameters, out var directMatch))
+                                {
+                                    // Simple field DirectScan: SortedDrivingMatch walks the ITermsProvider
+                                    // in term order (field-value sort order). No SortingMatch needed.
+                                    innerDisposableMatch?.Dispose();
+                                    innerDisposableMatch = directMatch as IDisposable;
+                                    queryMatch = directMatch;
+                                }
+                                else
+                                {
+                                    // Set seek hint if WHERE field matches ORDER BY field (optimization for
+                                    // SortUsingIndexFromBitmap to skip walking irrelevant tree terms).
+                                    if (queryMatch is global::Corax.Querying.Matches.CompiledQueryMatch seekMatch)
+                                        QueryPlanBuilder.TrySetSortSeekHint(seekMatch, queryPlan, orderByFields);
+
+                                    queryMatch = QueryPlanBuilder.OrderBy(
+                                        builderParameters, queryMatch, orderByFields, hasEmptySorts);
+                                }
                             }
                             else if (take > 0 && query.Metadata.IsDistinct == false
+                                && query.SkipStatistics
                                 && queryMatch is global::Corax.Querying.Matches.CompiledQueryMatch compiledMatch)
                             {
-                                // No ORDER BY and no DISTINCT — enable limit-aware bitmap
-                                // accumulation. Distinct queries need the full bitmap for dedup.
+                                // No ORDER BY, no DISTINCT, and client doesn't need exact total —
+                                // enable limit-aware bitmap accumulation. The bitmap may be truncated,
+                                // so Count is a lower bound (Confidence = Low).
                                 compiledMatch.Limit = take;
                             }
                         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -75,10 +75,71 @@ internal static partial class QueryPlanBuilder
             execList.Add(CreateExecution(cached));
         }
 
+        // Step 2b: Evaluate WHEN conditions and eliminate inactive clauses
+        if (template.WhenConditions != null)
+        {
+            for (int ci = clauses.Count - 1; ci >= 0; ci--)
+            {
+                int whenIdx = clauses[ci].WhenConditionIndex;
+                if (whenIdx < 0)
+                    continue;
+                var conditionExpr = (Raven.Server.Documents.Queries.AST.BinaryExpression)template.WhenConditions[whenIdx];
+                bool conditionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery(conditionExpr, planParams.QueryParameters);
+                if (conditionResult == false)
+                {
+                    clauses.RemoveAt(ci);
+                    execList.RemoveAt(ci);
+                }
+            }
+        }
+
         // Step 3: Populate parameter values into typed arrays
         var writer = new ValueWriter();
         for (int ci = 0; ci < clauses.Count; ci++)
             PopulateClauseValues(clauses[ci], execList[ci], planParams.QueryParameters, writer);
+
+        // Step 3b: Constant propagation — simplify trivially-false/simple clauses
+        bool isOr = template.IsOr;
+        for (int ci = clauses.Count - 1; ci >= 0; ci--)
+        {
+            var c = clauses[ci];
+            var e = execList[ci];
+
+            // Contradictory BETWEEN: low > high → clause matches nothing
+            if (c.ClauseType == ClauseType.Between && e.PackedParamValue.IsNone == false)
+            {
+                var p = e.PackedParamValue;
+                if (p.Param2 != PackedParam.NoParamValue)
+                {
+                    bool contradictory = p.ValueType switch
+                    {
+                        PackedParam.TypeLong => writer.GetLongs()[p.Param1] > writer.GetLongs()[p.Param2],
+                        PackedParam.TypeDouble => writer.GetDoubles()[p.Param1] > writer.GetDoubles()[p.Param2],
+                        PackedParam.TypeString => string.Compare(writer.GetStrings()[p.Param1], writer.GetStrings()[p.Param2], StringComparison.Ordinal) > 0,
+                        _ => false
+                    };
+                    if (contradictory)
+                    {
+                        // Mark with zero cardinality. EmitPlan handles:
+                        // AND chain: zero-cardinality → empty result.
+                        // OR chain: remove the clause (contributes nothing).
+                        e.Cardinality = 0;
+                        e.InTermCount = 0;
+                        e.HasNullTerm = false;
+                        c.ClauseType = ClauseType.In; // Reuse empty-IN elimination in EmitPlan
+                    }
+                }
+            }
+
+            // Single-value IN → convert to Equals (simpler plan, single PostingList lookup)
+            if (c.ClauseType == ClauseType.In && e.InTermCount == 1 && e.HasNullTerm == false)
+            {
+                c.ClauseType = ClauseType.Equals;
+            }
+            // Null-only IN (InTermCount=0, HasNullTerm=true): already optimized —
+            // EmitInOps skips OrRange (no non-null terms) and emits only the null-term
+            // OrWithPostings op. No conversion needed.
+        }
 
         // Step 4: Estimate cardinality (needs populated values)
         for (int ci = 0; ci < clauses.Count; ci++)
@@ -90,7 +151,6 @@ internal static partial class QueryPlanBuilder
         var executions = execList.ToArray();
 
         // Step 5: Sort operands by cardinality (sort clauses and executions in lockstep)
-        bool isOr = template.IsOr;
         if (!isOr)
         {
             // Build index array, sort by cardinality, then reorder both arrays
@@ -144,7 +204,6 @@ internal static partial class QueryPlanBuilder
         {
             plan = EmitPlan(clauses, executions, isOr);
         }
-        plan.IsOr = isOr;
         plan.LongValues = writer.GetLongs();
         plan.DoubleValues = writer.GetDoubles();
         plan.StringValues = writer.GetStrings();
@@ -202,7 +261,8 @@ internal static partial class QueryPlanBuilder
         {
             compiledPlan = new CompiledPlan
             {
-                CompiledDelegate = QueryIlEmitter.EmitDelegate(plan, out var explainText),
+                CompiledDelegate = QueryIlEmitter.EmitDelegate(plan, out var explainText, emitTimings: false),
+                CompiledTimedDelegate = QueryIlEmitter.EmitDelegate(plan, out _, emitTimings: true),
                 ExplainSource = explainText,
                 Ordering = plan.OperandOrdering,
                 TypeSignature = plan.TypeSignature,
@@ -215,16 +275,26 @@ internal static partial class QueryPlanBuilder
         compiledPlanOut = compiledPlan;
         var resolvedMatches = ResolveMatches(plan, indexSearcher, planParams, builderParameters);
         var termSources = ResolveTermSources(plan, indexSearcher, planParams, builderParameters);
+        var termsProviders = ResolveTermsProviders(plan, indexSearcher, planParams, builderParameters);
         ExtractScanParameters(plan, indexSearcher,
             out var longParams, out var doubleParams, out var sliceParams, out var fieldRootPages);
 
         if (highlightingTerms != null)
             PopulateHighlightingTerms(plan, highlightingTerms, planParams.Metadata);
 
-        IQueryMatch result = new CompiledQueryMatch(
-            compiledPlan, plan.RequiredBitmaps, plan.Ops?.Length ?? 0, resolvedMatches, termSources, null,
+        var compiledMatch = new CompiledQueryMatch(
+            compiledPlan, plan.RequiredBitmaps, plan.Ops?.Length ?? 0, resolvedMatches, termSources, termsProviders,
             longParams, doubleParams, sliceParams, fieldRootPages,
-            indexSearcher, planParams.Allocator, wantTimings, token);
+            indexSearcher, planParams.Allocator, wantTimings, token)
+        {
+            InRangeCounts = plan.InRangeCounts,
+            ScanPredicateInfos = plan.ScanPredicateInfos,
+            ScanLongParams = longParams,
+            ScanDoubleParams = doubleParams,
+            ScanSliceParams = sliceParams,
+            ScanFieldRootPages = fieldRootPages
+        };
+        IQueryMatch result = compiledMatch;
 
         // Spatial post-filter phase: AND each spatial match with the candidate bitmap.
         if (plan.SpatialFilters is { Length: > 0 })
@@ -730,18 +800,21 @@ internal static partial class QueryPlanBuilder
 
                     break;
                 }
-                case ClauseType.AllIn or ClauseType.In when (exec.InTermCount > 0 || exec.HasNullTerm):
+                case ClauseType.AllIn or ClauseType.In:
                 {
                     for (int t = 0; t < exec.InTermCount; t++)
                         matches[matchIdx++] = ResolveInTerm(clause, exec, t, indexSearcher, plan, parameters, builderParams);
-                    if (exec.HasNullTerm)
+                    // Always allocate the null-term slot (plan structure is parameter-independent).
+                    // When HasNullTerm is false, fill with a TermQuery(null) that resolves to an
+                    // empty posting list — the OR with an empty match is a no-op.
                     {
                         FieldMetadata nullMeta = builderParams != null
                             ? QueryBuilderHelper.GetFieldMetadata(in builderParams, clause.FieldName, hasBoost: builderParams.HasBoost)
                             : indexSearcher.FieldMetadataBuilder(clause.FieldName, hasBoost: parameters?.HasBoost ?? false);
-                        matches[matchIdx++] = indexSearcher.TermQuery(nullMeta, null);
+                        matches[matchIdx++] = exec.HasNullTerm
+                            ? indexSearcher.TermQuery(nullMeta, null)
+                            : TermMatch.CreateEmpty(indexSearcher, indexSearcher.Allocator);
                     }
-
                     break;
                 }
                 default:
@@ -762,6 +835,49 @@ internal static partial class QueryPlanBuilder
         if (plan.AllNegated)
             matches[matchIdx] = indexSearcher.AllEntries();
         return matches;
+    }
+
+    /// <summary>Resolve a range clause with explicit forward/backward direction for DirectScanMatch.</summary>
+    private static IQueryMatch ResolveRangeClauseWithDirection(ClauseInfo clause, ClauseExecution exec,
+        IndexSearcher indexSearcher, QueryExecution plan, PlanParameters parameters, QueryBuilderParameters builderParams, bool forward)
+    {
+        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, indexSearcher, parameters, builderParams);
+        var packed = exec.PackedParamValue;
+
+        return clause.ClauseType switch
+        {
+            ClauseType.GreaterThan => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.GreaterThanQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.GreaterThanQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.GreaterThanQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            },
+            ClauseType.GreaterThanOrEqual => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            },
+            ClauseType.LessThan => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.LessThanQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.LessThanQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.LessThanQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            },
+            ClauseType.LessThanOrEqual => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            },
+            ClauseType.Between => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.BetweenQuery(fieldMeta, plan.LongValues[packed.Param1], plan.LongValues[packed.Param2], forward: forward),
+                PackedParam.TypeDouble => indexSearcher.BetweenQuery(fieldMeta, plan.DoubleValues[packed.Param1], plan.DoubleValues[packed.Param2], forward: forward),
+                _ => indexSearcher.BetweenQuery(fieldMeta, plan.StringValues[packed.Param1], plan.StringValues[packed.Param2], forward: forward)
+            },
+            _ => ResolveClause(clause, exec, indexSearcher, plan, parameters, builderParams) // fallback
+        };
     }
 
     private static IQueryMatch ResolveClause(ClauseInfo clause, ClauseExecution exec, IndexSearcher indexSearcher,
@@ -1119,12 +1235,11 @@ internal static partial class QueryPlanBuilder
 
                     break;
                 }
-                case ClauseType.AllIn or ClauseType.In when (exec.InTermCount > 0 || exec.HasNullTerm):
+                case ClauseType.AllIn or ClauseType.In:
                 {
                     for (int t = 0; t < exec.InTermCount; t++)
                         termSources[matchIdx++] = ResolveInTermSource(clause, exec, t, indexSearcher, plan, parameters, builderParams);
-                    if (exec.HasNullTerm)
-                        matchIdx++; // null-term slot — stays Empty in TermSources (uses QueryMatch path)
+                    matchIdx++; // null-term slot — always allocated, stays Empty in TermSources (uses QueryMatch path)
                     break;
                 }
                 default:
@@ -1141,6 +1256,134 @@ internal static partial class QueryPlanBuilder
         }
         // AllNegated extra slot is AllEntries — stays Empty in TermSources.
         return termSources;
+    }
+
+    /// <summary>Resolve TreeScan-eligible clauses to ITermsProvider instances for direct
+    /// tree-scan dispatch in the compiled pipeline. Slot indexing is parallel to
+    /// ResolveMatches/ResolveTermSources. Returns null if no TreeScan clauses exist.</summary>
+    private static ITermsProvider[] ResolveTermsProviders(QueryExecution plan, IndexSearcher indexSearcher,
+        PlanParameters parameters = null, QueryBuilderParameters builderParams = null)
+    {
+        if (plan.IsAllEntries || plan.Clauses is not { Count: > 0 } clauses)
+            return null;
+
+        var execs = plan.Executions;
+        bool hasAnyTreeScan = false;
+
+        // Quick check: do we have any TreeScan clauses at all?
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            var clause = clauses[ci];
+            var exec = execs != null && ci < execs.Length ? execs[ci] : null;
+
+            if (IsTreeScanEligibleClause(clause, exec))
+            {
+                hasAnyTreeScan = true;
+                break;
+            }
+
+            // Check subclauses
+            if (clause.OrSubClauses != null)
+            {
+                for (int si = 0; si < clause.OrSubClauses.Count; si++)
+                {
+                    var subExec = exec?.OrSubExecutions?[si];
+                    if (IsTreeScanEligibleClause(clause.OrSubClauses[si], subExec))
+                    {
+                        hasAnyTreeScan = true;
+                        break;
+                    }
+                }
+            }
+            if (hasAnyTreeScan) break;
+
+            if (clause.AndSubClauses != null)
+            {
+                for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                {
+                    var subExec = exec?.AndSubExecutions?[si];
+                    if (IsTreeScanEligibleClause(clause.AndSubClauses[si], subExec))
+                    {
+                        hasAnyTreeScan = true;
+                        break;
+                    }
+                }
+            }
+            if (hasAnyTreeScan) break;
+        }
+
+        if (!hasAnyTreeScan)
+            return null;
+
+        int totalSlots = CountMatchSlots(clauses, execs, plan.IsAllEntries, plan.AllNegated);
+        var providers = new ITermsProvider[totalSlots];
+        int matchIdx = 0;
+
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            ClauseInfo clause = clauses[ci];
+            ClauseExecution exec = execs != null && ci < execs.Length ? execs[ci] : null;
+
+            switch (clause.ClauseType)
+            {
+                case ClauseType.OrGroup when clause.OrSubClauses is { Count: > 0 }:
+                    for (int si = 0; si < clause.OrSubClauses.Count; si++)
+                    {
+                        var sub = clause.OrSubClauses[si];
+                        var subExec = exec?.OrSubExecutions?[si];
+                        providers[matchIdx] = ResolveSingleTermsProvider(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                        matchIdx++;
+                    }
+                    break;
+
+                case ClauseType.AndGroup when clause.AndSubClauses is { Count: > 0 }:
+                    for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                    {
+                        var sub = clause.AndSubClauses[si];
+                        var subExec = exec?.AndSubExecutions?[si];
+                        providers[matchIdx] = ResolveSingleTermsProvider(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                        matchIdx++;
+                    }
+                    break;
+
+                case ClauseType.AllIn or ClauseType.In:
+                    // IN terms use PostingList dispatch, not TreeScan. +1 for null-term slot (always allocated).
+                    matchIdx += (exec?.InTermCount ?? 0) + 1;
+                    break;
+
+                default:
+                    providers[matchIdx] = ResolveSingleTermsProvider(clause, exec, indexSearcher, plan, parameters, builderParams);
+                    matchIdx++;
+                    break;
+            }
+        }
+
+        if (plan.AllNegated)
+            matchIdx++; // AllEntries slot — no provider needed
+
+        return providers;
+    }
+
+    /// <summary>Resolve a single TreeScan-eligible clause to its raw ITermsProvider.
+    /// Returns null for non-TreeScan clauses or when the field doesn't exist in the
+    /// index (factory method returned TermMatch.Empty instead of TermsProviderMatch).
+    /// Null slots cause the IL to fall through to the QueryMatch dispatch path.</summary>
+    private static ITermsProvider ResolveSingleTermsProvider(ClauseInfo clause, ClauseExecution exec,
+        IndexSearcher indexSearcher, QueryExecution plan, PlanParameters parameters, QueryBuilderParameters builderParams)
+    {
+        if (IsTreeScanEligibleClause(clause, exec) == false)
+            return null;
+
+        // Create the match via the existing factory methods, then extract the provider.
+        // The factory methods handle all complexity (analyzer, CompactKey, tree lookup).
+        var match = ResolveClause(clause, exec ?? new ClauseExecution(), indexSearcher, plan, parameters, builderParams);
+        if (match is TermsProviderMatch tpm)
+            return tpm.Provider;
+
+        // Factory returned something other than TermsProviderMatch (e.g. TermMatch.Empty
+        // when the field doesn't exist). Return an empty provider so the IL's TreeScan
+        // dispatch gets a valid (no-op) provider instead of null.
+        return EmptyTermsProviderInstance.Instance;
     }
 
     /// <summary>Resolve a single Equals / NotEquals clause to a posting-list ID and
@@ -1256,17 +1499,25 @@ internal static partial class QueryPlanBuilder
         var slices = new List<Voron.Slice>();
         var roots = new List<long>();
 
-        // Walk predicates and clauses in a lock-step (same order as BuildScanPredicateInfo visited them).
-        // Using field-name search instead would incorrectly return the first matching clause for
-        // every predicate when multiple clauses share the same field (e.g. Name != 'a' AND Name != 'b').
+        // Walk predicates and clauses in lock-step. BuildScanPredicateInfo skips non-eligible
+        // clauses (Search, In, AllIn, Exists, StartsWith, EndsWith, Regex, Spatial, Vector,
+        // AndGroup), so we must skip them here too to keep the 1:1 positional mapping.
         int scanStart = plan.AllNegated ? 0 : 1;
         int clauseIdx = scanStart;
         var clauses = plan.Clauses;
         var execs = plan.Executions;
+        int dummyL = 0, dummyD = 0, dummyS = 0;
         foreach (ScanPredicateInfo pred in predicates)
         {
-            // Advance to the next eligible clause for this predicate.
-            ClauseInfo matchingClause = clauses?[clauseIdx];
+            // Advance past clauses that BuildScanPredicateInfo would have skipped (returned null).
+            while (clauseIdx < clauses.Count &&
+                   BuildScanPredicateInfo(clauses[clauseIdx], execs != null && clauseIdx < execs.Length ? execs[clauseIdx] : null,
+                       ref dummyL, ref dummyD, ref dummyS) == null)
+            {
+                clauseIdx++;
+            }
+
+            ClauseInfo matchingClause = clauses != null && clauseIdx < clauses.Count ? clauses[clauseIdx] : null;
             ClauseExecution matchingExec = execs != null && clauseIdx < execs.Length ? execs[clauseIdx] : null;
             clauseIdx++;
             ExtractParamsFromPredicate(pred, matchingClause, matchingExec, indexSearcher, plan, longs, doubles, slices, roots);
@@ -1282,17 +1533,17 @@ internal static partial class QueryPlanBuilder
         IndexSearcher indexSearcher, QueryExecution plan, List<long> longs, List<double> doubles,
         List<Voron.Slice> slices, List<long> roots)
     {
-        if (pred.OrBranches != null)
+        if (pred.SubPredicates != null)
         {
             // Each OrBranch corresponds to a subclause of the OrGroup.
             // Pass subclauses positionally to avoid the same field-name ambiguity.
             List<ClauseInfo> subClauses = clause?.OrSubClauses;
             ClauseExecution[] subExecs = exec?.OrSubExecutions;
-            for (int b = 0; b < pred.OrBranches.Length; b++)
+            for (int b = 0; b < pred.SubPredicates.Length; b++)
             {
                 ClauseInfo subClause = (subClauses != null && b < subClauses.Count) ? subClauses[b] : null;
                 ClauseExecution subExec = (subExecs != null && b < subExecs.Length) ? subExecs[b] : null;
-                ExtractParamsFromPredicate(pred.OrBranches[b], subClause, subExec, indexSearcher, plan, longs, doubles, slices, roots);
+                ExtractParamsFromPredicate(pred.SubPredicates[b], subClause, subExec, indexSearcher, plan, longs, doubles, slices, roots);
             }
             return;
         }
@@ -1888,6 +2139,866 @@ internal static partial class QueryPlanBuilder
         }
     }
 
+    // ── Compound field merging (WHERE only, no ORDER BY) ──────────────────
+
+    // ── Compound field exact match (no ORDER BY) ─────────────────────────
+
+    /// <summary>Check if two Equals clauses on (field1, field2) match a compound field.
+    /// If so, build a single TermQuery on the compound tree with the composite key.
+    /// One tree lookup instead of two posting list intersections.</summary>
+    public static bool TryCreateCompoundExactMatch(
+        QueryExecution plan, PlanParameters planParams, QueryBuilderParameters builderParams,
+        out IQueryMatch compoundMatch)
+    {
+        compoundMatch = null;
+        if (plan.Clauses == null || plan.Clauses.Count < 2 || plan.AllNegated)
+            return false;
+        if (planParams.Index == null)
+            return false;
+
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        var index = planParams.Index;
+        var indexSearcher = planParams.IndexSearcher;
+        var allocator = planParams.Allocator;
+
+        // Find two unboosted Equals clauses that match a compound field
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            var c1 = clauses[i];
+            if (c1.ClauseType != ClauseType.Equals || c1.IsNegated || c1.HasBoost)
+                continue;
+            var e1 = execs[i];
+            if (e1.BoostFactor > 0 || e1.PackedParamValue.IsNone)
+                continue;
+
+            for (int j = i + 1; j < clauses.Count; j++)
+            {
+                var c2 = clauses[j];
+                if (c2.ClauseType != ClauseType.Equals || c2.IsNegated || c2.HasBoost)
+                    continue;
+                var e2 = execs[j];
+                if (e2.BoostFactor > 0 || e2.PackedParamValue.IsNone)
+                    continue;
+
+                // Check both orderings
+                string firstField = null, secondField = null;
+                ClauseExecution firstExec = null, secondExec = null;
+
+                using (Voron.Slice.From(allocator, c1.FieldName, out var s1))
+                using (Voron.Slice.From(allocator, c2.FieldName, out var s2))
+                {
+                    if (index.HasCompoundField(s1, s2, out _))
+                    {
+                        firstField = c1.FieldName; secondField = c2.FieldName;
+                        firstExec = e1; secondExec = e2;
+                    }
+                    else if (index.HasCompoundField(s2, s1, out _))
+                    {
+                        firstField = c2.FieldName; secondField = c1.FieldName;
+                        firstExec = e2; secondExec = e1;
+                    }
+                }
+
+                if (firstField == null) continue;
+
+                // Build field1 bytes
+                byte[] field1Bytes = BuildCompoundFieldBytes(firstField, firstExec, indexSearcher, plan);
+                if (field1Bytes == null || field1Bytes.Length > byte.MaxValue) continue;
+
+                // Build field2 bytes
+                byte[] field2Bytes = BuildCompoundFieldBytes(secondField, secondExec, indexSearcher, plan);
+                if (field2Bytes == null) continue;
+
+                // Build composite key
+                int totalLen = field1Bytes.Length + field2Bytes.Length + 1;
+                if (totalLen > global::Corax.Constants.Terms.MaxLength) continue;
+
+                var compositeKey = new byte[totalLen];
+                field1Bytes.CopyTo(compositeKey, 0);
+                field2Bytes.CopyTo(compositeKey.AsSpan(field1Bytes.Length));
+                compositeKey[^1] = (byte)field1Bytes.Length;
+
+                var compoundFieldName = $"compound({firstField},{secondField})";
+                var compoundFieldMeta = indexSearcher.FieldMetadataBuilder(compoundFieldName, hasBoost: false);
+                Voron.Slice.From(allocator, compositeKey, out var keySlice);
+
+                // Single exact-term lookup on the compound tree
+                compoundMatch = indexSearcher.TermQuery(compoundFieldMeta, keySlice);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static byte[] BuildCompoundFieldBytes(string fieldName, ClauseExecution exec,
+        IndexSearcher indexSearcher, QueryExecution plan)
+    {
+        var p = exec.PackedParamValue;
+        if (p.ValueType == PackedParam.TypeString)
+        {
+            var meta = indexSearcher.FieldMetadataBuilder(fieldName, hasBoost: false);
+            var analyzed = indexSearcher.EncodeAndApplyAnalyzer(meta, plan.StringValues[p.Param1]);
+            if (analyzed.Size > byte.MaxValue) return null;
+            var bytes = new byte[analyzed.Size];
+            analyzed.CopyTo(bytes);
+            return bytes;
+        }
+        if (p.ValueType == PackedParam.TypeLong)
+        {
+            var bytes = new byte[sizeof(long)];
+            System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                bytes, Sparrow.Binary.Bits.SwapBytes(plan.LongValues[p.Param1]));
+            return bytes;
+        }
+        if (p.ValueType == PackedParam.TypeDouble)
+        {
+            var bytes = new byte[sizeof(long)];
+            long sortable = Sparrow.Binary.Bits.DoubleToSortableLong(plan.DoubleValues[p.Param1]);
+            System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                bytes, Sparrow.Binary.Bits.SwapBytes(sortable));
+            return bytes;
+        }
+        return null;
+    }
+
+    // ── Compound field optimization (with ORDER BY) ─────────────────────
+
+    /// <summary>Check if WHERE + ORDER BY can be served by a compound tree scan.
+    /// Condition: an Equals clause on field1, ORDER BY on field2 (or field1, or both),
+    /// compound(field1, field2) exists in the index, and any residual clauses are
+    /// entry-scan eligible.
+    /// Returns a DirectScanMatch wrapping a compound tree StartsWith with optional
+    /// residual predicate checking.</summary>
+    public static bool TryCreateCompoundFieldMatch(
+        QueryExecution plan, OrderMetadata[] orderByFields,
+        PlanParameters planParams, QueryBuilderParameters builderParams,
+        out IQueryMatch compoundMatch)
+    {
+        compoundMatch = null;
+
+        if (orderByFields == null || orderByFields.Length == 0)
+            return false;
+        if (plan.Clauses == null || plan.Clauses.Count == 0 || plan.AllNegated)
+            return false;
+
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        var index = planParams.Index;
+        var indexSearcher = planParams.IndexSearcher;
+        var allocator = planParams.Allocator;
+
+        // Determine which field to pair with the Equals clause for compound lookup.
+        // Single ORDER BY: compound(equalsField, sortField)
+        // Two ORDER BY fields: compound(orderBy[0], orderBy[1]) — the Equals must be on orderBy[0]
+        string sortFieldName;
+        string compoundField1ForMultiSort = null;
+        if (orderByFields.Length == 1)
+        {
+            sortFieldName = orderByFields[0].Field.FieldName.ToString();
+        }
+        else if (orderByFields.Length == 2)
+        {
+            // Check if compound(orderBy[0], orderBy[1]) exists
+            string f1 = orderByFields[0].Field.FieldName.ToString();
+            string f2 = orderByFields[1].Field.FieldName.ToString();
+            using (Voron.Slice.From(allocator, f1, out var s1))
+            using (Voron.Slice.From(allocator, f2, out var s2))
+            {
+                if (index.HasCompoundField(s1, s2, out _))
+                {
+                    sortFieldName = f2; // The compound tree sorts by f1 then f2
+                    compoundField1ForMultiSort = f1; // The Equals clause must be on f1
+                }
+                else
+                {
+                    return false; // No compound field for this ORDER BY pair
+                }
+            }
+        }
+        else
+        {
+            return false; // >2 ORDER BY fields not supported
+        }
+
+        // Find an Equals clause that, paired with the ORDER BY field, matches a compound field
+        int drivingClauseIdx = -1;
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            var c = clauses[i];
+            if (c.ClauseType != ClauseType.Equals || c.IsNegated || c.HasBoost)
+                continue;
+            var e = execs[i];
+            if (e.BoostFactor > 0)
+                continue;
+
+            if (compoundField1ForMultiSort != null)
+            {
+                // Multi-field ORDER BY: the Equals must be on the first ORDER BY field
+                if (c.FieldName == compoundField1ForMultiSort)
+                {
+                    drivingClauseIdx = i;
+                    break;
+                }
+            }
+            else
+            {
+                // Single-field ORDER BY: check compound(equalsField, sortField)
+                using (Voron.Slice.From(allocator, c.FieldName, out var f1Slice))
+                using (Voron.Slice.From(allocator, sortFieldName, out var sortSlice))
+                {
+                    if (index.HasCompoundField(f1Slice, sortSlice, out _))
+                    {
+                        drivingClauseIdx = i;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (drivingClauseIdx == -1)
+            return false;
+
+        var drivingClause = clauses[drivingClauseIdx];
+        var drivingExec = execs[drivingClauseIdx];
+        var packed = drivingExec.PackedParamValue;
+        if (packed.IsNone)
+            return false;
+
+        // Look for an optional range clause on field2 (the sort field) — narrows the compound scan
+        int field2RangeIdx = -1;
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            if (i == drivingClauseIdx) continue;
+            if (clauses[i].FieldName != sortFieldName) continue;
+            if (clauses[i].ClauseType is ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual
+                or ClauseType.LessThan or ClauseType.LessThanOrEqual or ClauseType.Between)
+            {
+                field2RangeIdx = i;
+                break;
+            }
+        }
+
+        // Check residual clauses are entry-scan eligible
+        var residualPreds = new List<ScanPredicateInfo>();
+        int longIdx = 0, doubleIdx = 0, sliceIdx = 0;
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            if (i == drivingClauseIdx || i == field2RangeIdx)
+                continue;
+            if (clauses[i].HasBoost || (execs[i] is { BoostFactor: > 0 }))
+                return false; // boosted clauses need scoring — can't entry scan
+            var pred = BuildScanPredicateInfo(clauses[i], execs[i], ref longIdx, ref doubleIdx, ref sliceIdx);
+            if (pred == null)
+                return false; // non-scannable residual → fall back to bitmap
+            residualPreds.Add(pred.Value);
+        }
+
+        // Cost check: estimate scan count vs bitmap cost
+        long drivingCardinality = drivingExec.Cardinality > 0 ? drivingExec.Cardinality : indexSearcher.NumberOfEntries;
+        long bitmapCost = 0;
+        for (int i = 0; i < clauses.Count; i++)
+            bitmapCost += execs[i].Cardinality > 0 ? execs[i].Cardinality : indexSearcher.NumberOfEntries;
+
+        // Estimate entries to scan (accounting for residual selectivity)
+        long entriesToScan = drivingCardinality;
+        if (residualPreds.Count > 0)
+        {
+            long minResidualCardinality = long.MaxValue;
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (i == drivingClauseIdx) continue;
+                long card = execs[i].Cardinality > 0 ? execs[i].Cardinality : indexSearcher.NumberOfEntries;
+                if (card < minResidualCardinality)
+                    minResidualCardinality = card;
+            }
+            if (minResidualCardinality > 0 && minResidualCardinality < indexSearcher.NumberOfEntries)
+            {
+                double passRate = (double)minResidualCardinality / indexSearcher.NumberOfEntries;
+                if (passRate > 0)
+                    entriesToScan = (long)(drivingCardinality / passRate);
+            }
+        }
+
+        long directCost = entriesToScan > long.MaxValue / QueryPrimitives.EntryScanCostMultiplier ? long.MaxValue : entriesToScan * QueryPrimitives.EntryScanCostMultiplier;
+        if (directCost >= bitmapCost || entriesToScan > QueryPrimitives.EntryScanCountThreshold)
+            return false; // bitmap is cheaper
+
+        // Build the compound tree match
+        string field1Name = drivingClause.FieldName;
+        var compoundFieldName = $"compound({field1Name},{sortFieldName})";
+        var compoundFieldMeta = indexSearcher.FieldMetadataBuilder(compoundFieldName, hasBoost: false);
+
+        // Build the prefix bytes for field1's value.
+        // String: analyzed via field1's analyzer. Numeric: Bits.SwapBytes big-endian encoding.
+        Voron.Slice analyzedPrefix;
+        string field1ValueStr = null;
+        switch (packed.ValueType)
+        {
+            case PackedParam.TypeString:
+            {
+                field1ValueStr = plan.StringValues[packed.Param1];
+                var field1Meta = builderParams != null
+                    ? QueryBuilderHelper.GetFieldMetadata(in builderParams, field1Name, hasBoost: false)
+                    : indexSearcher.FieldMetadataBuilder(field1Name, hasBoost: false);
+                analyzedPrefix = indexSearcher.EncodeAndApplyAnalyzer(field1Meta, field1ValueStr);
+                break;
+            }
+            case PackedParam.TypeLong:
+            {
+                long longVal = plan.LongValues[packed.Param1];
+                field1ValueStr = longVal.ToString();
+                var bytes = new byte[sizeof(long)];
+                System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(bytes, Sparrow.Binary.Bits.SwapBytes(longVal));
+                Voron.Slice.From(allocator, bytes, out analyzedPrefix);
+                break;
+            }
+            case PackedParam.TypeDouble:
+            {
+                double dblVal = plan.DoubleValues[packed.Param1];
+                field1ValueStr = dblVal.ToString();
+                long sortable = Sparrow.Binary.Bits.DoubleToSortableLong(dblVal);
+                var bytes = new byte[sizeof(long)];
+                System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(bytes, Sparrow.Binary.Bits.SwapBytes(sortable));
+                Voron.Slice.From(allocator, bytes, out analyzedPrefix);
+                break;
+            }
+            default:
+                return false;
+        }
+
+        // Compound key trailing byte stores field1 length as a single byte.
+        // If the analyzed prefix exceeds 255 bytes, the compound key format can't represent it.
+        // Fall back to the bitmap pipeline which queries individual fields normally.
+        if (analyzedPrefix.Size > byte.MaxValue)
+            return false;
+
+        IQueryMatch drivingMatch = null;
+        if (field2RangeIdx >= 0)
+        {
+            // Compound range: build composite low/high keys incorporating the field2 bound
+            var field2Exec = execs[field2RangeIdx];
+            var field2Clause = clauses[field2RangeIdx];
+            var field2Packed = field2Exec.PackedParamValue;
+
+            if (field2Packed.IsNone == false)
+            {
+                // Encode field2 bound value into bytes (same encoding as indexing).
+                // Long/Double: Bits.SwapBytes big-endian. String: analyze with field2's analyzer.
+                byte[] field2Bytes = null;
+                byte[] field2HighBytes = null;
+                bool usePrefix = false;
+
+                if (field2Packed.ValueType == PackedParam.TypeLong)
+                {
+                    field2Bytes = new byte[sizeof(long)];
+                    System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                        field2Bytes, Sparrow.Binary.Bits.SwapBytes(plan.LongValues[field2Packed.Param1]));
+                    if (field2Clause.ClauseType == ClauseType.Between)
+                    {
+                        field2HighBytes = new byte[sizeof(long)];
+                        System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                            field2HighBytes, Sparrow.Binary.Bits.SwapBytes(plan.LongValues[field2Packed.Param2]));
+                    }
+                }
+                else if (field2Packed.ValueType == PackedParam.TypeDouble)
+                {
+                    field2Bytes = new byte[sizeof(long)];
+                    long sortable = Sparrow.Binary.Bits.DoubleToSortableLong(plan.DoubleValues[field2Packed.Param1]);
+                    System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                        field2Bytes, Sparrow.Binary.Bits.SwapBytes(sortable));
+                    if (field2Clause.ClauseType == ClauseType.Between)
+                    {
+                        field2HighBytes = new byte[sizeof(long)];
+                        long highSortable = Sparrow.Binary.Bits.DoubleToSortableLong(plan.DoubleValues[field2Packed.Param2]);
+                        System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                            field2HighBytes, Sparrow.Binary.Bits.SwapBytes(highSortable));
+                    }
+                }
+                else if (field2Packed.ValueType == PackedParam.TypeString)
+                {
+                    // Analyze field2's value with the sort field's analyzer (same as indexing)
+                    var field2Meta = builderParams != null
+                        ? QueryBuilderHelper.GetFieldMetadata(in builderParams, sortFieldName, hasBoost: false)
+                        : indexSearcher.FieldMetadataBuilder(sortFieldName, hasBoost: false);
+                    var analyzed = indexSearcher.EncodeAndApplyAnalyzer(field2Meta, plan.StringValues[field2Packed.Param1]);
+                    if (analyzed.Size > byte.MaxValue)
+                        usePrefix = true;
+                    else
+                    {
+                        field2Bytes = new byte[analyzed.Size];
+                        analyzed.CopyTo(field2Bytes);
+                        if (field2Clause.ClauseType == ClauseType.Between)
+                        {
+                            var analyzedHigh = indexSearcher.EncodeAndApplyAnalyzer(field2Meta, plan.StringValues[field2Packed.Param2]);
+                            if (analyzedHigh.Size > byte.MaxValue)
+                                usePrefix = true;
+                            else
+                            {
+                                field2HighBytes = new byte[analyzedHigh.Size];
+                                analyzedHigh.CopyTo(field2HighBytes);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    usePrefix = true;
+                }
+
+                if (usePrefix || field2Bytes == null)
+                {
+                    // Field2 value too long or unsupported type — fall back to prefix-only
+                    drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
+                        isNegated: false, forward: orderByFields[0].Ascending,
+                        validatePostfixLen: true);
+                }
+                else
+                {
+
+                // Build low and high composite keys
+                int prefixLen = analyzedPrefix.Size;
+                int field2Len = field2Bytes.Length;
+                int keyLen = prefixLen + field2Len + 1; // +1 for field1 length byte
+                int highField2Len = field2HighBytes?.Length ?? field2Len;
+                int highKeyLen = prefixLen + highField2Len + 1;
+
+                // Check total key length against max
+                if (keyLen > global::Corax.Constants.Terms.MaxLength || highKeyLen > global::Corax.Constants.Terms.MaxLength)
+                {
+                    drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
+                        isNegated: false, forward: orderByFields[0].Ascending, validatePostfixLen: true);
+                    goto DrivingMatchReady;
+                }
+
+                byte[] lowKeyBytes = new byte[keyLen];
+                byte[] highKeyBytes = new byte[highKeyLen];
+
+                analyzedPrefix.CopyTo(lowKeyBytes);
+                analyzedPrefix.CopyTo(highKeyBytes);
+
+                // Low key: either the field2 bound or min value (0x00s)
+                // High key: either the field2 bound or max value (0xFFs)
+                bool isGt = field2Clause.ClauseType is ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual;
+                if (isGt || field2Clause.ClauseType == ClauseType.Between)
+                {
+                    field2Bytes.CopyTo(lowKeyBytes.AsSpan(prefixLen));
+                }
+                // else: low = field1 prefix + 0x00s (already zeroed)
+
+                if (field2Clause.ClauseType is ClauseType.LessThan or ClauseType.LessThanOrEqual || field2Clause.ClauseType == ClauseType.Between)
+                {
+                    var highBytes = field2HighBytes ?? field2Bytes;
+                    highBytes.CopyTo(highKeyBytes.AsSpan(prefixLen));
+                }
+                else
+                {
+                    // GT/GTE: high = field1 prefix + 0xFF...FF
+                    highKeyBytes.AsSpan(prefixLen, highField2Len).Fill(0xFF);
+                }
+
+                // Trailing field1 length byte
+                lowKeyBytes[^1] = (byte)prefixLen;
+                highKeyBytes[^1] = (byte)prefixLen;
+
+                Voron.Slice.From(allocator, lowKeyBytes, out var lowSlice);
+                Voron.Slice.From(allocator, highKeyBytes, out var highSlice);
+
+                drivingMatch = indexSearcher.RangeBuilder<global::Corax.Querying.Matches.Meta.Range.Inclusive, global::Corax.Querying.Matches.Meta.Range.Inclusive>(
+                    compoundFieldMeta, lowSlice, highSlice,
+                    forward: orderByFields[0].Ascending, default);
+                }
+            }
+        }
+        else
+        {
+            // Pure prefix scan (no field2 constraint)
+            drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
+                isNegated: false, forward: orderByFields[0].Ascending,
+                validatePostfixLen: true);
+        }
+        DrivingMatchReady:
+
+        // Extract scan parameters for residual predicates
+        ScanPredicateInfo[] residualArray = residualPreds.Count > 0 ? residualPreds.ToArray() : null;
+        long[] longParams = null;
+        double[] doubleParams = null;
+        Voron.Slice[] sliceParams = null;
+        long[] fieldRootPages = null;
+
+        if (residualArray != null)
+        {
+            var longs = new List<long>();
+            var doubles = new List<double>();
+            var slices = new List<Voron.Slice>();
+            var roots = new List<long>();
+
+            int residualIdx = 0;
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (i == drivingClauseIdx || i == field2RangeIdx) continue;
+                var matchingExec = execs[i];
+
+                // Add field root page
+                roots.Add(indexSearcher.FieldCache.GetLookupRootPage(clauses[i].FieldName));
+
+                var predPacked = matchingExec.PackedParamValue;
+                if (predPacked.IsNone) { residualIdx++; continue; }
+
+                int idx1 = predPacked.Param1;
+                int idx2 = predPacked.Param2;
+                bool hasBetween = idx2 != PackedParam.NoParamValue;
+
+                switch (residualArray[residualIdx].ValueType)
+                {
+                    case ScanValueType.Long:
+                        longs.Add(plan.LongValues[idx1]);
+                        if (hasBetween) longs.Add(plan.LongValues[idx2]);
+                        break;
+                    case ScanValueType.Double:
+                        doubles.Add(plan.DoubleValues[idx1]);
+                        if (hasBetween) doubles.Add(plan.DoubleValues[idx2]);
+                        break;
+                    case ScanValueType.Slice:
+                    {
+                        Voron.Slice.From(allocator, plan.StringValues[idx1], out var s1);
+                        slices.Add(s1);
+                        if (hasBetween)
+                        {
+                            Voron.Slice.From(allocator, plan.StringValues[idx2], out var s2);
+                            slices.Add(s2);
+                        }
+                        break;
+                    }
+                }
+                residualIdx++;
+            }
+
+            longParams = longs.Count > 0 ? longs.ToArray() : null;
+            doubleParams = doubles.Count > 0 ? doubles.ToArray() : null;
+            sliceParams = slices.Count > 0 ? slices.ToArray() : null;
+            fieldRootPages = roots.Count > 0 ? roots.ToArray() : null;
+        }
+
+        var directScan = new global::Corax.Querying.Matches.DirectScanMatch(
+            indexSearcher, drivingMatch, residualArray,
+            longParams, doubleParams, sliceParams, fieldRootPages,
+            take: -1)  // take is set by SortingMatch or the caller
+        {
+            DrivingTreeName = compoundFieldName,
+            DrivingClause = $"{field1Name} = '{field1ValueStr}'",
+            SeekBound = $"'{field1ValueStr}' (prefix, validatePostfixLen)",
+            Direction = orderByFields[0].Ascending ? "Forward" : "Backward",
+            ResidualDescription = residualArray != null
+                ? string.Join(", ", residualPreds.ConvertAll(p => $"{p.FieldName} {p.CompareOp}"))
+                : null,
+            Reason = $"entries_to_scan({entriesToScan}) × {QueryPrimitives.EntryScanCostMultiplier} < bitmap_cost({bitmapCost})"
+        };
+
+        compoundMatch = directScan;
+        return true;
+    }
+
+    // ── Simple field direct scan ──────────────────────────────────────────
+
+    /// <summary>Check if a range clause on the ORDER BY field can be served by a direct
+    /// tree scan instead of the bitmap pipeline. The range query already walks the tree
+    /// in sort order, so no SortingMatch wrapper is needed.</summary>
+    public static bool TryCreateSimpleFieldDirectScan(
+        QueryExecution plan, OrderMetadata[] orderByFields,
+        PlanParameters planParams, QueryBuilderParameters builderParams,
+        out IQueryMatch directMatch)
+    {
+        directMatch = null;
+
+        if (orderByFields == null || orderByFields.Length != 1)
+            return false;
+        if (plan.Clauses == null || plan.Clauses.Count == 0 || plan.AllNegated)
+            return false;
+
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        var indexSearcher = planParams.IndexSearcher;
+        string sortFieldName = orderByFields[0].Field.FieldName.ToString();
+
+        // Find a range clause on the sort field
+        int drivingIdx = -1;
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            if (clauses[i].FieldName != sortFieldName)
+                continue;
+            if (clauses[i].ClauseType is not (ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual
+                or ClauseType.LessThan or ClauseType.LessThanOrEqual or ClauseType.Between))
+                continue;
+            if (clauses[i].HasBoost || (execs[i] is { BoostFactor: > 0 }))
+                continue;
+            drivingIdx = i;
+            break;
+        }
+
+        if (drivingIdx == -1)
+            return false;
+
+        // SortedDrivingMatch walks the ITermsProvider directly — the provider enforces
+        // range bounds and the entries come out in term order (field-value sort order).
+        // No bitmap phase needed.
+
+        var drivingPacked = execs[drivingIdx].PackedParamValue;
+        if (drivingPacked.IsNone)
+            return false;
+
+        // Check residual eligibility
+        int longIdx = 0, doubleIdx = 0, sliceIdx = 0;
+        var residualPreds = new List<ScanPredicateInfo>();
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            if (i == drivingIdx) continue;
+            if (clauses[i].HasBoost || (execs[i] is { BoostFactor: > 0 }))
+                return false;
+            var pred = BuildScanPredicateInfo(clauses[i], execs[i], ref longIdx, ref doubleIdx, ref sliceIdx);
+            if (pred == null)
+                return false;
+            residualPreds.Add(pred.Value);
+        }
+
+        // Cost check
+        long drivingCardinality = execs[drivingIdx].Cardinality > 0 ? execs[drivingIdx].Cardinality : indexSearcher.NumberOfEntries;
+        long bitmapCost = 0;
+        for (int i = 0; i < clauses.Count; i++)
+            bitmapCost += execs[i].Cardinality > 0 ? execs[i].Cardinality : indexSearcher.NumberOfEntries;
+
+        long entriesToScan = drivingCardinality;
+        if (residualPreds.Count > 0)
+        {
+            long minResidual = long.MaxValue;
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (i == drivingIdx) continue;
+                long c = execs[i].Cardinality > 0 ? execs[i].Cardinality : indexSearcher.NumberOfEntries;
+                if (c < minResidual) minResidual = c;
+            }
+            if (minResidual > 0 && minResidual < indexSearcher.NumberOfEntries)
+            {
+                double passRate = (double)minResidual / indexSearcher.NumberOfEntries;
+                if (passRate > 0) entriesToScan = (long)(drivingCardinality / passRate);
+            }
+        }
+
+        long directCost = entriesToScan > long.MaxValue / QueryPrimitives.EntryScanCostMultiplier ? long.MaxValue : entriesToScan * QueryPrimitives.EntryScanCostMultiplier;
+        if (directCost >= bitmapCost || entriesToScan > QueryPrimitives.EntryScanCountThreshold)
+            return false;
+
+        // Create the driving match: SortedDrivingMatch walks the ITermsProvider directly.
+        // The provider enforces range bounds; entries come out in term order (sort order).
+        var drivingClause = clauses[drivingIdx];
+        var drivingExec = execs[drivingIdx];
+        bool forward = orderByFields[0].Ascending;
+
+        // Build the range match to extract the ITermsProvider (TermsProviderMatch wraps it)
+        var rangeMatch = ResolveRangeClauseWithDirection(drivingClause, drivingExec, indexSearcher, plan, planParams, builderParams, forward);
+
+        // Extract seek value for the tree walk start position
+        var packed2 = drivingExec.PackedParamValue;
+        object seekValue = null;
+        if (packed2.IsNone == false)
+        {
+            if (forward && drivingClause.ClauseType is ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual)
+            {
+                seekValue = packed2.ValueType switch
+                {
+                    PackedParam.TypeLong => (object)plan.LongValues[packed2.Param1],
+                    PackedParam.TypeDouble => plan.DoubleValues[packed2.Param1],
+                    PackedParam.TypeString => plan.StringValues[packed2.Param1],
+                    _ => null
+                };
+            }
+            else if (forward == false && drivingClause.ClauseType is ClauseType.LessThan or ClauseType.LessThanOrEqual)
+            {
+                seekValue = packed2.ValueType switch
+                {
+                    PackedParam.TypeLong => (object)plan.LongValues[packed2.Param1],
+                    PackedParam.TypeDouble => plan.DoubleValues[packed2.Param1],
+                    PackedParam.TypeString => plan.StringValues[packed2.Param1],
+                    _ => null
+                };
+            }
+            else if (drivingClause.ClauseType == ClauseType.Between)
+            {
+                int idx = forward ? packed2.Param1 : packed2.Param2;
+                seekValue = packed2.ValueType switch
+                {
+                    PackedParam.TypeLong => (object)plan.LongValues[idx],
+                    PackedParam.TypeDouble => plan.DoubleValues[idx],
+                    PackedParam.TypeString => plan.StringValues[idx],
+                    _ => null
+                };
+            }
+        }
+
+        // Extract the ITermsProvider from the range match (TermsProviderMatch wraps it).
+        // SortedDrivingMatch walks the provider directly in term order.
+        ITermsProvider provider = null;
+        if (rangeMatch is TermsProviderMatch tpm)
+            provider = tpm.Provider;
+        if (provider == null)
+            return false; // range match didn't produce a TermsProviderMatch (e.g., empty field)
+
+        var drivingMatch = new global::Corax.Querying.Matches.SortedDrivingMatch(
+            provider, ((TermsProviderMatch)rangeMatch).Llt, planParams.Allocator);
+
+        // Extract residual scan parameters
+        ScanPredicateInfo[] residualArray = residualPreds.Count > 0 ? residualPreds.ToArray() : null;
+        long[] longParams = null;
+        double[] doubleParams = null;
+        Voron.Slice[] sliceParams = null;
+        long[] fieldRootPages = null;
+
+        if (residualArray != null)
+        {
+            var longs = new List<long>();
+            var doubles = new List<double>();
+            var slices = new List<Voron.Slice>();
+            var roots = new List<long>();
+
+            int residualIdx = 0;
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (i == drivingIdx) continue;
+                roots.Add(indexSearcher.FieldCache.GetLookupRootPage(clauses[i].FieldName));
+                var predPacked = execs[i].PackedParamValue;
+                if (predPacked.IsNone) { residualIdx++; continue; }
+                int idx1 = predPacked.Param1;
+                int idx2 = predPacked.Param2;
+                bool hasBetween = idx2 != PackedParam.NoParamValue;
+                switch (residualArray[residualIdx].ValueType)
+                {
+                    case ScanValueType.Long:
+                        longs.Add(plan.LongValues[idx1]);
+                        if (hasBetween) longs.Add(plan.LongValues[idx2]);
+                        break;
+                    case ScanValueType.Double:
+                        doubles.Add(plan.DoubleValues[idx1]);
+                        if (hasBetween) doubles.Add(plan.DoubleValues[idx2]);
+                        break;
+                    case ScanValueType.Slice:
+                        Voron.Slice.From(planParams.Allocator, plan.StringValues[idx1], out var s1);
+                        slices.Add(s1);
+                        if (hasBetween) { Voron.Slice.From(planParams.Allocator, plan.StringValues[idx2], out var s2); slices.Add(s2); }
+                        break;
+                }
+                residualIdx++;
+            }
+            longParams = longs.Count > 0 ? longs.ToArray() : null;
+            doubleParams = doubles.Count > 0 ? doubles.ToArray() : null;
+            sliceParams = slices.Count > 0 ? slices.ToArray() : null;
+            fieldRootPages = roots.Count > 0 ? roots.ToArray() : null;
+        }
+
+        directMatch = new global::Corax.Querying.Matches.DirectScanMatch(
+            indexSearcher, drivingMatch, residualArray,
+            longParams, doubleParams, sliceParams, fieldRootPages,
+            take: -1)
+        {
+            DrivingTreeName = sortFieldName,
+            DrivingClause = $"{drivingClause.FieldName} {drivingClause.ClauseType}",
+            Direction = orderByFields[0].Ascending ? "Forward" : "Backward",
+            ResidualDescription = residualArray != null
+                ? string.Join(", ", residualPreds.ConvertAll(p => $"{p.FieldName} {p.CompareOp}"))
+                : null,
+            Reason = $"entries_to_scan({entriesToScan}) × {QueryPrimitives.EntryScanCostMultiplier} < bitmap_cost({bitmapCost})"
+        };
+        return true;
+    }
+
+    // ── Sort seek hint ────────────────────────────────────────────────────
+
+    /// <summary>If the first clause is a range predicate on the same field as the first
+    /// ORDER BY field, set a seek hint on the CompiledQueryMatch so SortedIndexReader
+    /// can skip walking irrelevant tree terms.</summary>
+    public static void TrySetSortSeekHint(global::Corax.Querying.Matches.CompiledQueryMatch match,
+        QueryExecution plan, OrderMetadata[] orderByFields)
+    {
+        if (orderByFields == null || orderByFields.Length == 0)
+            return;
+
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        if (clauses == null || clauses.Count == 0 || execs == null || execs.Length == 0)
+            return;
+
+        // Only consider the first ORDER BY field
+        var sortField = orderByFields[0].Field.FieldName;
+
+        // Find a range clause on the same field (scan all clauses, not just first — the sort-eligible
+        // clause may not be the cheapest and thus not clause[0]).
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            var clause = clauses[i];
+            var exec = execs[i];
+
+            if (clause.FieldName != sortField.ToString())
+                continue;
+
+            // Range clauses on the sort field — supports long, double, and string
+            if (clause.ClauseType is not (ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual
+                or ClauseType.LessThan or ClauseType.LessThanOrEqual or ClauseType.Between))
+                continue;
+
+            var packed = exec.PackedParamValue;
+            if (packed.IsNone)
+                continue;
+
+            // For ascending order: seek to the lower bound (GT/GTE value)
+            // For descending order: seek to the upper bound (LT/LTE value)
+            bool ascending = orderByFields[0].Ascending;
+            object seekValue = null;
+            bool inclusive = false;
+
+            if (ascending && clause.ClauseType is ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual)
+            {
+                seekValue = packed.ValueType switch
+                {
+                    PackedParam.TypeLong => (object)plan.LongValues[packed.Param1],
+                    PackedParam.TypeDouble => plan.DoubleValues[packed.Param1],
+                    PackedParam.TypeString => plan.StringValues[packed.Param1],
+                    _ => null
+                };
+                inclusive = clause.ClauseType == ClauseType.GreaterThanOrEqual;
+            }
+            else if (ascending == false && clause.ClauseType is ClauseType.LessThan or ClauseType.LessThanOrEqual)
+            {
+                seekValue = packed.ValueType switch
+                {
+                    PackedParam.TypeLong => (object)plan.LongValues[packed.Param1],
+                    PackedParam.TypeDouble => plan.DoubleValues[packed.Param1],
+                    PackedParam.TypeString => plan.StringValues[packed.Param1],
+                    _ => null
+                };
+                inclusive = clause.ClauseType == ClauseType.LessThanOrEqual;
+            }
+            else if (clause.ClauseType == ClauseType.Between)
+            {
+                // Between: seek to the lower bound for ASC, upper bound for DESC
+                int idx = ascending ? packed.Param1 : packed.Param2;
+                seekValue = packed.ValueType switch
+                {
+                    PackedParam.TypeLong => (object)plan.LongValues[idx],
+                    PackedParam.TypeDouble => plan.DoubleValues[idx],
+                    PackedParam.TypeString => plan.StringValues[idx],
+                    _ => null
+                };
+                inclusive = true; // Between is always inclusive on both sides
+            }
+
+            if (seekValue != null)
+            {
+                match.SetSortHint(clause.FieldName, seekValue, inclusive);
+                return;
+            }
+        }
+    }
+
     // ── Sorting / Ordering ───────────────────────────────────────────────
 
     public static OrderMetadata[] GetSortMetadata(QueryBuilderParameters builderParameters, out bool hasEmpty)
@@ -2173,5 +3284,18 @@ internal static partial class QueryPlanBuilder
 
         if (value.Length - lastStart > 0)
             yield return value.Substring(lastStart, value.Length - lastStart);
+    }
+
+    /// <summary>Singleton no-op ITermsProvider for TreeScan slots where the field doesn't exist.
+    /// FillPostingListIds returns 0 immediately, so the bitmap op is a no-op.</summary>
+    private sealed class EmptyTermsProviderInstance : ITermsProvider
+    {
+        public static readonly EmptyTermsProviderInstance Instance = new();
+        public bool IsFillSupported => false;
+        public int Fill(Span<long> containers) => 0;
+        public int FillPostingListIds(Span<long> postingListIds) => 0;
+        public void Reset() { }
+        public bool Next(out TermMatch term) { term = default; return false; }
+        public QueryInspectionNode Inspect() => new("EmptyTermsProvider");
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.cs
@@ -46,6 +46,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 /// </summary>
 internal static partial class QueryPlanBuilder
 {
+    /// <summary>Thread-local WHEN condition accumulator used during ParseTemplate.
+    /// Avoids threading a List through all ParseExpression call sites.</summary>
     /// <summary>
     /// Parameters needed by the planner for field metadata resolution,
     /// analyzer setup, and cardinality estimation.
@@ -197,7 +199,9 @@ internal static partial class QueryPlanBuilder
 
         bool hasMixedAndOr = false;
         var clauses = new List<ClauseInfo>();
-        var rootOp = ParseExpression(query.Where, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+        var whenConditionsList = new List<object>();
+        var rootOp = ParseExpression(query.Where, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditionsList);
+        var whenConditions = whenConditionsList.Count > 0 ? whenConditionsList.ToArray() : null;
 
         if (rootOp == BooleanOp.True || clauses.Count == 0)
             return new ClauseTemplate { IsAllEntries = true, Clauses = [] };
@@ -250,7 +254,8 @@ internal static partial class QueryPlanBuilder
             IsAllEntries = false,
             IsOr = isOr,
             SpatialClauses = spatialClauses,
-            VectorClauses = vectorClauses
+            VectorClauses = vectorClauses,
+            WhenConditions = whenConditions
         };
     }
 
@@ -260,12 +265,13 @@ internal static partial class QueryPlanBuilder
         List<ClauseInfo> clauses,
         BlittableJsonReaderObject queryParameters,
         QueryMetadata metadata,
-        ref bool hasMixedAndOr)
+        ref bool hasMixedAndOr,
+        List<object> whenConditions = null)
     {
         switch (expr)
         {
             case BinaryExpression be:
-                return ParseBinaryExpression(be, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                return ParseBinaryExpression(be, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
 
             case BetweenExpression between:
                 ParseBetween(between, clauses, queryParameters, metadata);
@@ -276,14 +282,14 @@ internal static partial class QueryPlanBuilder
                 return BooleanOp.Leaf;
 
             case NegatedExpression negated:
-                ParseNegated(negated, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                ParseNegated(negated, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                 return BooleanOp.Leaf;
 
             case TrueExpression:
                 return BooleanOp.True;
 
             case MethodExpression method:
-                ParseMethod(method, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                ParseMethod(method, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                 return BooleanOp.Leaf;
 
             default:
@@ -298,7 +304,8 @@ internal static partial class QueryPlanBuilder
         List<ClauseInfo> clauses,
         BlittableJsonReaderObject queryParameters,
         QueryMetadata metadata,
-        ref bool hasMixedAndOr)
+        ref bool hasMixedAndOr,
+        List<object> whenConditions = null)
     {
         switch (be.Operator)
         {
@@ -310,7 +317,7 @@ internal static partial class QueryPlanBuilder
                 if (be.Left is BinaryExpression { Operator: OperatorType.Or })
                 {
                     var orClauses = new List<ClauseInfo>();
-                    left = ParseExpression(be.Left, indexSearcher, orClauses, queryParameters, metadata, ref hasMixedAndOr);
+                    left = ParseExpression(be.Left, indexSearcher, orClauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                     clauses.Add(new ClauseInfo
                     {
                         ClauseType = ClauseType.OrGroup,
@@ -320,13 +327,13 @@ internal static partial class QueryPlanBuilder
                 }
                 else
                 {
-                    left = ParseExpression(be.Left, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                    left = ParseExpression(be.Left, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                 }
 
                 if (be.Right is BinaryExpression { Operator: OperatorType.Or })
                 {
                     var orClauses = new List<ClauseInfo>();
-                    right = ParseExpression(be.Right, indexSearcher, orClauses, queryParameters, metadata, ref hasMixedAndOr);
+                    right = ParseExpression(be.Right, indexSearcher, orClauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                     clauses.Add(new ClauseInfo
                     {
                         ClauseType = ClauseType.OrGroup,
@@ -336,7 +343,7 @@ internal static partial class QueryPlanBuilder
                 }
                 else
                 {
-                    right = ParseExpression(be.Right, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                    right = ParseExpression(be.Right, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                 }
                 if (left == BooleanOp.True) return right;
                 if (right == BooleanOp.True) return left;
@@ -351,7 +358,7 @@ internal static partial class QueryPlanBuilder
                 if (be.Left is BinaryExpression { Operator: OperatorType.And })
                 {
                     var andClauses = new List<ClauseInfo>();
-                    left = ParseExpression(be.Left, indexSearcher, andClauses, queryParameters, metadata, ref hasMixedAndOr);
+                    left = ParseExpression(be.Left, indexSearcher, andClauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                     clauses.Add(new ClauseInfo
                     {
                         ClauseType = ClauseType.AndGroup,
@@ -361,13 +368,13 @@ internal static partial class QueryPlanBuilder
                 }
                 else
                 {
-                    left = ParseExpression(be.Left, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                    left = ParseExpression(be.Left, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                 }
 
                 if (be.Right is BinaryExpression { Operator: OperatorType.And })
                 {
                     var andClauses = new List<ClauseInfo>();
-                    right = ParseExpression(be.Right, indexSearcher, andClauses, queryParameters, metadata, ref hasMixedAndOr);
+                    right = ParseExpression(be.Right, indexSearcher, andClauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                     clauses.Add(new ClauseInfo
                     {
                         ClauseType = ClauseType.AndGroup,
@@ -377,7 +384,7 @@ internal static partial class QueryPlanBuilder
                 }
                 else
                 {
-                    right = ParseExpression(be.Right, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                    right = ParseExpression(be.Right, indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                 }
 
                 if (left == BooleanOp.True || right == BooleanOp.True) return BooleanOp.True;
@@ -510,10 +517,10 @@ internal static partial class QueryPlanBuilder
     }
 
     private static void ParseNegated(NegatedExpression negated, IndexSearcher indexSearcher,
-        List<ClauseInfo> clauses, BlittableJsonReaderObject queryParameters, QueryMetadata metadata, ref bool hasMixedAndOr)
+        List<ClauseInfo> clauses, BlittableJsonReaderObject queryParameters, QueryMetadata metadata, ref bool hasMixedAndOr, List<object> whenConditions = null)
     {
         var innerClauses = new List<ClauseInfo>();
-        ParseExpression(negated.Expression, indexSearcher, innerClauses, queryParameters, metadata, ref hasMixedAndOr);
+        ParseExpression(negated.Expression, indexSearcher, innerClauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
 
         foreach (var inner in innerClauses)
         {
@@ -523,7 +530,8 @@ internal static partial class QueryPlanBuilder
     }
 
     private static void ParseMethod(MethodExpression method, IndexSearcher indexSearcher,
-        List<ClauseInfo> clauses, BlittableJsonReaderObject queryParameters, QueryMetadata metadata, ref bool hasMixedAndOr)
+        List<ClauseInfo> clauses, BlittableJsonReaderObject queryParameters, QueryMetadata metadata, ref bool hasMixedAndOr,
+        List<object> whenConditions = null)
     {
         var methodType = QueryMethod.GetMethodType(method.Name.Value);
         switch (methodType)
@@ -560,7 +568,7 @@ internal static partial class QueryPlanBuilder
                 // exact(expr) → recurse, then mark all new clauses as exact
                 int beforeCount = clauses.Count;
                 if (method.Arguments.Count > 0)
-                    ParseExpression(method.Arguments[0], indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                    ParseExpression(method.Arguments[0], indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                 for (int c = beforeCount; c < clauses.Count; c++)
                     clauses[c].IsExact = true;
                 break;
@@ -571,7 +579,7 @@ internal static partial class QueryPlanBuilder
                 // boost(expr, factor) → recurse, then set boost factor on new clauses
                 int beforeCount = clauses.Count;
                 if (method.Arguments.Count > 0)
-                    ParseExpression(method.Arguments[0], indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                    ParseExpression(method.Arguments[0], indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr, whenConditions);
                 // Append boost factor binding to each inner clause's Bindings array.
                 ParameterBinding boostBinding = method.Arguments.Count > 1
                     ? CreateBinding(method.Arguments[1], queryParameters) : null;
@@ -719,16 +727,20 @@ internal static partial class QueryPlanBuilder
 
             case MethodType.When:
             {
-                // when(condition, expr) — evaluate the constant condition at plan time.
-                // If false, produce no clause (empty result for this branch).
-                // If true, recurse into the inner expression.
+                // when(condition, expr) — always parse the inner expression into the template.
+                // The condition is evaluated per-execution in PopulateClauseValues.
+                // If false, the clause is marked WhenEliminated and stripped in EmitPlan.
                 if (method.Arguments.Count != 2)
                     break;
-                var conditionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery(
-                    (BinaryExpression)method.Arguments[0], queryParameters);
-                if (conditionResult)
-                    ParseExpression(method.Arguments[1], indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
-                // If false, we simply don't add any clause — the branch is eliminated.
+                int beforeCount = clauses.Count;
+                ParseExpression(method.Arguments[1], indexSearcher, clauses, queryParameters, metadata, ref hasMixedAndOr);
+                // Tag all newly-added clauses with the WHEN condition index.
+                // The condition expression is stored on ClauseTemplate.WhenConditions
+                // (set below after ParseTemplate returns).
+                var conditionExpr = method.Arguments[0];
+                for (int wi = beforeCount; wi < clauses.Count; wi++)
+                    clauses[wi].WhenConditionIndex = whenConditions?.Count ?? 0;
+                whenConditions?.Add(conditionExpr);
                 break;
             }
 
@@ -1068,6 +1080,7 @@ internal static partial class QueryPlanBuilder
         }
 
         List<PlanOp> ops = [];
+        List<int> rangeCounts = [];
         bool needsThreeBitmaps = false;
 
         if (isOr)
@@ -1081,7 +1094,7 @@ internal static partial class QueryPlanBuilder
                 switch (it.ClauseType)
                 {
                     case ClauseType.In or ClauseType.AllIn when (itExec.InTermCount > 0 || itExec.HasNullTerm):
-                        EmitInOps(ops, itExec, bitmapLocal: 0, isSeed: matchIndex == 0, ref matchIndex);
+                        EmitInOps(ops, itExec, bitmapLocal: 0, isSeed: matchIndex == 0, ref matchIndex, rangeCounts);
                         break;
                     case ClauseType.OrGroup when it.OrSubClauses is {Count: > 0}:
                     {
@@ -1289,10 +1302,10 @@ internal static partial class QueryPlanBuilder
                             break;
                         }
                         case ClauseType.In when executions[0].InTermCount > 0 || executions[0].HasNullTerm:
-                            EmitInOps(ops, executions[0], bitmapLocal: 0, isSeed: true, ref matchIndex);
+                            EmitInOps(ops, executions[0], bitmapLocal: 0, isSeed: true, ref matchIndex, rangeCounts);
                             break;
                         case ClauseType.AllIn when executions[0].InTermCount > 0:
-                            EmitAllInOps(ops, executions[0], ref matchIndex);
+                            EmitAllInOps(ops, executions[0], ref matchIndex, rangeCounts);
                             break;
                         default:
                             ops.Add(new PlanOp
@@ -1367,7 +1380,7 @@ internal static partial class QueryPlanBuilder
                             // isSeed: false — FillFromPostings always targets bitmap[0], so we use
                             // OrRange which respects bitmapLocal. Bitmap[1] is freshly cleared.
                             ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 1 });
-                            EmitInOps(ops, iExec, bitmapLocal: 1, isSeed: false, ref matchIndex);
+                            EmitInOps(ops, iExec, bitmapLocal: 1, isSeed: false, ref matchIndex, rangeCounts);
                             ops.Add(new PlanOp
                             {
                                 Kind = clauses[i].IsNegated ? PlanOpKind.AndNotBitmaps : PlanOpKind.AndBitmaps,
@@ -1379,17 +1392,21 @@ internal static partial class QueryPlanBuilder
                             break;
                         }
                         case ClauseType.AllIn when iExec.InTermCount > 0:
+                        {
+                            int rangeIdx = rangeCounts.Count;
+                            rangeCounts.Add(iExec.InTermCount);
                             ops.Add(new PlanOp
                             {
                                 Kind = PlanOpKind.AndRange,
                                 ParamIndex = matchIndex,
-                                ParamIndex2 = iExec.InTermCount,
+                                ParamIndex2 = rangeIdx,
                                 BitmapLocal = 0,
                                 EstimatedCardinality = iExec.Cardinality,
                                 Dispatch = MatchDispatch.PostingList
                             });
                             matchIndex += iExec.InTermCount;
                             break;
+                        }
                         default:
                         {
                             // Simple clause: AND or ANDNOT with bitmap[0]
@@ -1418,7 +1435,10 @@ internal static partial class QueryPlanBuilder
             }
         }
 
-        // Pack operand ordering
+        // Pack operand ordering — encodes clause sort order after cardinality reordering.
+        // The plan structure must be the same for all parameter values of the same query text.
+        // Variable-count IN terms use InRangeCounts (read at runtime by the IL).
+        // Null-term slots are always allocated — the match is a no-op when null isn't present.
         int ordering = 0;
         for (int i = 0; i < Math.Min(clauses.Count, 10); i++)
             ordering |= (clauses[i].OriginalIndex & 0x7) << (i * 3);
@@ -1464,7 +1484,8 @@ internal static partial class QueryPlanBuilder
             ScanPredicateInfos = scanPredicateInfos,
             TypeSignature = typeSignature,
             FullKinds = fullKinds,
-            RequiredBitmaps = needsThreeBitmaps ? 3 : 2
+            RequiredBitmaps = needsThreeBitmaps ? 3 : 2,
+            InRangeCounts = rangeCounts.Count > 0 ? rangeCounts.ToArray() : null
         };
     }
 
@@ -1509,7 +1530,7 @@ internal static partial class QueryPlanBuilder
     // ── Plan helpers ─────────────────────────────────────────────────────
 
     /// <summary>Emit ops for an IN clause: Fill the first term + OrRange for the rest, plus null-term if needed.</summary>
-    private static void EmitInOps(List<PlanOp> ops, ClauseExecution exec, int bitmapLocal, bool isSeed, ref int matchIndex)
+    private static void EmitInOps(List<PlanOp> ops, ClauseExecution exec, int bitmapLocal, bool isSeed, ref int matchIndex, List<int> rangeCounts)
     {
         int terms = exec.InTermCount;
         if (terms > 0)
@@ -1526,11 +1547,13 @@ internal static partial class QueryPlanBuilder
                 });
                 if (terms > 1)
                 {
+                    int rangeIdx = rangeCounts.Count;
+                    rangeCounts.Add(terms - 1);
                     ops.Add(new PlanOp
                     {
                         Kind = PlanOpKind.OrRange,
                         ParamIndex = matchIndex + 1,
-                        ParamIndex2 = terms - 1,
+                        ParamIndex2 = rangeIdx,
                         BitmapLocal = bitmapLocal,
                         EstimatedCardinality = exec.Cardinality,
                         Dispatch = MatchDispatch.PostingList
@@ -1539,11 +1562,13 @@ internal static partial class QueryPlanBuilder
             }
             else
             {
+                int rangeIdx = rangeCounts.Count;
+                rangeCounts.Add(terms);
                 ops.Add(new PlanOp
                 {
                     Kind = PlanOpKind.OrRange,
                     ParamIndex = matchIndex,
-                    ParamIndex2 = terms,
+                    ParamIndex2 = rangeIdx,
                     BitmapLocal = bitmapLocal,
                     EstimatedCardinality = exec.Cardinality,
                     Dispatch = MatchDispatch.PostingList
@@ -1552,9 +1577,9 @@ internal static partial class QueryPlanBuilder
             matchIndex += terms;
         }
 
-        if (exec.HasNullTerm is false) 
-            return;
-        
+        // Always emit the null-term slot so the plan structure is the same regardless
+        // of whether the parameter array contains null. When null isn't present,
+        // ResolveMatches fills the slot with an empty match (Fill returns 0 → no-op OR).
         bool isFirstOp = isSeed && exec.InTermCount == 0;
         ops.Add(new PlanOp
         {
@@ -1567,7 +1592,7 @@ internal static partial class QueryPlanBuilder
     }
 
     /// <summary>Emit ops for an AllIn clause: Fill the first term + AndRange for the rest.</summary>
-    private static void EmitAllInOps(List<PlanOp> ops, ClauseExecution exec, ref int matchIndex)
+    private static void EmitAllInOps(List<PlanOp> ops, ClauseExecution exec, ref int matchIndex, List<int> rangeCounts)
     {
         int terms = exec.InTermCount;
         ops.Add(new PlanOp
@@ -1580,11 +1605,13 @@ internal static partial class QueryPlanBuilder
         });
         if (terms > 1)
         {
+            int rangeIdx = rangeCounts.Count;
+            rangeCounts.Add(terms - 1);
             ops.Add(new PlanOp
             {
                 Kind = PlanOpKind.AndRange,
                 ParamIndex = matchIndex + 1,
-                ParamIndex2 = terms - 1,
+                ParamIndex2 = rangeIdx,
                 BitmapLocal = 0,
                 EstimatedCardinality = exec.Cardinality,
                 Dispatch = MatchDispatch.PostingList
@@ -1669,7 +1696,9 @@ internal static partial class QueryPlanBuilder
             {
                 ClauseType.OrGroup when clause.OrSubClauses != null => clause.OrSubClauses.Count,
                 ClauseType.AndGroup when clause.AndSubClauses != null => clause.AndSubClauses.Count,
-                ClauseType.In or ClauseType.AllIn when inTermCount > 0 || hasNullTerm => inTermCount + (hasNullTerm ? 1 : 0),
+                // Always +1 for the null-term slot so the plan structure is parameter-independent.
+                // The slot is filled with an empty match when null isn't in the parameter.
+                ClauseType.In or ClauseType.AllIn => inTermCount + 1,
                 _ => 1
             };
         }
@@ -1694,11 +1723,37 @@ internal static partial class QueryPlanBuilder
         return clause.ClauseType is ClauseType.Equals or ClauseType.NotEquals;
     }
 
+    /// <summary>TreeScan-eligible: multi-term clauses that have a direct ITermsProvider
+    /// (StartsWith, EndsWith, Exists, Regex, ranges). Boosted clauses go through QueryMatch
+    /// for scoring. Contains is excluded because its tree walk pattern doesn't benefit
+    /// from the direct dispatch (it walks the full tree regardless).</summary>
+    internal static bool IsTreeScanEligibleClause(ClauseInfo clause, ClauseExecution exec = null)
+    {
+        if (clause == null)
+            return false;
+        if (exec is { BoostFactor: > 0 })
+            return false;
+        if (clause.HasBoost)
+            return false;
+        return clause.ClauseType is ClauseType.StartsWith or ClauseType.EndsWith
+            or ClauseType.Exists or ClauseType.Regex
+            or ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual
+            or ClauseType.LessThan or ClauseType.LessThanOrEqual
+            or ClauseType.Between;
+    }
+
     /// <summary>Resolve the <see cref="MatchDispatch"/> mode for a clause at plan-build time.
-    /// Equals / NotEquals (unboosted) → <c>PostingList</c> (native posting-list, no IQueryMatch wrapper).
+    /// Equals / NotEquals (unboosted) → <c>PostingList</c> (native posting-list).
+    /// Multi-term (unboosted) → <c>TreeScan</c> (direct ITermsProvider, no IQueryMatch wrapper).
     /// All other clause types → <c>QueryMatch</c> (IQueryMatch interface dispatch).</summary>
-    private static MatchDispatch GetDispatch(ClauseInfo clause, ClauseExecution exec = null) => 
-        IsTermSourceEligibleClause(clause, exec) ? MatchDispatch.PostingList : MatchDispatch.QueryMatch;
+    private static MatchDispatch GetDispatch(ClauseInfo clause, ClauseExecution exec = null)
+    {
+        if (IsTermSourceEligibleClause(clause, exec))
+            return MatchDispatch.PostingList;
+        if (IsTreeScanEligibleClause(clause, exec))
+            return MatchDispatch.TreeScan;
+        return MatchDispatch.QueryMatch;
+    }
 
     // ── Entry scan predicate building ────────────────────────────────────
 
@@ -1716,11 +1771,64 @@ internal static partial class QueryPlanBuilder
             case ClauseType.Vector:
             case ClauseType.In:
             case ClauseType.AllIn:
-            case ClauseType.Exists:
             case ClauseType.StartsWith:
+            {
+                var packed2 = exec?.PackedParamValue ?? PackedParam.None;
+                if (packed2.IsNone || packed2.ValueType != PackedParam.TypeString) return null;
+                sliceIndex++;
+                return new ScanPredicateInfo
+                {
+                    FieldName = clause.FieldName,
+                    ValueType = ScanValueType.Slice,
+                    CompareOp = ScanCompareOp.StartsWith,
+                    ParamIndex = sliceIndex - 1
+                };
+            }
             case ClauseType.EndsWith:
-            case ClauseType.AndGroup: // AND-groups inside OR chains are handled at the bitmap level
-                return null;
+            {
+                var packed2 = exec?.PackedParamValue ?? PackedParam.None;
+                if (packed2.IsNone || packed2.ValueType != PackedParam.TypeString) return null;
+                sliceIndex++;
+                return new ScanPredicateInfo
+                {
+                    FieldName = clause.FieldName,
+                    ValueType = ScanValueType.Slice,
+                    CompareOp = ScanCompareOp.EndsWith,
+                    ParamIndex = sliceIndex - 1
+                };
+            }
+            case ClauseType.AndGroup:
+            {
+                if (clause.AndSubClauses == null || clause.AndSubClauses.Count == 0)
+                    return null;
+                var branches = new List<ScanPredicateInfo>();
+                var subExecs = exec?.AndSubExecutions;
+                for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                {
+                    var sub = clause.AndSubClauses[si];
+                    var subExec = subExecs != null && si < subExecs.Length ? subExecs[si] : null;
+                    var subPred = BuildScanPredicateInfo(sub, subExec, ref longIndex, ref doubleIndex, ref sliceIndex);
+                    if (subPred == null) return null;
+                    branches.Add(subPred.Value);
+                }
+                // SubPredicates for AND group — RunEntryScan checks ALL must pass
+                return new ScanPredicateInfo
+                {
+                    FieldName = clause.FieldName ?? clause.AndSubClauses[0].FieldName,
+                    ValueType = ScanValueType.Long,
+                    CompareOp = ScanCompareOp.Equal,
+                    SubPredicates = branches.ToArray()
+                };
+            }
+
+            case ClauseType.Exists:
+                return new ScanPredicateInfo
+                {
+                    FieldName = clause.FieldName,
+                    ValueType = ScanValueType.Long, // unused for Exists but must be set
+                    CompareOp = ScanCompareOp.Exists,
+                    ParamIndex = 0 // unused
+                };
 
             case ClauseType.OrGroup:
             {
@@ -1742,7 +1850,7 @@ internal static partial class QueryPlanBuilder
                 return new ScanPredicateInfo
                 {
                     FieldName = clause.OrSubClauses[0].FieldName,
-                    OrBranches = branches.ToArray()
+                    SubPredicates = branches.ToArray()
                 };
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-22703_LowLevel.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-22703_LowLevel.cs
@@ -147,7 +147,7 @@ public class RavenDB_22703_LowLevel : StorageTest
             QueryParameters = null,
             Allocator = Allocator
         };
-        var match = QueryPlanBuilder.BuildAndCompile(planParams, null, out _, out _, null, default);
+        var match = QueryPlanBuilder.BuildAndCompile(planParams, null, out _, out _, null, false, default);
         var list = new List<string>();
         Span<long> ids = stackalloc long[256];
         int count;

--- a/test/SlowTests/Corax/RavenDB_23631.cs
+++ b/test/SlowTests/Corax/RavenDB_23631.cs
@@ -85,6 +85,50 @@ public class RavenDB_23631(ITestOutputHelper output) : StorageTest(output)
         Assert.Equal(results.Distinct().Count(), results.Count);
     }
 
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void InQueryAndExistsOnListFieldDoesNotProduceDuplicates()
+    {
+        // This is the exact scenario from the original RavenDB-23631 bug:
+        // AND of InQuery with ExistsQuery on a list-valued field (multiple values per doc).
+        // The list field produces multiple postings per document in the CompactTree,
+        // which could cause duplicate entry IDs in the intersection result.
+        using var mapping = IndexFieldsMappingBuilder.CreateForWriter(false)
+            .AddBinding(0, "docId")
+            .AddBinding(1, "name")
+            .Build();
+
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var builder = writer.Index($"id/{i}"))
+                {
+                    builder.Write(0, Encodings.Utf8.GetBytes($"id/{i}"));
+                    builder.IncrementList();
+                    builder.Write(1, Encodings.Utf8.GetBytes("name/0"));
+                    builder.Write(1, Encodings.Utf8.GetBytes("name/1"));
+                    builder.DecrementList();
+                    builder.EndWriting();
+                }
+            }
+
+            writer.Commit();
+        }
+
+        // IN(docId, ['id/0', 'id/10']) AND exists(name)
+        // The exists on a list field with 2 values per doc must not produce duplicates.
+        var results = ExecuteRQLQuery(mapping, "FROM TestIndex WHERE docId IN ('id/0', 'id/10') AND exists(name)");
+        Assert.Equal(2, results.Count);
+        Assert.Equal(results.Distinct().Count(), results.Count);
+
+        // Larger IN set + exists
+        var inTerms = Enumerable.Range(0, 10).Select(i => $"id/{i}").ToList();
+        var inClause = string.Join(", ", inTerms.Select(t => $"'{t}'"));
+        results = ExecuteRQLQuery(mapping, $"FROM TestIndex WHERE docId IN ({inClause}) AND exists(name)");
+        Assert.Equal(10, results.Count);
+        Assert.Equal(results.Distinct().Count(), results.Count);
+    }
+
     private List<string> ExecuteRQLQuery(IndexFieldsMapping mapping, string rqlQuery)
     {
         using var searcher = new IndexSearcher(Env, mapping);


### PR DESCRIPTION
## Summary
**Stack: 3 of 3** — Raven.Server integration + tests

Wire the new Corax query engine features into the RavenDB server layer.

### QueryPlanBuilder extensions
- **GetDispatch**: three-way dispatch — PostingList (bitmap), TreeScan (provider), or QueryMatch (fallback)
- **EmitPlan**: three-bitmap strategy with OrRange/AndRange reading dynamic InRangeCounts at runtime
- **BuildScanPredicateInfo**: expanded for Exists, StartsWith, EndsWith, AndGroup compound predicates
- WHEN conditions threaded as parameter through parse methods (not ThreadStatic)
- Null-term slots always allocated (plan structure is parameter-independent)

### QueryPlanBuilder.Resolution — compound fields + DirectScan
- **TryCreateCompoundFieldMatch**: compound prefix scan + range within prefix (long, double, string)
- **TryCreateCompoundExactMatch**: `WHERE f1=val AND f2=val` → single compound tree lookup
- **TryCreateSimpleFieldDirectScan**: range on sort field → SortedDrivingMatch
- **TrySetSortSeekHint**: seek hint for long/double/string sort fields
- **PopulateClauseValues**: WHEN evaluation, constant propagation, single-value IN→Equals
- **Cost model**: reject DirectScan when EITHER cost >= bitmap_cost OR entries > threshold
- Guard compound field queries against >255 byte prefix

### Plan cache to index-instance level
- `SharedPlanCache` on `CoraxIndexPersistence` — compiled delegates shared across transactions
- Wired into both `CoraxIndexReadOperation` and `CoraxIndexFacetedReadOperation`

### CoraxIndexReadOperation
- Wire scan predicates + parameters for RunEntryScan
- Entry scan telemetry in Inspect() output
- Confidence reports Low when Limit hit

### Tests
- `RavenDB_23631`: IN + Exists on list field deduplication
- `RavenDB-22703_LowLevel`: adapt to new BuildAndCompile signature

## Stack
- [1/3] RoaringBitmap bugfix
- [2/3] Corax query engine: entry scan rewrite, new match types
- **→ [3/3] Server integration** (this PR)

## Files changed (7 files, +1405 -78)
- `src/Raven.Server/.../Corax/QueryPlanBuilder.cs` (+210)
- `src/Raven.Server/.../Corax/QueryPlanBuilder.Resolution.cs` (+1166)
- `src/Raven.Server/.../Corax/CoraxIndexReadOperation.cs` (+51)
- `src/Raven.Server/.../Corax/CoraxIndexPersistence.cs` (+7)
- `src/Raven.Server/.../Corax/CoraxIndexFacetedReadOperation.cs` (+3)
- `test/SlowTests/Corax/RavenDB_23631.cs` (+44)
- `test/SlowTests.Issues/.../RavenDB-22703_LowLevel.cs` (+2)

## Test plan
- [ ] `dotnet build src/Raven.Server/Raven.Server.csproj -c Release` compiles
- [ ] FastTests pass
- [ ] SlowTests/Corax tests pass
- [ ] Compound field queries produce correct results
- [ ] DirectScan cost model rejects expensive scans