### PR TITLE
RavenDB-25281 [6/9] Corax: plan compilation, IL emitter, plan cache

### DIFF
--- a/src/Corax/Querying/Matches/CompiledQueryMatch.cs
+++ b/src/Corax/Querying/Matches/CompiledQueryMatch.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Threading;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Planning;
+using Voron.Data.RoaringBitmaps;
+using Sparrow.Server;
+using Voron;
+using Voron.Impl;
+
+namespace Corax.Querying.Matches;
+
+/// <summary>Sort seek hint — value to seek to in the sort field, plus whether the bound is inclusive.</summary>
+public sealed record SortHint(string FieldName, object Value, bool Inclusive);
+
+public class CompiledQueryMatch(
+    CompiledPlan compiledPlan,
+    int bitmapCount,
+    int opCount,
+    IQueryMatch[] resolvedMatches,
+    PostingSource[] postingSources,
+    ITermsProvider[] termsProviders,
+    IndexSearcher searcher,
+    ByteStringContext allocator,
+    bool wantTimings,
+    CancellationToken token)
+    : IBitmapQueryMatch, IPredicateEvaluationContext, IDisposable
+{
+    private readonly QueryIlEmitter.CompiledExecuteDelegate _compiledDelegate =
+        wantTimings ? compiledPlan.CompiledTimedDelegate : compiledPlan.CompiledDelegate;
+
+    public readonly ResidualScanIlEmitter.ResidualScanPredicate CompiledEntryPredicate = compiledPlan.CompiledEntryPredicate;
+
+    public SortHint SortHint;
+    public readonly IQueryMatch[] ResolvedMatches = resolvedMatches;
+    public readonly PostingSource[] PostingSources = postingSources;
+    public readonly ITermsProvider[] TermsProviders = termsProviders;
+
+    /// <summary>Per-execution term counts for OrRange/AndRange ops. Each range op
+    /// stores its index into this array instead of a hardcoded count in the IL.
+    /// Set during resolution — different executions of the same query can have
+    /// different IN term counts without needing different compiled delegates.</summary>
+    public int[] InRangeCounts;
+
+    // Entry scan: predicates + parameters for CompiledQueryHelper.RunEntryScan
+    public ScanPredicateInfo[] ScanPredicateInfos;
+    public long[] ScanLongParams;
+    public double[] ScanDoubleParams;
+    public Slice[] ScanSliceParams;
+    public long[] ScanFieldRootPages;
+
+    long[] IPredicateEvaluationContext.ResidualLongParams => ScanLongParams;
+    double[] IPredicateEvaluationContext.ResidualDoubleParams => ScanDoubleParams;
+    Slice[] IPredicateEvaluationContext.ResidualSliceParams => ScanSliceParams;
+    long[] IPredicateEvaluationContext.ResidualFieldRootPages => ScanFieldRootPages;
+
+    // Entry scan telemetry (populated by IL/C# entry scan when it triggers)
+    public long EntryScanEntriesScanned;
+    public long EntryScanEntriesPassed;
+
+    private readonly string _explainSource = compiledPlan.ExplainSource;
+    public readonly IndexSearcher Searcher = searcher;
+    public readonly CancellationToken Token = token;
+
+    private RoaringBitmap _bitmapData = new(allocator);
+    private RoaringBitmapIterator _iterator;
+    private bool _executed;
+    private long _count = -1;
+
+    // Bitmap pool: [0] = main result, [1 ... N] = scratch.
+    // Allocated once in Execute(), then accessed by the compiled delegate via IL.
+    public RoaringBitmap[] Bitmaps;
+
+    // LowLevelTransaction cached at Execute() time so the emitted IL does not re-fetch it per op.
+    public LowLevelTransaction Llt;
+
+    /// <summary>Limit for early-exit during bitmap accumulation (unsorted queries only).
+    /// When set, FillFromPostings stops after limit entries and OR branches are
+    /// skipped once the bitmap has enough. Set to long.MaxValue when an ORDER BY
+    /// is present (sorting needs the full bitmap for Contains checks).
+    /// Stored as long to avoid casts when comparing with Count (long) in the IL-emitted code.</summary>
+    public long Limit = long.MaxValue;
+
+    // Telemetry — populated during Execute if timings are requested
+    public long[] Timings;
+    public long[] ResultCounts;
+    public int EntryScanTakenAtOp;
+
+    public long Count
+    {
+        get
+        {
+            if (!_executed) Execute();
+            return _count;
+        }
+    }
+
+    public QueryCountConfidence Confidence => _executed
+        ? (_count < Limit ? QueryCountConfidence.High : QueryCountConfidence.Low)
+        : QueryCountConfidence.Normal;
+
+    public bool IsBoosting
+    {
+        get
+        {
+            foreach (var it in ResolvedMatches ?? [])
+            {
+                if (it.IsBoosting)
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
+
+    public bool Contains(long entryId)
+    {
+        if (!_executed) Execute();
+        return _bitmapData.Contains(entryId);
+    }
+
+    public long MinEntryId
+    {
+        get
+        {
+            if (!_executed) Execute();
+            long minKey = _bitmapData.MinContainerKey;
+            return minKey < 0 ? 0 : minKey * RoaringBitmap.ContainerSize;
+        }
+    }
+
+    public long MaxEntryId
+    {
+        get
+        {
+            if (!_executed) Execute();
+            long maxKey = _bitmapData.MaxContainerKey;
+            return maxKey < 0 ? 0 : (maxKey + 1) * RoaringBitmap.ContainerSize - 1;
+        }
+    }
+
+    public ref RoaringBitmap BitmapState
+    {
+        get
+        {
+            if (!_executed) Execute();
+            return ref _bitmapData;
+        }
+    }
+
+    public int Fill(Span<long> matches)
+    {
+        if (!_executed) Execute();
+        return _iterator.Fill(ref _bitmapData, matches);
+    }
+
+    public int AndWith(Span<long> buffer, int matches)
+    {
+        if (!_executed) Execute();
+        // Cannot use AndWithSorted: callers (StreamAndIntersect) pass entry IDs
+        // in sort-field order (e.g. alphabetical by Name), not in entry-ID order.
+        int kept = 0;
+        foreach(var cur in buffer[..matches])
+        {
+            if (_bitmapData.Contains(cur))
+                buffer[kept++] = cur;
+        }
+        return kept;
+    }
+
+    public void Score(Span<long> matches, Span<float> scores, float boostFactor)
+    {
+        foreach (var it in ResolvedMatches ?? [])
+        {
+            it.Score(matches, scores, boostFactor);
+        }
+    }
+
+    public void GetTelemetry(out long[] timings, out long[] resultCounts, out int entryScanTakenAtOp)
+    {
+        timings = Timings;
+        resultCounts = ResultCounts;
+        entryScanTakenAtOp = EntryScanTakenAtOp;
+    }
+
+    public QueryInspectionNode Inspect()
+    {
+        var parameters = new Dictionary<string, string>
+        {
+            ["Explain"] = _explainSource ?? "N/A"
+        };
+
+        if (EntryScanTakenAtOp >= 0)
+        {
+            parameters["EntryScanAt"] = EntryScanTakenAtOp.ToString();
+            if (EntryScanEntriesScanned > 0)
+                parameters["EntryScanScanned"] = EntryScanEntriesScanned.ToString();
+            if (EntryScanEntriesPassed > 0)
+                parameters["EntryScanPassed"] = EntryScanEntriesPassed.ToString();
+        }
+
+        if (Timings is { Length: > 0 })
+        {
+            double tickFreq = System.Diagnostics.Stopwatch.Frequency / 1000.0; // ticks per ms
+            for (int i = 0; i < Timings.Length; i++)
+            {
+                if (Timings[i] > 0)
+                    parameters[$"Op{i}_ms"] = (Timings[i] / tickFreq).ToString("F3");
+                if (i < ResultCounts.Length && ResultCounts[i] > 0)
+                    parameters[$"Op{i}_count"] = ResultCounts[i].ToString();
+            }
+        }
+
+        var children = new List<QueryInspectionNode>();
+        if (ResolvedMatches != null)
+        {
+            foreach (var it in ResolvedMatches)
+            {
+                children.Add(it.Inspect());
+            }
+        }
+
+        return new QueryInspectionNode("CompiledQuery", parameters: parameters, children: children);
+    }
+
+
+    private void Execute()
+    {
+        if (_executed) return;
+
+        // Rent bitmap pool from ArrayPool — returned in finally block
+        Bitmaps = ArrayPool<RoaringBitmap>.Shared.Rent(bitmapCount);
+        Bitmaps[0] = _bitmapData; // main bitmap (owned by this instance)
+        for (int i = 1; i < bitmapCount; i++) Bitmaps[i] = new RoaringBitmap(allocator);
+
+        Llt = Searcher.Transaction.LowLevelTransaction;
+
+        // Only allocate timing arrays when explicitly requested (include timings())
+        Timings = wantTimings ? new long[opCount] : null;
+        ResultCounts = wantTimings ? new long[opCount] : null;
+        EntryScanTakenAtOp = -1;
+
+        try
+        {
+            _compiledDelegate(this);
+
+            _bitmapData = Bitmaps[0];
+            _bitmapData.PrepareForReading();
+            _count = _bitmapData.Count;
+            _iterator = _bitmapData.GetIterator();
+            _executed = true;
+        }
+        finally
+        {
+            for (int i = 1; i < bitmapCount; i++)
+                Bitmaps[i].Dispose();
+            ArrayPool<RoaringBitmap>.Shared.Return(Bitmaps);
+            Bitmaps = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        _iterator.Dispose();
+        _bitmapData.Dispose();
+    }
+}

--- a/src/Corax/Querying/Matches/DirectScanMatch.cs
+++ b/src/Corax/Querying/Matches/DirectScanMatch.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Planning;
+using Corax.Querying.Primitives;
+using Sparrow;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.Containers;
+using Voron.Data.RoaringBitmaps;
+using Corax.Utils;
+using Voron.Impl;
+
+namespace Corax.Querying.Matches;
+
+/// <summary>
+/// Walks a driving tree in sort order, optionally checking residual predicates per entry
+/// via stored field reads. Two subclasses handle the residual/no-residual cases:
+/// <see cref="DirectScanSimpleMatch"/> (simple pass-through) and
+/// <see cref="DirectScanFilteredMatch"/> (evaluates compiled predicate delegate).
+/// </summary>
+public abstract class DirectScanMatchBase : IQueryMatch, IDisposable
+{
+    protected readonly IndexSearcher Searcher;
+    protected readonly LowLevelTransaction Llt;
+    protected readonly IQueryMatch DrivingMatch;
+    protected readonly int Take;
+    protected long TotalMatched;
+
+    protected RoaringBitmap EmittedBitmap;
+
+    protected long TreeEntriesScanned;
+    protected long EntriesPassedFilter;
+    protected long EntriesRejected;
+    protected long TreeScanTicks;
+    protected long EntryScanTicks;
+    protected string StoppedReason;
+
+    public string DrivingTreeName;
+    public string DrivingClause;
+    public string SeekBound;
+    public string Direction;
+    public string ResidualDescription;
+    public string Reason;
+
+    protected DirectScanMatchBase(IndexSearcher searcher, IQueryMatch drivingMatch, int take)
+    {
+        Searcher = searcher;
+        Llt = searcher.Transaction.LowLevelTransaction;
+        DrivingMatch = drivingMatch;
+        Take = take;
+        ByteStringContext allocator = searcher.Allocator;
+        EmittedBitmap = new RoaringBitmap(allocator);
+    }
+
+    public long Count => TotalMatched;
+    public QueryCountConfidence Confidence => QueryCountConfidence.Low;
+    public bool IsBoosting => false;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
+
+    public abstract int Fill(Span<long> matches);
+
+    public int AndWith(Span<long> buffer, int matches) => throw new NotSupportedException("DirectScanMatch produces final sorted results");
+
+    public void Score(Span<long> matches, Span<float> scores, float boostFactor) { }
+
+
+    public virtual QueryInspectionNode Inspect()
+    {
+        double tickFreq = Stopwatch.Frequency / 1000.0;
+        var parameters = new Dictionary<string, string>();
+
+        if (DrivingTreeName != null) parameters["DrivingTree"] = DrivingTreeName;
+        if (DrivingClause != null) parameters["DrivingClause"] = DrivingClause;
+        if (SeekBound != null) parameters["SeekBound"] = SeekBound;
+        if (Direction != null) parameters["TreeDirection"] = Direction;
+        if (ResidualDescription != null) parameters["ResidualPredicates"] = ResidualDescription;
+        if (Reason != null) parameters["Reason"] = Reason;
+
+        if (TreeScanTicks > 0) parameters["TreeScan_ms"] = (TreeScanTicks / tickFreq).ToString("F3");
+        if (EntryScanTicks > 0) parameters["EntryScans_ms"] = (EntryScanTicks / tickFreq).ToString("F3");
+
+        parameters["TreeEntriesScanned"] = TreeEntriesScanned.ToString();
+        parameters["EntriesPassedFilter"] = EntriesPassedFilter.ToString();
+        parameters["EntriesRejected"] = EntriesRejected.ToString();
+
+        if (StoppedReason != null) parameters["StoppedAt"] = StoppedReason;
+
+        return new QueryInspectionNode("DirectScan", parameters: parameters);
+    }
+
+    public void Dispose()
+    {
+        EmittedBitmap.Dispose();
+        (DrivingMatch as IDisposable)?.Dispose();
+    }
+}
+
+/// <summary>DirectScan with no residual predicates — simple dedup + pass-through.</summary>
+public sealed class DirectScanSimpleMatch(IndexSearcher searcher, IQueryMatch drivingMatch, int take) : DirectScanMatchBase(searcher, drivingMatch, take)
+{
+    [SkipLocalsInit]
+    public override unsafe int Fill(Span<long> matches)
+    {
+        if (Take > 0 && TotalMatched >= Take)
+            return 0;
+
+        int count = 0;
+        int remaining = Take > 0 ? (int)Math.Min(matches.Length, Take - TotalMatched) : matches.Length;
+        int batchSize = Math.Min(QueryPrimitives.EntryScanBatchSize, Math.Max(1, remaining));
+        Span<long> batch = stackalloc long[QueryPrimitives.EntryScanBatchSize];
+
+        while (count < remaining)
+        {
+            long t0 = Stopwatch.GetTimestamp();
+            int read = DrivingMatch.Fill(batch[..batchSize]);
+            TreeScanTicks += Stopwatch.GetTimestamp() - t0;
+
+            if (read == 0)
+            {
+                StoppedReason ??= "TreeExhausted";
+                break;
+            }
+            TreeEntriesScanned += read;
+
+            for (int i = 0; i < read && count < remaining; i++)
+            {
+                long id = batch[i];
+                if (EmittedBitmap.Contains(id) == false)
+                {
+                    EmittedBitmap.Add(id);
+                    matches[count++] = id;
+                }
+            }
+        }
+
+        if (Take > 0 && TotalMatched + count >= Take)
+            StoppedReason ??= $"_take({Take})";
+
+        TotalMatched += count;
+        return count;
+    }
+}
+
+/// <summary>
+/// DirectScan with residual predicates: evaluates a compiled IL delegate against
+/// stored-field readers for each entry batch. Entry IDs are sorted by container
+/// location for sequential page access, then the delegate compacts survivors to
+/// the front. A parallel index tracks original sort positions so results are
+/// emitted in field-value order.
+///
+/// Uses the same compiled delegate as the entry-scan path (CompiledQueryMatch),
+/// evaluating ALL baked-in predicates — re-evaluating the driving-clause
+/// predicates is harmless since the tree scan already matched them.
+/// </summary>
+public sealed class DirectScanFilteredMatch(
+    IndexSearcher searcher,
+    IQueryMatch drivingMatch,
+    long[] longParams,
+    double[] doubleParams,
+    Slice[] sliceParams,
+    long[] fieldRootPages,
+    int take,
+    ResidualScanIlEmitter.ResidualScanPredicate precompiledDelegate)
+    : DirectScanMatchBase(searcher, drivingMatch, take), IPredicateEvaluationContext
+{
+    [SkipLocalsInit]
+    public override unsafe int Fill(Span<long> matches)
+    {
+        if (Take > 0 && TotalMatched >= Take)
+            return 0;
+
+        int count = 0;
+        int remaining = Take > 0 ? (int)Math.Min(matches.Length, Take - TotalMatched) : matches.Length;
+        int batchSize = Math.Min(QueryPrimitives.EntryScanBatchSize, Math.Max(1, remaining));
+        Span<long> batch = stackalloc long[QueryPrimitives.EntryScanBatchSize];
+        Span<int> indices = stackalloc int[QueryPrimitives.EntryScanBatchSize];
+        Span<bool> passed = stackalloc bool[QueryPrimitives.EntryScanBatchSize];
+        Span<long> sortedIds = stackalloc long[QueryPrimitives.EntryScanBatchSize];
+        Span<long> containerLocs = stackalloc long[QueryPrimitives.EntryScanBatchSize];
+        Span<UnmanagedSpan> containerSpans = stackalloc UnmanagedSpan[QueryPrimitives.EntryScanBatchSize];
+        Span<long> packedIds = stackalloc long[QueryPrimitives.EntryScanBatchSize];
+        Span<int> packedOrigIdx = stackalloc int[QueryPrimitives.EntryScanBatchSize];
+        var readersArr = ArrayPool<EntryTermsReader>.Shared.Rent(QueryPrimitives.EntryScanBatchSize);
+        try
+        {
+            while (count < remaining)
+            {
+                long t0 = Stopwatch.GetTimestamp();
+                int read = DrivingMatch.Fill(batch[..batchSize]);
+                TreeScanTicks += Stopwatch.GetTimestamp() - t0;
+
+                if (read == 0)
+                {
+                    StoppedReason ??= "TreeExhausted";
+                    break;
+                }
+
+                TreeEntriesScanned += read;
+
+                var sorted = sortedIds[..read];
+                batch[..read].CopyTo(sorted);
+                Voron.Data.RoaringBitmaps.RoaringBitmap.InitializeIndices(indices, read);
+                sorted.Sort(indices[..read]);
+
+                passed[..read].Clear();
+
+                long t1 = Stopwatch.GetTimestamp();
+
+                var locs = containerLocs[..read];
+                Searcher.ResolveEntryLocations(sorted, locs);
+
+                var spans = containerSpans[..read];
+                Container.GetAll(Llt, locs, spans, -1, Llt.PageLocator);
+
+                Searcher.InitializeSpecialTermsMarkers();
+
+                var pIds = packedIds[..read];
+                var pIdxs = packedOrigIdx[..read];
+                int packed = 0;
+                for (int s = 0; s < read; s++)
+                {
+                    int origIdx = indices[s];
+                    long entryId = batch[origIdx];
+
+                    if (EmittedBitmap.Contains(entryId))
+                        continue;
+
+                    if (locs[s] == -1 || spans[s].Address == null)
+                    {
+                        EntriesRejected++;
+                        continue;
+                    }
+
+                    readersArr[packed] = new EntryTermsReader(Llt,
+                        Searcher.NullTermsMarkers, Searcher.NonExistingTermsMarkers,
+                        spans[s].Address, spans[s].Length, Searcher.DictionaryId, Searcher.VectorFieldsMarkers, null);
+                    pIds[packed] = entryId;
+                    pIdxs[packed] = origIdx;
+                    packed++;
+                }
+
+                int matched = precompiledDelegate(this,
+                    readersArr.AsSpan(0, packed),
+                    packedIds[..packed],
+                    packedOrigIdx[..packed]);
+
+                EntriesRejected += packed - matched;
+
+                for (int k = 0; k < matched; k++)
+                    passed[pIdxs[k]] = true;
+                EntryScanTicks += Stopwatch.GetTimestamp() - t1;
+
+                // Emit in original sort-field order, not container-location order.
+                // The delegate compacted survivors in the order of sortedIds (page-order
+                // for sequential I/O). pIdxs[] holds each survivor's original sort-field
+                // position, but iterating pIdxs[] would emit results in page order, not
+                // sort order. Instead, scan the original batch (which is in sort-field
+                // order) and emit only the positions that passed.
+                for (int i = 0; i < read && count < remaining; i++)
+                {
+                    if (passed[i])
+                    {
+                        long id = batch[i];
+                        EmittedBitmap.Add(id);
+                        EntriesPassedFilter++;
+                        matches[count++] = id;
+                    }
+                }
+            }
+
+            if (Take > 0 && TotalMatched + count >= Take)
+                StoppedReason ??= $"_take({Take})";
+
+            TotalMatched += count;
+            return count;
+        }
+        finally
+        {
+            ArrayPool<EntryTermsReader>.Shared.Return(readersArr);
+        }
+    }
+
+    long[] IPredicateEvaluationContext.ResidualLongParams => longParams;
+    double[] IPredicateEvaluationContext.ResidualDoubleParams => doubleParams;
+    Slice[] IPredicateEvaluationContext.ResidualSliceParams => sliceParams;
+    long[] IPredicateEvaluationContext.ResidualFieldRootPages => fieldRootPages;
+}

--- a/src/Corax/Querying/Planning/BindingIndex.cs
+++ b/src/Corax/Querying/Planning/BindingIndex.cs
@@ -1,0 +1,32 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Named binding indices per clause type. Each clause type stores its
+/// parameter bindings in a flat array at these known positions.</summary>
+public static class BindingIndex
+{
+    // Equals, NotEquals, Range (GT/GTE/LT/LTE), StartsWith, EndsWith, Search, Regex:
+    public const int Value = 0;
+
+    // Between:
+    public const int BetweenLow = 0;
+    public const int BetweenHigh = 1;
+
+    // Spatial circle: [0]=distErrPct, [1]=radius, [2]=lat, [3]=lng, [4]=units
+    public const int SpatialCircleBindingCount = 5; // distErrPct + radius + lat + lng + units
+    public const int SpatialDistErrPct = 0;
+    public const int SpatialRadius = 1;
+    public const int SpatialLatitude = 2;
+    public const int SpatialLongitude = 3;
+    public const int SpatialUnits = 4;
+    // Spatial WKT: [0]=distErrPct, [1]=wkt, [2]=units
+    public const int SpatialWkt = 1;
+    public const int SpatialWktUnits = 2;
+
+    // Vector: [0]=vectorValue, [1]=minimumMatch, [2]=numberOfCandidates, [3]=aiTaskName
+    public const int VectorValue = 0;
+    public const int VectorMinMatch = 1;
+    public const int VectorCandidates = 2;
+    public const int VectorAiTask = 3;
+
+    // IN/AllIn: [0..N] = each term binding (array params expand at resolution time)
+}

--- a/src/Corax/Querying/Planning/ClauseExecution.cs
+++ b/src/Corax/Querying/Planning/ClauseExecution.cs
@@ -1,0 +1,38 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Per-execution state for a clause. Parallel to <see cref="ClauseInfo"/>[] —
+/// populated by PopulateClauseValues each execution. This is computed each time the query is executed, not cached.
+/// Also used for operand reordering (Cardinality)</summary>
+public sealed class ClauseExecution
+{
+    public PackedParam PackedParamValue = PackedParam.None;
+    public ParamValueType TermValueType;
+    public long Cardinality = -1;
+    public int InTermCount;
+    public bool HasNullTerm;
+    public float BoostFactor;
+    public SpatialParams Spatial;
+    public VectorParams Vector;
+
+    /// <summary>For BETWEEN clauses, true when the client sent the unbounded-low sentinel ("*")
+    /// as the low bound (i.e. <c>WhereBetween(field, null, high)</c>). Resolution rewrites
+    /// such a clause to LessThanOrEqual(high) — null-valued docs are NOT included
+    /// (matches Lucene semantics for asymmetric null-sentinel BETWEEN).</summary>
+    public bool BetweenLowUnbounded;
+
+    /// <summary>For BETWEEN clauses, true when the client sent the unbounded-high sentinel ("NULL")
+    /// as the high bound (i.e. <c>WhereBetween(field, low, null)</c>). Resolution rewrites
+    /// such a clause to <c>AllEntries() AndNot LessThan(low)</c>, which DOES include
+    /// null-valued docs (Lucene quirk: high-null pulls in missing-field documents).</summary>
+    public bool BetweenHighUnbounded;
+
+    /// <summary>True when a WHEN condition evaluated to false for this execution.
+    /// The clause is stripped from the plan (like empty IN).</summary>
+    public bool WhenEliminated;
+
+    /// <summary>Per-execution state for OrGroup subclauses. Parallel to <see cref="ClauseInfo.OrSubClauses"/>.</summary>
+    public ClauseExecution[] OrSubExecutions;
+
+    /// <summary>Per-execution state for AndGroup subclauses. Parallel to <see cref="ClauseInfo.AndSubClauses"/>.</summary>
+    public ClauseExecution[] AndSubExecutions;
+}

--- a/src/Corax/Querying/Planning/ClauseInfo.cs
+++ b/src/Corax/Querying/Planning/ClauseInfo.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using Sparrow;
+using Sparrow.Json;
+
+namespace Corax.Querying.Planning;
+
+/// <summary>
+/// Intermediate representation of a single WHERE predicate, between the RQL AST
+/// and the PlanOp[] execution plan.
+///
+/// Why not reuse the RQL AST directly?
+/// - RQL AST exists in the Raven.Server project, not accessible here
+/// - The AST is a recursive tree (AND(AND(A,B),C)); ClauseInfo is a flat list suitable for
+///   plan emission. Mixed AND/OR trees are flattened into OrGroup/AndGroup sub-lists.
+/// - Field names are resolved (alias substitution, id() expansion, quoted-name handling).
+/// - Parameter values are resolved from the blittable and stored as native types in the
+///   plan's typed arrays (LongValues, DoubleValues, StringValues). PackedParam encodes
+///   (type, index), so resolution never reparses strings.
+/// - A clause type is classified into a flat enum — downstream code switches on one value
+///   instead of pattern-matching AST node types and method names.
+/// - Planning annotations (Cardinality, IsExact, BoostFactor, IsNegated) are attached per
+///   clause for operand reordering, dispatch classification, and entry-scan eligibility.
+///
+/// <para><b>Freeze contract:</b> ClauseInfo participates in the plan-cache template. Once
+/// <see cref="Freeze"/> has been called (at the end of plan-template construction), any
+/// subsequent attempt to mutate a property throws <see cref="InvalidOperationException"/>.
+/// This catches a regression class where post-build code rewrites a shared template in
+/// place — different executions of the same cached plan would then see inconsistent state.
+/// The fix in such cases is to <see cref="Clone"/> the ClauseInfo (clones are un-frozen)
+/// and mutate the copy. See the RavenDB_17423 fix history for the original bug pattern.</para>
+/// </summary>
+public sealed class ClauseInfo
+{
+    private bool _frozen;
+
+    private string _fieldName;
+    private ClauseType _clauseType;
+    private int _originalIndex;
+    private bool _isNegated;
+    private bool _isExact;
+    private int _searchOperator;
+    private SpatialOperationType _spatialMethodType;
+    private VectorSourceKind _vectorMethod;
+    private bool _isOrChainNotEquals;
+    private List<ClauseInfo> _orSubClauses;
+    private List<ClauseInfo> _andSubClauses;
+    private ParameterBinding[] _bindings;
+    private bool _hasBoost;
+    private Func<BlittableJsonReaderObject, bool> _whenCondition;
+
+    public string FieldName
+    {
+        get => _fieldName;
+        set { ThrowIfFrozen(); _fieldName = value; }
+    }
+
+    public ClauseType ClauseType
+    {
+        get => _clauseType;
+        set { ThrowIfFrozen(); _clauseType = value; }
+    }
+
+    public int OriginalIndex
+    {
+        get => _originalIndex;
+        set { ThrowIfFrozen(); _originalIndex = value; }
+    }
+
+    public bool IsNegated
+    {
+        get => _isNegated;
+        set { ThrowIfFrozen(); _isNegated = value; }
+    }
+
+    public bool IsExact
+    {
+        get => _isExact;
+        set { ThrowIfFrozen(); _isExact = value; }
+    }
+
+    /// <summary>for Search (AND=1/OR=0)</summary>
+    public int SearchOperator
+    {
+        get => _searchOperator;
+        set { ThrowIfFrozen(); _searchOperator = value; }
+    }
+
+    public SpatialOperationType SpatialMethodType
+    {
+        get => _spatialMethodType;
+        set { ThrowIfFrozen(); _spatialMethodType = value; }
+    }
+
+    public VectorSourceKind VectorMethod
+    {
+        get => _vectorMethod;
+        set { ThrowIfFrozen(); _vectorMethod = value; }
+    }
+
+    /// <summary>Set for any negated clause appearing in an OR chain — NotEquals,
+    /// NOT IN, NOT AllIn, NOT exists(), NOT startsWith(), etc.
+    /// Example: `WHERE Name != 'a' OR Age = 25` or `WHERE NOT exists(Tags) OR Score &gt; 10`.
+    /// The complement set cannot be delivered by the raw posting list / range / tree-scan
+    /// (which would produce the POSITIVE form). Instead, ResolveMatches pre-materializes
+    /// AllEntries ANDNOT(positive form) into a BitmapMatch via CreateNotEqualsOrMatch,
+    /// so FillFromMatch during execution correctly ORs in the complement set. The slot
+    /// is always dispatched via QueryMatch, regardless of the underlying clause type.</summary>
+    public bool IsOrChainNotEquals
+    {
+        get => _isOrChainNotEquals;
+        set { ThrowIfFrozen(); _isOrChainNotEquals = value; }
+    }
+
+    public List<ClauseInfo> OrSubClauses
+    {
+        get => _orSubClauses;
+        set { ThrowIfFrozen(); _orSubClauses = value; }
+    }
+
+    public List<ClauseInfo> AndSubClauses
+    {
+        get => _andSubClauses;
+        set { ThrowIfFrozen(); _andSubClauses = value; }
+    }
+
+    /// <summary>Parameter bindings indexed by <see cref="BindingIndex"/> constants.
+    /// If <see cref="HasBoost"/> is true, the last entry is the boost factor binding.</summary>
+    public ParameterBinding[] Bindings
+    {
+        get => _bindings;
+        set { ThrowIfFrozen(); _bindings = value; }
+    }
+
+    /// <summary>True if this clause is wrapped in boost(). When set, Bindings[^1] is the
+    /// boost factor binding and exec.BoostFactor is resolved from it per-execution.</summary>
+    public bool HasBoost
+    {
+        get => _hasBoost;
+        set { ThrowIfFrozen(); _hasBoost = value; }
+    }
+
+    /// <summary>Optional WHEN condition delegate. Null when no WHEN wraps this clause.
+    /// Created at ParseTemplate time as a closure over the parsed condition expression.
+    /// Evaluated per-execution in BuildAndCompile: called with the query's BlittableJsonReaderObject
+    /// parameters; returns true to keep the clause, false to eliminate it.</summary>
+    public Func<BlittableJsonReaderObject, bool> WhenCondition
+    {
+        get => _whenCondition;
+        set { ThrowIfFrozen(); _whenCondition = value; }
+    }
+
+    /// <summary>True once <see cref="Freeze"/> has been called. Frozen instances reject
+    /// all property mutations with <see cref="InvalidOperationException"/>.</summary>
+    public bool IsFrozen => _frozen;
+
+    /// <summary>Mark this ClauseInfo as part of an immutable plan-cache template. After
+    /// freezing, any property write throws. Idempotent — calling Freeze() on an already
+    /// frozen instance is a no-op. Sub-clauses (OrSubClauses, AndSubClauses) are NOT
+    /// auto-frozen; callers must freeze each sub-clause individually.</summary>
+    public void Freeze() => _frozen = true;
+
+    /// <summary>Create a mutable (un-frozen) copy of this ClauseInfo. Used by per-execution
+    /// rewrite paths that need to override a field for a single query without disturbing
+    /// the shared template. Shallow-copies reference fields (Bindings array, OrSub/AndSub
+    /// lists, WhenCondition delegate); the copy may share those references with the original.
+    /// If a caller mutates the array/list contents (not just the reference), it must clone
+    /// those first too.</summary>
+    public ClauseInfo Clone()
+    {
+        return new ClauseInfo
+        {
+            _fieldName = _fieldName,
+            _clauseType = _clauseType,
+            _originalIndex = _originalIndex,
+            _isNegated = _isNegated,
+            _isExact = _isExact,
+            _searchOperator = _searchOperator,
+            _spatialMethodType = _spatialMethodType,
+            _vectorMethod = _vectorMethod,
+            _isOrChainNotEquals = _isOrChainNotEquals,
+            _orSubClauses = _orSubClauses,
+            _andSubClauses = _andSubClauses,
+            _bindings = _bindings,
+            _hasBoost = _hasBoost,
+            _whenCondition = _whenCondition,
+            // _frozen intentionally left false — clones are mutable
+        };
+    }
+
+    private void ThrowIfFrozen()
+    {
+        if (_frozen)
+            throw new InvalidOperationException(
+                "ClauseInfo is frozen as part of the plan-cache template. Mutations would corrupt " +
+                "cached plans shared across executions. Use Clone() to get a mutable copy.");
+    }
+}

--- a/src/Corax/Querying/Planning/ClauseTemplate.cs
+++ b/src/Corax/Querying/Planning/ClauseTemplate.cs
@@ -1,0 +1,16 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Immutable structural template built on the first execution of a query text.
+/// Cached on PerQueryPlans.Template. On cache hit, clauses are cloned and their
+/// per-execution fields overwritten by PopulateParameters.</summary>
+public sealed class ClauseTemplate
+{
+    public ClauseInfo[] Clauses;
+    public bool IsAllEntries;
+    public bool IsOr;              // root boolean operator
+
+    /// <summary>Spatial clauses separated from the main filter chain (AND queries only).</summary>
+    public ClauseInfo[] SpatialClauses;
+    /// <summary>Vector clauses separated from the main filter chain (AND queries only).</summary>
+    public ClauseInfo[] VectorClauses;
+}

--- a/src/Corax/Querying/Planning/ClauseType.cs
+++ b/src/Corax/Querying/Planning/ClauseType.cs
@@ -1,0 +1,24 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Predicate types for the query plan clause list.</summary>
+public enum ClauseType : byte
+{
+    Equals,
+    NotEquals,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+    Between,
+    In,
+    AllIn,
+    Exists,
+    StartsWith,
+    EndsWith,
+    Search,
+    Regex,
+    Spatial,
+    Vector,
+    OrGroup,  // A group of OR'd subclauses
+    AndGroup, // A group of AND'd subclauses inside an OR chain
+}

--- a/src/Corax/Querying/Planning/CompiledPlan.cs
+++ b/src/Corax/Querying/Planning/CompiledPlan.cs
@@ -1,0 +1,70 @@
+namespace Corax.Querying.Planning;
+
+public sealed class CompiledPlan
+{
+    /// <summary>IL-emitted delegate that executes the posting-list scan plan (no timing instrumentation).</summary>
+    public QueryIlEmitter.CompiledExecuteDelegate CompiledDelegate { get; init; }
+
+    /// <summary>IL-emitted delegate with per-op timing instrumentation. Compiled lazily on
+    /// first `include timings()` request. Null until then.</summary>
+    public QueryIlEmitter.CompiledExecuteDelegate CompiledTimedDelegate { get; set; }
+
+    /// <summary>IL-emitted per-entry predicate evaluator for the entry-scan path.
+    /// Bakes in the plan's full ScanPredicateInfo[] structure. Null when the plan
+    /// has no entry-scan predicates.</summary>
+    public ResidualScanIlEmitter.ResidualScanPredicate CompiledEntryPredicate { get; init; }
+
+
+
+    /* A single query may be represented by different compiled plans, because the shape
+     * of the data is different. Consider `WHERE Tag = $tag and Published = $published`.
+     * If $tag is a popular term, and $published is true, that usually means that we
+     * need to generate a plan that would:
+     * - Read the posting list for $tag
+     * - AND that posting list with the Published=true posting list.
+     *
+     * On the other hand, if we want all the _unpublished_ items in a popular tag, we can check
+     * that Published=false is a small amount, then start from that, then we find that we have
+     * low enough results that we are going to just scan through them, instead of going through
+     * the posting list.
+     *
+     * In other words, the parameters we use for the query impact the query plan.
+     * The `Ordering` field is the order of steps in the query plan, and we use that as a cache key for disambiguation.
+     */
+    
+    /// <summary>Packed operand ordering used as part of the cache key.</summary>
+    public int Ordering { get; init; }
+
+    /* The same query may be called with parameters of different types:
+     *      Age = "25" vs. Age = 25 vs. Age = 25.0
+     * Each one of them has a different posting list that they use, and that matters, so we
+     * need a different compiled plan for each set of ordering.
+     */
+    
+    /// <summary>Packed parameter type signature (2 bits per param for first 16).</summary>
+    public int TypeSignature { get; init; }
+
+    /* The `TypeSignature` here is able to hold up to 16 parameter types, with 2 bits per parameter.
+     * Users may want to use queries with > 16 parameters, and we need to respect the same problem that
+     * `TypeSignature` is solving. In those cases, we use `FullKinds` to store the full kind vector for
+     * the full check.
+     */
+    
+    /// <summary>Full per-predicate kind vector for >16 typed scan predicates.</summary>
+    public byte[] FullKinds { get; init; }
+
+    /// <summary>Chain pointer for hash-collision disambiguation in PlanCache.</summary>
+    public CompiledPlan Next;
+
+    /// <summary>Depth of this entry in the chain (0 for head). Used by TryChainPrepend
+    /// to limit chain growth — when depth exceeds MaxChainDepth, the chain is replaced.</summary>
+    public int ChainDepth;
+
+    /// <summary>EXPLAIN pseudocode. Generated in the same pass as IL emission.</summary>
+    public string ExplainSource { get; init; }
+
+    /// <summary>Template inspection nodes built during IL emission.
+    /// At query time, cloned and populated with per-execution telemetry
+    /// (timings, result counts, scanned entries) from CompiledQueryMatch.</summary>
+    public InspectionOp[] InspectionTemplate { get; init; }
+}

--- a/src/Corax/Querying/Planning/CompiledQueryHelper.cs
+++ b/src/Corax/Querying/Planning/CompiledQueryHelper.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Corax.Querying.Matches;
+using Corax.Querying.Primitives;
+using Corax.Utils;
+using Sparrow;
+using Voron.Data.Containers;
+using Voron.Data.RoaringBitmaps;
+
+namespace Corax.Querying.Planning;
+
+/// <summary>
+/// Helper methods called by emitted IL for timing, result tracking, and
+/// the entry-scan iteration loop. The per-entry predicate evaluation is
+/// no longer in this file — it's emitted as specialized IL by
+/// <see cref="ResidualScanIlEmitter"/> and reached via
+/// <c>CompiledQueryMatch.CompiledEntryPredicate</c>.
+/// </summary>
+public static class CompiledQueryHelper
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void RecordTiming(CompiledQueryMatch ctx, int opIndex, long startTick)
+    {
+        ctx.Timings[opIndex] = Stopwatch.GetTimestamp() - startTick;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void RecordResultCount(CompiledQueryMatch ctx, int opIndex)
+    {
+        ctx.ResultCounts[opIndex] = ctx.Bitmaps[0].Count;
+    }
+
+    /// <summary>Check StartsWith/EndsWith against ALL terms for a field (multi-value support).
+    /// Returns true if ANY term matches.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CheckFieldTermStartsWith(ref EntryTermsReader reader, long fieldRootPage, ReadOnlySpan<byte> prefix)
+    {
+        reader.Reset();
+        while (reader.FindNext(fieldRootPage))
+        {
+            if (reader.Current.Decoded().StartsWith(prefix))
+                return true;
+        }
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CheckFieldTermEndsWith(ref EntryTermsReader reader, long fieldRootPage, ReadOnlySpan<byte> suffix)
+    {
+        reader.Reset();
+        while (reader.FindNext(fieldRootPage))
+        {
+            if (reader.Current.Decoded().EndsWith(suffix))
+                return true;
+        }
+        return false;
+    }
+
+    // ── Entry scan iteration loop ───────────────────────────────────────
+
+    /// <summary>Run entry scan: iterate the source bitmap in batches, resolve all entries
+    /// in each batch, evaluate the compiled predicate delegate once per batch (compact
+    /// survivors in-place), and add passing entries to the target bitmap. Batching avoids
+    /// the per-entry delegate invocation overhead — the IL-emitted predicate processes
+    /// the entire reader span and compacts entry IDs in a single call.</summary>
+    public static unsafe void RunEntryScan(
+        CompiledQueryMatch ctx,
+        ref RoaringBitmap sourceBitmap,
+        ref RoaringBitmap targetBitmap)
+    {
+        Span<long> buffer = stackalloc long[QueryPrimitives.EntryScanBatchSize];
+        Span<long> containerLocs = stackalloc long[QueryPrimitives.EntryScanBatchSize];
+        Span<UnmanagedSpan> spans = stackalloc UnmanagedSpan[QueryPrimitives.EntryScanBatchSize];
+        var readers = new EntryTermsReader[QueryPrimitives.EntryScanBatchSize];
+
+        var iterator = sourceBitmap.GetIterator();
+        var searcher = ctx.Searcher;
+        var predicate = ctx.CompiledEntryPredicate;
+        var llt = searcher.Transaction.LowLevelTransaction;
+
+        int read;
+        try
+        {
+            while ((read = iterator.Fill(ref sourceBitmap, buffer)) > 0)
+            {
+                ctx.Token.ThrowIfCancellationRequested();
+
+                var batch = buffer[..read];
+                ctx.EntryScanEntriesScanned += read;
+
+                searcher.ResolveEntryLocations(batch, containerLocs);
+                Container.GetAll(llt, containerLocs[..read], spans, -1, llt.PageLocator);
+                searcher.InitializeSpecialTermsMarkers();
+
+                int validCount = 0;
+                for (int i = 0; i < read; i++)
+                {
+                    if (containerLocs[i] == -1 || spans[i].Address == null)
+                        continue;
+                    readers[validCount] = new EntryTermsReader(llt,
+                        searcher.NullTermsMarkers, searcher.NonExistingTermsMarkers,
+                        spans[i].Address, spans[i].Length, searcher.DictionaryId,
+                        searcher.VectorFieldsMarkers, null);
+                    buffer[validCount] = buffer[i]; // compact entry IDs in-place
+                    validCount++;
+                }
+
+                if (validCount == 0)
+                    continue;
+
+                int passed = predicate(ctx, readers.AsSpan(0, validCount), buffer[..validCount], Span<int>.Empty);
+                ctx.EntryScanEntriesPassed += passed;
+                for (int i = 0; i < passed; i++)
+                    targetBitmap.Add(buffer[i]);
+            }
+        }
+        finally
+        {
+            iterator.Dispose();
+        }
+    }
+}

--- a/src/Corax/Querying/Planning/IPredicateEvaluationContext.cs
+++ b/src/Corax/Querying/Planning/IPredicateEvaluationContext.cs
@@ -1,0 +1,16 @@
+using Voron;
+
+namespace Corax.Querying.Planning;
+
+/// <summary>Common interface for types that provide the parameter arrays and field root
+/// pages needed by the emitted residual-scan predicate delegates. Both
+/// <see cref="Matches.CompiledQueryMatch"/> and <see cref="Matches.DirectScanMatch"/>
+/// implement this so a single <see cref="ResidualScanIlEmitter"/> can emit IL against
+/// either context type.</summary>
+public interface IPredicateEvaluationContext
+{
+    long[] ResidualLongParams { get; }
+    double[] ResidualDoubleParams { get; }
+    Slice[] ResidualSliceParams { get; }
+    long[] ResidualFieldRootPages { get; }
+}

--- a/src/Corax/Querying/Planning/IlEmitterShared.cs
+++ b/src/Corax/Querying/Planning/IlEmitterShared.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Threading;
+using Corax.Querying;
+using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Primitives;
+using Corax.Utils;
+using Sparrow;
+using Voron;
+using Voron.Data.CompactTrees;
+using Voron.Data.RoaringBitmaps;
+
+namespace Corax.Querying.Planning;
+
+/// <summary>Shared IL emission helpers and reflection members used by both <see cref="QueryILEmitter"/>
+/// and <see cref="ResidualScanIlEmitter"/>.</summary>
+public static class IlEmitterShared
+{
+    // --- From QueryILEmitter ---
+
+    // CompiledQueryMatch fields (accessed by emitted IL)
+    public static readonly FieldInfo CtxBitmaps = typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.Bitmaps));
+    public static readonly FieldInfo CtxTermSources = typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.PostingSources));
+    public static readonly FieldInfo CtxLimit = typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.Limit));
+
+    // Timing helpers
+    public static readonly MethodInfo GetTimestamp =
+        typeof(Stopwatch).GetMethod(nameof(Stopwatch.GetTimestamp))!;
+    public static readonly MethodInfo RecordTiming =
+        typeof(CompiledQueryHelper).GetMethod(nameof(CompiledQueryHelper.RecordTiming))!;
+    public static readonly MethodInfo RecordResultCount =
+        typeof(CompiledQueryHelper).GetMethod(nameof(CompiledQueryHelper.RecordResultCount))!;
+    public static readonly MethodInfo RunEntryScanMethod =
+        typeof(CompiledQueryHelper).GetMethod(nameof(CompiledQueryHelper.RunEntryScan))!;
+
+    // IQueryMatch
+    public static readonly MethodInfo MatchCountGetter = typeof(IQueryMatch).GetProperty(nameof(IQueryMatch.Count))!.GetGetMethod()!;
+
+    // RoaringBitmap — methods called directly by emitted IL
+    public static readonly MethodInfo AndWith =
+        typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.AndWith),
+            [typeof(RoaringBitmap).MakeByRefType()])!;
+    public static readonly MethodInfo LazyOrWith =
+        typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.LazyOrWith),
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public,
+            [typeof(RoaringBitmap).MakeByRefType()])!;
+    public static readonly MethodInfo AndNotWith =
+        typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.AndNotWith),
+            [typeof(RoaringBitmap).MakeByRefType()])!;
+    public static readonly MethodInfo Clear =
+        typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.Clear), Type.EmptyTypes)!;
+    public static readonly MethodInfo IsEmptyGetter = typeof(RoaringBitmap).GetProperty(nameof(RoaringBitmap.IsEmpty))!.GetGetMethod()!;
+    public static readonly MethodInfo CountGetter = typeof(RoaringBitmap).GetProperty(nameof(RoaringBitmap.Count))!.GetGetMethod()!;
+    public static readonly MethodInfo RepairAfterLazy =
+        typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.RepairAfterLazy), Type.EmptyTypes)!;
+    public static readonly MethodInfo SwapContents =
+        typeof(RoaringBitmap).GetMethod(nameof(RoaringBitmap.SwapContents),
+            [typeof(RoaringBitmap).MakeByRefType()])!;
+
+    // CancellationToken
+    public static readonly MethodInfo ThrowIfCancelled = typeof(CancellationToken).GetMethod(nameof(CancellationToken.ThrowIfCancellationRequested))!;
+
+    // IndexSearcher — for entry scan
+
+    // CompiledQueryMatch typed parameter arrays
+    public static readonly FieldInfo CtxResolvedMatches =
+        typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.ResolvedMatches));
+    public static readonly FieldInfo CtxInRangeCounts =
+        typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.InRangeCounts));
+    public static readonly FieldInfo CtxTermsProviders =
+        typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.TermsProviders));
+    public static readonly FieldInfo CtxEntryScanTakenAtOp =
+        typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.EntryScanTakenAtOp));
+    public static readonly FieldInfo CtxToken =
+        typeof(CompiledQueryMatch).GetField(nameof(CompiledQueryMatch.Token));
+
+    // CompactKey.Decoded() → ReadOnlySpan<byte>
+    public static readonly MethodInfo CompactKeyDecoded =
+        typeof(CompactKey).GetMethod(nameof(CompactKey.Decoded), Type.EmptyTypes)!;
+
+    // Ctx-based entry points — take ref CompiledQueryMatch, IL just pushes ldarg.0 + int constants
+    public static readonly MethodInfo CtxFillFromPostingSource = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxFillFromPostingSource))!;
+    public static readonly MethodInfo CtxFillFromTreeScan = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxFillFromTreeScan))!;
+    public static readonly MethodInfo CtxFillFromMatch = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxFillFromMatch))!;
+    public static readonly MethodInfo CtxOrFillFromPostingSource = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxOrFillFromPostingSource))!;
+    public static readonly MethodInfo CtxOrFillFromTreeScan = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxOrFillFromTreeScan))!;
+    public static readonly MethodInfo CtxOrFillFromMatch = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxOrFillFromMatch))!;
+    public static readonly MethodInfo CtxAndFromPostingSource = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxAndFromPostingSource))!;
+    public static readonly MethodInfo CtxAndFromTreeScan = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxAndFromTreeScan))!;
+    public static readonly MethodInfo CtxAndFromMatch = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxAndFromMatch))!;
+    public static readonly MethodInfo CtxAndNotFromPostingSource = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxAndNotFromPostingSource))!;
+    public static readonly MethodInfo CtxAndNotFromTreeScan = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxAndNotFromTreeScan))!;
+    public static readonly MethodInfo CtxAndNotFromMatch = typeof(QueryPrimitives).GetMethod(nameof(QueryPrimitives.CtxAndNotFromMatch))!;
+
+    // MemoryExtensions.SequenceCompareTo<byte>(ReadOnlySpan<byte>, ReadOnlySpan<byte>)
+    public static readonly MethodInfo SequenceCompareTo = typeof(MemoryExtensions)
+        .GetMethods(BindingFlags.Public | BindingFlags.Static)
+        .First(m => m.Name == nameof(MemoryExtensions.SequenceCompareTo)
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length == 2)
+        .MakeGenericMethod(typeof(byte));
+
+    // MemoryExtensions.SequenceEqual<byte>(ReadOnlySpan<byte>, ReadOnlySpan<byte>)
+    public static readonly MethodInfo SequenceEqual = typeof(MemoryExtensions)
+        .GetMethods(BindingFlags.Public | BindingFlags.Static)
+        .First(m => m.Name == nameof(MemoryExtensions.SequenceEqual)
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>)
+                    && m.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>))
+        .MakeGenericMethod(typeof(byte));
+
+    // Entry-scan cost heuristics — called from emitted IL so thresholds stay in one place
+    public static readonly MethodInfo ShouldSwitchToEntryScan =
+        typeof(QueryPrimitives).GetMethod(
+            nameof(QueryPrimitives.ShouldSwitchToEntryScan),
+            [typeof(long), typeof(long)])!;
+
+    // --- From ResidualScanIlEmitter ---
+
+    // IPredicateEvaluationContext interface property getters
+    public static readonly MethodInfo CtxLongParams =
+        typeof(IPredicateEvaluationContext).GetProperty(nameof(IPredicateEvaluationContext.ResidualLongParams)).GetGetMethod();
+    public static readonly MethodInfo CtxDoubleParams =
+        typeof(IPredicateEvaluationContext).GetProperty(nameof(IPredicateEvaluationContext.ResidualDoubleParams)).GetGetMethod();
+    public static readonly MethodInfo CtxSliceParams =
+        typeof(IPredicateEvaluationContext).GetProperty(nameof(IPredicateEvaluationContext.ResidualSliceParams)).GetGetMethod();
+    public static readonly MethodInfo CtxFieldRootPages =
+        typeof(IPredicateEvaluationContext).GetProperty(nameof(IPredicateEvaluationContext.ResidualFieldRootPages)).GetGetMethod();
+
+    // EntryTermsReader members
+    public static readonly MethodInfo ReaderReset =
+        typeof(EntryTermsReader).GetMethod(nameof(EntryTermsReader.Reset));
+    public static readonly MethodInfo ReaderFindNext =
+        typeof(EntryTermsReader).GetMethod(nameof(EntryTermsReader.FindNext));
+    public static readonly FieldInfo ReaderCurrentLong =
+        typeof(EntryTermsReader).GetField(nameof(EntryTermsReader.CurrentLong));
+    public static readonly FieldInfo ReaderCurrentDouble =
+        typeof(EntryTermsReader).GetField(nameof(EntryTermsReader.CurrentDouble));
+    public static readonly FieldInfo ReaderCurrent =
+        typeof(EntryTermsReader).GetField(nameof(EntryTermsReader.Current));
+
+    // Span<T> reflection handles (used by emitted IL for array access/length in the delegate)
+    public static readonly MethodInfo SpanLongLength =
+        typeof(Span<long>).GetMethod("get_Length")!;
+    public static readonly MethodInfo SpanIntLength =
+        typeof(Span<int>).GetMethod("get_Length")!;
+    public static readonly MethodInfo SpanLongGetItem =
+        typeof(Span<long>).GetMethod("get_Item", [typeof(int)])!;
+    public static readonly MethodInfo SpanIntGetItem =
+        typeof(Span<int>).GetMethod("get_Item", [typeof(int)])!;
+    public static readonly MethodInfo SpanEntryTermsReaderGetItem =
+        typeof(Span<EntryTermsReader>).GetMethod("get_Item", [typeof(int)])!;
+
+    public static readonly MethodInfo SliceAsReadOnlySpan =
+        typeof(Slice).GetMethod(nameof(Slice.AsReadOnlySpan));
+
+    public static readonly MethodInfo CheckFieldTermStartsWith =
+        typeof(CompiledQueryHelper).GetMethod(nameof(CompiledQueryHelper.CheckFieldTermStartsWith));
+    public static readonly MethodInfo CheckFieldTermEndsWith =
+        typeof(CompiledQueryHelper).GetMethod(nameof(CompiledQueryHelper.CheckFieldTermEndsWith));
+
+    /// <summary>Emit the most compact Ldc_I4 opcode for the given value.</summary>
+    public static void EmitLdcI4(ILGenerator il, int value)
+    {
+        switch (value)
+        {
+            case 0: il.Emit(OpCodes.Ldc_I4_0); break;
+            case 1: il.Emit(OpCodes.Ldc_I4_1); break;
+            case 2: il.Emit(OpCodes.Ldc_I4_2); break;
+            case 3: il.Emit(OpCodes.Ldc_I4_3); break;
+            case 4: il.Emit(OpCodes.Ldc_I4_4); break;
+            case 5: il.Emit(OpCodes.Ldc_I4_5); break;
+            case 6: il.Emit(OpCodes.Ldc_I4_6); break;
+            case 7: il.Emit(OpCodes.Ldc_I4_7); break;
+            case 8: il.Emit(OpCodes.Ldc_I4_8); break;
+            default:
+                if (value is >= -128 and <= 127)
+                    il.Emit(OpCodes.Ldc_I4_S, (sbyte)value);
+                else
+                    il.Emit(OpCodes.Ldc_I4, value);
+                break;
+        }
+    }
+
+}

