### PR TITLE
RavenDB-25281 [1/9] Voron: RoaringBitmap container

### DIFF
--- a/src/Voron/Data/RoaringBitmaps/ContainerEntry.cs
+++ b/src/Voron/Data/RoaringBitmaps/ContainerEntry.cs
@@ -1,0 +1,71 @@
+﻿using System.Runtime.CompilerServices;
+using Sparrow.Server;
+
+namespace Voron.Data.RoaringBitmaps;
+
+public unsafe struct ContainerEntry
+{
+    /// <summary>
+    /// Direct pointer to container data for Array, ArrayUnsorted, and Bitmap containers.
+    /// For Range containers, this stores RangeStart encoded as (RangeStart + 1), avoiding
+    /// per-entry size growth while keeping Range as allocation-free.
+    /// We pay 8 bytes per entry to cache this instead of going through Storage.Ptr,
+    /// which is a double-dereference (ByteString._pointer->Ptr). Every Contains, Add,
+    /// and iterator step accesses this pointer. The 8 bytes per container is negligible
+    /// compared to container data (64B–8KB each), and it also avoids a null check on
+    /// Storage for Range containers which have Storage=default.
+    /// </summary>
+    public byte* Data;
+
+    /// <summary>Memory handle for disposal. Default for Range containers.</summary>
+    internal ByteString Storage;
+
+    /// <summary>Number of set bits (0..65536)..</summary>
+    public int Cardinality;
+
+    /// <summary>
+    /// Container key (value >> 16). Allows walking entries without index indirection.
+    /// The key allows us to have ~140 T entries in the bitmap (2^47), big enough
+    /// </summary>
+    public uint Key;
+
+    /// <summary>
+    /// This is to reuse the Key field in a clearer manner
+    /// </summary>
+    internal uint NextFreeSlot
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Key;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => Key = value;
+    }
+
+
+    /// <summary>
+    /// Access container data as an ushort array.
+    /// </summary>
+    public ushort* ArrayData
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (ushort*)Data;
+    }
+
+    /// <summary>Raw ulong pointer for SIMD operations and methods requiring pointers.</summary>
+    public ulong* BitmapPtr
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (ulong*)Data;
+    }
+
+    /// <summary>
+    /// Start offset (0..65535) for Range containers. Encoded in Data as (start + 1),
+    /// so start=0 remains representable.
+    /// </summary>
+    internal ushort RangeStart
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (ushort)((nuint)Data - 1);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => Data = (byte*)(nuint)(value + 1);
+    }
+}