--- a/src/Corax/Querying/Planning/InspectionOp.cs
+++ b/src/Corax/Querying/Planning/InspectionOp.cs
@@ -1,0 +1,22 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Pre-built metadata for one query plan inspection node.
+/// Created during IL emission, immutable, shared across cached executions.
+/// At inspection time, each entry becomes a QueryInspectionNode with
+/// runtime telemetry attached.</summary>
+public sealed class InspectionOp
+{
+    public string Name;
+    public string Dispatch;
+    public string FieldName;
+    public string Term;
+    public string Term2;
+    public string ClauseType;
+    public string Terms;
+    public bool IsNegated;
+    public long EstimatedCardinality;
+
+    /// <summary>True when this op is part of an AND-group inside an OR chain.
+    /// Used to nest these ops under an "AND-Group" node in the inspection tree.</summary>
+    public bool InsideAndGroup;
+}

--- a/src/Corax/Querying/Planning/MatchDispatch.cs
+++ b/src/Corax/Querying/Planning/MatchDispatch.cs
@@ -1,0 +1,20 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Selects the execution-time source for term ops in a <see cref="PlanOp"/>.</summary>
+public enum MatchDispatch : byte
+{
+    /// <summary>IQueryMatch.Fill() dispatch — the general-purpose path for spatial,
+    /// vector, search, boosted, and any clause that can't be expressed as a posting
+    /// list or tree scan.</summary>
+    QueryMatch,
+
+    /// <summary>Native posting-list dispatch — a single resolved posting list
+    /// (Single / SmallPostingList / PostingList.Iterator). The fastest path.
+    /// Used for Equals and NotEquals clauses.</summary>
+    PostingList,
+
+    /// <summary>CompactTree scan — iterates the tree at execution time, decoding each
+    /// matching posting list directly into the bitmap. Used for StartsWith, EndsWith,
+    /// Contains, Exists, Regex, and range clauses.</summary>
+    TreeScan,
+}

--- a/src/Corax/Querying/Planning/PackedParam.cs
+++ b/src/Corax/Querying/Planning/PackedParam.cs
@@ -1,0 +1,56 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>
+/// Packed parameter reference — a 32-bit value encoding the type and index(es)
+/// of a clause's resolved value within the plan's typed arrays
+/// (QueryExecution.LongValues / DoubleValues / StringValues).
+///
+///   bits [31:30] = value type (Long=0, Double=1, String=2, None=3)
+///   bits [29:15] = first parameter index (0..32767)
+///   bits [14:0]  = second parameter index (0..32767, 0x7FFF = no second param)
+///
+/// For simple predicates (Equals, GT, LT, etc.): Param1 = value index, Param2 = NoParam.
+/// For BETWEEN: Param1 = low-bound index, Param2 = high-bound index (same-typed array).
+/// For IN/AllIn: Param1 = start index into the typed array. Term count is stored separately
+///   in ClauseInfo.InTermCount (not packed) because IN can exceed 32K terms.
+/// For parameterless clauses (Exists): None sentinel.
+/// </summary>
+public readonly struct PackedParam
+{
+    public const int NoParamValue = 0x7FFF;
+    private const int MaxIndex = 0x7FFF; // 32767
+
+    public const int TypeLong = 0;
+    public const int TypeDouble = 1;
+    public const int TypeString = 2;
+    private const int TypeNone = 3;
+
+    /// <summary>Sentinel: no parameter ("exists(Field)" clauses). Spatial and vector clauses
+    /// store their numeric parameters directly on ClauseInfo fields instead.</summary>
+    public static readonly PackedParam None = new((TypeNone << 30) | (NoParamValue << 15) | NoParamValue);
+
+    private readonly int _value;
+
+    private PackedParam(int raw) => _value = raw;
+
+    public PackedParam(int type, int param1, int param2 = NoParamValue)
+    {
+        if (param1 > MaxIndex)
+            ThrowLimitExceeded(param1);
+        if (param2 != NoParamValue && param2 > MaxIndex)
+            ThrowLimitExceeded(param2);
+        _value = (type << 30) | ((param1 & 0x7FFF) << 15) | (param2 & 0x7FFF);
+    }
+
+    public int ValueType => (_value >>> 30) & 0x3;
+    public int Param1 => (_value >>> 15) & 0x7FFF;
+    public int Param2 => _value & 0x7FFF;
+    public bool IsNone => _value == None._value;
+
+    private static void ThrowLimitExceeded(int index)
+    {
+        throw new System.InvalidOperationException(
+            $"Query parameter index {index} exceeds maximum ({MaxIndex}). " +
+            "Simplify the query or reduce the number of IN terms.");
+    }
+}