--- a/src/Voron/Data/RoaringBitmaps/ContainerType.cs
+++ b/src/Voron/Data/RoaringBitmaps/ContainerType.cs
@@ -1,0 +1,22 @@
+﻿namespace Voron.Data.RoaringBitmaps;
+
+public enum ContainerType : byte
+{
+    /// <summary>Sorted ushort array. Binary search for Contains. Merge-based set ops.</summary>
+    Array = 0,
+    /// <summary>8KB bitmap (1024 longs). Direct bit access.</summary>
+    Bitmap = 1,
+    /// <summary>
+    /// Contiguous values RangeStart..RangeStart+Cardinality-1 are set. No data allocation needed.
+    /// Cardinality == BitsPerContainer means all 65,536 bits set (full container).
+    /// Sequential Add at either edge is an O(1) increment.
+    /// </summary>
+    Range = 2,
+    /// <summary>
+    /// Unsorted ushort array. Add is O(1) append. On the first read (Contains, set ops, iteration),
+    /// sorts and deduplicates, converting to Array. Avoids O(log n + shift) per Add.
+    /// </summary>
+    ArrayUnsorted = 3,
+    /// <summary>Tombstone marker for free-list entries in the entries array.</summary>
+    Free = 0xFF
+}

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
@@ -1,0 +1,807 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using Sparrow;
+using Sparrow.Server;
+
+namespace Voron.Data.RoaringBitmaps;
+
+public unsafe partial struct RoaringBitmap
+{
+    #region Bitmap Container
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool BitmapContains(ulong* bitmap, ushort val) =>
+        (bitmap[val >> 6] & (1UL << (val & 63))) != 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapSet(ulong* bitmap, ushort val) =>
+        bitmap[val >> 6] |= 1UL << (val & 63);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int BitmapContainerCardinality(byte* data)
+    {
+        if (AdvInstructionSet.Arm.IsSupportedArm64)
+        {
+            Vector128<ulong>* bitmapVec = (Vector128<ulong>*)data;
+            Vector128<ushort> acc = Vector128<ushort>.Zero;
+            for (int i = 0; i < BitmapContainerSizeInUInt64 / Vector128<ulong>.Count; i++)
+            {
+                Vector128<byte> popCounts = AdvSimd.PopCount(bitmapVec[i].AsByte());
+                var (lower, upper) = Vector128.Widen(popCounts);
+                acc = AdvSimd.Add(acc, AdvSimd.Add(lower, upper));
+            }
+
+            // we scan 8KB, which is 65,536 bits, which fits in 16 bits and can't overflow the ushort accumulator.
+            return Vector128.Sum(acc);
+        }
+
+        // Scalar fallback: 4-way unrolled for ILP via independent accumulator chains.
+        // 1024 is divisible by 4 so no remainder handling is needed.
+        int c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+        ulong* bitmap = (ulong*)data;
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i += 4)
+        {
+            c0 += BitOperations.PopCount(bitmap[i]);
+            c1 += BitOperations.PopCount(bitmap[i + 1]);
+            c2 += BitOperations.PopCount(bitmap[i + 2]);
+            c3 += BitOperations.PopCount(bitmap[i + 3]);
+        }
+
+        return c0 + c1 + c2 + c3;
+    }
+
+    /// <summary>Helper to clear an 8KB bitmap buffer.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ClearBitmap(ulong* bitmap)
+    {
+        new Span<byte>(bitmap, BitmapContainerSizeInBytes).Clear();
+    }
+
+    private interface IArrayToBitmapOp
+    {
+        static abstract ulong Apply(ulong current, ulong mask);
+    }
+
+    private struct ArrayOrOp : IArrayToBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong current, ulong mask) => current | mask;
+    }
+
+    private struct ArrayAndNotOp : IArrayToBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong current, ulong mask) => current & ~mask;
+    }
+
+    private static void ApplyArrayToBitmap<TOp>(ushort* arr, int arrLen, ulong* bitmap)
+        where TOp : struct, IArrayToBitmapOp
+    {
+        for (int i = 0; i < arrLen; i++)
+        {
+            ushort val = arr[i];
+            int wordIdx = val >> 6;
+            ulong mask = 1UL << (val & 63);
+            bitmap[wordIdx] = TOp.Apply(bitmap[wordIdx], mask);
+        }
+    }
+
+    /// <summary>Set bits in <paramref name="bitmap"/> for every value in <paramref name="arr"/>.</summary>
+    internal static void SetArrayInBitmap(ushort* arr, int arrLen, ulong* bitmap)
+        => ApplyArrayToBitmap<ArrayOrOp>(arr, arrLen, bitmap);
+
+    /// <summary>Clear bits in <paramref name="bitmap"/> for every value in <paramref name="arr"/>.</summary>
+    internal static void ClearArrayInBitmap(ushort* arr, int arrLen, ulong* bitmap)
+        => ApplyArrayToBitmap<ArrayAndNotOp>(arr, arrLen, bitmap);
+
+    #endregion
+
+    #region SIMD Bitmap Operations
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapOrNoPop(ulong* a, ulong* b, ulong* dst) =>
+        BitmapOpDispatch<OrOp>(a, b, dst);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapAndNoPop(ulong* a, ulong* b, ulong* dst) =>
+        BitmapOpDispatch<AndOp>(a, b, dst);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapAndNotNoPop(ulong* a, ulong* b, ulong* dst) =>
+        BitmapOpDispatch<AndNotOp>(a, b, dst);
+
+    private interface IBitmapOp
+    {
+        static abstract ulong Apply(ulong a, ulong b);
+        static abstract Vector128<ulong> Apply(Vector128<ulong> a, Vector128<ulong> b);
+        static abstract Vector256<ulong> Apply(Vector256<ulong> a, Vector256<ulong> b);
+        static abstract Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b);
+    }
+
+    private struct AndOp : IBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong a, ulong b) => a & b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> Apply(Vector128<ulong> a, Vector128<ulong> b) => a & b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<ulong> Apply(Vector256<ulong> a, Vector256<ulong> b) => a & b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b) => a & b;
+    }
+
+    private struct OrOp : IBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong a, ulong b) => a | b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> Apply(Vector128<ulong> a, Vector128<ulong> b) => a | b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<ulong> Apply(Vector256<ulong> a, Vector256<ulong> b) => a | b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b) => a | b;
+    }
+
+    private struct AndNotOp : IBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong a, ulong b) => a & ~b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> Apply(Vector128<ulong> a, Vector128<ulong> b) => Vector128.AndNot(a, b);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<ulong> Apply(Vector256<ulong> a, Vector256<ulong> b) => Vector256.AndNot(a, b);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b) => Vector512.AndNot(a, b);
+    }
+
+    /// <summary>
+    /// Narrow long values to ushort (extract low 16 bits) using SIMD when available.
+    /// </summary>
+    internal static void CopyDenseBottom16BitsToUshortArray(ReadOnlySpan<long> source, ushort* destination)
+    {
+        int j = 0;
+        int count = source.Length;
+        ref long src = ref MemoryMarshal.GetReference(source);
+
+        // Vector load + chained Narrow (ulong→uint→ushort) — truncation is equivalent to masking with 0xFFFF
+        // for non-negative values, so no explicit AND with ContainerValueMask is needed.
+        if (Vector256.IsHardwareAccelerated && count >= 16)
+        {
+            for (; j <= count - 16; j += 16)
+            {
+                var v0 = Vector256.LoadUnsafe(ref src, (nuint)j).AsUInt64();
+                var v1 = Vector256.LoadUnsafe(ref src, (nuint)(j + 4)).AsUInt64();
+                var v2 = Vector256.LoadUnsafe(ref src, (nuint)(j + 8)).AsUInt64();
+                var v3 = Vector256.LoadUnsafe(ref src, (nuint)(j + 12)).AsUInt64();
+
+                var u0 = Vector256.Narrow(v0, v1); // 8 uints
+                var u1 = Vector256.Narrow(v2, v3); // 8 uints
+                Vector256.Narrow(u0, u1).StoreUnsafe(ref *destination, (nuint)j); // 16 shorts
+            }
+        }
+        else if (Vector128.IsHardwareAccelerated && count >= 8)
+        {
+            for (; j <= count - 8; j += 8)
+            {
+                var v0 = Vector128.LoadUnsafe(ref src, (nuint)j).AsUInt64();
+                var v1 = Vector128.LoadUnsafe(ref src, (nuint)(j + 2)).AsUInt64();
+                var v2 = Vector128.LoadUnsafe(ref src, (nuint)(j + 4)).AsUInt64();
+                var v3 = Vector128.LoadUnsafe(ref src, (nuint)(j + 6)).AsUInt64();
+
+                var u0 = Vector128.Narrow(v0, v1); // 4 uints
+                var u1 = Vector128.Narrow(v2, v3); // 4 uints
+                Vector128.Narrow(u0, u1).StoreUnsafe(ref *destination, (nuint)j); // 8 shorts
+            }
+        }
+
+        for (; j < count; j++)
+            destination[j] = (ushort)(source[j] & ContainerValueMask);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void FillSequentialUInt16(ushort* destination, int startValue, int count)
+    {
+        int i = 0;
+        if (AdvInstructionSet.IsAcceleratedVector256 && count >= Vector256<ushort>.Count)
+        {
+            Vector256<ushort> offsets = Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, (ushort)15);
+            Vector256<ushort> valueVec = Vector256.Create((ushort)startValue);
+            Vector256<ushort> stride = Vector256.Create((ushort)Vector256<ushort>.Count);
+
+            for (; i + Vector256<ushort>.Count <= count; i += Vector256<ushort>.Count)
+            {
+                (valueVec + offsets).Store(destination + i);
+                valueVec = valueVec + stride;
+            }
+        }
+
+        if (AdvInstructionSet.IsAcceleratedVector128 && count - i >= Vector128<ushort>.Count)
+        {
+            Vector128<ushort> offsets = Vector128.Create(0, 1, 2, 3, 4, 5, 6, (ushort)7);
+            Vector128<ushort> valueVec = Vector128.Create((ushort)(startValue + i));
+            Vector128<ushort> stride = Vector128.Create((ushort)Vector128<ushort>.Count);
+
+            for (; i + Vector128<ushort>.Count <= count; i += Vector128<ushort>.Count)
+            {
+                (valueVec + offsets).Store(destination + i);
+                valueVec = valueVec + stride;
+            }
+        }
+
+        for (; i < count; i++)
+            destination[i] = (ushort)(startValue + i);
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapOpDispatch<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        if (AdvInstructionSet.IsAcceleratedVector512)
+            BitmapOpVector512NoPop<TOp>(a, b, dst);
+        else if (AdvInstructionSet.IsAcceleratedVector256)
+            BitmapOpVector256NoPop<TOp>(a, b, dst);
+        else if (AdvInstructionSet.IsAcceleratedVector128)
+            BitmapOpVector128NoPop<TOp>(a, b, dst);
+        else
+            BitmapOpScalarNoPop<TOp>(a, b, dst);
+    }
+
+    private static void BitmapOpVector512NoPop<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        int N = Vector512<ulong>.Count;
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i += N)
+            TOp.Apply(Vector512.Load(a + i), Vector512.Load(b + i)).Store(dst + i);
+    }
+
+    private static void BitmapOpVector256NoPop<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        int N = Vector256<ulong>.Count;
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i += N)
+            TOp.Apply(Vector256.Load(a + i), Vector256.Load(b + i)).Store(dst + i);
+    }
+
+    private static void BitmapOpVector128NoPop<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        int N = Vector128<ulong>.Count;
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i += N)
+            TOp.Apply(Vector128.Load(a + i), Vector128.Load(b + i)).Store(dst + i);
+    }
+
+    private static void BitmapOpScalarNoPop<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i++)
+            dst[i] = TOp.Apply(a[i], b[i]);
+    }
+
+    internal static ContainerEntry CloneContainer(ByteStringContext ctx, ref ContainerEntry entry, ContainerType type)
+    {
+        switch (type)
+        {
+            case ContainerType.Range:
+                return new ContainerEntry { Cardinality = entry.Cardinality, RangeStart = entry.RangeStart, Storage = default };
+            case ContainerType.Free:
+                return entry;
+            default:
+                int dataSize = entry.Storage.Length;
+                ctx.Allocate(dataSize, out ByteString storage);
+                Unsafe.CopyBlockUnaligned(storage.Ptr, entry.Data, (uint)dataSize);
+                return new ContainerEntry { Cardinality = entry.Cardinality, Data = storage.Ptr, Storage = storage };
+        }
+    }
+
+    #endregion
+
+    #region Array Container
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool ArrayContainerContains(ushort* data, int cardinality, ushort value)
+    {
+        return AdvInstructionSet.IsAcceleratedVector128 switch
+        {
+            // if we don't have a lot of data, we can do a linear scan using SIMD more efficiently 
+            true when cardinality <= SimdLinearScanThreshold => SimdLinearContains(data, cardinality, value),
+            true => SimdQuadContains(data, cardinality, value),
+            _ => ArrayContainerFind(data, cardinality, value) >= 0
+        };
+    }
+
+    /// <summary>
+    /// SIMD linear scan for small arrays (less than 64 values). Works on both sorted and unsorted data.
+    /// Uses Vector256 (16 shorts) when available, Vector128 (8 shorts) otherwise.
+    /// Iterates in full-vector chunks (ceiling division); the last chunk may over-read into zeroed
+    /// padding. <c>found greater than cardinality</c> excludes any false-positive from a zero padding match.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool SimdLinearContains(ushort* arr, int cardinality, ushort value)
+    {
+        if (cardinality == 0)
+            return false;
+
+        if (AdvInstructionSet.IsAcceleratedVector256)
+        {
+            int vecCount = (cardinality + Vector256<ushort>.Count - 1) / Vector256<ushort>.Count;
+            Vector256<ushort> needle = Vector256.Create(value);
+            for (int v = 0; v < vecCount; v++)
+            {
+                // Safe to over-read: allocation is SIMD-aligned with zeroed padding.
+                var hasMatch = Vector256.Equals(Vector256.Load(arr + v * Vector256<ushort>.Count), needle).ExtractMostSignificantBits();
+                if (hasMatch == 0) 
+                    continue;
+                
+                int found = BitOperations.TrailingZeroCount(hasMatch) + v * Vector256<ushort>.Count;
+                return found < cardinality;
+            }
+        }
+        else if (AdvInstructionSet.IsAcceleratedVector128)
+        {
+            int vecCount = (cardinality + Vector128<ushort>.Count - 1) / Vector128<ushort>.Count;
+            Vector128<ushort> needle = Vector128.Create(value);
+            for (int v = 0; v < vecCount; v++)
+            {
+                var hasMatch = Vector128.Equals(Vector128.Load(arr + v * Vector128<ushort>.Count), needle).ExtractMostSignificantBits();
+                if (hasMatch == 0) 
+                    continue;
+                
+                int found = BitOperations.TrailingZeroCount(hasMatch) + v * Vector128<ushort>.Count;
+                return found < cardinality;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < cardinality; i++)
+            {
+                if (arr[i] == value)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// SIMD Quad search for larger sorted arrays (&gt; 64 values): quaternary interpolation + SIMD block check.
+    /// Divides sorted ushort[] into 8-element blocks (Vector128), narrows via quaternary
+    /// search on block boundaries, then checks the final block with a single SIMD compare.
+    /// Based on Daniel Lemire's algorithm (https://lemire.me/blog/2026/04/27/you-can-beat-the-binary-search/)
+    /// </summary>
+    internal static bool SimdQuadContains(ushort* arr, int cardinality, ushort value)
+    {
+        int gap = Vector128<ushort>.Count; // 8
+        int numBlocks = cardinality / gap;
+        int @base = 0;
+        int n = numBlocks;
+
+        // Quaternary search on block boundaries
+        while (n > 3)
+        {
+            int quarter = n >> 2;
+            int k1 = arr[(@base + quarter + 1) * gap - 1];
+            int k2 = arr[(@base + 2 * quarter + 1) * gap - 1];
+            int k3 = arr[(@base + 3 * quarter + 1) * gap - 1];
+            @base += ((k1 < value ? 1 : 0) + (k2 < value ? 1 : 0) + (k3 < value ? 1 : 0)) * quarter;
+            n -= 3 * quarter;
+        }
+
+        while (n > 1)
+        {
+            int half = n >> 1;
+            @base = arr[(@base + half + 1) * gap - 1] < value ? @base + half : @base;
+            n -= half;
+        }
+
+        int lo = arr[(@base + 1) * gap - 1] < value ? @base + 1 : @base;
+
+        // lo is in [0, numBlocks]: either the candidate full block, or one past the last block
+        // (value exceeds all block maxima), in which case lo * gap is the tail start anyway.
+        // The buffer is SIMD-aligned with zeroed padding, so the over-read is safe.
+        // A match in the padding (beyond cardinality) is excluded by: lo * gap + found < cardinality.
+        int startIdx = lo * gap;
+        var tailMatch = Vector128.Equals(Vector128.Load(arr + startIdx), Vector128.Create(value)).ExtractMostSignificantBits();
+        return tailMatch is not 0 && startIdx + BitOperations.TrailingZeroCount(tailMatch) < cardinality;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int ArrayContainerFind(ushort* arr, int count, ushort value)
+    {
+        int lo = 0;
+        int hi = count - 1;
+
+        while (lo <= hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            ushort midVal = arr[mid];
+
+            if (midVal == value)
+                return mid;
+            if (midVal < value)
+                lo = mid + 1;
+            else
+                hi = mid - 1;
+        }
+
+        return ~lo;
+    }
+
+    /// <summary>
+    /// SIMD cross-compare AND: for each element in A, check if it exists anywhere in B.
+    /// Broadcasts each A[i] across Vector256, compares against all chunks of B simultaneously.
+    /// Works on unsorted data. Both arrays must be ≤ SimdLinearScanThreshold and buffers % 64 bytes.
+    /// </summary>
+    private static int SimdCrossAnd(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+    {
+        int di = 0;
+        int bVecCount = (bLen + Vector256<ushort>.Count - 1) / Vector256<ushort>.Count;
+
+        for (int i = 0; i < aLen; i++)
+        {
+            Vector256<ushort> needle = Vector256.Create(a[i]);
+            int found = int.MaxValue;
+
+            for (int bv = 0; bv < bVecCount; bv++)
+            {
+                // Safe to over-read: buffer guaranteed ≥ 64 bytes, and bLen ≤ 64
+                Vector256<ushort> bChunk = Vector256.Load(b + bv * Vector256<ushort>.Count);
+
+                var hasMatch = Vector256.Equals(needle, bChunk).ExtractMostSignificantBits();
+                if (hasMatch == 0) 
+                    continue;
+                
+                found = BitOperations.TrailingZeroCount(hasMatch) + bv * Vector256<ushort>.Count;
+                break;
+            }
+
+            // Keep the element if found within [0, bLen) -- AND semantics.
+            // found == int.MaxValue means no match anywhere;
+            // found >= bLen means the match was in the over-allocated padding past the live count.
+            if (found >= bLen)
+                continue;
+            dst[di++] = a[i];
+        }
+
+        return di;
+    }
+
+    /// <summary>
+    /// SIMD cross-compare ANDNOT: keep elements in A that do NOT exist in B.
+    /// Same cross-compare pattern, inverted match logic.
+    /// </summary>
+    private static int SimdCrossAndNot(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+    {
+        // Same over-read guarantee and found-index pattern as SimdCrossAnd — see comment there.
+        int di = 0;
+        int bVecCount = (bLen + Vector256<ushort>.Count - 1) / Vector256<ushort>.Count;
+
+        for (int i = 0; i < aLen; i++)
+        {
+            Vector256<ushort> needle = Vector256.Create(a[i]);
+            int found = int.MaxValue;
+
+            for (int bv = 0; bv < bVecCount; bv++)
+            {
+                // Safe to over-read: buffer guaranteed ≥ 64 bytes (minimum SIMD-aligned allocation), and bLen ≤ 64
+                Vector256<ushort> bChunk = Vector256.Load(b + bv * Vector256<ushort>.Count);
+
+                var hasMatch = Vector256.Equals(needle, bChunk).ExtractMostSignificantBits();
+                if (hasMatch == 0) 
+                    continue;
+                
+                found = BitOperations.TrailingZeroCount(hasMatch) + bv * Vector256<ushort>.Count;
+                break;
+            }
+
+            // Keep the element if found within [0, bLen) -- AND semantics.
+            // found == int.MaxValue means no match anywhere;
+            // found >= bLen means the match was in the over-allocated padding past the live count.
+            if (found >= bLen)
+                dst[di++] = a[i];
+        }
+
+        return di;
+    }
+
+    /// <summary>
+    /// Strategy interface for generic array match operations (AND / ANDNOT).
+    /// Both share the same SIMD galloping structure; only the keep/discard logic differs.
+    /// </summary>
+    private interface IArrayMatchStrategy
+    {
+        /// <summary>true for AND (keep matches), false for AND NOT (discard matches).</summary>
+        static abstract bool KeepOnMatch { get; }
+
+        /// <summary>false for AND (skip A values not in B), true for AND NOT (keep A values not in B).</summary>
+        static abstract bool KeepOnMissInSmaller { get; }
+    }
+
+    private struct AndStrategy : IArrayMatchStrategy
+    {
+        public static bool KeepOnMatch => true;
+        public static bool KeepOnMissInSmaller => false;
+    }
+
+    private struct AndNotStrategy : IArrayMatchStrategy
+    {
+        public static bool KeepOnMatch => false;
+        public static bool KeepOnMissInSmaller => true;
+    }
+
+    /// <summary>
+    /// Compute the intersection of two array containers, writing the result to dst.
+    /// Uses SIMD galloping when Vector256 is available, scalar merge otherwise.
+    /// </summary>
+    internal static int ArrayContainerAnd(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+        => ArrayContainerMatch<AndStrategy>(a, aLen, b, bLen, dst);
+
+    /// <summary>
+    /// Compute A AND NOT B for two array containers.
+    /// Uses SIMD galloping when Vector256 is available, scalar merge otherwise.
+    /// </summary>
+    internal static int ArrayContainerAndNot(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+        => ArrayContainerMatch<AndNotStrategy>(a, aLen, b, bLen, dst);
+
+    private static int ArrayContainerMatch<TStrategy>(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+        where TStrategy : struct, IArrayMatchStrategy
+    {
+        uint N = (uint)Vector256<ushort>.Count; // 16
+        int ai = 0, bi = 0, di = 0;
+
+        if (AdvInstructionSet.IsAcceleratedVector256)
+        {
+            while (ai < aLen && bi + (int)N <= bLen)
+            {
+                ushort val = a[ai];
+
+                // If val is past the current block of B, advance B
+                if (val > b[bi + N - 1])
+                {
+                    bi += (int)N;
+                    continue;
+                }
+
+                // If val is before the current block of B, it's not in B
+                if (val < b[bi])
+                {
+                    if (TStrategy.KeepOnMissInSmaller)
+                        dst[di++] = val;
+                    ai++;
+                    continue;
+                }
+
+                // Check if val exists in this block of B
+                Vector256<ushort> vVal = Vector256.Create(val);
+                Vector256<ushort> vBlock = Vector256.Load(b + bi);
+                bool found = Vector256.EqualsAny(vVal, vBlock);
+                if (found == TStrategy.KeepOnMatch)
+                    dst[di++] = val;
+
+                ai++;
+            }
+        }
+
+        // Scalar tail — also handles the full input when SIMD is not available
+        while (ai < aLen && bi < bLen)
+        {
+            if (a[ai] < b[bi])
+            {
+                if (TStrategy.KeepOnMissInSmaller)
+                    dst[di++] = a[ai];
+                ai++;
+            }
+            else if (a[ai] > b[bi])
+                bi++;
+            else
+            {
+                if (TStrategy.KeepOnMatch)
+                    dst[di++] = a[ai];
+                ai++;
+                bi++;
+            }
+        }
+
+        if (TStrategy.KeepOnMissInSmaller)
+        {
+            while (ai < aLen)
+                dst[di++] = a[ai++];
+        }
+
+        return di;
+    }
+
+    
+    [Conditional("DEBUG")]
+    private static void AssertSorted(ReadOnlySpan<long> values)
+    {
+        for (int i = 1; i < values.Length; i++)
+        {
+            Debug.Assert(values[i] > values[i - 1],
+                $"AddRange requires strictly sorted (unique) input: values[{i - 1}]={values[i - 1]} >= values[{i}]={values[i]}");
+        }
+    }
+
+    /// <summary>
+    /// Comparison sort + dedup for small arrays below the bitmap radix sort threshold.
+    /// </summary>
+    private static void SortAndDedupSmallArray(ref ContainerEntry entry, out ContainerType type)
+    {
+        var arr = entry.ArrayData;
+        int count = entry.Cardinality;
+
+        new Span<ushort>(arr, count).Sort();
+
+        if (count > 1)
+        {
+            int write = 1;
+            for (int read = 1; read < count; read++)
+            {
+                if (arr[read] != arr[write - 1])
+                    arr[write++] = arr[read];
+            }
+            count = write;
+        }
+
+        entry.Cardinality = count;
+        type = ContainerType.Array;
+    }
+
+    #endregion
+    
+    
+    #region Range Container
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int RangeEndExclusive(ref ContainerEntry entry) => entry.RangeStart + entry.Cardinality;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryMergeRangeInPlace(ref ContainerEntry entry, int otherStart, int otherEndExclusive)
+    {
+        int rangeStart = entry.RangeStart;
+        int rangeEnd = rangeStart + entry.Cardinality;
+
+        // Half-open interval merge: [rangeStart, rangeEnd) with [otherStart, otherEndExclusive).
+        // Merge on overlap or exact touch; fail only when there is an actual gap.
+        if (otherStart > rangeEnd || otherEndExclusive < rangeStart)
+            return false;
+
+        int mergedStart = Math.Min(rangeStart, otherStart);
+        int mergedEnd = Math.Max(rangeEnd, otherEndExclusive);
+        entry.RangeStart = (ushort)mergedStart;
+        entry.Cardinality = mergedEnd - mergedStart;
+        return true;
+    }
+
+    /// <summary>
+    /// Convert a Range container to Bitmap or Array to handle an Add outside the contiguous range.
+    /// </summary>
+    private void ConvertRangeForAdd(ref ContainerEntry entry, ref ContainerType type, ushort value)
+    {
+        Debug.Assert(type == ContainerType.Range);
+        int rangeStart = entry.RangeStart;
+        int rangeCount = entry.Cardinality;
+
+        Span<long> extraValuesSpan = stackalloc long[1];
+        extraValuesSpan[0] = value;
+        
+        if (MaybeConvertRangeToArray(ref entry, ref type, rangeStart, rangeCount, extraValuesSpan))
+            return;
+        
+        ConvertRangeToBitmap(ref entry, ref type);
+        BitmapSet(entry.BitmapPtr, value);
+        entry.Cardinality = LazyCardinality;
+    }
+
+    /// <summary>
+    /// Fill a cleared bitmap buffer with bits rangeStart ... (rangeStart+rangeCount-1) set.
+    /// </summary>
+    internal static void FillBitmapFromRange(ulong* bitmap, int rangeStart, int rangeCount)
+    {
+        if (rangeCount <= 0)
+            return;
+
+        int firstWord = rangeStart >> 6;
+        int firstBit = rangeStart & 63;
+        int lastValue = rangeStart + rangeCount - 1;
+        int lastWord = lastValue >> 6;
+        int lastBit = lastValue & 63;
+
+        if (firstWord == lastWord)
+        {
+            ulong startMask = ulong.MaxValue << firstBit;
+            ulong endMask = lastBit == 63 ? ulong.MaxValue : (1UL << (lastBit + 1)) - 1;
+            bitmap[firstWord] = startMask & endMask;
+            return;
+        }
+
+        bitmap[firstWord] = ulong.MaxValue << firstBit;
+        if (lastWord > firstWord + 1)
+            new Span<ulong>(bitmap + firstWord + 1, lastWord - firstWord - 1).Fill(ulong.MaxValue);
+        bitmap[lastWord] = lastBit == 63 ? ulong.MaxValue : (1UL << (lastBit + 1)) - 1;
+    }
+
+    private void ConvertRangeToBitmap(ref ContainerEntry entry, ref ContainerType type)
+    {
+        Debug.Assert(type == ContainerType.Range);
+
+        AllocateOrRecycle(BitmapContainerSizeInBytes, out ByteString storage);
+        ulong* bitmap = (ulong*)storage.Ptr;
+        ClearBitmap(bitmap);
+        FillBitmapFromRange(bitmap, entry.RangeStart, entry.Cardinality);
+
+        if (entry.Storage.HasValue)
+            _ctx.Release(ref entry.Storage);
+
+        entry.Storage = storage;
+        entry.Data = storage.Ptr;
+        type = ContainerType.Bitmap;
+    }
+
+    private void ConvertRangeToArray(ref ContainerEntry entry, ref ContainerType type, int rangeStart, int rangeCount, ReadOnlySpan<long> sortedValues)
+    {
+        int totalCount = rangeCount + sortedValues.Length;
+        int neededBytes = AlignForSimd(totalCount * sizeof(ushort));
+        AllocateOrRecycle(neededBytes, out ByteString storage);
+        ushort* arr = (ushort*)storage.Ptr;
+
+        FillSequentialUInt16(arr, rangeStart, rangeCount);
+        CopyDenseBottom16BitsToUshortArray(sortedValues, arr + rangeCount);
+
+        Debug.Assert(entry.Storage.HasValue is false, "Range containers should not have Storage");
+
+        entry.Storage = storage;
+        entry.Data = storage.Ptr;
+        entry.Cardinality = totalCount;
+        type = ContainerType.ArrayUnsorted;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool MaybeConvertRangeToArray(ref ContainerEntry entry, ref ContainerType type, int rangeStart, int rangeCount, scoped ReadOnlySpan<long> sortedValues)
+    {
+        int totalCount = rangeCount + sortedValues.Length;
+        if (totalCount > ArrayContainerMaxCardinality)
+            return false;
+
+        ConvertRangeToArray(ref entry, ref type, rangeStart, rangeCount, sortedValues);
+        return true;
+    }
+
+    [SkipLocalsInit]
+    private bool TryConvertRangeRangeToBestContainer(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right)
+    {
+        int leftCount = left.Cardinality;
+        int rightCount = right.Cardinality;
+        int totalCount = leftCount + rightCount;
+        if (totalCount > ArrayContainerMaxCardinality)
+            return false;
+
+        if (left.RangeStart < right.RangeStart)
+        {
+            long* rightValues = stackalloc long[rightCount];
+            long rightCurrent = right.RangeStart;
+            for (int i = 0; i < rightCount; i++, rightCurrent++)
+                rightValues[i] = rightCurrent;
+
+            return MaybeConvertRangeToArray(ref left, ref leftType, left.RangeStart, leftCount, new ReadOnlySpan<long>(rightValues, rightCount));
+        }
+
+        long* leftValues = stackalloc long[leftCount];
+        long leftCurrent = left.RangeStart;
+        for (int i = 0; i < leftCount; i++, leftCurrent++)
+            leftValues[i] = leftCurrent;
+
+        return MaybeConvertRangeToArray(ref left, ref leftType, right.RangeStart, rightCount, new ReadOnlySpan<long>(leftValues, leftCount));
+    }
+
+    #endregion
+}

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -1,0 +1,1914 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Sparrow;
+using Sparrow.Server;
+using Voron.Util;
+
+namespace Voron.Data.RoaringBitmaps;
+
+/// <summary>
+/// A roaring bitmap implementation optimized for Corax's native memory model.
+/// All memory is allocated through ByteStringContext, ensuring zero-managed heap allocations
+/// for the bitmap data. Non-negative values are split into container key (value &gt;&gt; 16)
+/// and low 16 bits. Container lookup is O(1) via a flat index array sized to the max key.
+///
+/// Container types:
+/// - Range: contiguous values start..start+count-1 (no data allocation). count=65536 means full.
+///   Sequential Add at either range edge is O(1). Created automatically for contiguous inserts.
+/// - ArrayUnsorted: append-only ushort[]. Add is O(1). Sorted lazily on first read.
+/// - Array: sorted ushort[] for sparse data (cardinality &lt;= 4096, up to 8KB)
+/// - Bitmap: 8KB fixed bitmap (1024 longs) for dense data (&gt; 4096 values)
+///
+/// Threading and consumption model:
+/// - Single-threaded by design. Concurrent access from multiple threads is not supported;
+///   no internal locking, no atomic state. Callers are responsible for not sharing a bitmap
+///   across threads simultaneously.
+/// - Set operations (<see cref="AndWith"/>, <see cref="AndNotWith"/>, <see cref="LazyOrWith"/>)
+///   are intentionally destructive on their right-hand argument. The right side may have its
+///   containers stolen, sorted in place, or otherwise mutated. This is a deliberate trade —
+///   it lets the implementation skip a copy in hot paths. After being passed as the right side
+///   of a set op, a bitmap is considered consumed and must not be used for further reads or
+///   set ops on its own. Pair this with <see cref="Clear"/>'s storage recycling: a consumed
+///   bitmap can be Clear()'d and reused as a scratch buffer with no allocator round-trip.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+public unsafe partial struct RoaringBitmap : IDisposable
+{
+    internal NativeList<ContainerEntry> _entries;
+    internal NativeList<ContainerType> _types;
+    internal NativeList<int> _index;
+    internal int _containerCount;
+    /// <summary>
+    /// Head of the entry free list, 1-based: 0 = empty, n = real slot index (n-1).
+    /// Zero-init (default struct) is therefore a valid empty state.
+    /// <see cref="ContainerEntry.NextFreeSlot"/> uses the same encoding for chaining.
+    /// </summary>
+    internal int _freeListHead;
+    /// <summary>
+    /// Head of the storage free list — an intrusive singly-linked list.
+    /// The first <c>sizeof(ByteString)</c> bytes of each free storage contain the next
+    /// <see cref="ByteString"/> in the chain. Default (zero) means the list is empty.
+    /// </summary>
+    internal ByteString _nextFreeStorage;
+
+    private readonly ByteStringContext _ctx;
+
+#if DEBUG
+    /// <summary>Set after this bitmap is passed as the right-hand side of a destructive
+    /// set operation (OrWith, AndWith, AndNotWith). Any subsequent access asserts.
+    /// Reset by <see cref="Clear"/>.</summary>
+    private bool _consumed;
+#endif
+
+    [Conditional("DEBUG")]
+    private readonly void AssertNotConsumed()
+    {
+#if DEBUG
+        Debug.Assert(!_consumed, "Bitmap was consumed by a prior set operation. Call Clear() to reuse.");
+#endif
+    }
+
+    [Conditional("DEBUG")]
+    private static void MarkConsumed(ref RoaringBitmap bitmap)
+    {
+#if DEBUG
+        bitmap._consumed = true;
+#endif
+    }
+
+    /// <summary>
+    /// Construct a RoaringBitmap backed by the given allocator.
+    /// All operations on this bitmap MUST use the same ByteStringContext instance that was
+    /// passed to the constructor. Mixing allocators will corrupt the storage free list.
+    /// </summary>
+    public RoaringBitmap(ByteStringContext ctx)
+    {
+        _ctx = ctx;
+        // _freeListHead == 0 is the terminator; default fields are already zero.
+    }
+
+    private const int BitmapContainerSizeInBytes = 8192; // 8KB
+    public const int BitmapContainerSizeInUInt64 = BitmapContainerSizeInBytes / sizeof(ulong);
+    private const int ArrayContainerMaxCardinality = BitmapContainerSizeInBytes / sizeof(ushort); // crossover: array at max costs same as bitmap
+    public const int ContainerKeyShift = 16;
+    public const int ContainerSize = 1 << ContainerKeyShift; // 65,536 entry IDs per container
+    private const int ContainerValueMask = 0xFFFF;
+    private const int LazyCardinality = -1;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ResolveCardinality(ref ContainerEntry entry)
+    {
+        int card = entry.Cardinality;
+        if (card == LazyCardinality)
+        {
+            card = BitmapContainerCardinality(entry.Data);
+            entry.Cardinality = card;
+        }
+        return card;
+    }
+
+    private const int InitialArrayContainerSizeInBytes = 64; // 32 shorts — minimum for SIMD linear scan without scalar tail
+    private const int SimdAlignment = 32; // Vector256 width in bytes
+    private const int SimdLinearScanThreshold = 64; // below this, SIMD linear scan beats binary/quad search
+
+    private const int IndexAbsent = -1;        // key is not present in index
+
+    [DoesNotReturn]
+    private static void ThrowNegativeNotSupported(long value)
+    {
+        throw new ArgumentOutOfRangeException(nameof(value), value, "RoaringBitmap only supports non-negative values.");
+    }
+
+    public readonly int ContainerCount => _containerCount;
+
+    public long Count
+    {
+        get
+        {
+            AssertNotConsumed();
+            long total = 0;
+            ContainerEntry* entries = _entries.RawItems;
+            ContainerType* types = _types.RawItems;
+            int count = _entries.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (types[i] == ContainerType.Free)
+                    continue;
+
+                int card = entries[i].Cardinality;
+                if (card is LazyCardinality)
+                {
+                    // LazyCardinality: bitmap container was updated without recomputing the popcount.
+                    // Count bits directly so callers (e.g. ShouldSwitchToEntryScan) see a correct value
+                    // rather than the sentinel -1, which would incorrectly trigger early entry scan.
+                    Debug.Assert(types[i] is ContainerType.Bitmap, "only bitmaps can have lazy cardinality");
+                    entries[i].Cardinality = card = BitmapContainerCardinality(entries[i].Data);
+                    if (card is 0)
+                    {
+                        FreeContainer(entries[i].Key, i);
+                        continue;
+                    }
+                }
+                total += card;
+            }
+            return total;
+        }
+    }
+
+    public readonly bool IsEmpty => _containerCount == 0;
+
+    public readonly bool Contains(long value)
+    {
+        AssertNotConsumed();
+        long key = value >> ContainerKeyShift;
+        int slot = GetSlotForKey(key);
+        if (slot < 0)
+            return false;
+        return ContainsAtSlot(slot, (ushort)(value & ContainerValueMask));
+    }
+
+    /// <summary>
+    /// Container-internal membership test after the caller has already resolved the slot via
+    /// <see cref="GetSlotForKey"/>. Lets callers hoist the slot-resolution binary search out of
+    /// a hot loop when consecutive lookups share the same high-bits (e.g. BitmapMatch.AndWith
+    /// processing a batch with high entry-ID locality).
+    /// </summary>
+    internal readonly bool ContainsAtSlot(int slot, ushort low)
+    {
+        ref ContainerEntry entry = ref _entries[slot];
+        ContainerType type = _types.RawItems[slot];
+        return type switch
+        {
+            ContainerType.Array => ArrayContainerContains(entry.ArrayData, entry.Cardinality, low),
+            ContainerType.ArrayUnsorted => SimdLinearContains(entry.ArrayData, entry.Cardinality, low),
+            ContainerType.Bitmap => BitmapContains((ulong*)entry.Data, low),
+            ContainerType.Range => low >= entry.RangeStart && low < entry.RangeStart + entry.Cardinality,
+            ContainerType.Free => ThrowUnexpectedContainerType(type),
+            _ => ThrowUnexpectedContainerType(type)
+        };
+
+    [DoesNotReturn]
+    static bool ThrowUnexpectedContainerType(ContainerType type)
+    {
+        throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type");
+    }
+    }
+
+    public readonly long MinContainerKey
+    {
+        get
+        {
+            if (_containerCount == 0)
+                return -1;
+            for (int i = 0; i < _index.Count; i++)
+            {
+                if (_index[i] != IndexAbsent)
+                    return i;
+            }
+            return -1;
+        }
+    }
+
+    public readonly long MaxContainerKey
+    {
+        get
+        {
+            if (_containerCount == 0)
+                return -1;
+            for (int i = _index.Count - 1; i >= 0; i--)
+            {
+                if (_index[i] != IndexAbsent)
+                    return i;
+            }
+            return -1;
+        }
+    }
+
+    public readonly int GetSlotForKey(long key)
+    {
+        if (key < 0 || key >= _index.Count)
+            return IndexAbsent;
+        return _index.RawItems[key];
+    }
+
+    /// <summary>
+    /// Reset all containers without releasing memory. Container storages are pushed onto
+    /// the dedicated free list and made available for reuse on the next allocation,
+    /// avoiding the round-trip through the ByteStringContext free pool.
+    /// </summary>
+    public void Clear()
+    {
+#if DEBUG
+        _consumed = false;
+#endif
+        int count = _entries.Count;
+        if (count == 0 && _index.Count == 0)
+            return;
+
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+
+        // Recover every storage and park it on the storage free list.
+        for (int i = 0; i < count; i++)
+        {
+            if (types[i] != ContainerType.Free && entries[i].Storage.HasValue)
+                ReturnStorageToFreeList(entries[i].Storage);
+        }
+
+        _entries.Clear();
+        _types.Clear();
+        _containerCount = 0;
+        _freeListHead = 0; // 0 = empty (entries are gone, free list is empty too)
+
+        int* indexRaw = _index.RawItems;
+        int indexLen = _index.Count;
+        new Span<int>(indexRaw, indexLen).Fill(IndexAbsent);
+    }
+
+    /// <summary>
+    /// Push <paramref name="bs"/> onto the head of the storage free list.
+    /// The first <c>sizeof(ByteString)</c> bytes of <paramref name="bs"/>'s data are
+    /// overwritten with the current head, forming the intrusive next-pointer.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ReturnStorageToFreeList(ByteString bs)
+    {
+        *(ByteString*)bs.Ptr = _nextFreeStorage; // chain: new node's next = old head
+        _nextFreeStorage = bs;                   // new head = bs
+    }
+
+    /// <summary>
+    /// Acquire storage of at least <paramref name="neededBytes"/>. Walks the intrusive
+    /// storage free list for the best (smallest sufficient) fit, unlinks it in-place,
+    /// and returns it. Falls back to a fresh ctx allocation when nothing fits.
+    /// </summary>
+    private void AllocateOrRecycle(int neededBytes, out ByteString storage)
+    {
+        // `scan` is a managed ref to the ByteString field that holds the current node.
+        // Starting at the head field, it advances to each node's embedded next-pointer.
+        // `bestRef` tracks the field pointing to the best-fit node found so far, so we
+        // can unlink the winner with a single assignment after the walk.
+        ref ByteString bestRef =  ref _nextFreeStorage;
+        ref ByteString scan = ref _nextFreeStorage;
+        int bestLen = int.MaxValue;
+
+        while (scan.HasValue)
+        {
+            if (scan.Length >= neededBytes && scan.Length < bestLen)
+            {
+                bestRef = ref scan;
+                bestLen = scan.Length;
+            }
+            // Advance: the next ByteString is stored in the first bytes of scan's data.
+            scan = ref *(ByteString*)scan.Ptr;
+        }
+
+        if (bestLen != int.MaxValue)
+        {
+            storage = bestRef;                       // read the winner
+            bestRef = *(ByteString*)storage.Ptr;     // unlink: point prev's next to winner's next
+            return;
+        }
+
+        _ctx.Allocate(neededBytes, out storage);
+    }
+
+    /// <summary>
+    /// Swap the internal state of two bitmaps. O(1) — swaps all fields.
+    /// Used after entry scan to swap the filtered results into the main bitmap.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SwapContents(ref RoaringBitmap other)
+    {
+        (other, this) = (this, other);
+    }
+
+    /// <summary>Batch-add strictly sorted (no duplicates) values. Groups values by container
+    /// key and adds them in bulk per container. For large runs within a single container (>4096),
+    /// switches directly to bitmap. For contiguous runs, extends/creates Range containers.
+    ///
+    /// Input contract: values must be strictly increased The <c>Array</c>-type append fast-path
+    /// and the bitmap creation path both rely on input length equaling the unique-value count.
+    ///
+    /// Bitmap-container updates are *lazy*: cardinality is left as LazyCardinality and
+    /// must be repaired before reading <see cref="Count"/>. <see cref="PrepareForReading"/>
+    /// calls <see cref="RepairAfterLazy"/> as part of its normal pre-read fixup.</summary>
+    public void AddRange(ReadOnlySpan<long> sortedValues)
+    {
+        AssertNotConsumed();
+        if (sortedValues.IsEmpty)
+            return;
+
+        AssertSorted(sortedValues);
+
+        int index = 0;
+        while (index < sortedValues.Length)
+        {
+            long value = sortedValues[index];
+                if (value < 0)
+                ThrowNegativeNotSupported(value);
+            long key = value >> ContainerKeyShift;
+
+            int start = index;
+            // here we search for the index on the value in sortedValues that is the last that match
+            // the current container, so we can bulk insert it
+            index = SearchForContainerRangeEnd(sortedValues, (key + 1) << ContainerKeyShift, index + 1);
+            ReadOnlySpan<long> containerValues = sortedValues.Slice(start, index - start);
+
+            int slot = GetSlotForKey(key);
+            if (slot >= 0)
+            {
+                // Existing container — batch add via AddRangeToContainer
+                AddRangeToContainer(slot, containerValues);
+                continue;
+            }
+
+            // New container — keep contiguous runs as a range (any start offset)
+            ushort firstLow = (ushort)(containerValues[0] & ContainerValueMask);
+            ushort lastLow = (ushort)(containerValues[^1] & ContainerValueMask);
+            bool isRange = lastLow - firstLow == containerValues.Length - 1;
+
+            if (isRange)
+            {
+                AddNewContainer(key, ContainerType.Range, new ContainerEntry
+                {
+                    Cardinality = containerValues.Length,
+                    RangeStart = firstLow,
+                    Storage = default
+                });
+                continue;
+            }
+
+            if (containerValues.Length > ArrayContainerMaxCardinality)
+            {
+                CreateBitmapContainerFromSorted(key, containerValues);
+            }
+            else
+            {
+                CreateArrayContainerFromSorted(key, containerValues);
+            }
+        }
+    }
+
+    private static int SearchForContainerRangeEnd(ReadOnlySpan<long> sortedValues, long nextKeyStart, int start)
+    {
+        int jump = 1;
+        // Start with exponential jumps, then binary search within the last interval.
+        while (start + jump < sortedValues.Length && sortedValues[start + jump] < nextKeyStart)
+            jump <<= 1;
+        int lo = start + (jump >> 1);
+        int hi = Math.Min(start + jump, sortedValues.Length);
+        while (lo < hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            if (sortedValues[mid] < nextKeyStart)
+                lo = mid + 1;
+            else
+                hi = mid;
+        }
+        return lo;
+    }
+
+    private void CreateBitmapContainerFromSorted(long key, ReadOnlySpan<long> sortedValues)
+    {
+        AllocateOrRecycle(BitmapContainerSizeInBytes, out ByteString storage);
+        new Span<byte>(storage.Ptr, BitmapContainerSizeInBytes).Clear();
+
+        OrSortedIntoBitmap((ulong*)storage.Ptr, sortedValues);
+
+        AddNewContainer(key, ContainerType.Bitmap, new ContainerEntry
+        {
+            Cardinality = sortedValues.Length,
+            Data = storage.Ptr,
+            Storage = storage
+        });
+    }
+
+    /// <summary>
+    /// OR sorted values into a bitmap, accumulating per word and writing once per word boundary.
+    /// Sorted input means consecutive values often share the same word, collapsing N bit-sets
+    /// into ~N/64 word writes. Idempotent on already-zero words, so safe for fresh and existing bitmaps.
+    /// Cardinality tracking is the caller's responsibility.
+    /// </summary>
+    private static void OrSortedIntoBitmap(ulong* bitmapPtr, ReadOnlySpan<long> sortedValues)
+    {
+        ushort firstLow = (ushort)(sortedValues[0] & ContainerValueMask);
+        int currentWordIndex = firstLow >> 6;
+        ulong currentMask = 1UL << (firstLow & 63);
+
+        for (int j = 1; j < sortedValues.Length; j++)
+        {
+            ushort low = (ushort)(sortedValues[j] & ContainerValueMask);
+            int wordIndex = low >> 6;
+
+            if (wordIndex == currentWordIndex)
+            {
+                currentMask |= 1UL << (low & 63);
+            }
+            else
+            {
+                bitmapPtr[currentWordIndex] |= currentMask;
+                currentWordIndex = wordIndex;
+                currentMask = 1UL << (low & 63);
+            }
+        }
+        bitmapPtr[currentWordIndex] |= currentMask;
+    }
+
+    /// <summary>Create a new array container from sorted values with SIMD-friendly allocation.</summary>
+    private void CreateArrayContainerFromSorted(long key, ReadOnlySpan<long> sortedValues)
+    {
+        int neededBytes = AlignForSimd(sortedValues.Length * sizeof(ushort));
+        AllocateOrRecycle(neededBytes, out ByteString storage);
+
+        CopyDenseBottom16BitsToUshortArray(sortedValues, (ushort*)storage.Ptr);
+
+        AddNewContainer(key, ContainerType.ArrayUnsorted, new ContainerEntry
+        {
+            Cardinality = sortedValues.Length,
+            Data = storage.Ptr,
+            Storage = storage
+        });
+    }
+
+    /// <summary>Batch-add sorted values into an existing container.</summary>
+    private void AddRangeToContainer(int slot, ReadOnlySpan<long> sortedValues)
+    {
+        ref ContainerEntry entry = ref _entries[slot];
+        ref ContainerType type = ref _types.RawItems[slot];
+
+        switch (type)
+        {
+            case ContainerType.Bitmap:
+            {
+                // Lazy: bits are OR'd in; cardinality is marked dirty, so RepairAfterLazy
+                // (called by PrepareForReading) recomputes it via popcount.
+                OrSortedIntoBitmap((ulong*)entry.Data, sortedValues);
+                entry.Cardinality = LazyCardinality;
+                break;
+            }
+
+            case ContainerType.Range:
+            {
+                int rangeStart = entry.RangeStart;
+                int rangeEnd = rangeStart + entry.Cardinality;
+
+                // Check if all new values are contiguous and can extend one edge.
+                ushort firstLow = (ushort)(sortedValues[0] & ContainerValueMask);
+                ushort lastLow = (ushort)(sortedValues[^1] & ContainerValueMask);
+
+                // Fully contained in existing range - noop.
+                if (firstLow >= rangeStart && lastLow < rangeEnd)
+                {
+                    break;
+                }
+
+                bool contiguousBatch = lastLow - firstLow == sortedValues.Length - 1;
+                if (contiguousBatch && TryMergeRangeInPlace(ref entry, firstLow, lastLow + 1))
+                    break;
+
+                // Non-contiguous batch (or disjoint contiguous batch) cannot stay as Range.
+                if (MaybeConvertRangeToArray(ref entry, ref type, rangeStart, entry.Cardinality, sortedValues))
+                    break;
+
+                ConvertRangeToBitmap(ref entry, ref type);
+                goto case ContainerType.Bitmap; // Convert to bitmap and add
+            }
+
+            case ContainerType.Array or ContainerType.ArrayUnsorted:
+            {
+                int newTotal = entry.Cardinality + sortedValues.Length;
+                if (newTotal > ArrayContainerMaxCardinality)
+                {
+                    ConvertArrayToBitmap(ref entry, ref _types.RawItems[slot]);
+                    goto case ContainerType.Bitmap; // Convert to bitmap and add
+                }
+
+                // If existing data was sorted and the new batch starts strictly after the last
+                // existing value, the appended result stays sorted — no need to degrade to
+                // ArrayUnsorted (which would force a sort pass in PrepareForReading).
+                ushort firstNew = (ushort)(sortedValues[0] & ContainerValueMask);
+                bool stillSorted = type == ContainerType.Array
+                    && (entry.Cardinality == 0 || firstNew > entry.ArrayData[entry.Cardinality - 1]);
+
+                // Ensure enough space
+                int neededBytes = AlignForSimd(newTotal * sizeof(ushort));
+                if (entry.Storage.Length < neededBytes)
+                {
+                    AllocateOrRecycle(neededBytes, out ByteString newStorage);
+                    new Span<byte>(entry.Data, entry.Cardinality * sizeof(ushort))
+                        .CopyTo(new Span<byte>(newStorage.Ptr, newStorage.Length));
+                    ReturnStorageToFreeList(entry.Storage); // recycle old; new is larger
+                    entry.Data = newStorage.Ptr;
+                    entry.Storage = newStorage;
+                }
+
+                // Append new values
+                CopyDenseBottom16BitsToUshortArray(sortedValues, entry.ArrayData + entry.Cardinality);
+                entry.Cardinality = newTotal;
+                _types.RawItems[slot] = stillSorted ? ContainerType.Array : ContainerType.ArrayUnsorted;
+                break;
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type in AddRange");
+        }
+    }
+
+    /// <summary>
+    /// Lazy OR skips per-container cardinality tracking.
+    /// Bitmap containers get Cardinality = -1 (dirty). Call RepairAfterLazy() once
+    /// after all lazy OR operations to recompute cardinality in a single popcount pass.
+    ///
+    /// [1] Bitmap→Array conversion after set ops: we intentionally skip this.
+    /// Standard roaring bitmaps convert sparse bitmap results back to array containers
+    /// to save memory and speed up later operations. But in Corax, these bitmaps
+    /// are temporarily - built during query evaluation and discarded immediately after.
+    /// The 8KB bitmap is already allocated; converting to Array allocates another buffer
+    /// and scans 1024 words, costing more than it saves for short-lived data.
+    /// </summary>
+    public void LazyOrWith(scoped ref RoaringBitmap other)
+    {
+        if (other.IsEmpty)
+            return;
+
+        int otherLen = other._index.Count;
+        if (otherLen > 0)
+            EnsureIndexCoversKey(otherLen - 1);
+
+        _entries.EnsureCapacityFor(_ctx, other.ContainerCount);
+        _types.EnsureCapacityFor(_ctx, other.ContainerCount);
+
+        for (int key = 0; key < otherLen; key++)
+        {
+            int otherSlot = other.GetSlotForKey(key);
+            if (otherSlot < 0)
+                continue;
+
+            ref ContainerEntry otherEntry = ref other._entries[otherSlot];
+            int mySlot = GetSlotForKey(key);
+
+            if (mySlot >= 0)
+            {
+                LazyOrContainerInPlace(ref _entries[mySlot], ref _types.RawItems[mySlot],
+                    ref otherEntry, other._types.RawItems[otherSlot]);
+                continue;
+            }
+
+            // Steal container from other (zero-copy).
+            ContainerType otherType = other._types.RawItems[otherSlot];
+            ContainerEntry stolen = otherEntry;
+            otherEntry = default; // Clear the entry
+            AddNewContainer(key, otherType, stolen);
+        }
+    }
+
+    /// <summary>
+    /// OR this bitmap with another. Calls LazyOrWith then RepairAfterLazy.
+    /// </summary>
+    public void OrWith(ref RoaringBitmap other)
+    {
+        AssertNotConsumed();
+        LazyOrWith(ref other);
+        RepairAfterLazy();
+        MarkConsumed(ref other);
+    }
+
+    /// <summary>Lazy OR for a single container pair. Skips popcount — marks bitmap
+    /// containers with Cardinality = -1.</summary>
+    [SkipLocalsInit]
+    private void LazyOrContainerInPlace(ref ContainerEntry left, ref ContainerType leftType,
+        ref ContainerEntry right, ContainerType rightType)
+    {
+        switch (leftType, rightType)
+        {
+            case (ContainerType.Range, ContainerType.Range):
+            {
+                if (TryMergeRangeInPlace(ref left, right.RangeStart, RangeEndExclusive(ref right)))
+                    return;
+
+                if (TryConvertRangeRangeToBestContainer(ref left, ref leftType, ref right))
+                    return;
+
+                // Disjoint ranges: materialize the other range and keep lazy OR semantics.
+                ulong* stackBmp = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ContainerEntry temp = MaterializeRangeIntoBuffer(ref right, stackBmp);
+                LazyOrContainerInPlace(ref left, ref leftType, ref temp, ContainerType.Bitmap);
+                break;
+            }
+            case (ContainerType.Range, _):
+            {
+                ConvertRangeToBitmap(ref left, ref leftType);
+                LazyOrContainerInPlace(ref left, ref leftType, ref right, rightType);
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Range):
+            {
+                // Convert the array to a heap-allocated bitmap first. We cannot materialize
+                // the range into a stack buffer and recurse because the (Array, Bitmap) case
+                // steals the right-hand bitmap buffer — a stack pointer that becomes dangling
+                // once this frame returns.
+                ConvertArrayToBitmap(ref left, ref leftType);
+                LazyOrContainerInPlace(ref left, ref leftType, ref right, rightType);
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Range):
+            {
+                // Materialize the range into a stack buffer and bitwise-OR in place — safe because
+                // (Bitmap, Bitmap) does not steal the right-hand buffer.
+                ulong* stackBitmap = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ContainerEntry temp2 = MaterializeRangeIntoBuffer(ref right, stackBitmap);
+                LazyOrContainerInPlace(ref left, ref leftType, ref temp2, ContainerType.Bitmap);
+                break;
+            }
+            // From here, we no longer have ranges to worry about
+            case (ContainerType.Bitmap, ContainerType.Bitmap):
+            {
+                // OR bitmaps without popcount — just bitwise OR
+                BitmapOrNoPop(left.BitmapPtr, right.BitmapPtr, left.BitmapPtr);
+                left.Cardinality = LazyCardinality; // mark dirty
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                // Set bits unconditionally — no per-bit cardinality check
+                SetArrayInBitmap(right.ArrayData, right.Cardinality, left.BitmapPtr);
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                int maxResult = left.Cardinality + right.Cardinality;
+                if (maxResult > ArrayContainerMaxCardinality)
+                {
+                    ConvertArrayToBitmap(ref left, ref leftType);
+                    LazyOrContainerInPlace(ref left, ref leftType, ref right, rightType);
+                    return;
+                }
+                // Append values left & right — duplicates are harmless, deduped on PrepareForReading.
+                AppendArrayContainers(ref left, ref right, maxResult);
+                leftType = ContainerType.ArrayUnsorted;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Bitmap):
+            {
+                // Steal right's 8KB buffer
+                Debug.Assert(right.Storage.Length is BitmapContainerSizeInBytes, "Right container bitmap buffer must be exactly 8KB");
+                // OR left's array values into right's bitmap, then take ownership of the buffer.
+                SetArrayInBitmap(left.ArrayData, left.Cardinality, right.BitmapPtr);
+                if (left.Storage.HasValue)
+                    _ctx.Release(ref left.Storage);
+                left.Storage = right.Storage;
+                left.Data = right.Data;
+                left.Cardinality = LazyCardinality;
+                leftType = ContainerType.Bitmap;
+                right = default;
+                break;
+            }
+            default: // should never reach here
+                throw new InvalidOperationException($"Unexpected container type pair: {leftType}, {rightType}");
+        }
+    }
+
+    /// <summary>Recompute cardinality for all containers marked dirty (Cardinality == -1)
+    /// after a sequence of lazy bitmap ops (AddRange, LazyOrWith, AndWith, OrWith on
+    /// bitmap containers, etc.). Single popcount passes. Containers that pop to zero
+    /// (e.g., AND/ANDNOT removed all bits) are freed here.</summary>
+    public void RepairAfterLazy()
+    {
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            if (// _types is a dense array, so cheaper to scan through it first
+                _types.RawItems[i] != ContainerType.Bitmap ||
+                _entries[i].Cardinality != LazyCardinality)
+                continue;
+
+            ref ContainerEntry entry = ref _entries[i];
+
+             entry.Cardinality  = BitmapContainerCardinality(entry.Data);
+
+            if (entry.Cardinality is 0)
+                FreeContainer(entry.Key, i);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(long value)
+    {
+        AssertNotConsumed();
+        if (value < 0)
+            ThrowNegativeNotSupported(value);
+        long key = value >> ContainerKeyShift;
+        ushort low = (ushort)(value & ContainerValueMask);
+
+        int slot = GetSlotForKey(key);
+        if (slot >= 0)
+        {
+            ref ContainerEntry entry = ref _entries[slot];
+            AddToContainer(ref entry, slot, low);
+        }
+        else
+        {
+            AddNewContainer(key, ContainerType.Range, new ContainerEntry
+            {
+                Cardinality = 1,
+                RangeStart = low,
+                Storage = default
+            });
+        }
+    }
+
+    /// <summary>
+    /// Fill the buffer with values from the bitmap, starting from the current iteration state.
+    /// Returns the number of values written. Compatible with Corax's streaming evaluation.
+    /// </summary>
+    public int Fill(Span<long> buffer, ref RoaringBitmapIterator iterator)
+    {
+        AssertNotConsumed();
+        return iterator.Fill(ref this, buffer);
+    }
+
+    public RoaringBitmapIterator GetIterator()
+    {
+        AssertNotConsumed();
+        return new RoaringBitmapIterator(ref this, _ctx);
+    }
+
+    /// <summary>
+    /// Filter a sorted buffer in-place, keeping only values present in this bitmap.
+    /// Exploits sorted order: looks up each container key once, skips entire missing
+    /// container ranges, and checks membership within a container without per-element
+    /// key lookups.
+    /// </summary>
+    public readonly int AndWithSorted(Span<long> buffer, int count)
+    {
+        int kept = 0;
+        int i = 0;
+        int* idx = _index.RawItems;
+        int idxLen = _index.Count;
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+
+        while (i < count)
+        {
+            long containerKey = buffer[i] >> ContainerKeyShift;
+
+            // Fast reject: container key out of range or absent.
+            if (containerKey < 0 || containerKey >= idxLen || idx[containerKey] < 0)
+            {
+                // Skip all entries in this container key.
+                long nextContainerStart = (containerKey + 1) << ContainerKeyShift;
+                // Branchless linear scan for small runs; the common case is a short skip.
+                while (i < count && buffer[i] < nextContainerStart)
+                    i++;
+                continue;
+            }
+
+            int slot = idx[containerKey];
+            ref ContainerEntry entry = ref entries[slot];
+            ContainerType type = types[slot];
+            long containerEnd = (containerKey + 1) << ContainerKeyShift;
+
+            // Process all entries in this container.
+            switch (type)
+            {
+                case ContainerType.Bitmap:
+                {
+                    ulong* bmp = (ulong*)entry.Data;
+                    while (i < count && buffer[i] < containerEnd)
+                    {
+                        ushort low = (ushort)(buffer[i] & ContainerValueMask);
+                        if (BitmapContains(bmp, low))
+                            buffer[kept++] = buffer[i];
+                        i++;
+                    }
+                    break;
+                }
+
+                case ContainerType.Range:
+                {
+                    int rangeStart = entry.RangeStart;
+                    int rangeEnd = rangeStart + entry.Cardinality;
+                    while (i < count && buffer[i] < containerEnd)
+                    {
+                        ushort low = (ushort)(buffer[i] & ContainerValueMask);
+                        if (low >= rangeStart && low < rangeEnd)
+                            buffer[kept++] = buffer[i];
+                        i++;
+                    }
+                    break;
+                }
+
+                case ContainerType.Array:
+                {
+                    // Sorted array — use two-pointer merge.
+                    ushort* arr = entry.ArrayData;
+                    int arrLen = entry.Cardinality;
+                    int ai = 0;
+                    while (i < count && buffer[i] < containerEnd && ai < arrLen)
+                    {
+                        ushort low = (ushort)(buffer[i] & ContainerValueMask);
+                        if (low < arr[ai])
+                            i++;
+                        else if (low > arr[ai])
+                            ai++;
+                        else
+                        {
+                            buffer[kept++] = buffer[i];
+                            i++;
+                            ai++;
+                        }
+                    }
+                    // Skip remaining buffer entries in this container (no more array entries to match).
+                    while (i < count && buffer[i] < containerEnd)
+                        i++;
+                    break;
+                }
+
+                case ContainerType.ArrayUnsorted:
+                {
+                    // Fall back to per-element Contains for unsorted arrays.
+                    while (i < count && buffer[i] < containerEnd)
+                    {
+                        ushort low = (ushort)(buffer[i] & ContainerValueMask);
+                        if (SimdLinearContains(entry.ArrayData, entry.Cardinality, low))
+                            buffer[kept++] = buffer[i];
+                        i++;
+                    }
+                    break;
+                }
+
+                case ContainerType.Free:
+                    // Free entries are tombstones — skip to next container.
+                    while (i < count && buffer[i] < containerEnd)
+                        i++;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type in AndWith");
+            }
+        }
+        return kept;
+    }
+
+    /// <summary>
+    /// Bulk Select: for each rank in <paramref name="ranks"/>, write the corresponding
+    /// set-bit value into <paramref name="results"/> at the same index. Out-of-range
+    /// or negative ranks produce -1. <paramref name="ranks"/> is mutated (sorted in place).
+    /// <paramref name="ranks"/> and <paramref name="results"/> must NOT alias - we read
+    /// from ranks while writing to results in permuted order, so aliasing would corrupt input.
+    ///
+    /// Sorts ranks once, then walks containers a single time while accumulating
+    /// cardinality — O(C + N log N) instead of O(C * N) for repeated single-rank Select.
+    /// </summary>
+    public void Select(ByteStringContext allocator, Span<long> ranks, Span<long> results)
+    {
+        int n = ranks.Length;
+        Debug.Assert(results.Length >= n);
+        Debug.Assert(ranks.Overlaps(results) == false, "ranks and results must not alias");
+        if (n == 0)
+            return;
+
+        // Track each rank's original position so we can scatter results back in input order
+        // after sorting ranks ascending for the single-pass container walk.
+        // Pad the allocation up to a multiple of 8 ints so the AVX2 init loop below can
+        // store full Vector256<int> chunks without a scalar tail. Only indexes[0..n) is
+        // ever read after init; we slice back to n for Sort (parallel-keys API requires
+        // matching lengths) and subsequent reads.
+        int paddedLen = (n + 7) & ~7;
+        using var _ = allocator.Allocate(paddedLen * sizeof(int), out ByteString work);
+        InitializeIndices(new Span<int>(work.Ptr, paddedLen), n);
+        var indexes = new Span<int>(work.Ptr, n);
+
+        // Parallel sort: ranks ascending; indexes follow the same permutation so
+        // indexes[i] is the original position of the rank now at ranks[i].
+        ranks.Sort(indexes);
+
+        int rankIdx = 0;
+
+        // Negative ranks sort to the front - emit -1 for each.
+        while (rankIdx < n && ranks[rankIdx] < 0)
+        {
+            results[indexes[rankIdx]] = -1;
+            rankIdx++;
+        }
+
+        // Walk containers in key order, accumulating cardinality. Each rank lands
+        // inside the first container whose accumulated cardinality exceeds it.
+        int* idx = _index.RawItems;
+        int idxLen = _index.Count;
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+
+        long accCard = 0;
+        for (int key = 0; key < idxLen && rankIdx < n; key++)
+        {
+            int slot = idx[key];
+            if (slot < 0)
+                continue;
+
+            ref ContainerEntry entry = ref entries[slot];
+            ref ContainerType type = ref types[slot];
+            if (type == ContainerType.Free)
+                continue;
+
+            Debug.Assert(type is ContainerType.Bitmap);
+            int card = ResolveCardinality(ref entry);
+
+            if (type == ContainerType.ArrayUnsorted)
+            {   // Sort-on-first-select for ArrayUnsorted
+                new Span<ushort>(entry.ArrayData, card).Sort();
+                type = ContainerType.Array;
+            }
+
+            long containerEnd = accCard + card;
+            long baseValue = (long)key << ContainerKeyShift;
+            while (rankIdx < n && ranks[rankIdx] < containerEnd)
+            {
+                int localRank = (int)(ranks[rankIdx] - accCard);
+                results[indexes[rankIdx]] = baseValue + SelectInContainer(ref entry, type, localRank);
+                rankIdx++;
+            }
+            accCard = containerEnd;
+        }
+
+        // Anything still unprocessed is past the end of the bitmap.
+        while (rankIdx < n)
+        {
+            results[indexes[rankIdx]] = -1;
+            rankIdx++;
+        }
+    }
+
+    /// <summary>Fill <paramref name="indices"/> with 0..read-1 using AVX2 256-bit stores.
+    /// <paramref name="indices"/> must be padded to a multiple of 8 — i.e.
+    /// <c>indices.Length &gt;= ((read + 7) &amp; ~7)</c> — so the unrolled SIMD loop can store
+    /// full Vector256&lt;int&gt; chunks without a scalar tail. Used by RoaringBitmap.Select
+    /// here and by Corax's DirectScanMatch via InternalsVisibleTo.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void InitializeIndices(Span<int> indices, int read)
+    {
+        Debug.Assert(((read + 7) & ~7) <= indices.Length, "SIMD write past indices span");
+        ref int ptr = ref MemoryMarshal.GetReference(indices);
+
+        var countVec = Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7);
+        var increment = Vector256.Create(8);
+
+        int j = 0;
+        while (j < read)
+        {
+            countVec.StoreUnsafe(ref Unsafe.Add(ref ptr, j));
+            countVec += increment;
+            j += 8;
+        }
+    }
+
+    /// <summary>Find the nth set value inside a single container (0-based).
+    /// Caller is responsible for upgrading ArrayUnsorted to Array first.</summary>
+    private static int SelectInContainer(ref ContainerEntry entry, ContainerType type, int rank)
+    {
+        switch (type)
+        {
+            case ContainerType.Array:
+                return entry.ArrayData[rank];
+
+            case ContainerType.Range:
+                return entry.RangeStart + rank;
+
+            case ContainerType.Bitmap:
+            {
+                ulong* bmp = (ulong*)entry.Data;
+                int word = 0;
+
+                // scan 8 ulongs at a time. popcnt is a 1-cycle instruction with
+                // four-way ILP on modern x86, so an unrolled batch of 8 retires in ~3 cycles.
+                // The JIT may also fuse this into AVX-512 VPOPCNTQ when supported.
+                const int Unroll = 8;
+                while (word + Unroll <= BitmapContainerSizeInUInt64)
+                {
+                    int blockBits =   BitOperations.PopCount(bmp[word])
+                                    + BitOperations.PopCount(bmp[word + 1])
+                                    + BitOperations.PopCount(bmp[word + 2])
+                                    + BitOperations.PopCount(bmp[word + 3])
+                                    + BitOperations.PopCount(bmp[word + 4])
+                                    + BitOperations.PopCount(bmp[word + 5])
+                                    + BitOperations.PopCount(bmp[word + 6])
+                                    + BitOperations.PopCount(bmp[word + 7]);
+                    if (rank < blockBits)
+                        break;
+                    rank -= blockBits;
+                    word += Unroll;
+                }
+
+                for (; word < BitmapContainerSizeInUInt64; word++)
+                {
+                    ulong w = bmp[word];
+                    int bits = BitOperations.PopCount(w);
+                    if (rank < bits)
+                    {
+                        // Win 1: BMI2 PDEP deposits a single 1-bit at the rank-th set
+                        // position in w; trailing-zeros gives its bit index. One instruction.
+                        if (Bmi2.X64.IsSupported)
+                        {
+                            ulong target = Bmi2.X64.ParallelBitDeposit(1UL << rank, w);
+                            return word * 64 + BitOperations.TrailingZeroCount(target);
+                        }
+
+                        // Fallback: clear the lowest set bit `rank` times.
+                        while (rank > 0)
+                        {
+                            w &= w - 1;
+                            rank--;
+                        }
+                        return word * 64 + BitOperations.TrailingZeroCount(w);
+                    }
+                    rank -= bits;
+                }
+                return -1; // shouldn't reach here if rank was valid
+            }
+
+            case ContainerType.ArrayUnsorted:
+            case ContainerType.Free:
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type in SelectInContainer");
+        }
+    }
+
+    /// <summary>
+    /// Create a deep copy of this bitmap. All container data is cloned into the same ByteStringContext.
+    /// The source bitmap is not modified. The clone preserves container types (Range, Array, Bitmap).
+    /// </summary>
+    public RoaringBitmap Clone()
+    {
+        RoaringBitmap copy = new(_ctx);
+
+        // Walk entries directly using the Key field - no index indirection needed
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+        int entryCount = _entries.Count;
+        for (int i = 0; i < entryCount; i++)
+        {
+            if (types[i] != ContainerType.Free)
+                copy.AddContainer(entries[i].Key, types[i], CloneContainer(_ctx, ref entries[i], types[i]));
+        }
+        return copy;
+    }
+
+    // Threshold: below this count, comparison sort on a small array
+    // is cheaper than the bitmap radix sort path.
+    private const int BitmapSortThreshold = 128;
+
+    /// <summary>
+    /// Prepare for reading: sort and deduplicate all unsorted array containers,
+    /// and repair lazy bitmap cardinalities left dirty by <see cref="AddRange"/>
+    /// or <see cref="LazyOrWith"/>. Call this after all writes and before any
+    /// read operations (Contains, Fill, set ops, Count). Separates the sort
+    /// + popcount cost from the first query, making performance more predictable.
+    ///
+    /// For sorted input (e.g., Corax posting lists), the array sort step is
+    /// nearly free since the arrays are already in order.
+    /// </summary>
+    [SkipLocalsInit]
+    public void PrepareForReading()
+    {
+        AssertNotConsumed();
+        // 8KB scratch bitmap for radix sort: explode unsorted values into bits,
+        // extract back as sorted array. O(n) bit-sets + O(1024) word scan vs O(n log n).
+        // Dedup is free. Scratch reused across all containers (one clear per chunk touched).
+        ulong* scratch = stackalloc ulong[BitmapContainerSizeInUInt64];
+
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+        int entryCount = _entries.Count;
+        for (int i = 0; i < entryCount; i++)
+        {
+            switch (types[i])
+            {
+                case ContainerType.ArrayUnsorted:
+                {
+                    // All unsorted containers must be sorted for correct iteration order.
+                    // Contains() can use SIMD linear scan on unsorted data, but
+                    // Fill() (iteration) must emit entry IDs in ascending order.
+                    ref ContainerEntry entry = ref entries[i];
+                    if (entry.Cardinality >= BitmapSortThreshold)
+                        SortViaBitmapScratch(ref entry, ref types[i], scratch);
+                    else
+                        SortAndDedupSmallArray(ref entry, out types[i]);
+                    break;
+                }
+
+                case ContainerType.Bitmap when entries[i].Cardinality == LazyCardinality:
+                {
+                    ref ContainerEntry entry = ref entries[i];
+                    entry.Cardinality = BitmapContainerCardinality(entry.Data);
+                    if (entry.Cardinality == 0)
+                        FreeContainer(entry.Key, i);
+                    break;
+                }
+                case ContainerType.Array:
+                case ContainerType.Range:
+                case ContainerType.Bitmap:
+                case ContainerType.Free:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(ContainerType), types[i], "Unexpected container type in PrepareForReading");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Radix sort using 8KB bitmap scratch space.
+    /// O(n) bit-sets and O(n) word scan. Dedup is free (a duplicate bit-set is noop).
+    /// dirtyMap tracks which 4-ulong chunks have been written so extraction only
+    /// visits touched chunks, skipping clean regions entirely.
+    /// </summary>
+    private static void SortViaBitmapScratch(ref ContainerEntry entry, ref ContainerType type, ulong* scratch)
+    {
+        Debug.Assert(type == ContainerType.ArrayUnsorted);
+
+        var arr = entry.ArrayData;
+        int count = entry.Cardinality;
+
+        const int dirtyMapUlongLen = 4;
+        ulong* dirtyMap = stackalloc ulong[dirtyMapUlongLen];
+        Debug.Assert(dirtyMap[0] is 0 ,"This ensure that the stackalloc was cleared, *this* method should not have [SkipLocalsInit]");
+
+        // Explode: set bits for each value, mark the chunk dirty on first touch and clear it.
+        for (int i = 0; i < count; i++)
+        {
+            ushort val = arr[i];
+            int wordIdx = val >> 6;
+            int chunkIdx = wordIdx >> 2;
+            if (BitmapContains(dirtyMap, (ushort)chunkIdx) == false)
+            {
+                BitmapSet(dirtyMap, (ushort)chunkIdx);
+                new Span<byte>(scratch + chunkIdx * 4, 4 * sizeof(ulong)).Clear();
+            }
+
+            BitmapSet(scratch, val);
+        }
+
+        // Extract: only visit chunks marked dirty
+        int sorted = 0;
+        for (int i = 0; i < dirtyMapUlongLen; i++)
+        {
+            ulong currentWork = dirtyMap[i];
+            while (currentWork != 0)
+            {
+                int chunkBit = BitOperations.TrailingZeroCount(currentWork);
+                int wordBaseIdx = ((i << 6) + chunkBit) << 2;
+                const int bitmapWordsPerBit = 4;
+                for (int wordOffset = 0; wordOffset < bitmapWordsPerBit; wordOffset++)
+                {
+                    int wordIdx = wordBaseIdx + wordOffset;
+                    ulong currentWord = scratch[wordIdx];
+                    while (currentWord != 0)
+                    {
+                        int bit = BitOperations.TrailingZeroCount(currentWord);
+                        arr[sorted++] = (ushort)((wordIdx << 6) + bit);
+                        currentWord &= currentWord - 1;
+                    }
+                    scratch[wordIdx] = 0;
+                }
+                currentWork &= currentWork - 1;
+            }
+        }
+        entry.Cardinality = sorted;
+        type = ContainerType.Array;
+    }
+
+    #region In-place Set Operations
+
+    /// <summary>
+    /// In-place AND: retain only values that also exist in others.
+    /// Walks both index arrays; containers in this bitmap with no match in other are freed.
+    /// </summary>
+    public void AndWith(scoped ref RoaringBitmap other)
+    {
+        AssertNotConsumed();
+        int* myIdx = _index.RawItems;
+        int myLen = _index.Count;
+
+        for (int key = 0; key < myLen; key++)
+        {
+            int mySlot = myIdx[key];
+            if (mySlot < 0)
+                continue;
+
+            int otherSlot = other.GetSlotForKey(key);
+            if (otherSlot < 0)
+            {
+                // Not in other - remove; donate storage to other's free list so any
+                // remaining container conversions on that side can reuse it without
+                // round-tripping through ctx.Allocate.
+                DonateStorageThenFreeContainer(key, mySlot, ref other);
+            }
+            else
+            {
+                ref ContainerEntry myEntry = ref _entries[mySlot];
+                ref ContainerEntry otherEntry = ref other._entries[otherSlot];
+                AndContainerInPlace(ref myEntry, ref _types.RawItems[mySlot], ref otherEntry, other._types.RawItems[otherSlot]);
+                int card = ResolveCardinality(ref myEntry);
+                if (card == 0)
+                    DonateStorageThenFreeContainer(key, mySlot, ref other);
+            }
+        }
+        MarkConsumed(ref other);
+    }
+
+    /// <summary>
+    /// Limit-aware AND: same container-level intersection as <see cref="AndWith"/>,
+    /// but stops processing containers once the result has ≥ limit entries.
+    /// Remaining containers in this bitmap that haven't been intersected are removed.
+    /// For unsorted queries, any N valid results are sufficient.
+    /// </summary>
+    public void AndWithLimited(scoped ref RoaringBitmap other, long limit)
+    {
+        AssertNotConsumed();
+        if (limit <= 0)
+        {
+            Clear();
+            MarkConsumed(ref other);
+            return;
+        }
+        int* myIdx = _index.RawItems;
+        int myLen = _index.Count;
+        long accumulated = 0;
+        int stoppedAtKey = -1;
+
+        for (int key = 0; key < myLen; key++)
+        {
+            int mySlot = myIdx[key];
+            if (mySlot < 0)
+                continue;
+
+            int otherSlot = other.GetSlotForKey(key);
+            if (otherSlot < 0)
+            {
+                DonateStorageThenFreeContainer(key, mySlot, ref other);
+            }
+            else
+            {
+                ref ContainerEntry myEntry = ref _entries[mySlot];
+                ref ContainerEntry otherEntry = ref other._entries[otherSlot];
+                AndContainerInPlace(ref myEntry, ref _types.RawItems[mySlot], ref otherEntry, other._types.RawItems[otherSlot]);
+                int card = ResolveCardinality(ref myEntry);
+                if (card == 0)
+                    DonateStorageThenFreeContainer(key, mySlot, ref other);
+                else
+                    accumulated += card;
+            }
+
+            if (accumulated >= limit)
+            {
+                stoppedAtKey = key + 1;
+                break;
+            }
+        }
+
+        // Remove remaining un-intersected containers — they weren't checked against
+        // other, so they'd be false positives.
+        if (stoppedAtKey >= 0)
+        {
+            for (int key = stoppedAtKey; key < myLen; key++)
+            {
+                int mySlot = myIdx[key];
+                if (mySlot < 0)
+                    continue;
+                DonateStorageThenFreeContainer(key, mySlot, ref other);
+            }
+        }
+        MarkConsumed(ref other);
+    }
+
+    /// <summary>Donate this slot's storage to <paramref name="recipient"/>'s free pool
+    /// before freeing the entry. Used during AndWith / AndNotWith to arm the consumed
+    /// right-side bitmap with buffers that this side would otherwise have stranded on
+    /// its own pool.</summary>
+    private void DonateStorageThenFreeContainer(long key, int slot, scoped ref RoaringBitmap recipient)
+    {
+        ref ContainerEntry entry = ref _entries[slot];
+        if (entry.Storage.HasValue)
+        {
+            recipient.ReturnStorageToFreeList(entry.Storage);
+            entry.Storage = default;
+        }
+        FreeContainer(key, slot);
+    }
+
+    /// <summary>
+    /// In-place ANDNOT: remove all values that exist in other from this bitmap.
+    /// </summary>
+    public void AndNotWith(scoped ref RoaringBitmap other)
+    {
+        AssertNotConsumed();
+        int myLen = _index.Count;
+        int* myIdx = _index.RawItems;
+
+        for (int key = 0; key < myLen; key++)
+        {
+            int mySlot = myIdx[key];
+            if (mySlot < 0)
+                continue;
+
+            int otherSlot = other.GetSlotForKey(key);
+            if (otherSlot < 0)
+                continue; // nothing to subtract
+
+            ref ContainerEntry otherEntry = ref other._entries[otherSlot];
+            AndNotContainerInPlace(ref _entries[mySlot], ref _types.RawItems[mySlot], ref otherEntry, other._types.RawItems[otherSlot]);
+            if (_entries[mySlot].Cardinality == 0)
+                DonateStorageThenFreeContainer(key, mySlot, ref other);
+        }
+        MarkConsumed(ref other);
+    }
+
+    [SkipLocalsInit]
+    private void AndContainerInPlace(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right, ContainerType rightType)
+    {
+        switch (leftType, rightType)
+        {
+            // Range×Range fast paths - no allocation needed
+            case (ContainerType.Range, ContainerType.Range):
+            {
+                int intersectStart = Math.Max(left.RangeStart, right.RangeStart);
+                int intersectEnd = Math.Min(RangeEndExclusive(ref left), RangeEndExclusive(ref right));
+                if (intersectStart >= intersectEnd)
+                {
+                    left.Cardinality = 0;
+                }
+                else
+                {
+                    left.RangeStart = (ushort)intersectStart;
+                    left.Cardinality = intersectEnd - intersectStart;
+                }
+                return;
+            }
+            case (ContainerType.Range, _):
+            {
+                ConvertRangeToBitmap(ref left, ref leftType);
+                AndContainerInPlace(ref left, ref leftType, ref right, rightType);
+                return;
+            }
+            case (_, ContainerType.Range):
+            {
+                ulong* stackBmp = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ContainerEntry temp = MaterializeRangeIntoBuffer(ref right, stackBmp);
+                AndContainerInPlace(ref left, ref leftType, ref temp, ContainerType.Bitmap);
+                return;
+            }
+            case (ContainerType.Bitmap, ContainerType.Bitmap):
+            {
+                // Lazy: bitwise AND only; PreparForReading will popcount + free if empty.
+                BitmapAndNoPop(left.BitmapPtr, right.BitmapPtr, left.BitmapPtr);
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                // AND bitmap with array: build the intersection in a stack scratch by
+                // OR'ing only values that are set in left; then copy back. Lazy cardinality.
+                ushort* arr = right.ArrayData;
+                var bmp = left.BitmapPtr;
+                ulong* scratch = stackalloc ulong[BitmapContainerSizeInUInt64];
+                new Span<byte>(scratch, BitmapContainerSizeInBytes).Clear();
+
+                for (int i = 0; i < right.Cardinality; i++)
+                {
+                    ushort val = arr[i];
+                    if (BitmapContains(bmp, val))
+                        BitmapSet(scratch, val);
+                }
+
+                new Span<byte>(scratch, BitmapContainerSizeInBytes)
+                    .CopyTo(new Span<byte>(left.Data, BitmapContainerSizeInBytes));
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Bitmap):
+            {
+                // Filter left's values against right's bitmap, in-place. Order doesn't matter.
+                ushort* arr = left.ArrayData;
+                var bmp = right.BitmapPtr;
+                int count = 0;
+                for (int i = 0; i < left.Cardinality; i++)
+                {
+                    ushort val = arr[i];
+                    if (BitmapContains(bmp, val))
+                        arr[count++] = val;
+                }
+                left.Cardinality = count;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                if (AdvInstructionSet.IsAcceleratedVector256
+                    && left.Cardinality <= SimdLinearScanThreshold
+                    && right.Cardinality <= SimdLinearScanThreshold)
+                {
+                    Debug.Assert(left.Storage.Length % Vector256<ushort>.Count == 0 && right.Storage.Length % Vector256<ushort>.Count == 0,
+                            "array containers must be SIMD-aligned for SIMD AND, see SimdContains for details");
+
+                    left.Cardinality = SimdCrossAnd(left.ArrayData, left.Cardinality, right.ArrayData, right.Cardinality, left.ArrayData);
+                }
+                else
+                {
+                    // Need sorted arrays for galloping merge
+                    if (leftType == ContainerType.ArrayUnsorted)
+                        SortAndDedupSmallArray(ref left, out leftType);
+                    if (rightType == ContainerType.ArrayUnsorted)
+                        SortAndDedupSmallArray(ref right, out rightType);
+                    ushort* a = left.ArrayData;
+                    ushort* b = right.ArrayData;
+                    left.Cardinality = ArrayContainerAnd(a, left.Cardinality, b, right.Cardinality, a);
+                }
+                break;
+            }
+            default:
+                throw new InvalidOperationException($"Invalid container combination: {leftType} and {rightType}");
+        }
+    }
+
+    [SkipLocalsInit]
+    private void AndNotContainerInPlace(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right, ContainerType rightType)
+    {
+        switch (leftType, rightType)
+        {
+            case (ContainerType.Range, ContainerType.Range):
+            {
+                AndNotTwoRangesInPlace(ref left, ref leftType, ref right);
+                break;
+            }
+            case (ContainerType.Range, _):
+            {
+                ConvertRangeToBitmap(ref left, ref leftType);
+                AndNotContainerInPlace(ref left, ref leftType, ref right, rightType);
+                break;
+            }
+            case (_, ContainerType.Range):
+            {
+                ulong* stackBmp = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ContainerEntry temp = MaterializeRangeIntoBuffer(ref right, stackBmp);
+                AndNotContainerInPlace(ref left, ref leftType, ref temp, ContainerType.Bitmap);
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Bitmap):
+            {
+                // Lazy: bitwise ANDNOT only.
+                BitmapAndNotNoPop(left.BitmapPtr, right.BitmapPtr, left.BitmapPtr);
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                // Lazy: clear bits unconditionally — no per-bit cardinality check.
+                ClearArrayInBitmap(right.ArrayData, right.Cardinality, left.BitmapPtr);
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Bitmap):
+            {
+                // Keep left values NOT in the right's bitmap. Order doesn't matter.
+                ushort* arr = left.ArrayData;
+                var bmp = right.BitmapPtr;
+                int count = 0;
+                for (int i = 0; i < left.Cardinality; i++)
+                {
+                    ushort val = arr[i];
+                    if (BitmapContains(bmp, val) == false)
+                        arr[count++] = val;
+                }
+
+                left.Cardinality = count;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                // merge small arrays using SIMD
+                if (AdvInstructionSet.IsAcceleratedVector256
+                    && left.Cardinality <= SimdLinearScanThreshold
+                    && right.Cardinality <= SimdLinearScanThreshold)
+                {
+                    Debug.Assert(left.Storage.Length % Vector256<ushort>.Count == 0 && right.Storage.Length % Vector256<ushort>.Count == 0,
+                        "array containers must be SIMD-aligned for SIMD ANDNOT, see SimdCrossAndNot for details");
+                    left.Cardinality = SimdCrossAndNot(left.ArrayData, left.Cardinality, right.ArrayData, right.Cardinality, left.ArrayData);
+                    break;
+                }
+
+                if (leftType == ContainerType.ArrayUnsorted)
+                    SortAndDedupSmallArray(ref left, out leftType);
+                if (rightType == ContainerType.ArrayUnsorted)
+                    SortAndDedupSmallArray(ref right, out rightType);
+                ushort* a = left.ArrayData;
+                ushort* b = right.ArrayData;
+                left.Cardinality = ArrayContainerAndNot(a, left.Cardinality, b, right.Cardinality, a);
+                break;
+            }
+            default:
+                throw new InvalidOperationException($"Invalid container combination: {leftType} and {rightType}");
+        }
+    }
+
+    private void AndNotTwoRangesInPlace(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right)
+    {
+        int leftStart = left.RangeStart;
+        int leftEnd = RangeEndExclusive(ref left);
+        int rightStart = right.RangeStart;
+        int rightEnd = RangeEndExclusive(ref right);
+
+        // No overlap.
+        if (rightEnd <= leftStart || rightStart >= leftEnd)
+            return;
+
+        // Right is covering all of left.
+        if (rightStart <= leftStart && rightEnd >= leftEnd)
+        {
+            left.Cardinality = 0;
+            return;
+        }
+
+        // Trim low edge.
+        if (rightStart <= leftStart)
+        {
+            left.RangeStart = (ushort)rightEnd;
+            left.Cardinality = leftEnd - rightEnd;
+            return;
+        }
+
+        // Trim high edge.
+        if (rightEnd >= leftEnd)
+        {
+            left.Cardinality = rightStart - leftStart;
+            return;
+        }
+
+        // Middle cut would split into two ranges - materialize.
+        ConvertRangeToBitmap(ref left, ref leftType);
+        ulong* stackBmp = stackalloc ulong[BitmapContainerSizeInUInt64];
+        ContainerEntry temp = MaterializeRangeIntoBuffer(ref right, stackBmp);
+        AndNotContainerInPlace(ref left, ref leftType, ref temp, ContainerType.Bitmap);
+    }
+
+    /// <summary>
+    /// Create a temporary bitmap on the stack from a Range container.
+    /// Returns a ContainerEntry pointing to the stackalloc buffer (no ByteStringContext allocation).
+    /// The returned entry has Storage=default - the caller must NOT release it.
+    /// </summary>
+    [SkipLocalsInit]
+    private static ContainerEntry MaterializeRangeIntoBuffer(ref ContainerEntry entry, ulong* stackBitmap)
+    {
+        ClearBitmap(stackBitmap);
+        FillBitmapFromRange(stackBitmap, entry.RangeStart, entry.Cardinality);
+
+        return new ContainerEntry
+        {
+            Data = (byte*)stackBitmap,
+            Cardinality = entry.Cardinality,
+            Storage = default // no allocation to release
+        };
+    }
+
+
+    #endregion
+
+    #region Index Operations
+
+    /// <summary>
+    /// Ensure the index array covers the given key, filling new slots with -1.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureIndexCoversKey(long key)
+    {
+        if (key < _index.Count)
+            return;
+
+        IncreaseIndexCapacity(key);
+    }
+
+
+    private void IncreaseIndexCapacity(long key)
+    {
+        if (key is < 0 or >= int.MaxValue - 16)
+            throw new ArgumentOutOfRangeException(nameof(key), $"Container key {key} is out of the valid range (0..{int.MaxValue - 17}).");
+
+        int needed = checked((int)(key + 1));
+        int oldCount = _index.Count;
+        _index.EnsureCapacityFor(_ctx, needed - oldCount);
+        _index.Count = needed;
+
+        // Fill new slots with -1 (absent)
+        int* ptr = _index.RawItems;
+        new Span<int>(ptr + oldCount, needed - oldCount).Fill(IndexAbsent);
+    }
+
+    /// <summary>
+    /// Add a new container entry and register it in the index. Returns the entry slot.
+    /// </summary>
+    private int AddNewContainer(long key, ContainerType type, in ContainerEntry entry)
+    {
+        EnsureIndexCoversKey(key);
+
+        int slot;
+        if (_freeListHead != 0) // 0 = empty; non-zero = slot+1 (1-based)
+        {
+            slot = _freeListHead - 1; // decode: real index = stored - 1
+            Debug.Assert(_types.RawItems[slot] == ContainerType.Free, "Expected free entry");
+            _freeListHead = (int)_entries[slot].NextFreeSlot; // next encoded value (0 or slot+1)
+            _entries[slot] = entry;
+            _types.RawItems[slot] = type;
+        }
+        else
+        {
+            slot = _entries.Count;
+            _entries.Add(_ctx, entry);
+            _types.Add(_ctx, type);
+        }
+
+        // we checked size of key in EnsureIndexCoversKey, so this cast is safe
+        _entries[slot].Key = (uint)key;
+
+        _index.RawItems[key] = slot;
+        _containerCount++;
+        return slot;
+    }
+
+    /// <summary>
+    /// Remove a container: detach its storage onto the free list for reuse,
+    /// mark the index as absent, and chain the slot onto the entry free list.
+    /// </summary>
+    private void FreeContainer(long key, int slot)
+    {
+        ref ContainerEntry entry = ref _entries[slot];
+        if (entry.Storage.HasValue)
+            ReturnStorageToFreeList(entry.Storage);
+
+        entry = default;
+        _types.RawItems[slot] = ContainerType.Free;
+        entry.NextFreeSlot = (uint)_freeListHead; // current head (0 or prev_slot+1)
+        _freeListHead = slot + 1;                 // encode: store as real_index + 1
+
+        _index.RawItems[key] = IndexAbsent;
+        _containerCount--;
+    }
+
+    /// <summary>
+    /// Add a container entry during result-building (set operations). Used when building
+    /// a new bitmap from scratch where keys are added in order.
+    /// </summary>
+    private void AddContainer(long key, ContainerType type, in ContainerEntry entry)
+    {
+        if (entry.Cardinality == 0)
+            return;
+
+        AddNewContainer(key, type, entry);
+    }
+
+    #endregion
+
+    #region Container Management
+
+    /// <summary>
+    /// Round up to SIMD-aligned size. Ensures all array allocations
+    /// are multiples of 32 bytes so Vector256 operations don't need bounds checking.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int AlignForSimd(int bytes)
+    {
+        return Math.Max(InitialArrayContainerSizeInBytes, (bytes + SimdAlignment - 1) & ~(SimdAlignment - 1));
+    }
+
+    /// <summary>
+    /// Append all values from <paramref name="right"/> into <paramref name="left"/>, which together
+    /// hold <paramref name="totalCount"/> entries. Steals an existing buffer when possible to avoid allocation:
+    /// uses left's buffer if it already has room, right's buffer (swapping ownership) if it fits, otherwise
+    /// allocates a new one. Result is always <see cref="ContainerType.ArrayUnsorted"/>.
+    /// </summary>
+    private void AppendArrayContainers(ref ContainerEntry left, ref ContainerEntry right, int totalCount)
+    {
+        int neededBytes = totalCount * sizeof(ushort);
+        Debug.Assert(neededBytes <= BitmapContainerSizeInBytes, "Total count exceeds maximum for array container");
+        int leftCardinality = left.Cardinality;
+        if (neededBytes > right.Storage.Length)
+        {
+            EnsureArrayCapacity(ref left, totalCount);
+            Unsafe.CopyBlockUnaligned(left.ArrayData + leftCardinality, right.ArrayData, (uint)(right.Cardinality * sizeof(ushort)));
+            left.Cardinality = totalCount;
+            return;
+        }
+        // Right buffer fits both — prepend left's values into right, then take ownership.
+        Unsafe.CopyBlockUnaligned(right.ArrayData + right.Cardinality, left.ArrayData, (uint)(leftCardinality * sizeof(ushort)));
+        if (left.Storage.HasValue)
+            _ctx.Release(ref left.Storage);
+        left.Storage = right.Storage;
+        left.Data = right.Data;
+        left.Cardinality = totalCount;
+        right = default;
+    }
+
+    /// <summary>
+    /// Ensure the array container has room for the given number of entries.
+    /// Doubles the buffer size up to BitmapContainerSizeInBytes (8KB).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureArrayCapacity(ref ContainerEntry entry, int requiredEntries)
+    {
+        int requiredBytes = requiredEntries * sizeof(ushort);
+        if (requiredBytes <= entry.Storage.Length)
+            return;
+
+        IncreaseArrayCapacity(ref entry, requiredBytes);
+    }
+
+    private void IncreaseArrayCapacity(ref ContainerEntry entry, int requiredBytes)
+    {
+        int newSize = Math.Max(entry.Storage.Length * 2, requiredBytes);
+        newSize = Math.Min(newSize, BitmapContainerSizeInBytes);
+
+        AllocateOrRecycle(newSize, out ByteString newStorage);
+        int copyBytes = entry.Cardinality * sizeof(ushort);
+        if (copyBytes > 0)
+            Unsafe.CopyBlockUnaligned(newStorage.Ptr, entry.Data, (uint)copyBytes);
+
+        if (entry.Storage.HasValue)
+            ReturnStorageToFreeList(entry.Storage);
+        entry.Storage = newStorage;
+        entry.Data = newStorage.Ptr;
+    }
+
+    #endregion
+
+    #region Container Operations
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddToContainer(ref ContainerEntry entry, int slot, ushort value)
+    {
+        ref ContainerType type = ref _types.RawItems[slot];
+        switch (type)
+        {
+            case ContainerType.Array:
+                // If value is >= the last element, append (or noop for duplicate) and stay sorted
+                if (entry.Cardinality > 0 && value >= entry.ArrayData[entry.Cardinality - 1])
+                {
+                    if (value == entry.ArrayData[entry.Cardinality - 1])
+                        break; // duplicate of last element - noop
+                    if (entry.Cardinality >= ArrayContainerMaxCardinality)
+                    {
+                        ConvertArrayToBitmap(ref entry, ref type);
+                        BitmapSet(entry.BitmapPtr, value);
+                        entry.Cardinality = LazyCardinality;
+                        break;
+                    }
+                    EnsureArrayCapacity(ref entry, entry.Cardinality + 1);
+                    entry.ArrayData[entry.Cardinality++] = value;
+                    break;
+                }
+                // Would break sort order - switch to unsorted for O(1) appends
+                type = ContainerType.ArrayUnsorted;
+                goto case ContainerType.ArrayUnsorted;
+
+            case ContainerType.ArrayUnsorted:
+                if (entry.Cardinality >= ArrayContainerMaxCardinality)
+                {
+                    // At capacity: sort+dedup via bitmap scratch, then promote if still full
+                    ulong* scratch = stackalloc ulong[BitmapContainerSizeInUInt64];
+                    SortViaBitmapScratch(ref entry, ref type, scratch); // type → Array, deduped
+                    if (entry.Cardinality >= ArrayContainerMaxCardinality)
+                    {
+                        ConvertArrayToBitmap(ref entry, ref type);
+                        goto case ContainerType.Bitmap;
+                    }
+                    goto case ContainerType.Array;// we are now sorted (and not full), we'll let the array handler deal with it.
+                }
+                EnsureArrayCapacity(ref entry, entry.Cardinality + 1);
+                entry.ArrayData[entry.Cardinality++] = value;
+                break;
+
+            case ContainerType.Bitmap:
+                BitmapSet(entry.BitmapPtr, value);
+                entry.Cardinality = LazyCardinality;
+                break;
+
+            case ContainerType.Range:
+                if (TryMergeRangeInPlace(ref entry, value, value + 1) == false)
+                {
+                    ConvertRangeForAdd(ref entry, ref type, value);
+                }
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), $"Unexpected value to add: {type}");
+        }
+    }
+
+    #endregion
+
+    #region Container Conversions
+
+    /// <summary>
+    /// Convert an array container (sorted or unsorted) to bitmap.
+    /// For unsorted arrays with possible duplicates, cardinality is recounted via popcount.
+    /// </summary>
+    private void ConvertArrayToBitmap(ref ContainerEntry entry, ref ContainerType type)
+    {
+        Debug.Assert(type is ContainerType.Array or ContainerType.ArrayUnsorted);
+
+        bool unsorted = type == ContainerType.ArrayUnsorted;
+        ushort* arr = entry.ArrayData;
+        int count = entry.Cardinality;
+
+        AllocateOrRecycle(BitmapContainerSizeInBytes, out ByteString newStorage);
+        ClearBitmap((ulong*)newStorage.Ptr);
+        SetArrayInBitmap(arr, count, (ulong*)newStorage.Ptr);
+
+        if (unsorted)
+        {
+            var updatedCount = BitmapContainerCardinality(newStorage.Ptr);
+            entry.Cardinality = updatedCount;
+        }
+        if (entry.Storage.HasValue)
+            ReturnStorageToFreeList(entry.Storage);
+
+        entry.Storage = newStorage;
+        entry.Data = newStorage.Ptr;
+        type = ContainerType.Bitmap;
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        if (_entries.IsValid)
+        {
+            ContainerEntry* entries = _entries.RawItems;
+            int count = _entries.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (entries[i].Storage.HasValue)
+                    _ctx.Release(ref entries[i].Storage);
+            }
+
+            _entries.Dispose(_ctx);
+        }
+
+        // Release every storage parked on the storage free list — these are storages that
+        // were recycled via FreeContainer/Clear but never re-used before Dispose.
+        ByteString freeNode = _nextFreeStorage;
+        while (freeNode.HasValue)
+        {
+            ByteString nextNode = *(ByteString*)freeNode.Ptr; // read next before releasing
+            _ctx.Release(ref freeNode);
+            freeNode = nextNode;
+        }
+        _nextFreeStorage = default;
+
+        if (_types.IsValid)
+            _types.Dispose(_ctx);
+
+        if (_index.IsValid)
+            _index.Dispose(_ctx);
+    }
+}

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Sparrow;
+using Sparrow.Server;
+using Sparrow.Server.Utils.VxSort;
+
+namespace Voron.Data.RoaringBitmaps;
+
+/// <summary>
+/// Forward iterator for RoaringBitmap supporting Fill(Span&lt;long&gt;) streaming.
+/// On construction, builds a sorted array of packed (key, slot) ulongs for deterministic traversal.
+/// Each ulong packs: key in upper 32 bits, slot in lower 32 bits.
+/// _positionInContainer is shared: Array uses it as array index, Range as offset from RangeStart,
+/// Bitmap as the current ulong word index (0..1023). _bitmapCurrentWord stores remaining
+/// bits in the current word for bitmap iteration only.
+/// </summary>
+public unsafe struct RoaringBitmapIterator : IDisposable
+{
+    private ByteStringContext _ctx;
+    private ByteString _packedEntries; // array of packed (key << 32) | slot
+    private int _entryCount;
+    private int _containerIndex; // index into _packedEntries
+    /// <summary>Array: index into sorted array. Range: offset from RangeStart. Bitmap: current ulong index (0..1023).</summary>
+    private int _positionInContainer;
+    private ulong _bitmapCurrentWord; // Bitmap only: remaining bits in current word
+
+    public RoaringBitmapIterator(ref RoaringBitmap data, ByteStringContext ctx)
+    {
+        _ctx = ctx;
+        _containerIndex = 0;
+        _positionInContainer = 0;
+        _bitmapCurrentWord = 0;
+
+        // Build sorted array of packed (key, slot) ulongs from active containers
+        int containerCount = data.ContainerCount;
+        if (containerCount is 0)
+        {
+            _packedEntries = default;
+            _entryCount = 0;
+            return;
+        }
+
+        int sizeNeeded = containerCount * sizeof(ulong);
+        ctx.Allocate(sizeNeeded, out _packedEntries);
+
+        var packedPtr = (ulong*)_packedEntries.Ptr;
+        _entryCount = 0;
+
+        // Pack all active entries: (key << 32) | slot
+        var entries = new ReadOnlySpan<ContainerEntry>(data._entries.RawItems, data._entries.Count);
+        var types = data._types.RawItems;
+        for (int i = 0; i < entries.Length; i++)
+        {
+            if (types[i] != ContainerType.Free)
+            {
+                // Pack: upper 32 bits = key, lower 32 bits = slot
+                packedPtr[_entryCount] = ((ulong)entries[i].Key << 32) | (uint)i;
+                _entryCount++;
+            }
+        }
+
+        // Sort by packed value (key is in upper bits, so sorts by key)
+        Sort.Run(packedPtr, _entryCount);
+    }
+
+    /// <summary>
+    /// Fill the buffer with the next batch of values from the bitmap.
+    /// Returns the number of values written.
+    /// </summary>
+    public int Fill(ref RoaringBitmap data, Span<long> buffer)
+    {
+        int written = 0;
+        if (_entryCount == 0)
+            return 0;
+
+        var packedPtr = (ulong*)_packedEntries.Ptr;
+
+        while (written < buffer.Length && _containerIndex < _entryCount)
+        {
+            ulong packed = packedPtr[_containerIndex];
+            int slot = (int)(packed & 0xFFFFFFFF);          // Lower 32 bits = slot
+            uint key = (uint)(packed >> 32);                 // Upper 32 bits = key
+
+            ref ContainerEntry entry = ref data._entries[slot];
+            ContainerType type = data._types.RawItems[slot];
+            long baseValue = (long)key << RoaringBitmap.ContainerKeyShift;
+
+            // callers MUST call RoaringBitmap.PrepareForReading() before the first
+            // Fill() call, which converts every ArrayUnsorted container to sorted. 
+            Debug.Assert(type != ContainerType.ArrayUnsorted,
+                "RoaringBitmapIterator: ArrayUnsorted container at iteration time. " +
+                "PrepareForReading() must be called before Fill().");
+
+            switch (type)
+            {
+                case ContainerType.Array:
+                case ContainerType.ArrayUnsorted: // accepted defensively in Release; PrepareForReading should have removed these
+                    written = FillFromArray(ref entry, baseValue, buffer, written);
+                    break;
+
+                case ContainerType.Bitmap:
+                    written = FillFromBitmap(ref entry, baseValue, buffer, written);
+                    break;
+
+                case ContainerType.Range:
+                    written = FillFromRange(ref entry, baseValue, buffer, written);
+                    break;
+            }
+
+            bool containerCompleted = type == ContainerType.Bitmap
+                ? _positionInContainer >= RoaringBitmap.BitmapContainerSizeInUInt64 && _bitmapCurrentWord == 0
+                : _positionInContainer >= entry.Cardinality;
+
+            if (containerCompleted)
+            {
+                _containerIndex++;
+                _positionInContainer = 0;
+                _bitmapCurrentWord = 0;
+            }
+        }
+
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int FillFromArray(ref ContainerEntry entry, long baseValue, Span<long> buffer, int written)
+    {
+        ushort* arr = (ushort*)entry.ArrayData;
+        int count = entry.Cardinality;
+        int remaining = count - _positionInContainer;
+        int space = buffer.Length - written;
+        int toCopy = Math.Min(remaining, space);
+
+        if (toCopy <= 0)
+            return written;
+
+        fixed (long* dst = &buffer[written])
+        {
+            ushort* src = arr + _positionInContainer;
+            int i = 0;
+
+            // SIMD: widen 4 ushorts → 4 longs, OR with baseValue, store 4 longs.
+            if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
+            {
+                Vector256<long> vBase = Vector256.Create(baseValue);
+                for (; i + 4 <= toCopy; i += 4)
+                {
+                    Vector256<long> vals = Vector256.Create(
+                        (long)src[i], (long)src[i + 1], (long)src[i + 2], (long)src[i + 3]);
+                    (vals | vBase).Store(dst + i);
+                }
+            }
+
+            // Scalar remainder (or all, if no SIMD)
+            for (; i < toCopy; i++)
+                dst[i] = baseValue | src[i];
+        }
+
+        _positionInContainer += toCopy;
+        return written + toCopy;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int FillFromBitmap(ref ContainerEntry entry, long baseValue, Span<long> buffer, int written)
+    {
+        var bitmap = entry.BitmapPtr;
+
+        while (written < buffer.Length && _positionInContainer < RoaringBitmap.BitmapContainerSizeInUInt64)
+        {
+            if (_bitmapCurrentWord == 0)
+            {
+                _bitmapCurrentWord = bitmap[_positionInContainer];
+                if (_bitmapCurrentWord == 0)
+                {
+                    _positionInContainer++;
+                    continue;
+                }
+            }
+
+            while (_bitmapCurrentWord != 0 && written < buffer.Length)
+            {
+                int bit = BitOperations.TrailingZeroCount(_bitmapCurrentWord);
+                buffer[written++] = baseValue | (uint)(_positionInContainer * 64 + bit);
+                _bitmapCurrentWord &= _bitmapCurrentWord - 1;
+            }
+
+            if (_bitmapCurrentWord == 0)
+                _positionInContainer++;
+        }
+
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int FillFromRange(ref ContainerEntry entry, long baseValue, Span<long> buffer, int written)
+    {
+        int rangeStart = entry.RangeStart;
+        int remaining = entry.Cardinality - _positionInContainer;
+        int space = buffer.Length - written;
+        int toCopy = Math.Min(remaining, space);
+
+        if (toCopy <= 0)
+            return written;
+
+        fixed (long* dst = &buffer[written])
+        {
+            int i = 0;
+
+            // SIMD: generate 4 sequential values at a time
+            if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
+            {
+                Vector256<long> vCurrent = Vector256.Create(
+                    baseValue + rangeStart + _positionInContainer,
+                    baseValue + rangeStart + _positionInContainer + 1,
+                    baseValue + rangeStart + _positionInContainer + 2,
+                    baseValue + rangeStart + _positionInContainer + 3);
+                Vector256<long> vStep = Vector256.Create(4L);
+
+                for (; i + 4 <= toCopy; i += 4)
+                {
+                    vCurrent.Store(dst + i);
+                    vCurrent += vStep;
+                }
+                _positionInContainer += i;
+            }
+
+            // Scalar remainder (or all, if no SIMD)
+            for (; i < toCopy; i++)
+            {
+                dst[i] = baseValue | (uint)(rangeStart + _positionInContainer);
+                _positionInContainer++;
+            }
+        }
+
+        return written + toCopy;
+    }
+
+    public void Dispose()
+    {
+        if (_packedEntries.HasValue)
+        {
+            _ctx.Release(ref _packedEntries);
+            _packedEntries = default; // make Dispose idempotent — repeated callers are common in finally chains
+        }
+    }
+}

--- a/test/FastTests/Corax/RoaringBitmapTests.cs
+++ b/test/FastTests/Corax/RoaringBitmapTests.cs
@@ -1,0 +1,1417 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Voron.Data.RoaringBitmaps;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+public unsafe class RoaringBitmapTests : NoDisposalNeeded
+{
+    public RoaringBitmapTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // Set op helpers for testing: deep-clone left bitmap, then mutate in-place.
+    // Preserves the original bitmap's container structure for subsequent assertions.
+    // Returns RoaringBitmap; caller must dispose it.
+    private static RoaringBitmap And(ByteStringContext ctx, RoaringBitmap a, RoaringBitmap b)
+    {
+        RoaringBitmap result = a.Clone();
+        result.AndWith(ref b);
+        result.PrepareForReading();
+        return result;
+    }
+
+    private static RoaringBitmap Or(ByteStringContext ctx, RoaringBitmap a, RoaringBitmap b)
+    {
+        RoaringBitmap result = a.Clone();
+        RoaringBitmap bClone = b.Clone();
+        try
+        {
+            result.OrWith(ref bClone);
+            result.PrepareForReading();
+        }
+        finally
+        {
+            bClone.Dispose();
+        }
+        return result;
+    }
+
+    private static RoaringBitmap AndNot(ByteStringContext ctx, RoaringBitmap a, RoaringBitmap b)
+    {
+        RoaringBitmap result = a.Clone();
+        result.AndNotWith(ref b);
+        result.PrepareForReading();
+        return result;
+    }
+
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void CanAddAndContainsSingleValue()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        bitmap.Add(42);
+        bitmap.PrepareForReading();
+        Assert.True(bitmap.Contains(42));
+        Assert.False(bitmap.Contains(43));
+        Assert.Equal(1, bitmap.Count);
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void CanAddManyValuesInSameContainer()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        for (int i = 0; i < 1000; i++)
+            bitmap.Add(i);
+
+        for (int i = 0; i < 1000; i++)
+            Assert.True(bitmap.Contains(i));
+
+        bitmap.PrepareForReading();
+        Assert.False(bitmap.Contains(1000));
+        Assert.Equal(1000, bitmap.Count);
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void CanAddValuesAcrossMultipleContainers()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        // Values in different 64K ranges
+        bitmap.Add(0);
+        bitmap.Add(65536);     // container key 1
+        bitmap.Add(131072);    // container key 2
+        bitmap.Add(1_000_000); // container key 15
+
+        bitmap.PrepareForReading();
+        Assert.True(bitmap.Contains(0));
+        Assert.True(bitmap.Contains(65536));
+        Assert.True(bitmap.Contains(131072));
+        Assert.True(bitmap.Contains(1_000_000));
+        Assert.False(bitmap.Contains(1));
+        Assert.Equal(4, bitmap.Count);
+        Assert.Equal(4, bitmap.ContainerCount);
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void ArrayToBitmapConversionOnThreshold()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        // Add more than 4096 values within a single container using a non-sequential
+        // pattern (evens) to force ArrayUnsorted→Bitmap conversion (sequential 0..N
+        // creates a Range container, which never hits the ArrayUnsorted→Bitmap path).
+        for (int i = 0; i < 10000; i++)
+            bitmap.Add(i * 2);
+
+        bitmap.PrepareForReading();
+        Assert.Equal(10000, bitmap.Count);
+
+        for (int i = 0; i < 10000; i++)
+            Assert.True(bitmap.Contains(i * 2));
+        Assert.False(bitmap.Contains(1));
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void FullContainerAsRange()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        // Fill an entire container — should become Range with count=65536
+        for (int i = 0; i < 65536; i++)
+            bitmap.Add(i);
+
+        bitmap.PrepareForReading();
+        Assert.Equal(65536, bitmap.Count);
+        Assert.True(bitmap.Contains(0));
+        Assert.True(bitmap.Contains(65535));
+        Assert.False(bitmap.Contains(65536));
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void DuplicateAddIsIdempotent()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        bitmap.Add(42);
+        bitmap.Add(42);
+        bitmap.Add(42);
+        bitmap.PrepareForReading();
+        Assert.Equal(1, bitmap.Count);
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void CanHandle64BitValues()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        long largeValue = (long)int.MaxValue + 100;
+        bitmap.Add(largeValue);
+        bitmap.PrepareForReading();
+        Assert.True(bitmap.Contains(largeValue));
+        Assert.False(bitmap.Contains(largeValue + 1));
+        Assert.Equal(1, bitmap.Count);
+        bitmap.Dispose();
+    }
+
+    #region Set Operations
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndIntersection()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        for (int i = 0; i < 1000; i++)
+            a.Add(i);
+        for (int i = 500; i < 1500; i++)
+            b.Add(i);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = And(ctx, a, b);
+        try
+        {
+            Assert.Equal(500, result.Count);
+            for (int i = 500; i < 1000; i++)
+                Assert.True(result.Contains(i));
+            Assert.False(result.Contains(499));
+            Assert.False(result.Contains(1000));
+        }
+        finally
+        {
+            result.Dispose();
+            a.Dispose();
+            b.Dispose();
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void OrUnion()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+
+        for (int i = 0; i < 1000; i++)
+            a.Add(i);
+        for (int i = 500; i < 1500; i++)
+            b.Add(i);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = Or(ctx, a, b);
+
+        Assert.Equal(1500, result.Count);
+        for (int i = 0; i < 1500; i++)
+            Assert.True(result.Contains(i));
+        Assert.False(result.Contains(1500));
+        result.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndNotDifference()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        for (int i = 0; i < 1000; i++)
+            a.Add(i);
+        for (int i = 500; i < 1500; i++)
+            b.Add(i);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = AndNot(ctx, a, b);
+        try
+        {
+            Assert.Equal(500, result.Count);
+            for (int i = 0; i < 500; i++)
+                Assert.True(result.Contains(i));
+            for (int i = 500; i < 1000; i++)
+                Assert.False(result.Contains(i));
+        }
+        finally
+        {
+            result.Dispose();
+            a.Dispose();
+            b.Dispose();
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndWithDisjointBitmaps()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        for (int i = 0; i < 100; i++)
+            a.Add(i);
+        for (int i = 200; i < 300; i++)
+            b.Add(i);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = And(ctx, a, b);
+        try
+        {
+            Assert.Equal(0, result.Count);
+            Assert.True(result.IsEmpty);
+        }
+        finally
+        {
+            result.Dispose();
+            a.Dispose();
+            b.Dispose();
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void SetOpsWithDenseBitmapContainers()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        // Dense enough to be bitmap containers (>4096 each)
+        for (int i = 0; i < 10000; i++)
+            a.Add(i * 2); // evens 0..19998
+        for (int i = 0; i < 10000; i++)
+            b.Add(i * 2 + 1); // odds 1..19999
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+
+        // AND should be empty (no overlap)
+        RoaringBitmap andResult = And(ctx, a, b);
+        Assert.Equal(0, andResult.Count);
+        andResult.Dispose();
+
+        // OR should have all 20000
+        RoaringBitmap orResult = Or(ctx, a, b);
+        Assert.Equal(20000, orResult.Count);
+        orResult.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void SetOpsWithMixedContainerTypes()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap sparse = new(ctx);
+        RoaringBitmap dense = new(ctx);
+        // Sparse (array container): 100 values
+        for (int i = 0; i < 100; i++)
+            sparse.Add(i * 10);
+
+        // Dense (bitmap container): 5000 values
+        for (int i = 0; i < 5000; i++)
+            dense.Add(i);
+
+        // AND: sparse values that exist in dense
+        sparse.PrepareForReading();
+        dense.PrepareForReading();
+        RoaringBitmap andResult = And(ctx, sparse, dense);
+        try
+        {
+            // Values 0, 10, 20, ..., 490 (up to 4990 but dense only goes to 4999)
+            int expected = 0;
+            for (int i = 0; i < 100; i++)
+            {
+                if (i * 10 < 5000)
+                    expected++;
+            }
+            Assert.Equal(expected, andResult.Count);
+        }
+        finally
+        {
+            andResult.Dispose();
+            sparse.Dispose();
+            dense.Dispose();
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void SetOpsAcrossMultipleContainers()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        // a: containers 0 and 1
+        for (int i = 0; i < 200; i++)
+            a.Add(i);
+        for (int i = 65536; i < 65736; i++)
+            a.Add(i);
+
+        // b: containers 1 and 2
+        for (int i = 65536; i < 65636; i++)
+            b.Add(i);
+        for (int i = 131072; i < 131172; i++)
+            b.Add(i);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap orResult = Or(ctx, a, b);
+        try
+        {
+            Assert.Equal(200 + 200 + 100, orResult.Count); // container0(200) + container1(200 union) + container2(100)
+        }
+        finally
+        {
+            orResult.Dispose();
+        }
+
+        RoaringBitmap andResult = And(ctx, a, b);
+        try
+        {
+            Assert.Equal(100, andResult.Count); // only container1 intersection
+        }
+        finally
+        {
+            andResult.Dispose();
+            a.Dispose();
+            b.Dispose();
+        }
+    }
+
+    #endregion
+
+    #region Iterator Tests
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void IteratorReturnsAllValuesInOrder()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        long[] expected = { 5, 10, 100, 1000, 65536, 65537, 131072 };
+        foreach (long val in expected)
+            bitmap.Add(val);
+
+        var iterator = bitmap.GetIterator();
+        Span<long> buffer = stackalloc long[100];
+        bitmap.PrepareForReading();
+        int count = bitmap.Fill(buffer, ref iterator);
+
+        Assert.Equal(expected.Length, count);
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], buffer[i]);
+        iterator.Dispose();
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void IteratorWorksWithSmallBuffer()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        for (int i = 0; i < 100; i++)
+            bitmap.Add(i);
+
+        var iterator = bitmap.GetIterator();
+        List<long> allValues = new();
+        Span<long> buffer = stackalloc long[10];
+
+        int total = 0;
+        int count;
+        bitmap.PrepareForReading();
+        while ((count = bitmap.Fill(buffer, ref iterator)) > 0)
+        {
+            for (int i = 0; i < count; i++)
+                allValues.Add(buffer[i]);
+            total += count;
+        }
+
+        Assert.Equal(100, total);
+        for (int i = 0; i < 100; i++)
+            Assert.Equal(i, allValues[i]);
+        iterator.Dispose();
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void IteratorHandlesBitmapContainers()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        // Dense enough for bitmap container — use a non-sequential pattern (evens)
+        // within a single 64K range to produce Bitmap containers rather than Range.
+        for (int i = 0; i < 10000; i++)
+            bitmap.Add(i * 2);
+
+        var iterator = bitmap.GetIterator();
+        List<long> allValues = new();
+        long[] buffer = new long[256];
+
+        int count;
+        bitmap.PrepareForReading();
+        while ((count = bitmap.Fill(buffer, ref iterator)) > 0)
+        {
+            for (int i = 0; i < count; i++)
+                allValues.Add(buffer[i]);
+        }
+
+        Assert.Equal(10000, allValues.Count);
+        for (int i = 0; i < 10000; i++)
+            Assert.Equal(i * 2, allValues[i]);
+        iterator.Dispose();
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void IteratorHandlesFullContainer()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        for (int i = 0; i < 65536; i++)
+            bitmap.Add(i);
+
+        var iterator = bitmap.GetIterator();
+        long[] buffer = new long[1024];
+        int total = 0;
+
+        int count;
+        bitmap.PrepareForReading();
+        while ((count = bitmap.Fill(buffer, ref iterator)) > 0)
+            total += count;
+
+        Assert.Equal(65536, total);
+        iterator.Dispose();
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void IteratorHandlesMultipleContainers()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        bitmap.Add(10);
+        bitmap.Add(65546); // container 1, value 10
+        bitmap.Add(131082); // container 2, value 10
+
+        var iterator = bitmap.GetIterator();
+        Span<long> buffer = stackalloc long[10];
+        bitmap.PrepareForReading();
+        int count = bitmap.Fill(buffer, ref iterator);
+
+        Assert.Equal(3, count);
+        Assert.Equal(10, buffer[0]);
+        Assert.Equal(65546, buffer[1]);
+        Assert.Equal(131082, buffer[2]);
+        iterator.Dispose();
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void EmptyBitmapIteratorReturnsZero()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        var iterator = bitmap.GetIterator();
+        Span<long> buffer = stackalloc long[10];
+        bitmap.PrepareForReading();
+        int count = bitmap.Fill(buffer, ref iterator);
+        Assert.Equal(0, count);
+        iterator.Dispose();
+        bitmap.Dispose();
+    }
+
+    #endregion
+
+    #region Range Container Tests
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void RangeContainerCreatedForSequentialAdds()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        // Sequential adds from 0 should create a Range container
+        for (int i = 0; i < 1000; i++)
+            bitmap.Add(i);
+
+        bitmap.PrepareForReading();
+        Assert.Equal(1000, bitmap.Count);
+        for (int i = 0; i < 1000; i++)
+            Assert.True(bitmap.Contains(i));
+        Assert.False(bitmap.Contains(1000));
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void RangeContainerFullContainer()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        // Fill entire container sequentially — should be Range with count=65536
+        for (int i = 0; i < 65536; i++)
+            bitmap.Add(i);
+
+        bitmap.PrepareForReading();
+        Assert.Equal(65536, bitmap.Count);
+        Assert.True(bitmap.Contains(0));
+        Assert.True(bitmap.Contains(65535));
+        Assert.False(bitmap.Contains(65536));
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void RangeContainerIteratesCorrectly()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        for (int i = 0; i < 10000; i++)
+            bitmap.Add(i);
+
+        var iterator = bitmap.GetIterator();
+        long[] buffer = new long[1024];
+        int total = 0;
+
+        int count;
+        bitmap.PrepareForReading();
+        while ((count = bitmap.Fill(buffer, ref iterator)) > 0)
+            total += count;
+
+        Assert.Equal(10000, total);
+        iterator.Dispose();
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void SetOpsWithRangeContainers()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        HashSet<long> setA = new();
+        HashSet<long> setB = new();
+
+        // a: range container (sequential from 0)
+        for (int i = 0; i < 50000; i++)
+        {
+            a.Add(i);
+            setA.Add(i);
+        }
+
+        // b: overlapping bitmap container
+        for (int i = 30000; i < 60000; i++)
+        {
+            b.Add(i);
+            setB.Add(i);
+        }
+
+        // AND
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap andResult = And(ctx, a, b);
+        HashSet<long> expectedAnd = new(setA);
+        expectedAnd.IntersectWith(setB);
+        Assert.Equal(expectedAnd.Count, andResult.Count);
+        andResult.Dispose();
+
+        // OR
+        RoaringBitmap orResult = Or(ctx, a, b);
+        HashSet<long> expectedOr = new(setA);
+        expectedOr.UnionWith(setB);
+        Assert.Equal(expectedOr.Count, orResult.Count);
+        orResult.Dispose();
+
+        // ANDNOT
+        RoaringBitmap andNotResult = AndNot(ctx, a, b);
+        HashSet<long> expectedAndNot = new(setA);
+        expectedAndNot.ExceptWith(setB);
+        Assert.Equal(expectedAndNot.Count, andNotResult.Count);
+        andNotResult.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void RangeContainerGapConvertsToArrayOrBitmap()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        // Build a range 0..99
+        for (int i = 0; i < 100; i++)
+            bitmap.Add(i);
+
+        bitmap.PrepareForReading();
+        Assert.Equal(100, bitmap.Count);
+
+        // Add a value with a gap — should convert from Range to ArrayUnsorted
+        bitmap.Add(200);
+        bitmap.PrepareForReading();
+        Assert.Equal(101, bitmap.Count);
+        Assert.True(bitmap.Contains(0));
+        Assert.True(bitmap.Contains(99));
+        Assert.True(bitmap.Contains(200));
+        Assert.False(bitmap.Contains(100));
+        bitmap.Dispose();
+    }
+
+    #endregion
+
+    #region Stress / Large Scale Tests
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void LargeScaleAddAndIterate()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(ctx);
+        int totalValues = 100_000;
+        HashSet<long> expected = new();
+        Random rng = new(123);
+
+        for (int i = 0; i < totalValues; i++)
+        {
+            long value = rng.NextInt64(0, 1_000_000);
+            bitmap.Add(value);
+            expected.Add(value);
+        }
+
+        bitmap.PrepareForReading();
+        Assert.Equal(expected.Count, bitmap.Count);
+
+        // Verify all values via iteration
+        var iterator = bitmap.GetIterator();
+        long[] buffer = new long[4096];
+        HashSet<long> iterated = new();
+
+        int count;
+        while ((count = bitmap.Fill(buffer, ref iterator)) > 0)
+        {
+            for (int i = 0; i < count; i++)
+                iterated.Add(buffer[i]);
+        }
+
+        Assert.Equal(expected.Count, iterated.Count);
+        Assert.True(expected.SetEquals(iterated));
+        iterator.Dispose();
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void SetOpsCorrectnessAgainstHashSet()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        HashSet<long> setA = new();
+        HashSet<long> setB = new();
+
+        Random rng = new(456);
+        for (int i = 0; i < 10_000; i++)
+        {
+            long va = rng.NextInt64(0, 200_000);
+            long vb = rng.NextInt64(0, 200_000);
+            a.Add(va);
+            b.Add(vb);
+            setA.Add(va);
+            setB.Add(vb);
+        }
+
+        // AND
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap andResult = And(ctx, a, b);
+        HashSet<long> expectedAnd = new(setA);
+        expectedAnd.IntersectWith(setB);
+        Assert.Equal(expectedAnd.Count, andResult.Count);
+        foreach (long v in expectedAnd)
+            Assert.True(andResult.Contains(v));
+        andResult.Dispose();
+
+        // OR
+        RoaringBitmap orResult = Or(ctx, a, b);
+        HashSet<long> expectedOr = new(setA);
+        expectedOr.UnionWith(setB);
+        Assert.Equal(expectedOr.Count, orResult.Count);
+        orResult.Dispose();
+
+        // ANDNOT
+        RoaringBitmap andNotResult = AndNot(ctx, a, b);
+        HashSet<long> expectedAndNot = new(setA);
+        expectedAndNot.ExceptWith(setB);
+        Assert.Equal(expectedAndNot.Count, andNotResult.Count);
+        andNotResult.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+    #endregion
+
+    #region WP1: New methods (Clear, Count, AddRange, OrWith, RepairAfterLazy)
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void Count_ReturnsCorrectValue()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(bsc);
+        Assert.Equal(0, bitmap.Count);
+
+        for (int i = 0; i < 1000; i++)
+            bitmap.Add(i);
+        bitmap.PrepareForReading();
+        Assert.Equal(1000, bitmap.Count);
+
+        // Verify after clear
+        bitmap.Clear();
+        Assert.Equal(0, bitmap.Count);
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void Clear_ResetsToEmpty()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(bsc);
+        for (int i = 0; i < 100_000; i++)
+            bitmap.Add(i);
+        bitmap.PrepareForReading();
+        Assert.True(bitmap.Count > 0);
+
+        bitmap.Clear();
+        Assert.Equal(0, bitmap.Count);
+        Assert.True(bitmap.IsEmpty);
+        Assert.Equal(0, bitmap.ContainerCount);
+
+        // Can reuse after clear
+        bitmap.Add(42);
+        bitmap.PrepareForReading();
+        Assert.Equal(1, bitmap.Count);
+        Assert.True(bitmap.Contains(42));
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void Clear_RepeatedClearAndReuse()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(bsc);
+
+        for (int round = 0; round < 10; round++)
+        {
+            for (int i = round * 1000; i < (round + 1) * 1000; i++)
+                bitmap.Add(i);
+            bitmap.PrepareForReading();
+            Assert.Equal(1000, bitmap.Count);
+            bitmap.Clear();
+            Assert.Equal(0, bitmap.Count);
+        }
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AddRange_SortedValues()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(bsc);
+        var values = new long[10_000];
+        for (int i = 0; i < values.Length; i++)
+            values[i] = i * 3; // sparse but sorted
+        bitmap.AddRange(values);
+        bitmap.PrepareForReading();
+
+        Assert.Equal(10_000, bitmap.Count);
+        Assert.True(bitmap.Contains(0));
+        Assert.True(bitmap.Contains(3));
+        Assert.True(bitmap.Contains(29997));
+        Assert.False(bitmap.Contains(1));
+        Assert.False(bitmap.Contains(2));
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AddRange_MatchesIndividualAdds()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        var values = new long[50_000];
+        var rng = new Random(42);
+        var set = new HashSet<long>();
+        for (int i = 0; i < values.Length; i++)
+        {
+            long v = rng.NextInt64(0, 1_000_000);
+            values[i] = v;
+            set.Add(v);
+        }
+        Array.Sort(values);
+        // Remove duplicates for AddRange (expects sorted, unique not required but let's test)
+        var unique = new List<long>();
+        long prev = -1;
+        foreach (var v in values)
+        {
+            if (v != prev) unique.Add(v);
+            prev = v;
+        }
+
+        RoaringBitmap bitmapRange = new(bsc);
+        bitmapRange.AddRange(unique.ToArray());
+        bitmapRange.PrepareForReading();
+
+        RoaringBitmap bitmapSingle = new(bsc);
+        foreach (var v in set)
+            bitmapSingle.Add(v);
+        bitmapSingle.PrepareForReading();
+
+        Assert.Equal(bitmapSingle.Count, bitmapRange.Count);
+
+        // Spot-check containment
+        int checked_ = 0;
+        foreach (var v in set)
+        {
+            if (++checked_ > 100) break;
+            Assert.True(bitmapRange.Contains(v));
+        }
+
+        bitmapRange.Dispose();
+        bitmapSingle.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AddRange_EmptySpan()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap bitmap = new(bsc);
+        bitmap.AddRange(ReadOnlySpan<long>.Empty);
+        Assert.True(bitmap.IsEmpty);
+        bitmap.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void OrWith_ComputesCorrectCardinalityAfterRepair()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(bsc);
+        RoaringBitmap b = new(bsc);
+        for (int i = 0; i < 10_000; i++) a.Add(i * 2);     // evens
+        for (int i = 0; i < 10_000; i++) b.Add(i * 2 + 1); // odds
+        a.PrepareForReading();
+        b.PrepareForReading();
+
+        RoaringBitmap result = a.Clone();
+        RoaringBitmap bClone = b.Clone();
+        result.OrWith(ref bClone);
+
+        Assert.Equal(20_000, result.Count);
+
+        result.Dispose();
+        a.Dispose();
+        b.Dispose();
+        bClone.Dispose();
+    }
+
+    #endregion
+
+    #region AndWith Edge Cases (replacement for RavenDB-21052 SortHelper.FindMatches)
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndWithGapBetweenContainers()
+    {
+        // Two bitmaps with no overlapping containers — gap between key ranges.
+        // Equivalent to the old FindMatches gap detection test.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+
+        // a: container 0 (values 8, 9)
+        a.Add(8);
+        a.Add(9);
+        // b: container 1 (values 65546, 65547)
+        b.Add(65546);
+        b.Add(65547);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = And(ctx, a, b);
+        Assert.Equal(0, result.Count);
+        Assert.True(result.IsEmpty);
+        result.Dispose();
+
+        // Reverse order: a entirely after b
+        RoaringBitmap result2 = And(ctx, b, a);
+        Assert.Equal(0, result2.Count);
+        Assert.True(result2.IsEmpty);
+        result2.Dispose();
+
+        a.Dispose();
+        b.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndWithMatchAtFirstElement()
+    {
+        // Match is the first element of the right array.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+
+        a.Add(10);
+        a.Add(20);
+        // b starts at 10
+        b.Add(10);
+        b.Add(11);
+        b.Add(13);
+        b.Add(15);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = And(ctx, a, b);
+        Assert.Equal(1, result.Count);
+        Assert.True(result.Contains(10));
+        Assert.False(result.Contains(20));
+        result.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndWithMatchAtLastElement()
+    {
+        // Match is the last element of the right array.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+
+        a.Add(15);
+        a.Add(20);
+        // b ends at 15
+        b.Add(10);
+        b.Add(11);
+        b.Add(13);
+        b.Add(15);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = And(ctx, a, b);
+        Assert.Equal(1, result.Count);
+        Assert.True(result.Contains(15));
+        Assert.False(result.Contains(20));
+        result.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndWithSubset()
+    {
+        // One bitmap is a subset of the other — AND should return the subset.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap small = new(ctx);
+        RoaringBitmap large = new(ctx);
+
+        small.Add(5);
+        small.Add(10);
+        small.Add(15);
+        for (int i = 0; i < 20; i++)
+            large.Add(i);
+
+        small.PrepareForReading();
+        large.PrepareForReading();
+        RoaringBitmap result = And(ctx, large, small);
+        Assert.Equal(3, result.Count);
+        Assert.True(result.Contains(5));
+        Assert.True(result.Contains(10));
+        Assert.True(result.Contains(15));
+        result.Dispose();
+        small.Dispose();
+        large.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndWithEmptyBitmap()
+    {
+        // AND with empty bitmap should produce empty result.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap empty = new(ctx);
+
+        for (int i = 0; i < 100; i++)
+            a.Add(i);
+
+        a.PrepareForReading();
+        RoaringBitmap result = And(ctx, a, empty);
+        Assert.Equal(0, result.Count);
+        Assert.True(result.IsEmpty);
+        result.Dispose();
+        a.Dispose();
+        empty.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndWithContainerBoundaryValues()
+    {
+        // Test values at container boundaries: first (0) and last (65535) within a container.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+
+        a.Add(0);       // first value in container 0
+        a.Add(65535);   // last value in container 0
+        a.Add(65536);   // first value in container 1
+
+        b.Add(0);
+        b.Add(65535);
+        b.Add(131072);  // first value in container 2 (no match with a)
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = And(ctx, a, b);
+        Assert.Equal(2, result.Count);
+        Assert.True(result.Contains(0));
+        Assert.True(result.Contains(65535));
+        Assert.False(result.Contains(65536));
+        Assert.False(result.Contains(131072));
+        result.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void AndWithCrossContainerTypes()
+    {
+        // Force different container types: sparse (Array) vs dense (Bitmap) vs Range.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+
+        // Sparse array container: 3 values
+        RoaringBitmap sparse = new(ctx);
+        sparse.Add(100);
+        sparse.Add(200);
+        sparse.Add(300);
+
+        // Dense bitmap container: 5000 values (triggers Bitmap type)
+        RoaringBitmap dense = new(ctx);
+        for (int i = 0; i < 5000; i++)
+            dense.Add(i);
+
+        // Range container: sequential 0..999
+        RoaringBitmap range = new(ctx);
+        for (int i = 0; i < 1000; i++)
+            range.Add(i);
+
+        sparse.PrepareForReading();
+        dense.PrepareForReading();
+        range.PrepareForReading();
+
+        // Array AND Bitmap
+        RoaringBitmap r1 = And(ctx, sparse, dense);
+        Assert.Equal(3, r1.Count);
+        Assert.True(r1.Contains(100));
+        Assert.True(r1.Contains(200));
+        Assert.True(r1.Contains(300));
+        r1.Dispose();
+
+        // Array AND Range
+        RoaringBitmap r2 = And(ctx, sparse, range);
+        Assert.Equal(3, r2.Count);
+        r2.Dispose();
+
+        // Bitmap AND Range
+        RoaringBitmap r3 = And(ctx, dense, range);
+        Assert.Equal(1000, r3.Count);
+        r3.Dispose();
+
+        sparse.Dispose();
+        dense.Dispose();
+        range.Dispose();
+    }
+
+    #endregion
+
+    #region SIMD Boundary Tests (replacement for RavenDB-21471 vectorized AND out-of-bounds)
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void SimdAndWithSmallArraysDoesNotProduceFalsePositives()
+    {
+        // Small arrays (1-2 elements) where SIMD Vector256 reads past live data.
+        // The padding in the over-allocated buffer may contain stale values.
+        // Verify no false positives from phantom matches in padding.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+
+        // a: 2 values high in the container range
+        a.Add(5708);
+        a.Add(5709);
+
+        // b: 6 values low in the container range — no overlap with a
+        b.Add(763);
+        b.Add(764);
+        b.Add(941);
+        b.Add(942);
+        b.Add(946);
+        b.Add(966);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = And(ctx, a, b);
+        Assert.Equal(0, result.Count);
+        Assert.True(result.IsEmpty);
+        result.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void SimdAndWithSingleElementArrays()
+    {
+        // Minimal arrays: 1 element each. SIMD reads a full vector (16 ushorts)
+        // from a buffer that has only 1 live value.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+
+        // No match
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        a.Add(42);
+        b.Add(99);
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap r1 = And(ctx, a, b);
+        Assert.Equal(0, r1.Count);
+        r1.Dispose();
+
+        // Match
+        RoaringBitmap c = new(ctx);
+        c.Add(42);
+        c.PrepareForReading();
+        RoaringBitmap r2 = And(ctx, a, c);
+        Assert.Equal(1, r2.Count);
+        Assert.True(r2.Contains(42));
+        r2.Dispose();
+
+        a.Dispose();
+        b.Dispose();
+        c.Dispose();
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void SimdAndNotWithSmallArraysDoesNotProduceFalseExclusions()
+    {
+        // ANDNOT with small arrays — verify no false exclusions from padding.
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+
+        // a has values; b has non-overlapping values
+        a.Add(100);
+        a.Add(200);
+        a.Add(300);
+        b.Add(50);
+        b.Add(150);
+
+        a.PrepareForReading();
+        b.PrepareForReading();
+        RoaringBitmap result = AndNot(ctx, a, b);
+        // All of a's values should survive — none match b
+        Assert.Equal(3, result.Count);
+        Assert.True(result.Contains(100));
+        Assert.True(result.Contains(200));
+        Assert.True(result.Contains(300));
+        result.Dispose();
+        a.Dispose();
+        b.Dispose();
+    }
+
+    #endregion
+
+    #region Exhaustive Primitive Compatibility (replacement for deleted Primitives.cs 256^3 test)
+
+    /// <summary>Verify AND/OR/ANDNOT produce correct results for every combination of
+    /// container types (empty, sparse array, dense bitmap, range, cross-container).
+    /// Uses a reference HashSet to compare against RoaringBitmap set operations.</summary>
+    [RavenFact(RavenTestCategory.Corax)]
+    public void ExhaustiveSetOpCompatibility()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        var rng = new Random(42);
+
+        // Build bitmaps with different container configurations
+        var configs = new (string Name, long[] Values)[]
+        {
+            ("Empty", []),
+            ("SingleValue", [42]),
+            ("SparseArray_Small", GenerateValues(rng, 10, 0, 65535)),
+            ("SparseArray_Medium", GenerateValues(rng, 500, 0, 65535)),
+            ("DenseBitmap", GenerateValues(rng, 5000, 0, 65535)),
+            ("FullRange", Enumerable.Range(0, 1000).Select(x => (long)x).ToArray()),
+            ("TwoContainers_Sparse", GenerateValues(rng, 100, 0, 131071)),
+            ("TwoContainers_Dense", GenerateValues(rng, 8000, 0, 131071)),
+            ("HighValues", GenerateValues(rng, 200, 100000, 200000)),
+            ("Scattered", [0L, 100, 65535, 65536, 131071, 200000]),
+        };
+
+        int failures = 0;
+        foreach (var left in configs)
+        {
+            foreach (var right in configs)
+            {
+                // AND
+                if (VerifySetOp("AND", left, right, ctx,
+                    (a, b) => { var r = And(ctx, a, b); return r; },
+                    (a, b) => new HashSet<long>(a.Intersect(b))) == false)
+                    failures++;
+
+                // OR
+                if (VerifySetOp("OR", left, right, ctx,
+                    (a, b) => Or(ctx, a, b),
+                    (a, b) => new HashSet<long>(a.Union(b))) == false)
+                    failures++;
+
+                // ANDNOT
+                if (VerifySetOp("ANDNOT", left, right, ctx,
+                    (a, b) => AndNot(ctx, a, b),
+                    (a, b) => new HashSet<long>(a.Except(b))) == false)
+                    failures++;
+            }
+        }
+
+        Assert.Equal(0, failures);
+    }
+
+    private static long[] GenerateValues(Random rng, int count, long min, long max)
+    {
+        var set = new HashSet<long>();
+        while (set.Count < count)
+            set.Add(min + (long)(rng.NextDouble() * (max - min)));
+        var arr = set.ToArray();
+        Array.Sort(arr);
+        return arr;
+    }
+
+    private static bool VerifySetOp(string opName, (string Name, long[] Values) left, (string Name, long[] Values) right,
+        ByteStringContext ctx,
+        Func<RoaringBitmap, RoaringBitmap, RoaringBitmap> bitmapOp,
+        Func<long[], long[], HashSet<long>> referenceOp)
+    {
+        RoaringBitmap a = new(ctx);
+        RoaringBitmap b = new(ctx);
+        foreach (long v in left.Values) a.Add(v);
+        foreach (long v in right.Values) b.Add(v);
+        a.PrepareForReading();
+        b.PrepareForReading();
+
+        RoaringBitmap result;
+        try
+        {
+            result = bitmapOp(a, b);
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"{opName}({left.Name}, {right.Name}) threw: {ex.Message}");
+            return false;
+        }
+
+        var expected = referenceOp(left.Values, right.Values);
+        bool ok = true;
+
+        if (result.Count != expected.Count)
+        {
+            Assert.Fail($"{opName}({left.Name}, {right.Name}): count {result.Count} != expected {expected.Count}");
+            ok = false;
+        }
+
+        foreach (long v in expected)
+        {
+            if (result.Contains(v) == false)
+            {
+                Assert.Fail($"{opName}({left.Name}, {right.Name}): missing value {v}");
+                ok = false;
+                break;
+            }
+        }
+
+        result.Dispose();
+        a.Dispose();
+        b.Dispose();
+        return ok;
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [InlineDataWithRandomSeed]
+    public void ExhaustiveSetOpCompatibility_RandomSeed(int seed)
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        var rng = new Random(seed);
+
+        var configs = new (string Name, long[] Values)[]
+        {
+            ("Empty", []),
+            ("SingleValue", [rng.NextInt64(0, 100000)]),
+            ("SparseArray", GenerateValues(rng, 10, 0, 65535)),
+            ("MediumArray", GenerateValues(rng, 500, 0, 65535)),
+            ("DenseBitmap", GenerateValues(rng, 5000, 0, 65535)),
+            ("FullRange", Enumerable.Range(rng.Next(0, 1000), 1000).Select(x => (long)x).ToArray()),
+            ("TwoContainers", GenerateValues(rng, 200, 0, 131071)),
+            ("HighValues", GenerateValues(rng, 200, 100000, 200000)),
+        };
+
+        int failures = 0;
+        foreach (var left in configs)
+        foreach (var right in configs)
+        {
+            if (VerifySetOp("AND", left, right, ctx, (a, b) => And(ctx, a, b), (a, b) => new HashSet<long>(a.Intersect(b))) == false) failures++;
+            if (VerifySetOp("OR", left, right, ctx, (a, b) => Or(ctx, a, b), (a, b) => new HashSet<long>(a.Union(b))) == false) failures++;
+            if (VerifySetOp("ANDNOT", left, right, ctx, (a, b) => AndNot(ctx, a, b), (a, b) => new HashSet<long>(a.Except(b))) == false) failures++;
+        }
+
+        Assert.Equal(0, failures);
+    }
+
+    /// <summary>Targeted regression test for the (ArrayUnsorted, Range) dangling stack pointer bug.
+    /// LazyOrContainerInPlace materialized Range into a stack buffer, then (Array, Bitmap) stole
+    /// the pointer — dangling after stack unwind. Fixed by converting Array to heap Bitmap first.</summary>
+    [RavenFact(RavenTestCategory.Corax)]
+    public void OrWithArrayAndRange_NoDanglingPointer()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+
+        // Sparse array with values OUTSIDE the range (different container positions)
+        RoaringBitmap sparse = new(ctx);
+        sparse.Add(5000);
+        sparse.Add(10000);
+        sparse.Add(17209); // the value that was lost in the original bug
+        sparse.Add(33614);
+        sparse.Add(50000);
+
+        // Range container: sequential 0..999
+        RoaringBitmap range = new(ctx);
+        for (int i = 0; i < 1000; i++) range.Add(i);
+
+        sparse.PrepareForReading();
+        range.PrepareForReading();
+
+        // OR: must include all values from both
+        RoaringBitmap result = Or(ctx, sparse, range);
+        Assert.Equal(1005, result.Count); // 1000 from range + 5 from sparse
+        Assert.True(result.Contains(5000));
+        Assert.True(result.Contains(17209));
+        Assert.True(result.Contains(50000));
+        Assert.True(result.Contains(0));
+        Assert.True(result.Contains(999));
+        result.Dispose();
+
+        // Reverse order: range OR sparse
+        RoaringBitmap result2 = Or(ctx, range, sparse);
+        Assert.Equal(1005, result2.Count);
+        Assert.True(result2.Contains(17209));
+        result2.Dispose();
+
+        sparse.Dispose();
+        range.Dispose();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
**[Partial PR 1/9 — Corax 2.0 query engine. Apply all 9 to reproduce branch HEAD.]**

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25281

### Additional description

Foundation layer for the Corax 2.0 query engine: a new `RoaringBitmap` container in Voron that is the substrate the rest of the pipeline operates on.

Includes the data structure (page layout, run/array/bitmap container variants, set operations) and the unit test coverage that exercises it independently of Corax. Nothing else in the codebase uses it yet — that wiring lands in later PRs in this stack.

This PR is partial and not expected to compile or be reviewed in isolation; it is the bottom of a 9-PR stack that together reproduce the `RavenDB-25281` branch HEAD.

### Type of change

- [x] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