--- a/src/Corax/Querying/Planning/ParamValueType.cs
+++ b/src/Corax/Querying/Planning/ParamValueType.cs
@@ -1,0 +1,14 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Value type for resolved parameters. Corax-side equivalent of
+/// Raven.Server's ValueTokenType — only the subset needed for clause resolution.</summary>
+public enum ParamValueType : byte
+{
+    String,
+    Long,
+    Double,
+    Null,
+    /// <summary>Blittable object or array parameter — preserved as-is for vector/spatial resolution.
+    /// Maps to ValueTokenType.Parameter at the `Raven.Server` boundary.</summary>
+    Parameter
+}

--- a/src/Corax/Querying/Planning/ParameterBinding.cs
+++ b/src/Corax/Querying/Planning/ParameterBinding.cs
@@ -1,0 +1,27 @@
+using System;
+using Sparrow.Json;
+
+namespace Corax.Querying.Planning;
+
+/// <summary>Single parameter reference — either a literal (value cached) or a parameter
+/// name for blittable lookup. Leaf type with no nesting.</summary>
+public sealed class ParameterBinding
+{
+    /// <summary>Cached native value for literals (long/double/string). Null for parameters
+    /// and for literal nulls. Only valid when LiteralType != Parameter.</summary>
+    public object LiteralValue;
+
+    /// <summary>Type of the value. ParamValueType.Parameter means look up ParameterName
+    /// in the blittable at execution time. Other values mean LiteralValue is cached.</summary>
+    public ParamValueType LiteralType;
+
+    /// <summary>For parameters: name to look up in blittable ("p0"). Null for literals.</summary>
+    public string ParameterName;
+
+    /// <summary>For deferred method expressions (e.g. cmpxchg(), now(), today()) that must
+    /// be resolved at execution time rather than template creation time. The first parameter
+    /// is the QueryBuilderParameters boxed as object (cast at the resolution site in
+    /// Raven.Server); the second is the query's BlittableJsonReaderObject.
+    /// Returns the resolved native value, or null for null values.</summary>
+    public Func<object, BlittableJsonReaderObject, object> DeferredExpression;
+}

--- a/src/Corax/Querying/Planning/PlanCache.cs
+++ b/src/Corax/Querying/Planning/PlanCache.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Threading;
+
+namespace Corax.Querying.Planning;
+
+/// <summary>
+/// Caches compiled query plans per index instance.
+/// Lives on IndexSearcher — GC'd when the index is replaced.
+///
+/// Two-generation structure: a single atomic <see cref="CacheGeneration"/> reference
+/// holds both the current and previous ConcurrentDictionaries. Rotation swaps the
+/// entire generation atomically — no intermediate state where current and previous
+/// point to the same dict.
+///
+/// Per-query: fixed-capacity SoA (struct-of-arrays, default 32 slots) — parallel int[]
+/// for orderings and type signatures plus a CompiledPlan[] for the payloads. SIMD compares
+/// scan all slots in Vector256/Vector128 iterations. Capacity is configurable via the
+/// <see cref="PlanCache(int, int)"/> constructor; must be a multiple of 8 for alignment.
+/// </summary>
+public class PlanCache
+{
+    private int MaxPlansPerQuery { get; }
+    private int MaxDistinctQueries { get; }
+
+    private sealed record CacheGeneration(
+        ConcurrentDictionary<string, PerQueryPlans> Current,
+        ConcurrentDictionary<string, PerQueryPlans> Previous);
+
+    private CacheGeneration _generation;
+
+    public PlanCache(int maxPlansPerQuery = 32, int maxDistinctQueries = 2048)
+    {
+        // MaxPlansPerQuery must be a multiple of 8 for SIMD Vector256 alignment
+        if (maxPlansPerQuery % 8 != 0)
+            maxPlansPerQuery = ((maxPlansPerQuery / 8) + 1) * 8;
+        MaxPlansPerQuery = maxPlansPerQuery;
+        MaxDistinctQueries = maxDistinctQueries;
+        _generation = new CacheGeneration([], []);
+    }
+
+    public CompiledPlan Get(string queryText, int ordering, int typeSignature = 0)
+        => Get(queryText, ordering, typeSignature, default);
+
+    public CompiledPlan Get(string queryText, int ordering, int typeSignature, ReadOnlySpan<byte> kinds)
+    {
+        var gen = _generation;
+        if (gen.Current.TryGetValue(queryText, out var per) is false)
+            gen.Previous.TryGetValue(queryText, out per);
+
+        return per?.TryLookup(ordering, typeSignature, kinds);
+    }
+
+    /// <summary>Try to retrieve the cached clause template for a query text.
+    /// Stale reads are harmless — the worst case is one redundant ParseTemplate call.
+    /// Write side uses ConcurrentDictionary.GetOrAdd ensuring correctness.</summary>
+    public ClauseTemplate TryGetTemplate(string queryText)
+    {
+        var gen = _generation;
+        if (gen.Current.TryGetValue(queryText, out var per) is false)
+            gen.Previous.TryGetValue(queryText, out per);
+
+        return per?.Template;
+    }
+
+    public void Add(string queryText, CompiledPlan plan, ClauseTemplate template = null)
+    {
+        var gen = _generation;
+
+        // When the current generation exceeds half the max, rotate.
+        if (gen.Current.Count > MaxDistinctQueries / 2)
+        {
+            var newGen = new CacheGeneration([], gen.Current);
+            gen = Interlocked.CompareExchange(ref _generation, newGen, gen);
+            Debug.Assert(gen is not null);
+        }
+
+        var current = gen.Current;
+
+        var per = current.GetOrAdd(queryText,
+            static (_, arg) => new PerQueryPlans(arg.MaxPlansPerQuery, arg.template),
+            (MaxPlansPerQuery, template));
+
+        per.Publish(plan);
+    }
+
+    /// <summary>
+    /// Fixed-slot per-query plan cache. Three parallel arrays (_orderings, _typeSignatures,
+    /// _plans) of maxSlots entries (default 32, must be a multiple of 8).
+    ///
+    /// Lookup: broadcast the target ordering/typeSignature into a Vector256&lt;int&gt; (8 lanes)
+    /// and compare 8 slots per iteration. ExtractMostSignificantBits yields a bitmask of hits;
+    /// TrailingZeroCount walks set bits. Vec128 fallback does 4 lanes per iteration.
+    /// Matched candidates are revalidated against the plan's own embedded keys to
+    /// guard against torn-write races (parallel arrays are written non-atomically).
+    ///
+    /// maxSlots alignment: must be a multiple of 8 so the Vec256 loop never reads past the
+    /// array end. The constructor rounds up if needed.
+    /// </summary>
+    private sealed class PerQueryPlans(int maxSlots, ClauseTemplate template)
+    {
+        private readonly int[] _orderings = new int[maxSlots];
+        private readonly int[] _typeSignatures = new int[maxSlots];
+        private readonly CompiledPlan[] _plans = new CompiledPlan[maxSlots];
+        private int _filled;
+
+        /// <summary>Cached clause template. Set in constructor, immutable thereafter.</summary>
+        public readonly ClauseTemplate Template = template;
+
+        public CompiledPlan TryLookup(int ordering, int typeSignature, ReadOnlySpan<byte> kinds)
+        {
+            if (Vector256.IsHardwareAccelerated)
+                return Vec256Lookup(ordering, typeSignature, kinds);
+            if (Vector128.IsHardwareAccelerated)
+                return Vec128Lookup(ordering, typeSignature, kinds);
+            return ScalarLookup(ordering, typeSignature, kinds);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static CompiledPlan ResolveCandidate(CompiledPlan head, int ordering, int typeSignature, ReadOnlySpan<byte> kinds)
+        {
+            for (var p = head; p != null; p = p.Next)
+            {
+                if (p.Ordering != ordering || p.TypeSignature != typeSignature)
+                    continue;
+                if (kinds.IsEmpty)
+                {
+                    if (p.FullKinds is not null)
+                        continue;
+
+                    return p;
+                }
+                if (kinds.SequenceEqual(p.FullKinds))
+                    return p;
+            }
+
+            return null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private CompiledPlan Vec256Lookup(int ordering, int typeSignature, ReadOnlySpan<byte> kinds)
+        {
+            var ordVec = Vector256.Create(ordering);
+            var typVec = Vector256.Create(typeSignature);
+            for (int i = 0; i < _orderings.Length && i < _typeSignatures.Length; i += 8)
+            {
+                var ords = Vector256.LoadUnsafe(ref _orderings[i]);
+                var typs = Vector256.LoadUnsafe(ref _typeSignatures[i]);
+                var match = Vector256.Equals(ords, ordVec) & Vector256.Equals(typs, typVec);
+                uint mask = match.ExtractMostSignificantBits();
+                while (mask != 0)
+                {
+                    int lane = BitOperations.TrailingZeroCount(mask);
+                    mask &= mask - 1;
+                    var head = Volatile.Read(ref _plans[i + lane]);
+                    var resolved = ResolveCandidate(head, ordering, typeSignature, kinds);
+                    if (resolved != null)
+                        return resolved;
+                }
+            }
+
+            return null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private CompiledPlan Vec128Lookup(int ordering, int typeSignature, ReadOnlySpan<byte> kinds)
+        {
+            var ordVec = Vector128.Create(ordering);
+            var typVec = Vector128.Create(typeSignature);
+            for (int i = 0; i < _orderings.Length && i < _typeSignatures.Length; i += 4)
+            {
+                var ords = Vector128.LoadUnsafe(ref _orderings[i]);
+                var typs = Vector128.LoadUnsafe(ref _typeSignatures[i]);
+                var match = Vector128.Equals(ords, ordVec) & Vector128.Equals(typs, typVec);
+                uint mask = match.ExtractMostSignificantBits();
+                while (mask != 0)
+                {
+                    int lane = BitOperations.TrailingZeroCount(mask);
+                    mask &= mask - 1;
+                    var head = Volatile.Read(ref _plans[i + lane]);
+                    var resolved = ResolveCandidate(head, ordering, typeSignature, kinds);
+                    if (resolved != null)
+                        return resolved;
+                }
+            }
+
+            return null;
+        }
+
+        private CompiledPlan ScalarLookup(int ordering, int typeSignature, ReadOnlySpan<byte> kinds)
+        {
+            for (int i = 0; i < _orderings.Length && i < _typeSignatures.Length; i++)
+            {
+                if (_orderings[i] != ordering || _typeSignatures[i] != typeSignature)
+                    continue;
+                var head = Volatile.Read(ref _plans[i]);
+                var resolved = ResolveCandidate(head, ordering, typeSignature, kinds);
+                if (resolved != null)
+                    return resolved;
+            }
+
+            return null;
+        }
+
+        private const int MaxChainDepth = 8;
+
+        public void Publish(CompiledPlan plan)
+        {
+            // Try chain prepend for >16-kind plans that share (ordering, type signature) hash
+            if (plan.FullKinds != null && TryChainPrepend(plan))
+                return;
+
+            int slot;
+            while (true)
+            {
+                int filled = Volatile.Read(ref _filled);
+                if (filled >= maxSlots)
+                {
+                    // Cache full — random eviction.
+                    slot = Random.Shared.Next(0, maxSlots);
+                    break;
+                }
+
+                if (Interlocked.CompareExchange(ref _filled, filled + 1, filled) == filled)
+                {
+                    slot = filled;
+                    break;
+                }
+            }
+
+            Volatile.Write(ref _plans[slot], plan);
+            Volatile.Write(ref _orderings[slot], plan.Ordering);
+            Volatile.Write(ref _typeSignatures[slot], plan.TypeSignature);
+        }
+
+        private bool TryChainPrepend(CompiledPlan plan)
+        {
+            Debug.Assert(plan.FullKinds is not null);
+            for (int i = 0; i < _orderings.Length && i < _typeSignatures.Length && i < _plans.Length; i++)
+            {
+                if (_orderings[i] != plan.Ordering || _typeSignatures[i] != plan.TypeSignature)
+                    continue; // quick check
+                while (true)
+                {
+                    var head = Volatile.Read(ref _plans[i]);
+                    if (head == null)
+                        return false; // Slot was emptied — fall back to slot insert
+
+                    // Validate the head plan itself, not just the parallel arrays.
+                    // The SIMD scan is a fast filter; the head's own fields are the source of truth.
+                    // A concurrent eviction could have overwritten the parallel arrays.
+                    if (head.Ordering != plan.Ordering || 
+                        head.TypeSignature != plan.TypeSignature)
+                        break; // Slot was reused for a different plan — skip
+
+                    // Limit chain depth to prevent unbounded growth.
+                    // When depth exceeds the limit, replace the entire chain.
+                    if (head.ChainDepth >= MaxChainDepth)
+                    {
+                        plan.Next = null;
+                        plan.ChainDepth = 0;
+                        if (Interlocked.CompareExchange(ref _plans[i], plan, head) == head)
+                            return true;
+                        continue; // CAS failed, retry
+                    }
+
+                    plan.Next = head;
+                    plan.ChainDepth = head.ChainDepth + 1;
+                    if (Interlocked.CompareExchange(ref _plans[i], plan, head) == head)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Corax/Querying/Planning/PlanOp.cs
+++ b/src/Corax/Querying/Planning/PlanOp.cs
@@ -1,0 +1,28 @@
+namespace Corax.Querying.Planning;
+
+public struct PlanOp
+{
+    public PlanOpKind Kind;
+    public int ParamIndex;
+    public int ParamIndex2;
+    public int BitmapLocal;
+    public long EstimatedCardinality;
+
+    /// <summary>Controls how <see cref="ParamIndex"/> is resolved at execution time
+    /// for term ops (Fill/And/Or/AndNot WithPostings):
+    /// <list type="bullet">
+    /// <item><see cref="MatchDispatch.QueryMatch"/> — <c>ctx.ResolvedMatches[ParamIndex]</c>
+    ///   (IQueryMatch interface dispatch; vector, spatial, search, boosted clauses).</item>
+    /// <item><see cref="MatchDispatch.PostingList"/> — <c>ctx.PostingSources[ParamIndex]</c>
+    ///   (native posting-list dispatch; Equals / NotEquals / In / AllIn).</item>
+    /// <item><see cref="MatchDispatch.TreeScan"/> — <c>ctx.TermsProviders[ParamIndex]</c>
+    ///   (multi-term bitmap fill; StartsWith / EndsWith / Contains / Exists / Regex / ranges).</item>
+    /// </list></summary>
+    public MatchDispatch Dispatch;
+
+    /// <summary>When true, suppress the empty-check early exit after
+    /// <see cref="PlanOpKind.AndWithPostings"/>. Used for AND sub-chains inside
+    /// an OR accumulator where an empty intermediate result is not a reason to
+    /// abort the whole expression.</summary>
+    public bool SkipEarlyExit;
+}

--- a/src/Corax/Querying/Planning/PlanOpKind.cs
+++ b/src/Corax/Querying/Planning/PlanOpKind.cs
@@ -1,0 +1,74 @@
+namespace Corax.Querying.Planning;
+
+public enum PlanOpKind : byte
+{
+    /// <summary>Fill bitmap[0] from a term source, term provider, or IQueryMatch.
+    /// Dispatches to QueryPrimitives.FillBitmapFromPostingSource / FillBitmapFromTreeScan / FillFromMatch
+    /// depending on <see cref="PlanOp.Dispatch"/>.</summary>
+    FillFromPostings,
+
+    /// <summary>AND bitmap[0] with a term source, term provider, or IQueryMatch.
+    /// Uses bitmap[1] as scratch. Emits an early-exit branch when the result is empty
+    /// unless <see cref="PlanOp.SkipEarlyExit"/> is set (inside OR sub-chains).</summary>
+    AndWithPostings,
+
+    /// <summary>OR a term source / provider / match into bitmap[BitmapLocal].
+    /// Fills the target bitmap slot; the caller ORs slots together with <see cref="OrBitmaps"/>.</summary>
+    OrWithPostings,
+
+    /// <summary>ANDNOT bitmap[0] with a term source / provider / match.
+    /// Removes entries present in the operand from the current result set,
+    /// using bitmap[1] as scratch.</summary>
+    AndNotWithPostings,
+
+    /// <summary>Lazy OR: same as <see cref="OrWithPostings"/> but defers container
+    /// merging to avoid repeated decompression. Requires a subsequent
+    /// <see cref="RepairAfterLazy"/> before the bitmap can be iterated.</summary>
+    LazyOrWithPostings,
+
+    /// <summary>Finalize a bitmap that was built with <see cref="LazyOrWithPostings"/>.
+    /// Calls RoaringBitmap.RepairAfterLazy to reconcile deferred containers.</summary>
+    RepairAfterLazy,
+
+    /// <summary>Heuristic check: if bitmap[0].Count is small enough relative to the
+    /// IQueryMatch.Count, branch to the entry-scan path instead of continuing the
+    /// bitmap pipeline. Emits a conditional goto to the entry-scan label.</summary>
+    CheckAndMaybeEntryScan,
+
+    /// <summary>Unconditional branch to the done label. Used as the final op in the
+    /// bitmap pipeline before the entry-scan fallback block.</summary>
+    IterateInto,
+
+    /// <summary>Same emission as <see cref="FillFromPostings"/> — fills bitmap[0] from
+    /// a source. Exists as a separate kind for plan-builder bookkeeping to distinguish
+    /// the first fill of a direct-iterate plan.</summary>
+    DirectIterate,
+
+    /// <summary>Clear a specific bitmap slot. BitmapLocal = slot index.</summary>
+    ClearBitmap,
+
+    /// <summary>AND two bitmap slots. BitmapLocal = target, ParamIndex2 = source.</summary>
+    AndBitmaps,
+
+    /// <summary>ANDNOT two bitmap slots. BitmapLocal = target, ParamIndex2 = source.</summary>
+    AndNotBitmaps,
+
+    /// <summary>Check if bitmap is empty. BitmapLocal = slot. If empty, goto done.</summary>
+    CheckEmpty,
+
+    /// <summary>OR two bitmap slots. BitmapLocal = target, ParamIndex2 = source.</summary>
+    OrBitmaps,
+
+    /// <summary>Swap contents of two bitmap slots. BitmapLocal = slot A, ParamIndex2 = slot B.</summary>
+    SwapBitmaps,
+
+    /// <summary>OR a contiguous range of posting sources into bitmap[BitmapLocal].
+    /// ParamIndex = start index, ParamIndex2 = index into ctx.InRangeCounts for runtime count. Emits a loop in IL.
+    /// Used for IN clauses to avoid one PlanOp per term.</summary>
+    OrRange,
+
+    /// <summary>AND a contiguous range of posting sources with bitmap[0].
+    /// ParamIndex = start index, ParamIndex2 = index into ctx.InRangeCounts for runtime count. Emits a loop in IL with
+    /// empty-check after each (unless SkipEarlyExit). Used for AllIn clauses.</summary>
+    AndRange,
+}

--- a/src/Corax/Querying/Planning/PostingSource.cs
+++ b/src/Corax/Querying/Planning/PostingSource.cs
@@ -1,0 +1,26 @@
+using Voron.Data.PostingLists;
+
+namespace Corax.Querying.Planning;
+
+/// <summary>Three-way native posting-list source attached to term op.
+/// Mirrors the encoding used by <see cref="ITermsProvider.FillPostingListIds"/>:
+/// the low 2 bits of a CompactTree value distinguish Single / SmallPostingList /
+/// PostingList. Resolved up-front by <c>ResolveTermSources</c>; consumed by
+/// <c>FillBitmapFromPostingSource</c> / <c>AndWithPostingSource</c> /
+/// <c>AndNotWithPostingSource</c> at execution time.</summary>
+public struct PostingSource
+{
+    public PostingSourceKind Kind;
+
+    /// <summary>Decoded entry id (Kind == Single) — already passed through
+    /// EntryIdEncodings.GetContainerId.</summary>
+    public long SingleEntryId;
+
+    /// <summary>Container id for the small posting list (Kind == SmallPostingList) —
+    /// pass to <c>Container.Get</c> on the LowLevelTransaction, then decode the
+    /// FastPFor buffer.</summary>
+    public long SmallPostingListId;
+
+    /// <summary>Iterator over a large posting list (Kind == PostingList).</summary>
+    public PostingList.Iterator LargeIterator;
+}

--- a/src/Corax/Querying/Planning/PostingSourceKind.cs
+++ b/src/Corax/Querying/Planning/PostingSourceKind.cs
@@ -1,0 +1,12 @@
+namespace Corax.Querying.Planning;
+
+public enum PostingSourceKind : byte
+{
+    /// <summary>The term does not exist in the index (or the field has no compact tree).
+    /// Dispatcher primitives no-op on Empty for Or-shaped ops, and clear the bitmap
+    /// for And-shaped ops.</summary>
+    Empty,
+    Single,
+    SmallPostingList,
+    PostingList,
+}

--- a/src/Corax/Querying/Planning/QueryExecution.cs
+++ b/src/Corax/Querying/Planning/QueryExecution.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+
+namespace Corax.Querying.Planning;
+
+public class QueryExecution
+{
+    public PlanOp[] Ops;
+
+    /// <summary>
+    /// Cache-key disambiguator for <see cref="PlanCache"/>. Two query executions with the same
+    /// queryText but different shapes must produce different OperandOrdering values to avoid
+    /// reusing compiled IL across incompatible plans.
+    ///
+    /// Bit layout (low → high):
+    /// <list type="table">
+    ///   <listheader><term>Bits</term><description>Meaning</description></listheader>
+    ///   <item><term>0..29</term><description>Clause-ordering encoding. Up to 10 clauses × 3 bits each;
+    ///     slot i holds <c>clauses[i].OriginalIndex &amp; 0x7</c> shifted by <c>i*3</c>. Captures the
+    ///     post-cardinality-sort order so a query whose clauses get reordered into a different sequence
+    ///     gets a distinct cache key (set in QueryPlanBuilder.cs ~L1526).</description></item>
+    ///   <item><term>30</term><description>HasBoost flag. Set when any clause has boost(); forces
+    ///     every op to QueryMatch dispatch (so scores are accumulated). Set in QueryPlanBuilder.Resolution.cs ~L299.</description></item>
+    ///   <item><term>31</term><description>SentinelBetween flag. Set when any execution carries
+    ///     BetweenLowUnbounded / BetweenHighUnbounded — those rewrites force QueryMatch dispatch
+    ///     (IsTreeScanEligibleClause rejects sentinel BETWEEN) and must not collide with cached
+    ///     TreeScan IL for the same queryText. Set in QueryPlanBuilder.Resolution.cs ~L304. This is
+    ///     the int's sign bit, but PlanCache compares orderings bitwise (Vector256.Equals / scalar !=),
+    ///     never as a signed magnitude, so setting bit 31 is safe — it just makes the value negative.</description></item>
+    /// </list>
+    ///
+    /// <para>When adding a new disambiguator bit: only bit 31 was previously free and is now used by
+    /// SentinelBetween. The 10-slot × 3-bit ordering encoding fills bits 0..29 exactly. To add another
+    /// flag, either cap the ordering loop at 9 clauses (frees bits 27/28/29 as flag slots) or widen
+    /// OperandOrdering to a long (frees bits 32..63 — but the PlanCache SIMD comparison currently uses
+    /// Vector256&lt;int&gt; / Vector128&lt;int&gt;, so the change is non-trivial). Whichever path is taken,
+    /// document the new bit here, set it conditionally before the plan-cache lookup, and ensure the bit
+    /// is parameter-independent (depends only on query structure, not parameter values) — otherwise
+    /// different parameter values of the same query text would compile to different plans and defeat
+    /// the cache.</para>
+    /// </summary>
+    public int OperandOrdering;
+
+    /// <summary>Clause list from the query plan builder — structural template data.</summary>
+    public List<ClauseInfo> Clauses;
+
+    /// <summary>Per-execution state parallel to Clauses — parameter values, cardinality, etc.</summary>
+    public ClauseExecution[] Executions;
+    public bool IsAllEntries;
+    public bool AllNegated;
+
+    /// <summary>Typed parameter values for clause resolution. Populated during plan building
+    /// from resolved query parameters and literal values. Each clause's PackedParam field
+    /// encodes (type, index) pairs pointing into these arrays, so resolution never has to
+    /// reparse strings back to their native types.</summary>
+    public long[] LongValues;
+    public double[] DoubleValues;
+    public string[] StringValues;
+
+    /// <summary>Spatial operations to apply after the bitmap filter phase builds the candidate bitmap.
+    /// Each spatial match is ANDed with the candidate set.</summary>
+    public SpatialFilterOp[] SpatialFilters;
+
+    /// <summary>Vector operations to apply after spatial filtering.
+    /// The bitmap-producing CompiledQueryMatch is passed as the filterQuery to VectorSearchMatch.</summary>
+    public VectorSearchOp[] VectorSelects;
+
+    /// <summary>Packed parameter type signature from ScanPredicateInfos.
+    /// 2 bits per predicate (0=long, 1=double, 2=string) for the FIRST 16 predicates.
+    /// For ≤ 16 predicates this is the exact identity. For more, it acts as a lossy
+    /// hash and <see cref="FullKinds"/> carries the disambiguator.</summary>
+    public int TypeSignature;
+
+    /// <summary>Full per-predicate kind vector. Populated only when there are more than
+    /// 16 typed scan predicates. Null in the common case, so PlanCache lookups stay
+    /// branch-free on the hot path. When non-null, PlanCache.Add walks the slot chain
+    /// (CompiledPlan.Next) and SequenceEqual-compares this vs. existing FullKinds to
+    /// disambiguate plans whose <see cref="TypeSignature"/> ints collide.</summary>
+    public byte[] FullKinds;
+
+    /// <summary>Number of bitmaps this plan needs at execution time.
+    /// Slot 0 = main result, slot 1 = scratch for AND-with-postings / AND-NOT and OR-group
+    /// accumulation. Plans with multiple AndGroups inside an OR chain use slot 2 as a
+    /// save slot during the swap-build-or pattern, so the RequiredBitmaps field is set to 3 for those.
+    /// Default is 2 (covers all non-multi-AndGroup plans).</summary>
+    public int RequiredBitmaps = 2;
+
+    /// <summary>Metadata for entry scan predicates. Used by the IL emitter to generate
+    /// direct comparison calls. Null if no entry scan is possible.</summary>
+    public ScanPredicateInfo[] ScanPredicateInfos;
+
+    /// <summary>Per-execution term counts for OrRange/AndRange ops. Each range op's
+    /// ParamIndex2 is an index into this array. The IL reads the count at runtime,
+    /// so the same compiled delegate handles different IN parameter array sizes.</summary>
+    public int[] InRangeCounts;
+}

--- a/src/Corax/Querying/Planning/QueryILEmitter.cs
+++ b/src/Corax/Querying/Planning/QueryILEmitter.cs
@@ -1,0 +1,572 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using System.Threading;
+using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Primitives;
+using Corax.Utils;
+using Voron;
+using Voron.Data.CompactTrees;
+using Voron.Data.RoaringBitmaps;
+
+namespace Corax.Querying.Planning;
+
+public static class QueryIlEmitter
+{
+    public delegate void CompiledExecuteDelegate(CompiledQueryMatch ctx);
+
+    // Span<long>
+    private static readonly ConstructorInfo SpanCtor = typeof(Span<long>).GetConstructor([typeof(void*), typeof(int)])!;
+
+    public static CompiledExecuteDelegate EmitDelegate(QueryExecution plan, out string explainSource, bool emitTimings = true)
+    {
+        var ops = plan.Ops;
+        if (ops == null || ops.Length == 0)
+        {
+            explainSource = "// Empty plan";
+            return EmptyExecute;
+        }
+
+        // EXPLAIN pseudocode built alongside IL emission.
+        var explain = new StringBuilder();
+        explain.AppendLine("// Compiled query — pseudocode mirroring the emitted IL.");
+
+        var dm = new DynamicMethod(
+            "CompiledQuery",
+            typeof(void),
+            [typeof(CompiledQueryMatch)],
+            typeof(CompiledQueryMatch).Module,
+            skipVisibility: true)
+            {
+                InitLocals = false
+            };
+
+        var il = dm.GetILGenerator();
+
+        // Locals
+        var bufferLocal = il.DeclareLocal(typeof(Span<long>));    // 0: Fill buffer
+        var readLocal = il.DeclareLocal(typeof(int));              // 1: read count
+        var startTickLocal = il.DeclareLocal(typeof(long));        // 2: timing start tick
+
+        var doneLabel = il.DefineLabel();
+        var entryScanLabel = il.DefineLabel();
+        bool hasEntryScan = false;
+        bool needsLazyRepair = false;
+        int entryScanOpIndex = -1;
+
+        // stackalloc long[FillBufferSize]
+        IlEmitterShared.EmitLdcI4(il, QueryPrimitives.FillBufferSize);
+        il.Emit(OpCodes.Conv_U);
+        il.Emit(OpCodes.Sizeof, typeof(long));
+        il.Emit(OpCodes.Mul_Ovf_Un);
+        il.Emit(OpCodes.Localloc);
+        IlEmitterShared.EmitLdcI4(il, QueryPrimitives.FillBufferSize);
+        il.Emit(OpCodes.Newobj, SpanCtor);
+        il.Emit(OpCodes.Stloc, bufferLocal);
+
+        // Bounds-check elimination preamble: touch the max index of each array
+        // so the JIT can hoist the length checks out of loops.
+        EmitBoundsCheckPreamble(il, ops);
+
+        for (int i = 0; i < ops.Length; i++)
+        {
+            ref PlanOp op = ref ops[i];
+
+            // Timing: record start tick before each op (skipped for untimed delegate)
+            if (emitTimings)
+                EmitTimingStart(il, startTickLocal);
+
+            // Resolve dispatch once per op — used by both IL emission and EXPLAIN.
+            var (src, fillMethod, andMethod, orMethod, andNotMethod) = op.Dispatch switch
+            {
+                MatchDispatch.PostingList => (
+                    $"ctx.TermSources[{op.ParamIndex}]",
+                    IlEmitterShared.CtxFillFromPostingSource, IlEmitterShared.CtxAndFromPostingSource, IlEmitterShared.CtxOrFillFromPostingSource, IlEmitterShared.CtxAndNotFromPostingSource),
+                MatchDispatch.TreeScan => (
+                    $"ctx.TermsProviders[{op.ParamIndex}]",
+                    IlEmitterShared.CtxFillFromTreeScan, IlEmitterShared.CtxAndFromTreeScan, IlEmitterShared.CtxOrFillFromTreeScan, IlEmitterShared.CtxAndNotFromTreeScan),
+                _ => (
+                    $"ctx.ResolvedMatches[{op.ParamIndex}]",
+                    IlEmitterShared.CtxFillFromMatch, IlEmitterShared.CtxAndFromMatch, (MethodInfo)IlEmitterShared.CtxOrFillFromMatch, IlEmitterShared.CtxAndNotFromMatch)
+            };
+
+            switch (op.Kind)
+            {
+                case PlanOpKind.FillFromPostings:
+                case PlanOpKind.DirectIterate:
+                    EmitCancellationCheck(il);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldc_I4, op.ParamIndex);
+                    il.Emit(OpCodes.Call, fillMethod);
+                    explain.AppendLine($"QueryPrimitives.CtxFill(ctx, paramIndex: {op.ParamIndex});  // bitmap[0] ← {src}");
+                    break;
+
+                case PlanOpKind.AndWithPostings:
+                    EmitCancellationCheck(il);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldc_I4, op.ParamIndex);
+                    il.Emit(OpCodes.Call, andMethod);
+                    explain.AppendLine($"QueryPrimitives.CtxAnd(ctx, paramIndex: {op.ParamIndex});  // bitmap[0] &= {src}");
+                    if (!op.SkipEarlyExit)
+                    {
+                        EmitLoadBitmapRef(il, 0);
+                        il.Emit(OpCodes.Call, IlEmitterShared.IsEmptyGetter);
+                        il.Emit(OpCodes.Brtrue, doneLabel);
+                        explain.AppendLine("if (bitmap[0].IsEmpty) goto Done;");
+                    }
+                    break;
+
+                case PlanOpKind.OrWithPostings:
+                case PlanOpKind.LazyOrWithPostings:
+                    EmitCancellationCheck(il);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldc_I4, op.ParamIndex);
+                    il.Emit(OpCodes.Ldc_I4, op.BitmapLocal);
+                    il.Emit(OpCodes.Call, orMethod);
+                    explain.AppendLine($"QueryPrimitives.CtxOr(ctx, paramIndex: {op.ParamIndex}, bitmapSlot: {op.BitmapLocal});  // bitmap[{op.BitmapLocal}] |= {src}");
+                    if (op.BitmapLocal == 0)
+                    {
+                        EmitLoadBitmapRef(il, 0);
+                        il.Emit(OpCodes.Call, IlEmitterShared.CountGetter);
+                        il.Emit(OpCodes.Conv_I8);
+                        EmitLoadLimit(il);
+                        il.Emit(OpCodes.Bge, doneLabel);
+                        explain.AppendLine("if (bitmap[0].Count >= limit) goto Done;");
+                    }
+                    break;
+
+                case PlanOpKind.ClearBitmap:
+                    EmitLoadBitmapRef(il, op.BitmapLocal);
+                    il.Emit(OpCodes.Call, IlEmitterShared.Clear);
+                    explain.AppendLine($"bitmap[{op.BitmapLocal}].Clear();");
+                    break;
+
+                case PlanOpKind.AndBitmaps:
+                    EmitLoadBitmapRef(il, op.BitmapLocal);
+                    EmitLoadBitmapRef(il, op.ParamIndex2);
+                    il.Emit(OpCodes.Call, IlEmitterShared.AndWith);
+                    explain.AppendLine($"bitmap[{op.BitmapLocal}].AndWith(bitmap[{op.ParamIndex2}]);  // bitmap[{op.BitmapLocal}] &= bitmap[{op.ParamIndex2}]");
+                    break;
+
+                case PlanOpKind.AndNotBitmaps:
+                    EmitLoadBitmapRef(il, op.BitmapLocal);
+                    EmitLoadBitmapRef(il, op.ParamIndex2);
+                    il.Emit(OpCodes.Call, IlEmitterShared.AndNotWith);
+                    explain.AppendLine($"bitmap[{op.BitmapLocal}].AndNotWith(bitmap[{op.ParamIndex2}]);  // bitmap[{op.BitmapLocal}] &= ~bitmap[{op.ParamIndex2}]");
+                    break;
+
+                case PlanOpKind.OrBitmaps:
+                    EmitLoadBitmapRef(il, op.BitmapLocal);
+                    EmitLoadBitmapRef(il, op.ParamIndex2);
+                    il.Emit(OpCodes.Call, IlEmitterShared.LazyOrWith);
+                    needsLazyRepair = true;
+                    explain.AppendLine($"bitmap[{op.BitmapLocal}].LazyOrWith(bitmap[{op.ParamIndex2}]);  // lazy OR (cardinality repaired later)");
+                    break;
+
+                case PlanOpKind.SwapBitmaps:
+                    EmitLoadBitmapRef(il, op.BitmapLocal);
+                    EmitLoadBitmapRef(il, op.ParamIndex2);
+                    il.Emit(OpCodes.Call, IlEmitterShared.SwapContents);
+                    explain.AppendLine($"bitmap[{op.BitmapLocal}].SwapContents(bitmap[{op.ParamIndex2}]);");
+                    break;
+
+                case PlanOpKind.CheckEmpty:
+                    EmitLoadBitmapRef(il, op.BitmapLocal);
+                    il.Emit(OpCodes.Call, IlEmitterShared.IsEmptyGetter);
+                    il.Emit(OpCodes.Brtrue, doneLabel);
+                    explain.AppendLine($"if (bitmap[{op.BitmapLocal}].IsEmpty) goto Done;");
+                    break;
+
+                case PlanOpKind.AndNotWithPostings:
+                    EmitCancellationCheck(il);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldc_I4, op.ParamIndex);
+                    il.Emit(OpCodes.Call, andNotMethod);
+                    explain.AppendLine($"QueryPrimitives.CtxAndNot(ctx, paramIndex: {op.ParamIndex});  // bitmap[0] &= ~{src}");
+                    break;
+
+                case PlanOpKind.RepairAfterLazy:
+                    EmitLoadBitmapRef(il, 0);
+                    il.Emit(OpCodes.Call, IlEmitterShared.RepairAfterLazy);
+                    explain.AppendLine("bitmap[0].RepairAfterLazy();  // fix lazy cardinalities from LazyOrWith");
+                    break;
+
+                case PlanOpKind.CheckAndMaybeEntryScan:
+                {
+                    hasEntryScan = true;
+                    entryScanOpIndex = i;
+
+                    EmitLoadBitmapRef(il, 0);
+                    il.Emit(OpCodes.Call, IlEmitterShared.CountGetter);
+                    il.Emit(OpCodes.Conv_I8);
+                    EmitLoadMatch(il, op.ParamIndex);
+                    il.Emit(OpCodes.Callvirt, IlEmitterShared.MatchCountGetter);
+                    il.Emit(OpCodes.Call, IlEmitterShared.ShouldSwitchToEntryScan);
+                    il.Emit(OpCodes.Brtrue, entryScanLabel);
+                    explain.AppendLine($"if (QueryPrimitives.ShouldSwitchToEntryScan(bitmap[0].Count, {src}.Count))");
+                    explain.AppendLine($"    goto EntryScan;  // bitmap[0] is small, walk entries instead of decoding posting list");
+                    break;
+                }
+
+                case PlanOpKind.OrRange:
+                {
+                    int start = op.ParamIndex;
+                    int rangeIdx = op.ParamIndex2;
+                    var loopVar = il.DeclareLocal(typeof(int));
+                    var endVar = il.DeclareLocal(typeof(int));
+                    var loopCheck = il.DefineLabel();
+                    var loopBody = il.DefineLabel();
+
+                    il.Emit(OpCodes.Ldc_I4, start);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxInRangeCounts);
+                    IlEmitterShared.EmitLdcI4(il, rangeIdx);
+                    il.Emit(OpCodes.Ldelem_I4);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Stloc, endVar);
+
+                    EmitRangeEndIndexTouch(il, op.Dispatch, start, endVar);
+
+                    il.Emit(OpCodes.Ldc_I4, start);
+                    il.Emit(OpCodes.Stloc, loopVar);
+                    il.Emit(OpCodes.Br, loopCheck);
+
+                    il.MarkLabel(loopBody);
+                    EmitCancellationCheck(il);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldloc, loopVar);
+                    il.Emit(OpCodes.Ldc_I4, op.BitmapLocal);
+                    il.Emit(OpCodes.Call, orMethod);
+
+                    il.Emit(OpCodes.Ldloc, loopVar);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Stloc, loopVar);
+
+                    il.MarkLabel(loopCheck);
+                    il.Emit(OpCodes.Ldloc, loopVar);
+                    il.Emit(OpCodes.Ldloc, endVar);
+                    il.Emit(OpCodes.Blt, loopBody);
+
+                    explain.AppendLine($"// Range OR: ctx.InRangeCounts[{rangeIdx}] terms starting at index {start}");
+                    explain.AppendLine($"for (int j = {start}; j < {start} + ctx.InRangeCounts[{rangeIdx}]; j++)");
+                    explain.AppendLine($"    QueryPrimitives.CtxOr(ctx, j, bitmapSlot: {op.BitmapLocal});  // bitmap[{op.BitmapLocal}] |= ResolvedMatches[j]");
+                    break;
+                }
+
+                case PlanOpKind.AndRange:
+                {
+                    int start = op.ParamIndex;
+                    int rangeIdx = op.ParamIndex2;
+                    var loopVar = il.DeclareLocal(typeof(int));
+                    var endVar = il.DeclareLocal(typeof(int));
+                    var loopCheck = il.DefineLabel();
+                    var loopBody = il.DefineLabel();
+
+                    il.Emit(OpCodes.Ldc_I4, start);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxInRangeCounts);
+                    IlEmitterShared.EmitLdcI4(il, rangeIdx);
+                    il.Emit(OpCodes.Ldelem_I4);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Stloc, endVar);
+
+                    EmitRangeEndIndexTouch(il, op.Dispatch, start, endVar);
+
+                    il.Emit(OpCodes.Ldc_I4, start);
+                    il.Emit(OpCodes.Stloc, loopVar);
+                    il.Emit(OpCodes.Br, loopCheck);
+
+                    il.MarkLabel(loopBody);
+                    EmitCancellationCheck(il);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldloc, loopVar);
+                    il.Emit(OpCodes.Call, andMethod);
+
+                    if (!op.SkipEarlyExit)
+                    {
+                        EmitLoadBitmapRef(il, 0);
+                        il.Emit(OpCodes.Call, IlEmitterShared.IsEmptyGetter);
+                        il.Emit(OpCodes.Brtrue, doneLabel);
+                    }
+
+                    il.Emit(OpCodes.Ldloc, loopVar);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Stloc, loopVar);
+
+                    il.MarkLabel(loopCheck);
+                    il.Emit(OpCodes.Ldloc, loopVar);
+                    il.Emit(OpCodes.Ldloc, endVar);
+                    il.Emit(OpCodes.Blt, loopBody);
+
+                    explain.AppendLine($"// Range AND: ctx.InRangeCounts[{rangeIdx}] terms starting at index {start}");
+                    explain.AppendLine($"for (int j = {start}; j < {start} + ctx.InRangeCounts[{rangeIdx}]; j++)");
+                    explain.AppendLine($"{{");
+                    explain.AppendLine($"    QueryPrimitives.CtxAnd(ctx, j);  // bitmap[0] &= ResolvedMatches[j]");
+                    if (!op.SkipEarlyExit)
+                    {
+                        explain.AppendLine($"    if (bitmap[0].IsEmpty) goto Done;");
+                    }
+                    explain.AppendLine($"}}");
+                    break;
+                }
+
+                case PlanOpKind.IterateInto:
+                    il.Emit(OpCodes.Br, doneLabel);
+                    explain.AppendLine("goto Done;  // result ready in bitmap[0]");
+                    break;
+            }
+
+            // Timing: record elapsed time and result count after each op (skipped for untimed delegate)
+            if (emitTimings)
+                EmitTimingEnd(il, i, startTickLocal);
+        }
+
+        il.MarkLabel(doneLabel);
+        if (needsLazyRepair)
+        {
+            EmitLoadBitmapRef(il, 0);
+            il.Emit(OpCodes.Call, IlEmitterShared.RepairAfterLazy);
+            explain.AppendLine("bitmap[0].RepairAfterLazy();  // fix lazy cardinalities before returning");
+        }
+        il.Emit(OpCodes.Ret);
+
+        if (hasEntryScan)
+        {
+            il.MarkLabel(entryScanLabel);
+            explain.AppendLine();
+            explain.AppendLine("EntryScan:");
+            explain.AppendLine("// Per-entry scan path: walk bitmap[0] entries, check residual predicates,");
+            explain.AppendLine("// compact survivors into bitmap[1], then swap bitmap[0] ← bitmap[1].");
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4, entryScanOpIndex);
+            il.Emit(OpCodes.Stfld, IlEmitterShared.CtxEntryScanTakenAtOp);
+
+            il.Emit(OpCodes.Ldarg_0);
+            EmitLoadBitmapRef(il, 0);
+            EmitLoadBitmapRef(il, 1);
+            il.Emit(OpCodes.Call, IlEmitterShared.RunEntryScanMethod);
+
+            EmitLoadBitmapRef(il, 0);
+            EmitLoadBitmapRef(il, 1);
+            il.Emit(OpCodes.Call, IlEmitterShared.SwapContents);
+            EmitLoadBitmapRef(il, 1);
+            il.Emit(OpCodes.Call, IlEmitterShared.Clear);
+            il.Emit(OpCodes.Ret);
+        }
+        else
+        {
+            il.MarkLabel(entryScanLabel);
+            il.Emit(OpCodes.Ret);
+        }
+
+        explainSource = explain.ToString();
+        return (CompiledExecuteDelegate)dm.CreateDelegate(typeof(CompiledExecuteDelegate));
+    }
+
+    private static void EmitLoadBitmapRef(ILGenerator il, int slot)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxBitmaps);  // RoaringBitmap[]
+        IlEmitterShared.EmitLdcI4(il, slot);
+        il.Emit(OpCodes.Ldelema, typeof(RoaringBitmap)); // ref RoaringBitmap
+    }
+
+    private static void EmitLoadMatch(ILGenerator il, int index)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxResolvedMatches); // IQueryMatch[]
+        IlEmitterShared.EmitLdcI4(il, index);
+        il.Emit(OpCodes.Ldelem_Ref);                  // IQueryMatch
+    }
+
+    private static void EmitLoadLimit(ILGenerator il)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxLimit);
+    }
+
+    /// <summary>Emit: startTick = Stopwatch.GetTimestamp()</summary>
+    private static void EmitTimingStart(ILGenerator il, LocalBuilder startTickLocal)
+    {
+        il.Emit(OpCodes.Call, IlEmitterShared.GetTimestamp);
+        il.Emit(OpCodes.Stloc, startTickLocal);
+    }
+
+    /// <summary>Emit: IlEmitterShared.RecordTiming(ref ctx, opIndex, startTick); IlEmitterShared.RecordResultCount(ref ctx, opIndex);</summary>
+    private static void EmitTimingEnd(ILGenerator il, int opIndex, LocalBuilder startTickLocal)
+    {
+        il.Emit(OpCodes.Ldarg_0);         // ref ctx
+        IlEmitterShared.EmitLdcI4(il, opIndex);           // opIndex
+        il.Emit(OpCodes.Ldloc, startTickLocal); // startTick
+        il.Emit(OpCodes.Call, IlEmitterShared.RecordTiming);
+
+        il.Emit(OpCodes.Ldarg_0);
+        IlEmitterShared.EmitLdcI4(il, opIndex);
+        il.Emit(OpCodes.Call, IlEmitterShared.RecordResultCount);
+    }
+
+    private static void EmitCancellationCheck(ILGenerator il)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, IlEmitterShared.CtxToken);
+        il.Emit(OpCodes.Call, IlEmitterShared.ThrowIfCancelled);
+    }
+
+    /// <summary>Emit array-length validation hints at the start of the delegate.
+    /// Touch the maximum index of each array that will be accessed, so the JIT
+    /// can hoist bounds checks out of loops.</summary>
+    private static void EmitBoundsCheckPreamble(ILGenerator il, PlanOp[] ops)
+    {
+        int maxBitmapSlot = -1;
+        int maxMatchIndex = -1;
+        int maxTermSourceIndex = -1;
+        int maxTermsProviderIndex = -1;
+
+        for (int i = 0; i < ops.Length; i++)
+        {
+            ref PlanOp op = ref ops[i];
+
+            // Bitmap slots
+            if (op.BitmapLocal > maxBitmapSlot) maxBitmapSlot = op.BitmapLocal;
+            if (op.Kind is PlanOpKind.AndBitmaps or PlanOpKind.AndNotBitmaps or PlanOpKind.OrBitmaps or PlanOpKind.SwapBitmaps)
+            {
+                if (op.ParamIndex2 > maxBitmapSlot) maxBitmapSlot = op.ParamIndex2;
+            }
+            // FillFromPostings always uses bitmap[0]; And/AndNot use [0] and [1]
+            if (op.Kind is PlanOpKind.FillFromPostings or PlanOpKind.DirectIterate)
+            {
+                if (0 > maxBitmapSlot) maxBitmapSlot = 0;
+            }
+            if (op.Kind is PlanOpKind.AndWithPostings or PlanOpKind.AndNotWithPostings)
+            {
+                if (1 > maxBitmapSlot) maxBitmapSlot = 1;
+            }
+
+            // Source arrays. Skip OrRange / AndRange — their loop is bounded by
+            // ctx.InRangeCounts[rangeIdx] at runtime, so the static op.ParamIndex
+            // (the loop's start) may be past the resolved array length when the
+            // runtime range count is zero (e.g. an IN with only a null term, no
+            // typed terms). The per-iteration ldelem still performs bounds checks
+            // when the loop actually runs.
+            if (op.Kind is not (PlanOpKind.OrRange or PlanOpKind.AndRange))
+            {
+                switch (op.Dispatch)
+                {
+                    case MatchDispatch.QueryMatch:
+                        if (op.ParamIndex > maxMatchIndex) maxMatchIndex = op.ParamIndex;
+                        break;
+                    case MatchDispatch.PostingList:
+                        if (op.ParamIndex > maxTermSourceIndex) maxTermSourceIndex = op.ParamIndex;
+                        break;
+                    case MatchDispatch.TreeScan:
+                        if (op.ParamIndex > maxTermsProviderIndex) maxTermsProviderIndex = op.ParamIndex;
+                        break;
+                }
+            }
+
+            // CheckAndMaybeEntryScan uses DirectSources for the match count check
+            if (op.Kind == PlanOpKind.CheckAndMaybeEntryScan && op.ParamIndex > maxMatchIndex)
+                maxMatchIndex = op.ParamIndex;
+        }
+
+        // Touch _bitmaps[maxBitmapSlot] (RoaringBitmap is a value type, use ldelema)
+        if (maxBitmapSlot >= 0)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxBitmaps);
+            IlEmitterShared.EmitLdcI4(il, maxBitmapSlot);
+            il.Emit(OpCodes.Ldelema, typeof(RoaringBitmap));
+            il.Emit(OpCodes.Pop);
+        }
+
+        // Touch _resolvedMatches[maxMatchIndex]
+        if (maxMatchIndex >= 0)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxResolvedMatches);
+            IlEmitterShared.EmitLdcI4(il, maxMatchIndex);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Pop);
+        }
+
+        // Touch _termSources[maxTermSourceIndex]
+        if (maxTermSourceIndex >= 0)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxTermSources);
+            IlEmitterShared.EmitLdcI4(il, maxTermSourceIndex);
+            il.Emit(OpCodes.Ldelema, typeof(PostingSource));
+            il.Emit(OpCodes.Pop);
+        }
+
+        // Touch _termProviders[maxTermsProviderIndex]
+        if (maxTermsProviderIndex >= 0)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, IlEmitterShared.CtxTermsProviders);
+            IlEmitterShared.EmitLdcI4(il, maxTermsProviderIndex);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Pop);
+        }
+    }
+
+    private static void EmptyExecute(CompiledQueryMatch ctx) { }
+
+    /// <summary>Emit a bounds-check hint immediately after computing <paramref name="endVar"/>
+    /// (the exclusive upper bound of an OrRange / AndRange loop). Touches the source array
+    /// at <c>endVar - 1</c> so the JIT proves the array is at least <c>endVar</c> long;
+    /// per-iteration <c>ldelem</c> calls in the loop body can then elide bounds checks.
+    /// Guarded by <c>endVar != start</c> because when the runtime range count is zero the
+    /// static <paramref name="start"/> may be past the array length (see
+    /// EmitBoundsCheckPreamble for the explanation of why OrRange/AndRange are skipped there).
+    /// </summary>
+    private static void EmitRangeEndIndexTouch(ILGenerator il, MatchDispatch dispatch, int start, LocalBuilder endVar)
+    {
+        FieldInfo arrayField;
+        OpCode loadOp;
+        Type elementType;
+        switch (dispatch)
+        {
+            case MatchDispatch.PostingList:
+                arrayField = IlEmitterShared.CtxTermSources;
+                loadOp = OpCodes.Ldelema;
+                elementType = typeof(PostingSource);
+                break;
+            case MatchDispatch.TreeScan:
+                arrayField = IlEmitterShared.CtxTermsProviders;
+                loadOp = OpCodes.Ldelem_Ref;
+                elementType = null;
+                break;
+            default:
+                arrayField = IlEmitterShared.CtxResolvedMatches;
+                loadOp = OpCodes.Ldelem_Ref;
+                elementType = null;
+                break;
+        }
+
+        var skipTouch = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, endVar);
+        il.Emit(OpCodes.Ldc_I4, start);
+        il.Emit(OpCodes.Beq, skipTouch);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, arrayField);
+        il.Emit(OpCodes.Ldloc, endVar);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        if (elementType != null)
+            il.Emit(loadOp, elementType);
+        else
+            il.Emit(loadOp);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(skipTouch);
+    }
+}

--- a/src/Corax/Querying/Planning/ResidualScanIlEmitter.cs
+++ b/src/Corax/Querying/Planning/ResidualScanIlEmitter.cs
@@ -1,0 +1,464 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Corax.Querying.Matches;
+using Corax.Utils;
+using Voron;
+using Voron.Data.CompactTrees;
+
+namespace Corax.Querying.Planning;
+
+/// <summary>
+/// Emits IL for residual-predicate evaluation delegates used by both the entry-scan
+/// path (CompiledQueryMatch) and the direct-scan path (DirectScanMatch). A single
+/// delegate works against <see cref="IPredicateEvaluationContext"/>, which both
+/// context types implement. Per-predicate value type, compare op, AND/OR sub-groups,
+/// and fieldRootPages indexing are baked into IL at emit time.
+///
+/// The delegate ALWAYS evaluates ALL predicates baked into the IL, regardless of
+/// which path calls it. In the direct-scan case, the driving-clause predicates
+/// (already satisfied by the tree scan) are re-evaluated — this is redundant but
+/// harmless, and it eliminates the need for a separate delegate-per-path or a
+/// runtime predicate-count parameter. The extra cost is negligible: a handful
+/// of FindNext + compare operations per entry against already-cached stored fields.
+/// </summary>
+public static class ResidualScanIlEmitter
+{
+    /// <summary>Evaluates all baked-in scan predicates against each entry reader.
+    /// Passing entries are compacted to the front of <paramref name="entryIds"/>.
+    /// Both the entry-scan path (CompiledQueryMatch) and the direct-scan path
+    /// (DirectScanMatch) use the same delegate — the direct-scan path re-evaluates
+    /// driving-clause predicates that the tree scan already satisfied, which is
+    /// harmless — a few extra FindNext + compare operations per entry.</summary>
+    public delegate int ResidualScanPredicate(
+        IPredicateEvaluationContext ctx,
+        Span<EntryTermsReader> readers,
+        Span<long> entryIds,
+        Span<int> originalIndexes);
+
+
+
+    /// <summary>Emit a residual-scan delegate that evaluates <paramref name="predicates"/>
+    /// against each reader in the batch. Passing entry IDs and (optionally) original indexes
+    /// are compacted to the front of their spans. Returns the count of survivors.
+    /// The emitted IL always evaluates ALL predicates against every entry.
+    /// <paramref name="explainSource"/> receives a human-readable pseudocode description
+    /// of the predicates, matching the format used by <see cref="QueryILEmitter.EmitDelegate"/>.</summary>
+    public static ResidualScanPredicate EmitDelegate(ScanPredicateInfo[] predicates, out string explainSource)
+    {
+        if (predicates == null || predicates.Length == 0)
+        {
+            explainSource = "// No residual predicates";
+            return null;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("// Entry scan — residual predicate evaluation (emitted IL).");
+        for (int p = 0; p < predicates.Length; p++)
+        {
+            ref readonly var pred = ref predicates[p];
+            sb.Append($"//   [{p}] Field '{pred.FieldName}' {pred.ValueType} {pred.CompareOp}");
+            if (pred.SubPredicates != null)
+                sb.Append($" ({pred.Group} group, {pred.SubPredicates.Length} branches)");
+            sb.AppendLine($" at rootPage=[rootIdx]");
+        }
+        explainSource = sb.ToString();
+
+        var dm = new DynamicMethod(
+            "ResidualScan",
+            typeof(int),
+            [typeof(IPredicateEvaluationContext), typeof(Span<EntryTermsReader>), typeof(Span<long>), typeof(Span<int>)],
+            typeof(IPredicateEvaluationContext).Module,
+            skipVisibility: true)
+        {
+            InitLocals = false
+        };
+
+        var il = dm.GetILGenerator();
+
+        var iLocal = il.DeclareLocal(typeof(int));
+        var writeIdxLocal = il.DeclareLocal(typeof(int));
+        var lengthLocal = il.DeclareLocal(typeof(int));
+        var readerRefLocal = il.DeclareLocal(typeof(EntryTermsReader).MakeByRefType());
+        var origIdxLengthLocal = il.DeclareLocal(typeof(int));
+
+        il.Emit(OpCodes.Ldarga_S, (byte)2);
+        il.Emit(OpCodes.Call, IlEmitterShared.SpanLongLength);
+        il.Emit(OpCodes.Stloc, lengthLocal);
+
+        il.Emit(OpCodes.Ldarga_S, (byte)3);
+        il.Emit(OpCodes.Call, IlEmitterShared.SpanIntLength);
+        il.Emit(OpCodes.Stloc, origIdxLengthLocal);
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, writeIdxLocal);
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+
+        var loopCheck = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        var loopIncrement = il.DefineLabel();
+        var failLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Br, loopCheck);
+
+        il.MarkLabel(loopBody);
+
+        il.Emit(OpCodes.Ldarga_S, (byte)1);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Call, IlEmitterShared.SpanEntryTermsReaderGetItem);
+        il.Emit(OpCodes.Stloc, readerRefLocal);
+
+        int rootIdx = 0;
+        for (int p = 0; p < predicates.Length; p++)
+        {
+            EmitPredicate(il, in predicates[p], failLabel, ref rootIdx, readerRefLocal);
+        }
+
+        // All passed: entryIds[writeIdx] = entryIds[i]
+        il.Emit(OpCodes.Ldarga_S, (byte)2);
+        il.Emit(OpCodes.Ldloc, writeIdxLocal);
+        il.Emit(OpCodes.Call, IlEmitterShared.SpanLongGetItem);
+        il.Emit(OpCodes.Ldarga_S, (byte)2);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Call, IlEmitterShared.SpanLongGetItem);
+        il.Emit(OpCodes.Ldind_I8);
+        il.Emit(OpCodes.Stind_I8);
+
+        // originalIndexes compaction (only if span is non-empty — caller decides)
+        il.Emit(OpCodes.Ldarga_S, (byte)3);
+        il.Emit(OpCodes.Call, IlEmitterShared.SpanIntLength);
+        var noOrigIdx = il.DefineLabel();
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Brtrue, noOrigIdx);
+
+        // originalIndexes[writeIdx] = originalIndexes[i]
+        il.Emit(OpCodes.Ldarga_S, (byte)3);
+        il.Emit(OpCodes.Ldloc, writeIdxLocal);
+        il.Emit(OpCodes.Call, IlEmitterShared.SpanIntGetItem);
+        il.Emit(OpCodes.Ldarga_S, (byte)3);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Call, IlEmitterShared.SpanIntGetItem);
+        il.Emit(OpCodes.Ldind_I4);
+        il.Emit(OpCodes.Stind_I4);
+
+        il.MarkLabel(noOrigIdx);
+
+        il.Emit(OpCodes.Ldloc, writeIdxLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, writeIdxLocal);
+        il.Emit(OpCodes.Br, loopIncrement);
+
+        il.MarkLabel(failLabel);
+
+        il.MarkLabel(loopIncrement);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+
+        il.MarkLabel(loopCheck);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, lengthLocal);
+        il.Emit(OpCodes.Blt, loopBody);
+
+        il.Emit(OpCodes.Ldloc, writeIdxLocal);
+        il.Emit(OpCodes.Ret);
+
+        return (ResidualScanPredicate)dm.CreateDelegate(typeof(ResidualScanPredicate));
+    }
+
+    private static void EmitPredicate(
+        ILGenerator il,
+        in ScanPredicateInfo pred,
+        Label failLabel,
+        ref int rootIdx,
+        LocalBuilder readerRefLocal)
+    {
+        if (pred.SubPredicates != null)
+        {
+            if (pred.Group == GroupKind.Or)
+            {
+                var groupPassed = il.DefineLabel();
+                for (int b = 0; b < pred.SubPredicates.Length; b++)
+                {
+                    var nextSub = il.DefineLabel();
+                    EmitLeafPredicate(il, in pred.SubPredicates[b], nextSub, rootIdx, readerRefLocal);
+                    il.Emit(OpCodes.Br, groupPassed);
+                    il.MarkLabel(nextSub);
+                    rootIdx++;
+                }
+                il.Emit(OpCodes.Br, failLabel);
+                il.MarkLabel(groupPassed);
+            }
+            else
+            {
+                for (int b = 0; b < pred.SubPredicates.Length; b++)
+                {
+                    EmitLeafPredicate(il, in pred.SubPredicates[b], failLabel, rootIdx, readerRefLocal);
+                    rootIdx++;
+                }
+            }
+            return;
+        }
+
+        EmitLeafPredicate(il, in pred, failLabel, rootIdx, readerRefLocal);
+        rootIdx++;
+    }
+
+    private static void EmitLeafPredicate(
+        ILGenerator il,
+        in ScanPredicateInfo pred,
+        Label failLabel,
+        int rootIdx,
+        LocalBuilder readerRefLocal)
+    {
+        var nextPredicate = il.DefineLabel();
+        var foundLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldloc, readerRefLocal);
+        il.Emit(OpCodes.Call, IlEmitterShared.ReaderReset);
+
+        // FindNext(ctx.ResidualFieldRootPages[rootIdx])
+        il.Emit(OpCodes.Ldloc, readerRefLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, IlEmitterShared.CtxFieldRootPages);
+        IlEmitterShared.EmitLdcI4(il, rootIdx);
+        il.Emit(OpCodes.Ldelem_I8);
+        il.Emit(OpCodes.Call, IlEmitterShared.ReaderFindNext);
+
+        switch (pred.CompareOp)
+        {
+            case ScanCompareOp.Exists:
+                il.Emit(OpCodes.Brfalse, failLabel);
+                il.Emit(OpCodes.Br, nextPredicate);
+                break;
+
+            case ScanCompareOp.NotEqual:
+                il.Emit(OpCodes.Brtrue, foundLabel);
+                il.Emit(OpCodes.Br, nextPredicate);
+                il.MarkLabel(foundLabel);
+                EmitTypedComparison(il, in pred, rootIdx, readerRefLocal);
+                il.Emit(OpCodes.Brtrue, failLabel);
+                break;
+
+            default:
+                il.Emit(OpCodes.Brfalse, failLabel);
+                EmitTypedComparison(il, in pred, rootIdx, readerRefLocal);
+                il.Emit(OpCodes.Brfalse, failLabel);
+                break;
+        }
+
+        il.MarkLabel(nextPredicate);
+    }
+
+    private static void EmitTypedComparison(
+        ILGenerator il,
+        in ScanPredicateInfo pred,
+        int rootIdx,
+        LocalBuilder readerRefLocal)
+    {
+        _ = rootIdx;
+
+        if (pred.CompareOp == ScanCompareOp.StartsWith)
+        {
+            // Multi-term: iterate ALL field terms — correct for both entry-scan and direct-scan
+            il.Emit(OpCodes.Ldloc, readerRefLocal);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, IlEmitterShared.CtxFieldRootPages);
+            IlEmitterShared.EmitLdcI4(il, rootIdx);
+            il.Emit(OpCodes.Ldelem_I8);
+            EmitLoadSliceSpan(il, pred.ParamIndex);
+            il.Emit(OpCodes.Call, IlEmitterShared.CheckFieldTermStartsWith);
+            return;
+        }
+
+        if (pred.CompareOp == ScanCompareOp.EndsWith)
+        {
+            il.Emit(OpCodes.Ldloc, readerRefLocal);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, IlEmitterShared.CtxFieldRootPages);
+            IlEmitterShared.EmitLdcI4(il, rootIdx);
+            il.Emit(OpCodes.Ldelem_I8);
+            EmitLoadSliceSpan(il, pred.ParamIndex);
+            il.Emit(OpCodes.Call, IlEmitterShared.CheckFieldTermEndsWith);
+            return;
+        }
+
+        switch (pred.ValueType)
+        {
+            case ScanValueType.Long:
+            {
+                if (pred.CompareOp == ScanCompareOp.Between)
+                {
+                    var fail = il.DefineLabel();
+                    var done = il.DefineLabel();
+                    EmitLoadReaderCurrentLong(il, readerRefLocal);
+                    EmitLoadLongParam(il, pred.ParamIndex);
+                    il.Emit(OpCodes.Blt, fail);
+                    EmitLoadReaderCurrentLong(il, readerRefLocal);
+                    EmitLoadLongParam(il, pred.ParamIndex2);
+                    il.Emit(OpCodes.Bgt, fail);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Br, done);
+                    il.MarkLabel(fail);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.MarkLabel(done);
+                    break;
+                }
+                EmitLoadReaderCurrentLong(il, readerRefLocal);
+                EmitLoadLongParam(il, pred.ParamIndex);
+                EmitNumericCompareOp(il, pred.CompareOp);
+                break;
+            }
+
+            case ScanValueType.Double:
+            {
+                if (pred.CompareOp == ScanCompareOp.Between)
+                {
+                    var fail = il.DefineLabel();
+                    var done = il.DefineLabel();
+                    EmitLoadReaderCurrentDouble(il, readerRefLocal);
+                    EmitLoadDoubleParam(il, pred.ParamIndex);
+                    il.Emit(OpCodes.Blt_Un, fail);
+                    EmitLoadReaderCurrentDouble(il, readerRefLocal);
+                    EmitLoadDoubleParam(il, pred.ParamIndex2);
+                    il.Emit(OpCodes.Bgt_Un, fail);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Br, done);
+                    il.MarkLabel(fail);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.MarkLabel(done);
+                    break;
+                }
+                EmitLoadReaderCurrentDouble(il, readerRefLocal);
+                EmitLoadDoubleParam(il, pred.ParamIndex);
+                EmitNumericCompareOp(il, pred.CompareOp);
+                break;
+            }
+
+            case ScanValueType.Slice:
+            {
+                if (pred.CompareOp == ScanCompareOp.Between)
+                {
+                    var fail = il.DefineLabel();
+                    var done = il.DefineLabel();
+                    EmitLoadReaderDecodedSlice(il, readerRefLocal);
+                    EmitLoadSliceSpan(il, pred.ParamIndex);
+                    il.Emit(OpCodes.Call, IlEmitterShared.SequenceCompareTo);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Blt, fail);
+                    EmitLoadReaderDecodedSlice(il, readerRefLocal);
+                    EmitLoadSliceSpan(il, pred.ParamIndex2);
+                    il.Emit(OpCodes.Call, IlEmitterShared.SequenceCompareTo);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Bgt, fail);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Br, done);
+                    il.MarkLabel(fail);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.MarkLabel(done);
+                    break;
+                }
+                if (pred.CompareOp == ScanCompareOp.Equal || pred.CompareOp == ScanCompareOp.NotEqual)
+                {
+                    EmitLoadReaderDecodedSlice(il, readerRefLocal);
+                    EmitLoadSliceSpan(il, pred.ParamIndex);
+                    il.Emit(OpCodes.Call, IlEmitterShared.SequenceEqual);
+                    break;
+                }
+                EmitLoadReaderDecodedSlice(il, readerRefLocal);
+                EmitLoadSliceSpan(il, pred.ParamIndex);
+                il.Emit(OpCodes.Call, IlEmitterShared.SequenceCompareTo);
+                il.Emit(OpCodes.Ldc_I4_0);
+                EmitNumericCompareOp(il, pred.CompareOp);
+                break;
+            }
+
+            default:
+                il.Emit(OpCodes.Ldc_I4_0);
+                break;
+        }
+    }
+
+    private static void EmitNumericCompareOp(ILGenerator il, ScanCompareOp op)
+    {
+        switch (op)
+        {
+            case ScanCompareOp.Equal:
+            case ScanCompareOp.NotEqual:
+                il.Emit(OpCodes.Ceq);
+                break;
+            case ScanCompareOp.GreaterThan:
+                il.Emit(OpCodes.Cgt);
+                break;
+            case ScanCompareOp.GreaterThanOrEqual:
+                il.Emit(OpCodes.Clt);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ceq);
+                break;
+            case ScanCompareOp.LessThan:
+                il.Emit(OpCodes.Clt);
+                break;
+            case ScanCompareOp.LessThanOrEqual:
+                il.Emit(OpCodes.Cgt);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ceq);
+                break;
+            default:
+                il.Emit(OpCodes.Pop);
+                il.Emit(OpCodes.Pop);
+                il.Emit(OpCodes.Ldc_I4_0);
+                break;
+        }
+    }
+
+    private static void EmitLoadReaderCurrentLong(ILGenerator il, LocalBuilder readerRefLocal)
+    {
+        il.Emit(OpCodes.Ldloc, readerRefLocal);
+        il.Emit(OpCodes.Ldfld, IlEmitterShared.ReaderCurrentLong);
+    }
+
+    private static void EmitLoadReaderCurrentDouble(ILGenerator il, LocalBuilder readerRefLocal)
+    {
+        il.Emit(OpCodes.Ldloc, readerRefLocal);
+        il.Emit(OpCodes.Ldfld, IlEmitterShared.ReaderCurrentDouble);
+    }
+
+    private static void EmitLoadReaderDecodedSlice(ILGenerator il, LocalBuilder readerRefLocal)
+    {
+        il.Emit(OpCodes.Ldloc, readerRefLocal);
+        il.Emit(OpCodes.Ldfld, IlEmitterShared.ReaderCurrent);
+        il.Emit(OpCodes.Callvirt, IlEmitterShared.CompactKeyDecoded);
+    }
+
+    private static void EmitLoadLongParam(ILGenerator il, int index)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, IlEmitterShared.CtxLongParams);
+        IlEmitterShared.EmitLdcI4(il, index);
+        il.Emit(OpCodes.Ldelem_I8);
+    }
+
+    private static void EmitLoadDoubleParam(ILGenerator il, int index)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, IlEmitterShared.CtxDoubleParams);
+        IlEmitterShared.EmitLdcI4(il, index);
+        il.Emit(OpCodes.Ldelem_R8);
+    }
+
+    private static void EmitLoadSliceSpan(ILGenerator il, int paramIndex)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, IlEmitterShared.CtxSliceParams);
+        IlEmitterShared.EmitLdcI4(il, paramIndex);
+        il.Emit(OpCodes.Ldelema, typeof(Slice));
+        il.Emit(OpCodes.Call, IlEmitterShared.SliceAsReadOnlySpan);
+    }
+
+}

--- a/src/Corax/Querying/Planning/ScanCompareOp.cs
+++ b/src/Corax/Querying/Planning/ScanCompareOp.cs
@@ -1,0 +1,18 @@
+namespace Corax.Querying.Planning;
+
+public enum ScanCompareOp : byte
+{
+    Equal,
+    NotEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+    Between,
+    /// <summary>Field exists — reader.FindNext succeeds. No value comparison.</summary>
+    Exists,
+    /// <summary>StartsWith — reader term starts with the param slice. Iterate all terms for multi-value fields.</summary>
+    StartsWith,
+    /// <summary>EndsWith — reader term ends with the param slice.</summary>
+    EndsWith,
+}

--- a/src/Corax/Querying/Planning/ScanPredicateInfo.cs
+++ b/src/Corax/Querying/Planning/ScanPredicateInfo.cs
@@ -1,0 +1,30 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Distinguishes AND-group vs OR-group when <see cref="ScanPredicateInfo.SubPredicates"/>
+/// is non-null. Ignored for leaf predicates (SubPredicates == null).</summary>
+public enum GroupKind : byte
+{
+    And,
+    Or
+}
+
+/// <summary>One entry-scan predicate. Numeric predicates emit an IL-inlined compare
+/// against ctx.ResidualLongParams[ParamIndex] / ResidualDoubleParams[...];
+/// slice predicates emit an inline byte-sequence comparison. Between uses both
+/// ParamIndex slots.
+/// SubPredicates field is non-null for OR-group and AND-group predicates;
+/// <see cref="Group"/> picks which.</summary>
+public struct ScanPredicateInfo
+{
+    public string FieldName;
+    public ScanValueType ValueType;
+    public ScanCompareOp CompareOp;
+    public int ParamIndex;
+    public int ParamIndex2;
+    /// <summary>Sub-predicates for OR-group or AND-group compound predicates.
+    /// For OR: pass if ANY sub-predicate passes. For AND: pass if ALL pass.
+    /// <see cref="Group"/> discriminates.</summary>
+    public ScanPredicateInfo[] SubPredicates;
+    /// <summary>Valid only when <see cref="SubPredicates"/> is non-null.</summary>
+    public GroupKind Group;
+}

--- a/src/Corax/Querying/Planning/ScanValueType.cs
+++ b/src/Corax/Querying/Planning/ScanValueType.cs
@@ -1,0 +1,8 @@
+namespace Corax.Querying.Planning;
+
+public enum ScanValueType : byte
+{
+    Long,    // reader.CurrentLong vs ctx.ResidualLongParams[i]
+    Double,  // reader.CurrentDouble vs ctx.ResidualDoubleParams[i]
+    Slice,   // IL-emitted byte-sequence comparison
+}

--- a/src/Corax/Querying/Planning/SpatialFilterOp.cs
+++ b/src/Corax/Querying/Planning/SpatialFilterOp.cs
@@ -1,0 +1,11 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Spatial predicate applied after the bitmap filter phase. ANDs the spatial
+/// match result with the candidate bitmap to remove non-matching entries.
+/// MatchIndex is the slot in the resolved IQueryMatch[] for this post-filter.</summary>
+public struct SpatialFilterOp
+{
+    public int MatchIndex;
+    public ClauseInfo Clause;
+    public ClauseExecution Exec;
+}

--- a/src/Corax/Querying/Planning/SpatialOperationType.cs
+++ b/src/Corax/Querying/Planning/SpatialOperationType.cs
@@ -1,0 +1,11 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Spatial operation type. Corax-side equivalent of the Raven.Server
+/// MethodType enum — only the spatial operations.</summary>
+public enum SpatialOperationType : byte
+{
+    Within,
+    Contains,
+    Disjoint,
+    Intersects
+}

--- a/src/Corax/Querying/Planning/SpatialParams.cs
+++ b/src/Corax/Querying/Planning/SpatialParams.cs
@@ -1,0 +1,18 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Per-execution spatial query parameters. Resolved from ParameterBinding during
+/// PopulateClauseValues — scalar params looked up by name in the blittable.
+/// Shape construction (spatialField.ReadCircle / ReadShape) also runs at execution time
+/// because it needs the spatial field factory from builderParameters.</summary>
+public sealed class SpatialParams
+{
+    public double DistanceErrorPct = -1; // -1 = use default
+    public SpatialShapeType ShapeType;
+    // Circle parameters
+    public double CircleRadius;
+    public double CircleLatitude;
+    public double CircleLongitude;
+    // WKT parameter
+    public string Wkt;
+    public Utils.Spatial.SpatialUnits? Units;
+}

--- a/src/Corax/Querying/Planning/SpatialShapeType.cs
+++ b/src/Corax/Querying/Planning/SpatialShapeType.cs
@@ -1,0 +1,7 @@
+﻿namespace Corax.Querying.Planning;
+
+public enum SpatialShapeType : byte
+{
+    Circle,
+    Wkt
+}

--- a/src/Corax/Querying/Planning/VectorParams.cs
+++ b/src/Corax/Querying/Planning/VectorParams.cs
@@ -1,0 +1,15 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Per-execution vector query parameters. Resolved from ParameterBinding during
+/// PopulateClauseValues — scalar params from blittable lookup, vector payload passed
+/// through as-is. Embedding construction (base64 decode, AI embedding generation)
+/// also runs at execution time.</summary>
+public sealed class VectorParams
+{
+    public float MinimumMatch = -1;      // -1 = use index default
+    public int NumberOfCandidates = -1;  // -1 = use index default
+    public object ResolvedValue;         // the raw vector parameter (string, BlittableJsonReaderArray, etc.)
+    public ParamValueType ResolvedValueType;
+    public VectorSourceKind Method;      // which embedding method, if any
+    public string AiTaskName;            // AI task identifier for embedding.text
+}

--- a/src/Corax/Querying/Planning/VectorSearchOp.cs
+++ b/src/Corax/Querying/Planning/VectorSearchOp.cs
@@ -1,0 +1,10 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Vector nearest-neighbor search applied after the bitmap filter phase.
+/// The bitmap-producing match is passed as the filter source to VectorSearchMatch,
+/// restricting the search to the candidate set.</summary>
+public struct VectorSearchOp
+{
+    public ClauseInfo Clause;
+    public ClauseExecution Exec;
+}

--- a/src/Corax/Querying/Planning/VectorSourceKind.cs
+++ b/src/Corax/Querying/Planning/VectorSourceKind.cs
@@ -1,0 +1,9 @@
+namespace Corax.Querying.Planning;
+
+/// <summary>Where the vector data for a vector.search() query comes from.</summary>
+public enum VectorSourceKind : byte
+{
+    Inline,         // direct value or embedding.forRaw — vector data provided in the query
+    FromDocument,   // embedding.forDoc(docId) — vector copied from another document
+    FromText,       // embedding.text(text, ai.task(task)) — server generates embedding from text
+}

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Inspection.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Inspection.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Planning;
+
+namespace Raven.Server.Documents.Indexes.Persistence.Corax;
+
+/// <summary>
+/// Diagnostic / inspection methods for the compiled query plan.
+/// Builds the Studio-facing QueryInspectionNode tree from the cached
+/// InspectionTemplate plus runtime telemetry (timings, row counts,
+/// entry-scan triggers).
+/// </summary>
+internal static partial class QueryPlanBuilder
+{
+    /// <summary>Build the inspection graph from the cached template and runtime telemetry.</summary>
+    public static QueryInspectionNode BuildInspectionGraph(CompiledPlan compiledPlan, IQueryMatch executedMatch, IQueryMatch sortingWrapper = null)
+    {
+        long[] timings = null;
+        long[] resultCounts = null;
+        int entryScanAt = -1;
+        long scannedEntries = -1;
+
+        if (executedMatch is CompiledQueryMatch compiled)
+        {
+            compiled.GetTelemetry(out timings, out resultCounts, out entryScanAt);
+            scannedEntries = compiled.Count;
+        }
+
+        double tickFreq = Stopwatch.Frequency / 1000.0;
+        var template = compiledPlan.InspectionTemplate;
+        if (template == null || template.Length == 0)
+            return executedMatch.Inspect();
+
+        var rootParams = new Dictionary<string, string>();
+        if (scannedEntries >= 0)
+            rootParams["ScannedEntries"] = scannedEntries.ToString();
+        if (compiledPlan.ExplainSource != null)
+            rootParams["Explain"] = compiledPlan.ExplainSource;
+
+        var root = new QueryInspectionNode("CompiledQuery", parameters: rootParams);
+        QueryInspectionNode orGroupNode = null;
+
+        for (int i = 0; i < template.Length; i++)
+        {
+            var t = template[i];
+
+            // For queries like: WHERE (A AND B) OR (C AND D)
+            // the plan ops are:
+            //   ClearBitmap[2]           <- prepare scratch
+            //   SwapBitmaps[0,2]         <- save main, work in scratch  -> InsideAndGroup = true
+            //   FillFromPostings(A)      <- first AND-group
+            //   AndWithPostings(B)       <-
+            //   OrBitmaps[0,2]           <- merge scratch into main     -> InsideAndGroup = false
+            //   ClearBitmap[2]
+            //   SwapBitmaps[0,2]         <- second AND-group            -> InsideAndGroup = true
+            //   FillFromPostings(C)      <-
+            //   AndWithPostings(D)       <-
+            //   OrBitmaps[0,2]           <- merge                      -> InsideAndGroup = false
+            //
+            // The inspection tree groups these into:
+            //   CompiledQuery
+            //     AND-Group
+            //       Fill(A)
+            //       AND(B)
+            //     AND-Group
+            //       Fill(C)
+            //       AND(D)
+            if (t.InsideAndGroup && orGroupNode == null)
+                orGroupNode = new QueryInspectionNode("AND-Group");
+            else if (!t.InsideAndGroup && orGroupNode != null)
+            {
+                root.Children.Add(orGroupNode);
+                orGroupNode = null;
+            }
+
+            var parameters = new Dictionary<string, string>();
+            if (t.Dispatch != null) parameters["Dispatch"] = t.Dispatch;
+            if (t.FieldName != null) parameters["FieldName"] = t.FieldName;
+            if (t.Term != null) parameters["Term"] = t.Term;
+            if (t.Term2 != null) parameters["Term2"] = t.Term2;
+            if (t.ClauseType != null) parameters["ClauseType"] = t.ClauseType;
+            if (t.IsNegated) parameters["Negated"] = "true";
+            if (t.Terms != null) parameters["Terms"] = t.Terms;
+            if (t.EstimatedCardinality is > 0 and < long.MaxValue)
+                parameters["EstimatedRows"] = t.EstimatedCardinality.ToString("N0");
+
+            if (resultCounts != null && i < resultCounts.Length && resultCounts[i] > 0)
+                parameters["Count"] = resultCounts[i].ToString();
+            if (timings != null && i < timings.Length && timings[i] > 0)
+                parameters["Ms"] = (timings[i] / tickFreq).ToString("F3");
+            if (i == entryScanAt)
+                parameters["EntryScan"] = "triggered";
+
+            var node = new QueryInspectionNode(t.Name, parameters: parameters);
+            if (orGroupNode != null) orGroupNode.Children.Add(node);
+            else root.Children.Add(node);
+        }
+
+        if (orGroupNode != null) root.Children.Add(orGroupNode);
+
+        // Vector/spatial nodes from executed match
+        var matchInspection = executedMatch.Inspect();
+        AppendVectorNodes(matchInspection, root);
+
+        if (sortingWrapper != null)
+        {
+            var sortNode = sortingWrapper.Inspect();
+            sortNode.Children.Clear();
+            sortNode.Children.Add(root);
+            return sortNode;
+        }
+
+        return root;
+    }
+
+    private static void AppendVectorNodes(QueryInspectionNode source, QueryInspectionNode target)
+    {
+        if (source.Operation.Contains("VectorSearch") || source.Operation.Contains("Spatial"))
+        {
+            target.Children.Add(source);
+            return;
+        }
+        foreach (var child in source.Children)
+            AppendVectorNodes(child, target);
+    }
+
+    /// <summary>Build an inspection template from plan ops + clauses. Created once, cached.</summary>
+    private static InspectionOp[] BuildInspectionTemplate(QueryExecution plan)
+    {
+        var ops = plan.Ops;
+        if (ops == null || ops.Length == 0) return [];
+
+        var flatClauses = new List<(ClauseInfo Clause, ClauseExecution Exec)>();
+        if (plan.Clauses is { Count: > 0 } clauses)
+        {
+            var execs = plan.Executions;
+            for (int ci = 0; ci < clauses.Count; ci++)
+            {
+                var clause = clauses[ci];
+                var exec = execs != null && ci < execs.Length ? execs[ci] : null;
+                if (clause.ClauseType == ClauseType.OrGroup && clause.OrSubClauses != null)
+                {
+                    for (int si = 0; si < clause.OrSubClauses.Count; si++)
+                    {
+                        var subExec = exec?.OrSubExecutions != null && si < exec.OrSubExecutions.Length ? exec.OrSubExecutions[si] : null;
+                        flatClauses.Add((clause.OrSubClauses[si], subExec));
+                    }
+                }
+                else if (clause.ClauseType == ClauseType.AndGroup && clause.AndSubClauses != null)
+                {
+                    for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                    {
+                        var subExec = exec?.AndSubExecutions != null && si < exec.AndSubExecutions.Length ? exec.AndSubExecutions[si] : null;
+                        flatClauses.Add((clause.AndSubClauses[si], subExec));
+                    }
+                }
+                else if (clause.ClauseType is ClauseType.In or ClauseType.AllIn && exec != null && exec.InTermCount > 0)
+                {
+                    var p = exec.PackedParamValue;
+                    for (int t = 0; t < exec.InTermCount; t++)
+                    {
+                        var termExec = new ClauseExecution { PackedParamValue = new PackedParam(p.ValueType, p.Param1 + t) };
+                        flatClauses.Add((new ClauseInfo
+                        {
+                            FieldName = clause.FieldName,
+                            ClauseType = clause.ClauseType,
+                            IsNegated = clause.IsNegated
+                        }, termExec));
+                    }
+                }
+                else
+                    flatClauses.Add((clause, exec));
+            }
+        }
+
+        var result = new List<InspectionOp>();
+        bool insideAndGroup = false;
+        for (int i = 0; i < ops.Length; i++)
+        {
+            ref PlanOp op = ref ops[i];
+            // OR chains like: (A AND B) OR (C AND D)
+            // are compiled as:
+            //   SwapBitmaps       <- save bitmap[0], start fresh in bitmap[2]
+            //   Fill(A)           <- these ops form an AND-group
+            //   And(B)            <-
+            //   OrBitmaps         <- merge bitmap[2] into bitmap[0]
+            //   SwapBitmaps       <- start next AND-group
+            //   Fill(C)           <-
+            //   And(D)            <-
+            //   OrBitmaps         <- merge
+            // SwapBitmaps marks the start of an AND-group within the OR chain.
+            // OrBitmaps marks the end — it merges the group result back.
+            if (op.Kind == PlanOpKind.SwapBitmaps) { insideAndGroup = true; continue; }
+            if (op.Kind == PlanOpKind.OrBitmaps) { insideAndGroup = false; continue; }
+            if (op.Kind is PlanOpKind.ClearBitmap or PlanOpKind.CheckEmpty or PlanOpKind.RepairAfterLazy or PlanOpKind.IterateInto) continue;
+
+            var inspOp = new InspectionOp
+            {
+                Name = op.Kind switch
+                {
+                    PlanOpKind.FillFromPostings or PlanOpKind.DirectIterate => "Fill",
+                    PlanOpKind.AndWithPostings => "AND",
+                    PlanOpKind.OrWithPostings or PlanOpKind.LazyOrWithPostings => "OR",
+                    PlanOpKind.AndNotWithPostings => "ANDNOT",
+                    PlanOpKind.AndBitmaps => "AND-Bitmaps",
+                    PlanOpKind.AndNotBitmaps => "ANDNOT-Bitmaps",
+                    PlanOpKind.CheckAndMaybeEntryScan => "EntryScanCheck",
+                    PlanOpKind.OrRange => $"OR-Range({op.ParamIndex2} terms)",
+                    PlanOpKind.AndRange => $"AND-Range({op.ParamIndex2} terms)",
+                    _ => op.Kind.ToString()
+                },
+                Dispatch = op.Dispatch switch { MatchDispatch.PostingList => "Term", MatchDispatch.TreeScan => "MultiTerm", _ => "Match" },
+                EstimatedCardinality = op.EstimatedCardinality,
+                InsideAndGroup = insideAndGroup
+            };
+
+            if (op.ParamIndex >= 0 && op.ParamIndex < flatClauses.Count)
+            {
+                var (clause, exec) = flatClauses[op.ParamIndex];
+                if (clause != null)
+                {
+                    var packed = exec?.PackedParamValue ?? PackedParam.None;
+                    int inTermCount = exec?.InTermCount ?? 0;
+                    inspOp.FieldName = clause.FieldName;
+                    inspOp.Term = FormatValueFromPlan(packed, plan);
+                    inspOp.Term2 = FormatValue2FromPlan(packed, plan);
+                    inspOp.IsNegated = clause.IsNegated;
+                    if (clause.ClauseType != ClauseType.Equals) inspOp.ClauseType = clause.ClauseType.ToString();
+                    if (inTermCount > 0)
+                    {
+                        var p = packed;
+                        int displayCount = Math.Min(inTermCount, 5);
+                        var displayTerms = new string[displayCount];
+                        for (int t = 0; t < displayCount; t++)
+                            displayTerms[t] = FormatValueFromPlan(new PackedParam(p.ValueType, p.Param1 + t), plan);
+                        inspOp.Terms = string.Join(", ", displayTerms) + (inTermCount > 5 ? $" ... ({inTermCount} total)" : "");
+                    }
+                }
+            }
+
+            result.Add(inspOp);
+        }
+
+        return result.ToArray();
+    }
+}

--- a/test/FastTests/Corax/CompiledQueryBenchmark.cs
+++ b/test/FastTests/Corax/CompiledQueryBenchmark.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// End-to-end comparison benchmark: old streaming path vs bitmap path.
+/// Runs the same queries through the full RavenDB server with and without
+/// the bitmap pipeline enabled. Outputs timing comparison.
+/// </summary>
+public class CompiledQueryBenchmark : RavenTestBase
+{
+    public CompiledQueryBenchmark(Xunit.ITestOutputHelper output) : base(output) { }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying, Skip = "Benchmark — too slow for CI. Run manually.")]
+    public async Task CompareStreamingVsBitmap()
+    {
+        const int docCount = 10_000;
+        const int warmup = 3;
+        const int iterations = 50;
+
+        // Setup store
+        var optionsOld = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var storeOld = GetDocumentStore(optionsOld);
+        await SeedData(storeOld, docCount);
+
+        // Setup store (same configuration; both use the bitmap pipeline)
+        var optionsNew = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var storeNew = GetDocumentStore(optionsNew);
+        await SeedData(storeNew, docCount);
+
+        var queries = new (string name, string rql)[]
+        {
+            ("Term: Status=active", "from BenchDocs where Status = 'active'"),
+            ("AND: Status∩Category", "from BenchDocs where Status = 'active' and Category = 'cat-0'"),
+            ("OR: Cat0∪Cat1", "from BenchDocs where Category = 'cat-0' or Category = 'cat-1'"),
+            ("3-way AND", "from BenchDocs where Status = 'active' and Category = 'cat-0' and Tag = 'tag-0'"),
+            ("AND+Range", "from BenchDocs where Category = 'cat-0' and Price > 500"),
+            ("Mixed (OR)∩AND", "from BenchDocs where (Category = 'cat-0' or Category = 'cat-1') and Status = 'active'"),
+            ("startsWith", "from BenchDocs where startsWith(Name, 'doc-000')"),
+            ("IN clause", "from BenchDocs where Category in ('cat-0', 'cat-1', 'cat-2')"),
+        };
+
+        Output.WriteLine($"{"Query",-35} {"Old (ms)",-12} {"Bitmap (ms)",-12} {"Speedup",-10} {"Results",-10}");
+        Output.WriteLine(new string('-', 80));
+
+        foreach (var (name, rql) in queries)
+        {
+            var (oldMs, oldCount) = await BenchQuery(storeOld, rql, warmup, iterations);
+            var (newMs, newCount) = await BenchQuery(storeNew, rql, warmup, iterations);
+
+            double speedup = oldMs / Math.Max(newMs, 0.001);
+            Output.WriteLine($"{name,-35} {oldMs,8:F2}ms {newMs,8:F2}ms {speedup,8:F2}x {oldCount,8}");
+
+            // Results should match
+            Assert.Equal(oldCount, newCount);
+        }
+    }
+
+    private async Task<(double avgMs, int resultCount)> BenchQuery(IDocumentStore store, string rql, int warmup, int iterations)
+    {
+        // Warmup
+        for (int w = 0; w < warmup; w++)
+        {
+            using var session = store.OpenAsyncSession();
+            await session.Advanced.AsyncRawQuery<dynamic>(rql).ToListAsync();
+        }
+
+        // Measure
+        var times = new double[iterations];
+        int count = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            using var session = store.OpenAsyncSession();
+            var results = await session.Advanced.AsyncRawQuery<dynamic>(rql).ToListAsync();
+            sw.Stop();
+            times[i] = sw.Elapsed.TotalMilliseconds;
+            count = results.Count;
+        }
+
+        Array.Sort(times);
+        return (times.Average(), count);
+    }
+
+    private async Task SeedData(IDocumentStore store, int count)
+    {
+        for (int batch = 0; batch < count; batch += 1000)
+        {
+            using var session = store.OpenAsyncSession();
+            int end = Math.Min(batch + 1000, count);
+            for (int i = batch; i < end; i++)
+            {
+                await session.StoreAsync(new BenchDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}",
+                    Price = i * 3
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+    }
+
+    private class BenchDoc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public string Status { get; set; }
+        public string Tag { get; set; }
+        public int Price { get; set; }
+    }
+}


### PR DESCRIPTION
**[Partial PR 6/9 — Corax 2.0 query engine. Apply all 9 to reproduce branch HEAD.]**

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25281

### Additional description

Adds the plan-compilation layer that turns a Corax query plan into executable code:

- the plan data model under `src/Corax/Querying/Planning/`;
- the plan cache, keyed by `(queryText, OperandOrdering, TypeSignature, FullKinds)`;
- an IL emitter that compiles a plan into a single delegate;
- the runtime hosts for compiled plans (`CompiledQueryMatch`, `DirectScanMatch`);
- `QueryPlanBuilder.Inspection.cs` and a `CompiledQueryBenchmark` to make the compiled output observable.

The emitter is what replaces the role `BinaryMatch` used to play at runtime.

This PR is partial and depends on PRs 1–5/9. It is part of a 9-PR stack that together reproduce the `RavenDB-25281` branch HEAD.

### Type of change

- [x] New feature

### How risky is the change?

- [ ] Low
- [ ] Moderate
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
