### PR TITLE
RavenDB-25281 [8/9] Corax: clause resolution and compiled-query tests

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1,0 +1,3610 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Primitives;
+using Voron.Data.RoaringBitmaps;
+using Corax.Querying.Matches.SortingMatches.Meta;
+using Corax.Querying.Planning;
+using Corax.Mappings;
+using Corax.Utils;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Corax;
+using VectorOptions = Raven.Client.Documents.Indexes.Vector.VectorOptions;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
+using Raven.Server.Documents.Indexes.Persistence.Corax.QueryOptimizer;
+using Raven.Server.Documents.Indexes.VectorSearch;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.AST;
+using Spatial4n.Shapes;
+using Sparrow;
+using Sparrow.Json;
+using Constants = Corax.Constants;
+using RavenConstants = Raven.Client.Constants;
+using SpatialUnits = Raven.Client.Documents.Indexes.Spatial.SpatialUnits;
+using IndexSearcher = Corax.Querying.IndexSearcher;
+using SpatialRelation = Corax.Utils.Spatial.SpatialRelation;
+
+namespace Raven.Server.Documents.Indexes.Persistence.Corax;
+
+/// <summary>
+/// Per-execution resolution: compiles plans, resolves matches and term sources
+/// from clause metadata, extracts typed scan parameters, handles highlighting,
+/// sorting, and spatial/vector materialization.
+///
+/// Methods here run once per query execution (not cached).
+/// </summary>
+internal static partial class QueryPlanBuilder
+{
+    // ── Entry points ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Plan → compile → resolve pipeline. On cache hit (template exists for this query text),
+    /// skips AST parsing — re-resolves parameter values from the blittable, re-estimates
+    /// cardinality, re-sorts, and it looks up the compiled delegate by ordering.
+    /// On cache miss, parses the AST into a template and caches it.
+    /// Both paths then: populate → sort → emit → compile (if needed) → resolve.
+    /// </summary>
+    public static IQueryMatch BuildAndCompile(
+        PlanParameters planParams,
+        QueryBuilderParameters builderParameters,
+        out QueryExecution plan,
+        out CompiledPlan compiledPlanOut,
+        Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms,
+        bool wantTimings,
+        CancellationToken token)
+    {
+        var indexSearcher = planParams.IndexSearcher;
+        var queryText = planParams.Metadata.Query.QueryText;
+        var planCache = indexSearcher.PlanCache;
+
+        // Step 1: Get or build the clause template (structural, no values).
+        // cmpxchg()/now()/today() are safe to cache: the template stores a DeferredExpression
+        // delegate on the binding, and ResolveBindingScalar invokes it per execution with the
+        // current builderParameters/queryParameters — the resolved value lives on ClauseExecution,
+        // not on the cached binding.
+        var template = planCache.TryGetTemplate(queryText) ?? ParseTemplate(planParams);
+
+        // Step 2: Create per-execution state for each clause (template is immutable, not cloned)
+        var clauses = new List<ClauseInfo>(template.Clauses.Length);
+        var execList = new List<ClauseExecution>(template.Clauses.Length);
+        foreach (var cached in template.Clauses)
+        {
+            clauses.Add(cached);
+            execList.Add(CreateExecution(cached));
+        }
+
+        // Step 2b: Evaluate WHEN conditions and eliminate inactive clauses.
+        //
+        // Track which WHEN-guarded clauses survived in a bitmask keyed by template
+        // position. Plans built from the same queryText but different WHEN-survival
+        // subsets can produce the same (OperandOrdering, TypeSignature) cache key —
+        // for example, [Attach==true, Number!=1] sorted with Attach first gives
+        // ordering=1, which collides with the single-clause [Attach==true] plan that
+        // arises when WHEN eliminates the NotEquals clause. We mix this survival mask
+        // into the cache key below so each survival pattern gets its own slot.
+        //
+        // We index by the loop counter (template position), not by ClauseInfo.OriginalIndex:
+        // negated/nested clauses (e.g. "not when(...)") carry the index from their local
+        // inner sub-list, not the outer template position. Iterating clauses in reverse
+        // and removing only later indices keeps `ci` aligned with the template position
+        // at the point of removal.
+        int whenSurvivalMask = 0;
+        bool templateHasWhen = false;
+        for (int ti = 0; ti < template.Clauses.Length; ti++)
+        {
+            if (template.Clauses[ti].WhenCondition == null)
+                continue;
+            templateHasWhen = true;
+            whenSurvivalMask |= 1 << (ti & 31);
+        }
+        for (int ci = clauses.Count - 1; ci >= 0; ci--)
+        {
+            var whenCondition = clauses[ci].WhenCondition;
+            if (whenCondition == null)
+                continue;
+            if (whenCondition(planParams.QueryParameters) == false)
+            {
+                whenSurvivalMask &= ~(1 << (ci & 31));
+                clauses.RemoveAt(ci);
+                execList.RemoveAt(ci);
+            }
+        }
+
+        // Step 3: Populate parameter values into typed arrays
+        var writer = new ValueWriter();
+        for (int ci = 0; ci < clauses.Count; ci++)
+            PopulateClauseValues(clauses[ci], execList[ci], planParams.QueryParameters, writer, builderParameters);
+
+        // Step 3b: Constant propagation — simplify trivially-false/simple clauses
+        bool isOr = template.IsOr;
+        for (int ci = clauses.Count - 1; ci >= 0; ci--)
+        {
+            var c = clauses[ci];
+            var e = execList[ci];
+
+            // Contradictory BETWEEN: low > high → clause matches nothing
+            if (c.ClauseType == ClauseType.Between && e.PackedParamValue.IsNone == false)
+            {
+                var p = e.PackedParamValue;
+                if (p.Param2 != PackedParam.NoParamValue)
+                {
+                    bool contradictory = p.ValueType switch
+                    {
+                        PackedParam.TypeLong => writer.GetLongs()[p.Param1] > writer.GetLongs()[p.Param2],
+                        PackedParam.TypeDouble => writer.GetDoubles()[p.Param1] > writer.GetDoubles()[p.Param2],
+                        PackedParam.TypeString => string.Compare(writer.GetStrings()[p.Param1], writer.GetStrings()[p.Param2], StringComparison.Ordinal) > 0,
+                        _ => false
+                    };
+                    if (contradictory)
+                    {
+                        // Mark with zero cardinality. EmitPlan handles:
+                        // AND chain: zero-cardinality → empty result.
+                        // OR chain: remove the clause (contributes nothing).
+                        e.Cardinality = 0;
+                        e.InTermCount = 0;
+                        e.HasNullTerm = false;
+                        // Clone before mutating: c references the frozen template clause,
+                        // shared across executions. Mutating it in place would poison cached
+                        // plans (RavenDB-17423 pattern).
+                        c = c.Clone();
+                        c.ClauseType = ClauseType.In; // Reuse empty-IN elimination in EmitPlan
+                        clauses[ci] = c;
+                    }
+                }
+            }
+
+            // Note: we intentionally do NOT rewrite single-value IN → Equals here.
+            // The plan cache is keyed by (queryText, OperandOrdering), but parameter
+            // cardinality changes between executions of the same queryText (e.g.
+            // `Identifier.In($ids)` with $ids growing from 1 to N elements). If the
+            // first execution rewrote to Equals and cached an Equals-shaped IL, the
+            // second execution with N>1 terms would reuse the cached Equals delegate
+            // and silently drop the extra terms — see RavenDB-17423. Keeping the IN
+            // shape uniform across cardinalities makes EmitInOps emit a single
+            // OrRange op whose term count is read from InRangeCounts at runtime, so
+            // the same compiled delegate handles any IN size.
+            //
+            // Null-only IN (InTermCount=0, HasNullTerm=true): already optimized —
+            // EmitInOps skips OrRange (no non-null terms) and emits only the null-term
+            // OrWithPostings op. No conversion needed.
+        }
+
+        // Step 4: Estimate cardinality (needs populated values)
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            if (execList[ci].Cardinality < 0)
+                execList[ci].Cardinality = EstimateCardinality(clauses[ci], execList[ci], indexSearcher, writer);
+        }
+
+        var executions = execList.ToArray();
+
+        // Step 5: Sort operands by cardinality (sort clauses and executions in lockstep)
+        if (!isOr)
+        {
+            // Build index array, sort by cardinality, then reorder both arrays
+            var indices = new int[clauses.Count];
+            for (int j = 0; j < indices.Length; j++) indices[j] = j;
+            Array.Sort(indices, (a, b) =>
+            {
+                bool aNeg = clauses[a].IsNegated || clauses[a].ClauseType == ClauseType.NotEquals;
+                bool bNeg = clauses[b].IsNegated || clauses[b].ClauseType == ClauseType.NotEquals;
+                if (aNeg != bNeg)
+                    return aNeg ? 1 : -1;
+                return executions[a].Cardinality.CompareTo(executions[b].Cardinality);
+            });
+            var sortedClauses = new List<ClauseInfo>(clauses.Count);
+            var sortedExecs = new ClauseExecution[clauses.Count];
+            for (int j = 0; j < indices.Length; j++)
+            {
+                sortedClauses.Add(clauses[indices[j]]);
+                sortedExecs[j] = executions[indices[j]];
+            }
+            clauses = sortedClauses;
+            executions = sortedExecs;
+        }
+        else
+        {
+            int insertPos = 0;
+            for (int j = 0; j < clauses.Count; j++)
+            {
+                if (clauses[j].ClauseType == ClauseType.AndGroup)
+                {
+                    ClauseInfo ag = clauses[j];
+                    ClauseExecution agExec = executions[j];
+                    clauses.RemoveAt(j);
+                    var execListTmp = new List<ClauseExecution>(executions);
+                    execListTmp.RemoveAt(j);
+                    clauses.Insert(insertPos, ag);
+                    execListTmp.Insert(insertPos, agExec);
+                    executions = execListTmp.ToArray();
+                    insertPos++;
+                }
+            }
+        }
+
+        // Step 6: Emit plan ops + attach spatial/vector post-filters.
+        // clauses.Count == 0 can happen either because the template is AllEntries (no WHERE)
+        // or because every WHERE clause was eliminated by a false WHEN condition — both reduce
+        // to "match all entries".
+        if (clauses.Count == 0)
+        {
+            plan = BuildAllEntriesPlan();
+            plan.Executions = executions;
+        }
+        else
+        {
+            plan = EmitPlan(clauses, executions, isOr);
+        }
+        plan.LongValues = writer.GetLongs();
+        plan.DoubleValues = writer.GetDoubles();
+        plan.StringValues = writer.GetStrings();
+
+        // Empty-IN short-circuit: EmitPlan returns Ops=[] for an AND chain containing
+        // an empty IN clause (e.g. `Names in ()`), and the resulting QueryExecution has
+        // the default OperandOrdering=0 and TypeSignature=0. That cache key collides
+        // with single-clause "default" plans (e.g. a one-term Equals after constant
+        // propagation), so a subsequent execution against the same queryText would
+        // receive the cached empty IL and produce zero results for a real query.
+        // Return an explicit empty match here without touching the cache. Bail only
+        // when there are no spatial/vector post-filters — those phases still need to
+        // run (AND with empty is empty for spatial, but vector with a null filter
+        // would otherwise return unfiltered top-K).
+        if (plan.Ops is { Length: 0 } && plan.IsAllEntries == false
+            && template.SpatialClauses == null && template.VectorClauses == null)
+        {
+            compiledPlanOut = null;
+            return TermMatch.CreateEmpty(indexSearcher, indexSearcher.Allocator);
+        }
+
+        if (template.SpatialClauses != null || template.VectorClauses != null)
+        {
+            var spatialList = template.SpatialClauses != null ? new List<ClauseInfo>(template.SpatialClauses.Length) : null;
+            var vectorList = template.VectorClauses != null ? new List<ClauseInfo>(template.VectorClauses.Length) : null;
+            ClauseExecution[] spatialExecs = null;
+            ClauseExecution[] vectorExecs = null;
+            if (spatialList != null)
+            {
+                spatialExecs = new ClauseExecution[template.SpatialClauses.Length];
+                for (int si = 0; si < template.SpatialClauses.Length; si++)
+                {
+                    var sc = template.SpatialClauses[si];
+                    var scExec = new ClauseExecution();
+                    PopulateClauseValues(sc, scExec, planParams.QueryParameters, writer, builderParameters);
+                    spatialList.Add(sc);
+                    spatialExecs[si] = scExec;
+                }
+            }
+            if (vectorList != null)
+            {
+                vectorExecs = new ClauseExecution[template.VectorClauses.Length];
+                for (int vi = 0; vi < template.VectorClauses.Length; vi++)
+                {
+                    var vc = template.VectorClauses[vi];
+                    var vcExec = new ClauseExecution();
+                    PopulateClauseValues(vc, vcExec, planParams.QueryParameters, writer, builderParameters);
+                    vectorList.Add(vc);
+                    vectorExecs[vi] = vcExec;
+                }
+            }
+            AttachPostFilterPhases(plan, spatialList, spatialExecs, vectorList, vectorExecs);
+            // Re-store typed arrays after spatial/vector population may have added more
+            plan.LongValues = writer.GetLongs();
+            plan.DoubleValues = writer.GetDoubles();
+            plan.StringValues = writer.GetStrings();
+        }
+
+        // Step 7: Boost handling
+        if (planParams.HasBoost)
+        {
+            var ops = plan.Ops;
+            if (ops != null)
+                for (int i = 0; i < ops.Length; i++)
+                    ops[i].Dispatch = MatchDispatch.QueryMatch;
+            plan.OperandOrdering |= (1 << 30);
+        }
+
+        // Sentinel BETWEEN disambiguator. See QueryExecution.OperandOrdering doc for full bit layout.
+        if (HasAnySentinelBetween(executions))
+            plan.OperandOrdering |= (1 << 31);
+
+        // Step 8: Look up or compile the delegate for this ordering.
+        // When the template has WHEN clauses, prepend 4 bytes of the survival mask
+        // to FullKinds so plans with different surviving subsets get distinct cache slots
+        // — otherwise [Attach, Number!=1] (sorted, ord=1) collides with the 1-clause
+        // [Attach] survivor (also ord=1) since both share the same queryText.
+        if (templateHasWhen)
+        {
+            var existing = plan.FullKinds ?? Array.Empty<byte>();
+            var combined = new byte[4 + existing.Length];
+            combined[0] = (byte)(whenSurvivalMask & 0xFF);
+            combined[1] = (byte)((whenSurvivalMask >> 8) & 0xFF);
+            combined[2] = (byte)((whenSurvivalMask >> 16) & 0xFF);
+            combined[3] = (byte)((whenSurvivalMask >> 24) & 0xFF);
+            existing.CopyTo(combined, 4);
+            plan.FullKinds = combined;
+        }
+        var compiledPlan = planCache.Get(queryText, plan.OperandOrdering, plan.TypeSignature, plan.FullKinds);
+        if (compiledPlan == null)
+        {
+            compiledPlan = new CompiledPlan
+            {
+                CompiledDelegate = QueryIlEmitter.EmitDelegate(plan, out var explainText, emitTimings: false),
+                CompiledTimedDelegate = QueryIlEmitter.EmitDelegate(plan, out _, emitTimings: true),
+                CompiledEntryPredicate = ResidualScanIlEmitter.EmitDelegate(plan.ScanPredicateInfos, out var scanExplain),
+
+                ExplainSource = explainText + "\n" + scanExplain,
+                Ordering = plan.OperandOrdering,
+                TypeSignature = plan.TypeSignature,
+                FullKinds = plan.FullKinds,
+                InspectionTemplate = BuildInspectionTemplate(plan)
+            };
+            planCache.Add(queryText, compiledPlan, template);
+        }
+
+        compiledPlanOut = compiledPlan;
+        var resolvedMatches = ResolveMatches(plan, indexSearcher, planParams, builderParameters);
+        var termSources = ResolveTermSources(plan, indexSearcher, planParams, builderParameters);
+        var termsProviders = ResolveTermsProviders(plan, indexSearcher, planParams, builderParameters);
+        ExtractScanParameters(plan, indexSearcher,
+            out var longParams, out var doubleParams, out var sliceParams, out var fieldRootPages);
+
+        if (highlightingTerms != null)
+            PopulateHighlightingTerms(plan, highlightingTerms, planParams.Metadata);
+
+        var compiledMatch = new CompiledQueryMatch(
+            compiledPlan, plan.RequiredBitmaps, plan.Ops?.Length ?? 0, resolvedMatches, termSources, termsProviders,
+            indexSearcher, planParams.Allocator, wantTimings, token)
+        {
+            InRangeCounts = plan.InRangeCounts,
+            ScanPredicateInfos = plan.ScanPredicateInfos,
+            ScanLongParams = longParams,
+            ScanDoubleParams = doubleParams,
+            ScanSliceParams = sliceParams,
+            ScanFieldRootPages = fieldRootPages
+        };
+        IQueryMatch result = compiledMatch;
+
+        // Spatial post-filter phase: AND each spatial match with the candidate bitmap.
+        if (plan.SpatialFilters is { Length: > 0 })
+        {
+            var spatialFilters = new IQueryMatch[plan.SpatialFilters.Length];
+            for (int sf = 0; sf < plan.SpatialFilters.Length; sf++)
+                spatialFilters[sf] = resolvedMatches[plan.SpatialFilters[sf].MatchIndex];
+            result = new PostFilterMatch(result, spatialFilters);
+        }
+
+        // Vector select phase: each vector wraps the bitmap so far as its filter source.
+        if (plan.VectorSelects is { Length: > 0 } && builderParameters != null)
+        {
+            var vectorItems = ResolveVectorItems(plan, builderParameters);
+            bool hasActualFilter = !plan.IsAllEntries || plan.SpatialFilters is { Length: > 0 };
+            IQueryMatch vectorFilter = hasActualFilter ? result : null;
+            foreach (var item in vectorItems)
+                result = item.Materialize(vectorFilter);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Build a query match from a sub-expression (e.g. the inner BinaryExpression
+    /// of a moreLikeThis clause). Parses and resolves the expression directly
+    /// without going through the full plan/compile pipeline.
+    /// </summary>
+    public static IQueryMatch BuildFromSubExpression(QueryBuilderParameters builderParams, QueryExpression expression)
+    {
+        var indexSearcher = builderParams.IndexSearcher;
+        var clauses = new List<ClauseInfo>();
+        bool hasMixed = false;
+        ParseExpression(expression, indexSearcher, clauses, builderParams.QueryParameters,
+            builderParams.Metadata, ref hasMixed);
+
+        if (clauses.Count == 0)
+            return indexSearcher.AllEntries();
+
+        // Populate parameters for the sub-expression clauses
+        var writer = new ValueWriter();
+        var subExecs = new ClauseExecution[clauses.Count];
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            subExecs[ci] = CreateExecution(clauses[ci]);
+            PopulateClauseValues(clauses[ci], subExecs[ci], builderParams.QueryParameters, writer, builderParams);
+        }
+
+        var subPlan = new QueryExecution
+        {
+            LongValues = writer.GetLongs(),
+            DoubleValues = writer.GetDoubles(),
+            StringValues = writer.GetStrings(),
+            Executions = subExecs
+        };
+
+        if (clauses.Count == 1)
+            return ResolveClause(clauses[0], subExecs[0], indexSearcher, subPlan, builderParams: builderParams);
+
+        // Multiple clauses (AND chain) — resolve each and AND them via bitmap
+        var bitmap = new BitmapMatch(indexSearcher.Allocator);
+        var temp = new RoaringBitmap(indexSearcher.Allocator);
+        bool first = true;
+        for (int ci2 = 0; ci2 < clauses.Count; ci2++)
+        {
+            var clause = clauses[ci2];
+            var match = ResolveClause(clause, subExecs[ci2], indexSearcher, subPlan, builderParams: builderParams);
+            if (first)
+            {
+                QueryPrimitives.FillFromMatch(match, ref bitmap.BitmapState);
+                first = false;
+            }
+            else
+            {
+                QueryPrimitives.AndWithMatch(match, ref bitmap.BitmapState, ref temp);
+            }
+        }
+        temp.Dispose();
+        return bitmap;
+    }
+
+    // ── Template caching ──────────────────────────────────────────────
+
+    /// <summary>True if any clause execution carries a sentinel-BETWEEN flag (recurses into
+    /// OrGroup/AndGroup sub-executions). Used to disambiguate the plan-cache key — a sentinel
+    /// BETWEEN forces QueryMatch dispatch and must not collide with cached TreeScan IL for
+    /// the same query text.</summary>
+    private static bool HasAnySentinelBetween(ClauseExecution[] executions)
+    {
+        if (executions == null)
+            return false;
+        for (int i = 0; i < executions.Length; i++)
+        {
+            var e = executions[i];
+            if (e == null)
+                continue;
+            if (e.BetweenLowUnbounded || e.BetweenHighUnbounded)
+                return true;
+            if (HasAnySentinelBetween(e.OrSubExecutions))
+                return true;
+            if (HasAnySentinelBetween(e.AndSubExecutions))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>Create a ClauseExecution for a clause, including sub-executions for OrGroup/AndGroup.</summary>
+    private static ClauseExecution CreateExecution(ClauseInfo clause)
+    {
+        var exec = new ClauseExecution();
+        if (clause.OrSubClauses is { Count: > 0 })
+        {
+            exec.OrSubExecutions = new ClauseExecution[clause.OrSubClauses.Count];
+            for (int i = 0; i < clause.OrSubClauses.Count; i++)
+                exec.OrSubExecutions[i] = CreateExecution(clause.OrSubClauses[i]);
+        }
+        if (clause.AndSubClauses is { Count: > 0 })
+        {
+            exec.AndSubExecutions = new ClauseExecution[clause.AndSubClauses.Count];
+            for (int i = 0; i < clause.AndSubClauses.Count; i++)
+                exec.AndSubExecutions[i] = CreateExecution(clause.AndSubClauses[i]);
+        }
+        return exec;
+    }
+
+    /// <summary>Resolve a single clause's parameter value using its cached binding.
+    /// Called for each clause during parameter population (both first execution and cache hit).
+    /// The optional builderParameters is needed to resolve deferred method expressions (cmpxchg, now, today).</summary>
+    private static void PopulateClauseValues(ClauseInfo clause, ClauseExecution exec, BlittableJsonReaderObject queryParameters, ValueWriter writer, QueryBuilderParameters builderParameters = null)
+    {
+        // Always recurse into subclauses first (OrGroup/AndGroup have no binding of their own)
+        if (clause.OrSubClauses != null && exec.OrSubExecutions != null)
+            for (int si = 0; si < clause.OrSubClauses.Count; si++)
+                PopulateClauseValues(clause.OrSubClauses[si], exec.OrSubExecutions[si], queryParameters, writer, builderParameters);
+        if (clause.AndSubClauses != null && exec.AndSubExecutions != null)
+            for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                PopulateClauseValues(clause.AndSubClauses[si], exec.AndSubExecutions[si], queryParameters, writer, builderParameters);
+
+        // Resolve boost factor if this clause is boosted
+        if (clause.HasBoost && clause.Bindings is { Length: > 0 })
+        {
+            ResolveBoostFactor(clause, exec, queryParameters);
+        }
+
+        switch (clause.ClauseType)
+        {
+            // Spatial and vector resolve via their binding array.
+            case ClauseType.Spatial when clause.Bindings is { Length: > 0 }:
+                ResolveSpatialFromBindings(clause, exec, queryParameters);
+                return;
+            case ClauseType.Vector when clause.Bindings is { Length: > 0 }:
+                ResolveVectorFromBindings(clause, exec, queryParameters);
+                return;
+        }
+
+        var bindings = clause.Bindings;
+        if (bindings == null || bindings.Length == 0)
+            return;
+
+        switch (clause.ClauseType)
+        {
+            // BETWEEN: two values at Bindings[0] (low) and Bindings[1] (high)
+            case ClauseType.Between:
+                var (low, lowType) = ResolveBindingScalar(bindings[BindingIndex.BetweenLow], queryParameters, builderParameters);
+                var (high, highType) = ResolveBindingScalar(bindings[BindingIndex.BetweenHigh], queryParameters, builderParameters);
+                // Detect the client's unbounded-bound sentinel strings: WhereBetween(field, null, x)
+                // arrives as low="*"; WhereBetween(field, x, null) arrives as high="NULL"
+                // (see Raven.Client.Constants.Documents.Querying.Terms). When the OTHER bound
+                // is numeric, the sentinel string can't be coerced via Convert.ToInt64/Double,
+                // so we replace it with a type-appropriate extreme value and set a flag for
+                // resolution-time rewriting into LessThanOrEqual / GreaterThanOrEqual-with-null.
+                bool lowIsUnbounded = lowType == ParamValueType.String && low is string ls
+                                      && ls == Raven.Client.Constants.Documents.Querying.Terms.LeftNullValueOfBetweenQuery;
+                bool highIsUnbounded = highType == ParamValueType.String && high is string hs
+                                       && hs == Raven.Client.Constants.Documents.Querying.Terms.RightNullValueOfBetweenQuery;
+                exec.BetweenLowUnbounded = lowIsUnbounded;
+                exec.BetweenHighUnbounded = highIsUnbounded;
+                // Pick effective type: the non-sentinel side dictates. When both are sentinels
+                // the type is irrelevant — resolution returns AllEntries without consulting the
+                // stored values.
+                ParamValueType effectiveType = (lowIsUnbounded, highIsUnbounded) switch
+                {
+                    (true, true) => ParamValueType.String,
+                    (true, false) => highType,
+                    _ => lowType
+                };
+                object effectiveLow = lowIsUnbounded ? GetTypeMinSentinel(effectiveType) : low;
+                object effectiveHigh = highIsUnbounded ? GetTypeMaxSentinel(effectiveType) : high;
+                exec.TermValueType = effectiveType;
+                exec.PackedParamValue = writer.AddPair(effectiveLow, effectiveHigh, ToValueTokenType(effectiveType));
+                return;
+            case ClauseType.In or ClauseType.AllIn:
+                // IN/AllIn: each binding is a term (literal or parameter, possibly array-expanding)
+                ResolveInFromBindings(exec, queryParameters, writer, bindings);
+                break;
+            default:
+                // Simple clause (Equals, Range, Search, Regex, etc.): single value at Bindings[0]
+                var (value, valueType) = ResolveBindingScalar(bindings[BindingIndex.Value], queryParameters, builderParameters);
+                // startsWith/endsWith/search/regex require a String argument — reject Null (matches Lucene behavior).
+                if (value == null && clause.ClauseType is ClauseType.StartsWith or ClauseType.EndsWith or ClauseType.Search or ClauseType.Regex)
+                {
+                    string methodName = clause.ClauseType switch
+                    {
+                        ClauseType.StartsWith => "startsWith",
+                        ClauseType.EndsWith => "endsWith",
+                        ClauseType.Search => "search",
+                        ClauseType.Regex => "regex",
+                        _ => clause.ClauseType.ToString()
+                    };
+                    throw new Raven.Client.Exceptions.InvalidQueryException(
+                        $"Method {methodName}() expects to get an argument of type String while it got Null");
+                }
+                exec.TermValueType = valueType;
+                exec.PackedParamValue = writer.Add(value, ToValueTokenType(valueType));
+                break;
+        }
+    }
+
+    private static void ResolveBoostFactor(ClauseInfo clause, ClauseExecution exec, BlittableJsonReaderObject queryParameters)
+    {
+        var (boostVal, boostType) = ResolveBindingScalar(clause.Bindings[^1], queryParameters);
+        if (boostVal == null) return;
+
+        exec.BoostFactor = boostType switch
+        {
+            ParamValueType.Double => (float)(double)boostVal,
+            _ => boostType switch
+            {
+                ParamValueType.Long => (long)boostVal,
+                _ when float.TryParse(boostVal.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out float parsed) => parsed,
+                _ => 1f
+            }
+        };
+    }
+
+    private static void ResolveInFromBindings(ClauseExecution exec, BlittableJsonReaderObject queryParameters, ValueWriter writer, ParameterBinding[] bindings)
+    {
+        var termTypes = new List<ParamValueType>();
+        var resolvedValues = new List<object>();
+        bool hasNullTerm = false;
+
+        foreach (var it in bindings)
+        {
+            if (it.LiteralType != ParamValueType.Parameter)
+            {
+                resolvedValues.Add(it.LiteralValue);
+                termTypes.Add(it.LiteralType);
+                if (it.LiteralValue == null)
+                {
+                    hasNullTerm = true;
+                }
+            }
+            else
+            {
+                // Parameter — resolve from blittable. It may be scalar or array.
+                object inRaw = null;
+                queryParameters?.TryGet(it.ParameterName, out inRaw);
+                if (inRaw is BlittableJsonReaderArray arr)
+                {
+                    // Array parameter — expand each element
+                    foreach (var elem in arr)
+                    {
+                        var (elemVal, elemType) = ResolveInValue(elem, ValueTokenType.Parameter);
+                        resolvedValues.Add(elemVal);
+                        termTypes.Add(ToParamValueType(elemType));
+                        if (elemVal == null)
+                            hasNullTerm = true;
+                    }
+                }
+                else if (inRaw != null)
+                {
+                    // Scalar parameter — single term
+                    var (singleVal, singleType) = ResolveInValue(inRaw, ValueTokenType.Parameter);
+                    resolvedValues.Add(singleVal);
+                    termTypes.Add(ToParamValueType(singleType));
+                }
+                else
+                {
+                    resolvedValues.Add(null);
+                    termTypes.Add(ParamValueType.Null);
+                    hasNullTerm = true;
+                }
+            }
+        }
+
+        // Determine dominant type
+        ParamValueType dominantType = ParamValueType.Null;
+        for (int i = 0; i < termTypes.Count; i++)
+        {
+            if (resolvedValues[i] == null) continue;
+            if (dominantType == ParamValueType.Null)  
+                dominantType = termTypes[i];
+        }
+        if (dominantType == ParamValueType.Null) 
+            dominantType = ParamValueType.String;
+
+        int packedType = dominantType switch
+        {
+            ParamValueType.Long => PackedParam.TypeLong,
+            ParamValueType.Double => PackedParam.TypeDouble,
+            _ => PackedParam.TypeString
+        };
+        int startIdx = packedType switch
+        {
+            PackedParam.TypeLong => writer.LongCount,
+            PackedParam.TypeDouble => writer.DoubleCount,
+            _ => writer.StringCount
+        };
+        // Only store non-null values in the typed array. Null terms are handled
+        // separately via HasNullTerm — one null-term lookup covers all nulls.
+        //
+        // Skip values whose individual type can't be coerced to the dominant type.
+        // Example: IN(DateTime, "Shalom") on a DateTime-indexed field — the dominant
+        // type is Long (DateTime.Ticks); "Shalom" can never match a long-indexed term,
+        // so dropping it produces the correct empty/partial result (matches Lucene).
+        // Without this guard, Convert.ToInt64("Shalom") would throw FormatException.
+        int nonNullCount = 0;
+        for (int i = 0; i < resolvedValues.Count; i++)
+        {
+            if (resolvedValues[i] == null) continue;
+            if (termTypes[i] != dominantType && IsTypeIncompatible(termTypes[i], dominantType))
+                continue;
+            writer.Add(resolvedValues[i], ToValueTokenType(dominantType));
+            nonNullCount++;
+        }
+
+        exec.PackedParamValue = new PackedParam(packedType, startIdx);
+        exec.InTermCount = nonNullCount;
+        exec.HasNullTerm = hasNullTerm;
+    }
+
+    /// <summary>Resolve spatial parameters from cached bindings (no MethodExpression dependency).</summary>
+    private static void ResolveSpatialFromBindings(ClauseInfo clause, ClauseExecution exec, BlittableJsonReaderObject queryParameters)
+    {
+        var bindings = clause.Bindings;
+        var sp = new SpatialParams();
+
+        // [0] = distanceErrorPct
+        if (bindings.Length > 0 && bindings[BindingIndex.SpatialDistErrPct] != null)
+        {
+            var (depVal, _) = ResolveBindingScalar(bindings[BindingIndex.SpatialDistErrPct], queryParameters);
+            sp.DistanceErrorPct = depVal != null ? Convert.ToDouble(depVal) : -1;
+        }
+
+        // Shape type determined by the number of bindings:
+        // circle has 5 (distErrPct, radius, lat, lng, units), WKT has 3 (distErrPct, wkt, units)
+        if (bindings.Length >= BindingIndex.SpatialCircleBindingCount - 1) // circle: at least distErrPct + radius + lat + lng
+        {
+            sp.ShapeType = SpatialShapeType.Circle;
+            var (r, _) = ResolveBindingScalar(bindings[BindingIndex.SpatialRadius], queryParameters);
+            var (lat, _) = ResolveBindingScalar(bindings[BindingIndex.SpatialLatitude], queryParameters);
+            var (lng, _) = ResolveBindingScalar(bindings[BindingIndex.SpatialLongitude], queryParameters);
+            sp.CircleRadius = Convert.ToDouble(r);
+            sp.CircleLatitude = Convert.ToDouble(lat);
+            sp.CircleLongitude = Convert.ToDouble(lng);
+            if (bindings.Length > BindingIndex.SpatialUnits && bindings[BindingIndex.SpatialUnits] != null)
+            {
+                var (u, _) = ResolveBindingScalar(bindings[BindingIndex.SpatialUnits], queryParameters);
+                if (u != null && Enum.TryParse(typeof(SpatialUnits), u.ToString(), true, out var su))
+                    sp.Units = (SpatialUnits)su == SpatialUnits.Kilometers
+                            ? global::Corax.Utils.Spatial.SpatialUnits.Kilometers
+                            : global::Corax.Utils.Spatial.SpatialUnits.Miles;
+            }
+        }
+        else // WKT: distErrPct, wkt, [units]
+        {
+            sp.ShapeType = SpatialShapeType.Wkt;
+            if (bindings.Length > BindingIndex.SpatialWkt && bindings[BindingIndex.SpatialWkt] != null)
+            {
+                var (wkt, _) = ResolveBindingScalar(bindings[BindingIndex.SpatialWkt], queryParameters);
+                sp.Wkt = wkt?.ToString();
+                if (bindings.Length > BindingIndex.SpatialWktUnits && bindings[BindingIndex.SpatialWktUnits] != null)
+                {
+                    var (u, _) = ResolveBindingScalar(bindings[BindingIndex.SpatialWktUnits], queryParameters);
+                    if (u != null && Enum.TryParse(typeof(SpatialUnits), u.ToString(), true, out var su))
+                        sp.Units = (SpatialUnits)su == SpatialUnits.Kilometers
+                            ? global::Corax.Utils.Spatial.SpatialUnits.Kilometers
+                            : global::Corax.Utils.Spatial.SpatialUnits.Miles;
+                }
+            }
+        }
+
+        exec.Spatial = sp;
+    }
+
+    /// <summary>Resolve vector parameters from cached bindings (no MethodExpression dependency).</summary>
+    private static void ResolveVectorFromBindings(ClauseInfo clause, ClauseExecution exec, BlittableJsonReaderObject queryParameters)
+    {
+        var bindings = clause.Bindings;
+        var vec = new VectorParams { Method = clause.VectorMethod };
+
+        // [1]=minimumMatch, [2]=numberOfCandidates, [3]=aiTask
+        if (bindings.Length > BindingIndex.VectorMinMatch && bindings[BindingIndex.VectorMinMatch] != null)
+        {
+            var (simVal, simType) = ResolveBindingScalar(bindings[BindingIndex.VectorMinMatch], queryParameters);
+            if (simVal != null && simType != ParamValueType.Null)
+                vec.MinimumMatch = simType == ParamValueType.Double ? (float)(double)simVal
+                    : simType == ParamValueType.Long ? (long)simVal : -1;
+        }
+        if (bindings.Length > BindingIndex.VectorCandidates && bindings[BindingIndex.VectorCandidates] != null)
+        {
+            var (candVal, candType) = ResolveBindingScalar(bindings[BindingIndex.VectorCandidates], queryParameters);
+            if (candVal != null && candType != ParamValueType.Null)
+                vec.NumberOfCandidates = Convert.ToInt32(candVal);
+        }
+        if (bindings.Length > BindingIndex.VectorAiTask && bindings[BindingIndex.VectorAiTask] != null)
+        {
+            var (taskVal, _) = ResolveBindingScalar(bindings[BindingIndex.VectorAiTask], queryParameters);
+            vec.AiTaskName = taskVal?.ToString();
+        }
+
+        // [0]=vector value (may be scalar, array, or blittable object)
+        if (bindings.Length > BindingIndex.VectorValue && bindings[BindingIndex.VectorValue] != null)
+        {
+            var (val, valType) = ResolveBindingRaw(bindings[BindingIndex.VectorValue], queryParameters);
+            vec.ResolvedValue = val;
+            vec.ResolvedValueType = valType;
+            // For scalar parameters, resolve the native type
+            if (valType == ParamValueType.Parameter && val is not (BlittableJsonReaderArray or BlittableJsonReaderObject))
+            {
+                var (resolved, resolvedType) = ResolveParameterValue(val);
+                vec.ResolvedValue = resolved;
+                vec.ResolvedValueType = ToParamValueType(resolvedType);
+            }
+        }
+
+        exec.Vector = vec;
+    }
+
+    /// <summary>Look up a binding's value from the blittable. Returns the RAW value —
+    /// callers must check for arrays/objects before calling ResolveParameterValue.</summary>
+    private static (object Value, ParamValueType Type) ResolveBindingRaw(ParameterBinding binding, BlittableJsonReaderObject queryParameters)
+    {
+        if (binding.LiteralType != ParamValueType.Parameter)
+            return (binding.LiteralValue, binding.LiteralType);
+        if (queryParameters != null && queryParameters.TryGet(binding.ParameterName, out object raw) && raw != null)
+            return (raw, ParamValueType.Parameter); // raw from blittable — caller decides how to interpret
+        return (null, ParamValueType.Null);
+    }
+
+    /// <summary>Resolve a binding to a scalar value. Asserts the result is not an array/object.
+    /// For parameters that might be arrays, use ResolveBindingRaw and handle arrays first.
+    /// The optional builderParameters is needed to resolve deferred method expressions (cmpxchg, now, today).</summary>
+    private static (object Value, ParamValueType Type) ResolveBindingScalar(ParameterBinding binding, BlittableJsonReaderObject queryParameters, QueryBuilderParameters builderParameters = null)
+    {
+        // Handle deferred method expressions (cmpxchg, now, today) — resolve at execution time
+        if (binding.DeferredExpression != null)
+        {
+            var value = binding.DeferredExpression(builderParameters, queryParameters);
+            if (value == null)
+                return (null, ParamValueType.Null);
+            var (val, valType) = ResolveParameterValue(value);
+            return (val, ToParamValueType(valType));
+        }
+
+        if (binding.LiteralType != ParamValueType.Parameter)
+            return (binding.LiteralValue, binding.LiteralType);
+        if (queryParameters != null && queryParameters.TryGet(binding.ParameterName, out object raw) && raw != null)
+        {
+            var (val, type) = ResolveParameterValue(raw); // asserts not array/object
+            return (val, ToParamValueType(type));
+        }
+        return (null, ParamValueType.Null);
+    }
+
+    // ── Typed dispatch helpers ───────────────────────────────────────────
+
+    /// <summary>Create a TermQuery using the pre-resolved typed value from the plan's arrays.</summary>
+    private static IQueryMatch TermQueryFromParam(PackedParam packed, FieldMetadata fieldMeta,
+        IndexSearcher indexSearcher, QueryExecution plan)
+    {
+        int idx = packed.Param1;
+        return packed.ValueType switch
+        {
+            PackedParam.TypeLong => indexSearcher.TermQuery(fieldMeta, plan.LongValues[idx]),
+            PackedParam.TypeDouble => indexSearcher.TermQuery(fieldMeta, plan.DoubleValues[idx]),
+            _ => indexSearcher.TermQuery(fieldMeta, plan.StringValues[idx])
+        };
+    }
+
+    /// <summary>Get a posting-list ID using the pre-resolved typed value.</summary>
+    private static long GetTermPostingListIdFromParam(PackedParam packed, FieldMetadata fieldMeta,
+        IndexSearcher indexSearcher, QueryExecution plan)
+    {
+        int idx = packed.Param1;
+        return packed.ValueType switch
+        {
+            PackedParam.TypeLong => indexSearcher.GetTermPostingListId(fieldMeta, plan.LongValues[idx]),
+            PackedParam.TypeDouble => indexSearcher.GetTermPostingListId(fieldMeta, plan.DoubleValues[idx]),
+            _ => indexSearcher.GetTermPostingListId(fieldMeta, plan.StringValues[idx])
+        };
+    }
+
+    // ── Match resolution ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Resolve clause infos to IQueryMatch instances for execution.
+    /// Uses existing IndexSearcher methods (TermQuery, etc.) which handle
+    /// all the complexity of analyzer application, CompactKey encoding,
+    /// posting list resolution, etc.
+    /// </summary>
+    private static IQueryMatch[] ResolveMatches(QueryExecution plan, IndexSearcher indexSearcher,
+        PlanParameters parameters = null, QueryBuilderParameters builderParams = null)
+    {
+        var clauses = plan.Clauses ?? [];
+        // All-entries plan with possible post-filter phases
+        if (plan.IsAllEntries)
+        {
+            int spatialCount = plan.SpatialFilters?.Length ?? 0;
+            int vectorCount = plan.VectorSelects?.Length ?? 0;
+            int totalExtra = spatialCount + vectorCount;
+            if (totalExtra == 0)
+                return [indexSearcher.AllEntries()];
+
+            var allEntriesMatches = new IQueryMatch[1 + totalExtra];
+            allEntriesMatches[0] = indexSearcher.AllEntries();
+            int matchOfs = 1;
+            if (plan.SpatialFilters != null)
+            {
+                for (int i = 0; i < plan.SpatialFilters.Length; i++)
+                    allEntriesMatches[matchOfs++] = ResolveClause(plan.SpatialFilters[i].Clause, plan.SpatialFilters[i].Exec ?? new ClauseExecution(), indexSearcher, plan, parameters, builderParams);
+            }
+            if (plan.VectorSelects != null)
+            {
+                for (int i = 0; i < plan.VectorSelects.Length; i++)
+                    allEntriesMatches[matchOfs++] = ResolveClause(plan.VectorSelects[i].Clause, plan.VectorSelects[i].Exec ?? new ClauseExecution(), indexSearcher, plan, parameters, builderParams);
+            }
+            return allEntriesMatches;
+        }
+
+        if (clauses.Count == 0)
+            return [];
+
+        var execs = plan.Executions;
+
+        // Standalone NotEquals pattern: Fill(AllEntries) + ANDNOT(term).
+        if (clauses.Count == 1 && clauses[0].IsNegated && !plan.AllNegated)
+        {
+            var clause = clauses[0];
+            var exec0 = execs[0];
+            return
+            [
+                indexSearcher.AllEntries(),
+                TermQueryFromParam(exec0.PackedParamValue, indexSearcher.FieldMetadataBuilder(clause.FieldName), indexSearcher, plan)
+            ];
+        }
+
+        var matches = new IQueryMatch[CountMatchSlots(clauses, execs, plan.IsAllEntries, plan.AllNegated)];
+        int matchIdx = 0;
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            ClauseInfo clause = clauses[ci];
+            ClauseExecution exec = execs[ci];
+            switch (clause.ClauseType)
+            {
+                case ClauseType.OrGroup when clause.OrSubClauses is { Count: > 0 }:
+                {
+                    for (int si = 0; si < clause.OrSubClauses.Count; si++)
+                    {
+                        var sub = clause.OrSubClauses[si];
+                        var subExec = exec.OrSubExecutions[si];
+                        var match = ResolveClause(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                        if (subExec.BoostFactor > 0)
+                            match = indexSearcher.Boost(match, subExec.BoostFactor);
+                        matches[matchIdx++] = match;
+                    }
+
+                    break;
+                }
+                case ClauseType.AndGroup when clause.AndSubClauses is { Count : > 0 }:
+                {
+                    for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                    {
+                        var sub = clause.AndSubClauses[si];
+                        var subExec = exec.AndSubExecutions[si];
+                        var match = ResolveClause(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                        if (subExec.BoostFactor > 0)
+                            match = indexSearcher.Boost(match, subExec.BoostFactor);
+                        matches[matchIdx++] = match;
+                    }
+
+                    break;
+                }
+                case ClauseType.AllIn or ClauseType.In:
+                {
+                    for (int t = 0; t < exec.InTermCount; t++)
+                        matches[matchIdx++] = ResolveInTerm(clause, exec, t, indexSearcher, plan, parameters, builderParams);
+                    // Always allocate the null-term slot (plan structure is parameter-independent).
+                    // When HasNullTerm is false, fill with a TermQuery(null) that resolves to an
+                    // empty posting list — the OR with an empty match is a no-op.
+                    {
+                        FieldMetadata nullMeta = builderParams != null
+                            ? QueryBuilderHelper.GetFieldMetadata(in builderParams, clause.FieldName, hasBoost: builderParams.HasBoost)
+                            : indexSearcher.FieldMetadataBuilder(clause.FieldName, hasBoost: parameters?.HasBoost ?? false);
+                        matches[matchIdx++] = exec.HasNullTerm
+                            ? indexSearcher.TermQuery(nullMeta, null)
+                            : TermMatch.CreateEmpty(indexSearcher, indexSearcher.Allocator);
+                    }
+                    break;
+                }
+                default:
+                {
+                    IQueryMatch match = clause.IsOrChainNotEquals switch
+                    {
+                        true => CreateNotEqualsOrMatch(clause, exec, indexSearcher, plan, parameters, builderParams),
+                        false => ResolveClause(clause, exec, indexSearcher, plan, parameters, builderParams)
+                    };
+                    if (exec.BoostFactor > 0)
+                        match = indexSearcher.Boost(match, exec.BoostFactor);
+                    matches[matchIdx++] = match;
+                    break;
+                }
+            }
+        }
+
+        if (plan.AllNegated)
+            matches[matchIdx] = indexSearcher.AllEntries();
+        return matches;
+    }
+
+    private static IQueryMatch ResolveRangeClauseWithDirection(ClauseInfo clause, ClauseExecution exec,
+        IndexSearcher indexSearcher, QueryExecution plan, PlanParameters parameters, QueryBuilderParameters builderParams, bool forward)
+    {
+        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, indexSearcher, parameters, builderParams);
+        var packed = exec.PackedParamValue;
+
+        return clause.ClauseType switch
+        {
+            ClauseType.GreaterThan => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.GreaterThanQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.GreaterThanQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.GreaterThanQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            },
+            ClauseType.GreaterThanOrEqual => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            },
+            ClauseType.LessThan => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.LessThanQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.LessThanQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.LessThanQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            },
+            ClauseType.LessThanOrEqual => packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            },
+            ClauseType.Between => ResolveBetweenWithDirection(clause, exec, fieldMeta, indexSearcher, plan, forward),
+            _ => ResolveClause(clause, exec, indexSearcher, plan, parameters, builderParams) // fallback
+        };
+    }
+
+    /// <summary>Resolve a BETWEEN clause for sort-driving (TermsProviderMatch) paths,
+    /// honoring the client's unbounded sentinels. For high-unbounded we cannot deliver
+    /// sorted-by-field iteration of "AllEntries ANDNOT LessThan(low)" via a single
+    /// TermsProvider, so we fall back to the unbounded GreaterThanOrEqual range — losing
+    /// the null-doc inclusion quirk in sorted paths only. Callers that need exact Lucene
+    /// parity should land in ResolveClause instead.</summary>
+    private static IQueryMatch ResolveBetweenWithDirection(ClauseInfo clause, ClauseExecution exec, FieldMetadata fieldMeta,
+        IndexSearcher indexSearcher, QueryExecution plan, bool forward)
+    {
+        var packed = exec.PackedParamValue;
+        if (exec.BetweenLowUnbounded && exec.BetweenHighUnbounded)
+            return indexSearcher.AllEntries();
+        if (exec.BetweenLowUnbounded)
+        {
+            return packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.LongValues[packed.Param2], forward),
+                PackedParam.TypeDouble => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.DoubleValues[packed.Param2], forward),
+                _ => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.StringValues[packed.Param2], forward)
+            };
+        }
+        if (exec.BetweenHighUnbounded)
+        {
+            return packed.ValueType switch
+            {
+                PackedParam.TypeLong => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.LongValues[packed.Param1], forward),
+                PackedParam.TypeDouble => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.DoubleValues[packed.Param1], forward),
+                _ => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.StringValues[packed.Param1], forward)
+            };
+        }
+        return packed.ValueType switch
+        {
+            PackedParam.TypeLong => indexSearcher.BetweenQuery(fieldMeta, plan.LongValues[packed.Param1], plan.LongValues[packed.Param2], forward: forward),
+            PackedParam.TypeDouble => indexSearcher.BetweenQuery(fieldMeta, plan.DoubleValues[packed.Param1], plan.DoubleValues[packed.Param2], forward: forward),
+            _ => indexSearcher.BetweenQuery(fieldMeta, plan.StringValues[packed.Param1], plan.StringValues[packed.Param2], forward: forward)
+        };
+    }
+
+    /// <summary>Converts an Equals clause into a BetweenQuery(low==high==value) so
+    /// it produces a TermsProviderMatch that SortedDrivingMatch can walk in sort order.</summary>
+    private static IQueryMatch ResolveEqualsClauseWithDirection(ClauseInfo clause, ClauseExecution exec,
+        IndexSearcher indexSearcher, QueryExecution plan, PlanParameters parameters, QueryBuilderParameters builderParams, bool forward)
+    {
+        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, indexSearcher, parameters, builderParams);
+        var packed = exec.PackedParamValue;
+        return packed.ValueType switch
+        {
+            PackedParam.TypeLong => indexSearcher.BetweenQuery(fieldMeta, plan.LongValues[packed.Param1], plan.LongValues[packed.Param1],
+                UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual, forward: forward),
+            PackedParam.TypeDouble => indexSearcher.BetweenQuery(fieldMeta, plan.DoubleValues[packed.Param1], plan.DoubleValues[packed.Param1],
+                UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual, forward: forward),
+            _ => indexSearcher.BetweenQuery(fieldMeta, plan.StringValues[packed.Param1], plan.StringValues[packed.Param1],
+                UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual, forward: forward)
+        };
+    }
+
+    private static IQueryMatch ResolveClause(ClauseInfo clause, ClauseExecution exec, IndexSearcher indexSearcher,
+        QueryExecution plan, PlanParameters parameters = null, QueryBuilderParameters builderParams = null)
+    {
+        if (clause.ClauseType == ClauseType.OrGroup && clause.OrSubClauses != null)
+        {
+            var bm = new BitmapMatch(indexSearcher.Allocator);
+            var temp = new RoaringBitmap(indexSearcher.Allocator);
+            for (int si = 0; si < clause.OrSubClauses.Count; si++)
+            {
+                var subExec = exec.OrSubExecutions[si];
+                var subMatch = ResolveClause(clause.OrSubClauses[si], subExec, indexSearcher, plan, parameters, builderParams);
+                QueryPrimitives.FillFromMatch(subMatch, ref bm.BitmapState);
+            }
+            temp.Dispose();
+            return bm;
+        }
+        if (clause.ClauseType == ClauseType.AndGroup && clause.AndSubClauses != null)
+        {
+            var bm = new BitmapMatch(indexSearcher.Allocator);
+            var temp = new RoaringBitmap(indexSearcher.Allocator);
+            bool first = true;
+            for (int si = 0; si < clause.AndSubClauses.Count; si++)
+            {
+                var sub = clause.AndSubClauses[si];
+                var subExec = exec.AndSubExecutions[si];
+                var subMatch = ResolveClause(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                if (first)
+                {
+                    QueryPrimitives.FillFromMatch(subMatch, ref bm.BitmapState);
+                    first = false;
+                }
+                else if (sub.IsNegated)
+                    QueryPrimitives.AndNotWithMatch(subMatch, ref bm.BitmapState, ref temp);
+                else
+                    QueryPrimitives.AndWithMatch(subMatch, ref bm.BitmapState, ref temp);
+            }
+            temp.Dispose();
+            return bm;
+        }
+
+        // Spatial/Vector/Search have their own field resolution paths.
+        FieldMetadata fieldMeta = default;
+        bool needsFieldMeta = clause.ClauseType != ClauseType.Spatial
+            && clause.ClauseType != ClauseType.Vector
+            && clause.ClauseType != ClauseType.Search;
+        if (needsFieldMeta)
+        {
+            if (builderParams != null)
+            {
+                string resolvedFieldName = clause.FieldName;
+                if (clause.IsExact && builderParams.Metadata.IsDynamic)
+                    resolvedFieldName = AutoIndexField.GetExactAutoIndexFieldName(resolvedFieldName);
+                fieldMeta = QueryBuilderHelper.GetFieldMetadata(in builderParams, resolvedFieldName, exact: clause.IsExact, hasBoost: builderParams.HasBoost);
+            }
+            else
+            {
+                fieldMeta = indexSearcher.FieldMetadataBuilder(clause.FieldName, hasBoost: parameters?.HasBoost ?? false);
+            }
+        }
+
+        var packed = exec.PackedParamValue;
+
+        switch (clause.ClauseType)
+        {
+            case ClauseType.Equals:
+            case ClauseType.NotEquals:
+                return TermQueryFromParam(packed, fieldMeta, indexSearcher, plan);
+
+            case ClauseType.GreaterThan:
+            {
+                int idx = packed.Param1;
+                return packed.ValueType switch
+                {
+                    PackedParam.TypeLong => indexSearcher.GreaterThanQuery(fieldMeta, plan.LongValues[idx]),
+                    PackedParam.TypeDouble => indexSearcher.GreaterThanQuery(fieldMeta, plan.DoubleValues[idx]),
+                    _ => indexSearcher.GreaterThanQuery(fieldMeta, plan.StringValues[idx])
+                };
+            }
+
+            case ClauseType.GreaterThanOrEqual:
+            {
+                int idx = packed.Param1;
+                return packed.ValueType switch
+                {
+                    PackedParam.TypeLong => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.LongValues[idx]),
+                    PackedParam.TypeDouble => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.DoubleValues[idx]),
+                    _ => indexSearcher.GreaterThanOrEqualsQuery(fieldMeta, plan.StringValues[idx])
+                };
+            }
+
+            case ClauseType.LessThan:
+            {
+                int idx = packed.Param1;
+                return packed.ValueType switch
+                {
+                    PackedParam.TypeLong => indexSearcher.LessThanQuery(fieldMeta, plan.LongValues[idx]),
+                    PackedParam.TypeDouble => indexSearcher.LessThanQuery(fieldMeta, plan.DoubleValues[idx]),
+                    _ => indexSearcher.LessThanQuery(fieldMeta, plan.StringValues[idx])
+                };
+            }
+
+            case ClauseType.LessThanOrEqual:
+            {
+                int idx = packed.Param1;
+                return packed.ValueType switch
+                {
+                    PackedParam.TypeLong => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.LongValues[idx]),
+                    PackedParam.TypeDouble => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.DoubleValues[idx]),
+                    _ => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.StringValues[idx])
+                };
+            }
+
+            case ClauseType.Between:
+            {
+                int idx1 = packed.Param1;
+                int idx2 = packed.Param2;
+                // Handle client-sent unbounded sentinels (see PopulateClauseValues): rewrite the
+                // BETWEEN into the equivalent half-open / all-entries match.
+                if (exec.BetweenLowUnbounded && exec.BetweenHighUnbounded)
+                    return indexSearcher.AllEntries();
+                if (exec.BetweenLowUnbounded)
+                {
+                    return packed.ValueType switch
+                    {
+                        PackedParam.TypeLong => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.LongValues[idx2]),
+                        PackedParam.TypeDouble => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.DoubleValues[idx2]),
+                        _ => indexSearcher.LessThanOrEqualsQuery(fieldMeta, plan.StringValues[idx2])
+                    };
+                }
+                if (exec.BetweenHighUnbounded)
+                {
+                    // Lucene semantics: WhereBetween(field, low, null) ALSO includes docs whose
+                    // field is missing. Realize this as AllEntries() ANDNOT LessThan(low) so
+                    // null-valued documents (which have no entry in the numeric index, and only
+                    // a NULL_VALUE term in the string index) are pulled in via AllEntries and
+                    // not filtered out by the LessThan complement.
+                    IQueryMatch ltMatch = packed.ValueType switch
+                    {
+                        PackedParam.TypeLong => indexSearcher.LessThanQuery(fieldMeta, plan.LongValues[idx1]),
+                        PackedParam.TypeDouble => indexSearcher.LessThanQuery(fieldMeta, plan.DoubleValues[idx1]),
+                        _ => indexSearcher.LessThanQuery(fieldMeta, plan.StringValues[idx1])
+                    };
+                    var bmHigh = new BitmapMatch(indexSearcher.Allocator);
+                    var tempHigh = new RoaringBitmap(indexSearcher.Allocator);
+                    QueryPrimitives.FillFromMatch(indexSearcher.AllEntries(), ref bmHigh.BitmapState);
+                    QueryPrimitives.AndNotWithMatch(ltMatch, ref bmHigh.BitmapState, ref tempHigh);
+                    tempHigh.Dispose();
+                    return bmHigh;
+                }
+                return packed.ValueType switch
+                {
+                    PackedParam.TypeLong => indexSearcher.BetweenQuery(fieldMeta, plan.LongValues[idx1], plan.LongValues[idx2]),
+                    PackedParam.TypeDouble => indexSearcher.BetweenQuery(fieldMeta, plan.DoubleValues[idx1], plan.DoubleValues[idx2]),
+                    _ => indexSearcher.BetweenQuery(fieldMeta, plan.StringValues[idx1], plan.StringValues[idx2])
+                };
+            }
+
+            case ClauseType.In:
+            case ClauseType.AllIn:
+            {
+                // IN/AllIn inside an AndGroup reaches here as a single clause.
+                // Expand each term into a TermQuery and merge via bitmap, same as the
+                // top-level plan does with FillFromPostings/OrWithPostings/AndWithPostings.
+                if (exec.InTermCount == 0)
+                    return indexSearcher.EmptyMatch();
+                var bm = new BitmapMatch(indexSearcher.Allocator);
+                var temp = new RoaringBitmap(indexSearcher.Allocator);
+                for (int t = 0; t < exec.InTermCount; t++)
+                {
+                    var termMatch = ResolveInTerm(clause, exec, t, indexSearcher, plan, parameters, builderParams);
+                    if (clause.ClauseType == ClauseType.AllIn && t > 0)
+                        QueryPrimitives.AndWithMatch(termMatch, ref bm.BitmapState, ref temp);
+                    else
+                        QueryPrimitives.FillFromMatch(termMatch, ref bm.BitmapState);
+                }
+                temp.Dispose();
+                return bm;
+            }
+
+            case ClauseType.Exists:
+                return indexSearcher.ExistsQuery(fieldMeta);
+
+            case ClauseType.StartsWith:
+                return indexSearcher.StartWithQuery(fieldMeta, plan.StringValues[packed.Param1]);
+
+            case ClauseType.EndsWith:
+                return indexSearcher.EndsWithQuery(fieldMeta, plan.StringValues[packed.Param1]);
+
+            case ClauseType.Search:
+            {
+                FieldMetadata searchMeta;
+                // For auto-indexes, search() wraps a non-id field as "search(FieldName)" to use
+                // the analyzed variant of that field. id() is the document key, which is not
+                // analyzed, so we must skip the wrapping — matches Lucene's HandleSearch.
+                bool isDocumentId = string.Equals(clause.FieldName, Client.Constants.Documents.Indexing.Fields.DocumentIdFieldName, StringComparison.Ordinal);
+                if (builderParams != null)
+                {
+                    string searchFieldName = clause.FieldName;
+                    if (builderParams.Metadata.IsDynamic && isDocumentId == false)
+                        searchFieldName = AutoIndexField.GetSearchAutoIndexFieldName(searchFieldName);
+
+                    searchMeta = QueryBuilderHelper.GetFieldMetadata(
+                        builderParams.Allocator, searchFieldName, builderParams.Index,
+                        builderParams.IndexFieldsMapping, builderParams.FieldsToFetch,
+                        builderParams.HasDynamics, builderParams.DynamicFields,
+                        handleSearch: true, hasBoost: builderParams.HasBoost);
+                }
+                else if (parameters is { Index: not null, IndexFieldsMapping: not null })
+                {
+                    string searchFieldName = clause.FieldName;
+                    if (parameters.Metadata.IsDynamic && isDocumentId == false)
+                        searchFieldName = AutoIndexField.GetSearchAutoIndexFieldName(searchFieldName);
+
+                    searchMeta = QueryBuilderHelper.GetFieldMetadata(
+                        parameters.Allocator, searchFieldName, parameters.Index,
+                        parameters.IndexFieldsMapping, parameters.FieldsToFetch,
+                        parameters.HasDynamics, parameters.DynamicFields,
+                        handleSearch: true, hasBoost: parameters.HasBoost);
+                }
+                else
+                {
+                    searchMeta = fieldMeta;
+                }
+
+                var indexDef = builderParams?.Index?.Definition ?? parameters?.Index?.Definition;
+                IndexSearcher.SearchQueryOptions searchQueryOptions;
+                if (indexDef != null && IndexDefinitionBaseServerSide.IndexVersion.IsCoraxSearchWildcardAdjustmentSupported(indexDef.Version))
+                    searchQueryOptions = IndexSearcher.SearchQueryOptions.PhraseQueryWithWildcardAdjustments;
+                else if (indexDef is { Version: >= IndexDefinitionBaseServerSide.IndexVersion.PhraseQuerySupportInCoraxIndexes })
+                    searchQueryOptions = IndexSearcher.SearchQueryOptions.PhraseQuery;
+                else
+                    searchQueryOptions = IndexSearcher.SearchQueryOptions.Legacy;
+
+                var searchTerm = plan.StringValues[packed.Param1];
+                if (searchQueryOptions == IndexSearcher.SearchQueryOptions.PhraseQueryWithWildcardAdjustments
+                    && searchTerm is { Length: >= 1 }
+                    && (searchTerm[0] == '*' || (searchTerm.Length >= 2 && searchTerm[^1] == '*')))
+                {
+                    searchMeta = ReplaceAnalyzerForWildcardQueries(searchMeta, builderParams, parameters);
+                }
+
+                var searchValues = SplitSearchTerms(searchTerm);
+
+                return indexSearcher.SearchQuery(searchMeta,
+                    searchValues,
+                    (Constants.Search.Operator)clause.SearchOperator,
+                    searchQueryOptions);
+            }
+
+            case ClauseType.Regex:
+                return indexSearcher.RegexQuery(fieldMeta,
+                    new System.Text.RegularExpressions.Regex(plan.StringValues[packed.Param1]));
+
+            case ClauseType.Spatial:
+            {
+                if (builderParams == null)
+                    throw new InvalidOperationException("Spatial resolution requires builder parameters");
+                return HandleSpatial(builderParams, clause, exec, clause.SpatialMethodType);
+            }
+
+            case ClauseType.Vector:
+            {
+                if (builderParams == null)
+                    throw new InvalidOperationException("Vector resolution requires builder parameters");
+                var vectorItem = HandleVector(builderParams, clause, exec, false);
+                return vectorItem.Materialize(null);
+            }
+
+            case ClauseType.OrGroup:
+                throw new InvalidOperationException(
+                    "OrGroup should be expanded by ResolveMatches, not resolved as a single clause.");
+
+            case ClauseType.AndGroup:
+                throw new InvalidOperationException(
+                    "AndGroup should be expanded by ResolveMatches, not resolved as a single clause.");
+
+            default:
+                throw new InvalidOperationException($"Unexpected ClauseType {clause.ClauseType} in ResolveClause.");
+        }
+    }
+
+    /// <summary>Resolve a single IN term to a typed TermQuery.
+    /// IN terms are stored contiguously: PackedParamValue.Param1 = start index, InTermCount = count.
+    /// Only non-null terms are in the typed array. Null is handled separately via HasNullTerm.</summary>
+    private static IQueryMatch ResolveInTerm(ClauseInfo clause, ClauseExecution exec, int termIndex,
+        IndexSearcher indexSearcher, QueryExecution plan,
+        PlanParameters parameters, QueryBuilderParameters builderParams)
+    {
+        FieldMetadata fieldMeta = builderParams != null ?
+            QueryBuilderHelper.GetFieldMetadata(in builderParams, clause.FieldName, hasBoost: builderParams.HasBoost) :
+            indexSearcher.FieldMetadataBuilder(clause.FieldName, hasBoost: parameters?.HasBoost ?? false);
+
+        var p = exec.PackedParamValue;
+        int idx = p.Param1 + termIndex;
+        var termPacked = new PackedParam(p.ValueType, idx);
+        return TermQueryFromParam(termPacked, fieldMeta, indexSearcher, plan);
+    }
+
+    /// <summary>Create a pre-materialized <see cref="BitmapMatch"/> for a NotEquals clause
+    /// appearing in an OR chain. OR(NOT X, NOT Y, ...) cannot use the raw term posting list
+    /// (FillBitmapFromPostingSource would add entries WITH X, not WITHOUT X). Instead, we
+    /// pre-compute AllEntries ANDNOT TermQuery(X) into a BitmapMatch so that FillFromMatch
+    /// during execution correctly ORs in the set of entries NOT having X.</summary>
+    private static IQueryMatch CreateNotEqualsOrMatch(ClauseInfo clause, ClauseExecution exec, IndexSearcher indexSearcher,
+        QueryExecution plan, PlanParameters parameters, QueryBuilderParameters builderParams)
+    {
+        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, indexSearcher, parameters, builderParams);
+        IQueryMatch termMatch = TermQueryFromParam(exec.PackedParamValue, fieldMeta, indexSearcher, plan);
+
+        var bitmapMatch = new BitmapMatch(indexSearcher.Allocator);
+        var tempData = new RoaringBitmap(indexSearcher.Allocator);
+        QueryPrimitives.FillFromMatch(indexSearcher.AllEntries(), ref bitmapMatch.BitmapState);
+        QueryPrimitives.AndNotWithMatch(termMatch, ref bitmapMatch.BitmapState, ref tempData);
+        tempData.Dispose();
+        return bitmapMatch;
+    }
+
+    // ── Term-source resolution ───────────────────────────────────────────
+
+    /// <summary>
+    /// Resolve clause infos to <see cref="PostingSource"/> instances for the native
+    /// posting-list dispatch path. Parallels <see cref="ResolveMatches"/> — the
+    /// returned array uses the same indexing scheme. Slots whose underlying
+    /// clause is multi-term / non-term-shaped (Spatial, Vector, Search, Range,
+    /// StartsWith, EndsWith, Regex, AllEntries) keep <c>Kind == PostingSourceKind.Empty</c>;
+    /// only Equals / NotEquals / In / AllIn / OrGroup-of-(Not)Equals slots populate.
+    /// The IL emitter consults <see cref="PlanOp.Dispatch"/> to decide which
+    /// array to read.
+    /// </summary>
+    private static PostingSource[] ResolveTermSources(QueryExecution plan, IndexSearcher indexSearcher,
+        PlanParameters parameters = null, QueryBuilderParameters builderParams = null)
+    {
+        // IsAllEntries plans never emit term ops (FillFromPostings / AndWith / etc.) —
+        // their match[0] is AllEntries, post-filter slots are spatial/vector. No
+        // PostingSource population is needed.
+        if (plan.IsAllEntries)
+            return [];
+
+        if (plan.Clauses is not { Count: > 0 } clauses)
+            return [];
+
+        var execs = plan.Executions;
+
+        // Standalone NotEquals: matches[0] = AllEntries (NOT a term source),
+        // matches[1] = the negated term. Mirror that layout.
+        if (clauses.Count == 1 && clauses[0].IsNegated && !plan.AllNegated)
+        {
+            var sources = new PostingSource[2];
+            sources[1] = ResolveSingleTermSource(clauses[0], execs[0], indexSearcher, plan, parameters, builderParams);
+            return sources;
+        }
+
+        var termSources = new PostingSource[CountMatchSlots(clauses, execs, plan.IsAllEntries, plan.AllNegated)];
+        int matchIdx = 0;
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            ClauseInfo clause = clauses[ci];
+            ClauseExecution exec = execs[ci];
+            switch (clause.ClauseType)
+            {
+                case ClauseType.OrGroup when clause.OrSubClauses is { Count: > 0 }:
+                {
+                    for (int si = 0; si < clause.OrSubClauses.Count; si++)
+                    {
+                        var sub = clause.OrSubClauses[si];
+                        var subExec = exec.OrSubExecutions[si];
+                        if (subExec.BoostFactor > 0)
+                        {
+                            matchIdx++;
+                            continue;
+                        }
+                        termSources[matchIdx++] = ResolveSingleTermSource(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                    }
+
+                    break;
+                }
+                case ClauseType.AndGroup when clause.AndSubClauses is { Count: > 0 }:
+                {
+                    for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                    {
+                        var sub = clause.AndSubClauses[si];
+                        var subExec = exec.AndSubExecutions[si];
+                        if (subExec.BoostFactor > 0)
+                        {
+                            matchIdx++;
+                            continue;
+                        }
+                        termSources[matchIdx++] = ResolveSingleTermSource(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                    }
+
+                    break;
+                }
+                case ClauseType.AllIn or ClauseType.In:
+                {
+                    for (int t = 0; t < exec.InTermCount; t++)
+                        termSources[matchIdx++] = ResolveInTermSource(clause, exec, t, indexSearcher, plan, parameters, builderParams);
+                    matchIdx++; // null-term slot — always allocated, stays Empty in TermSources (uses QueryMatch path)
+                    break;
+                }
+                default:
+                {
+                    if (exec.BoostFactor > 0)
+                    {
+                        matchIdx++;
+                        continue;
+                    }
+                    termSources[matchIdx++] = ResolveSingleTermSource(clause, exec, indexSearcher, plan, parameters, builderParams);
+                    break;
+                }
+            }
+        }
+        // AllNegated extra slot is AllEntries — stays Empty in TermSources.
+        return termSources;
+    }
+
+    /// <summary>Resolve TreeScan-eligible clauses to ITermsProvider instances for direct
+    /// tree-scan dispatch in the compiled pipeline. Slot indexing is parallel to
+    /// ResolveMatches/ResolveTermSources. Returns null if no TreeScan clauses exist.</summary>
+    private static ITermsProvider[] ResolveTermsProviders(QueryExecution plan, IndexSearcher indexSearcher,
+        PlanParameters parameters = null, QueryBuilderParameters builderParams = null)
+    {
+        if (plan.IsAllEntries || plan.Clauses is not { Count: > 0 } clauses)
+            return null;
+
+        var execs = plan.Executions;
+        bool hasAnyTreeScan = false;
+
+        // Quick check: do we have any TreeScan clauses at all?
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            var clause = clauses[ci];
+            var exec = execs != null && ci < execs.Length ? execs[ci] : null;
+
+            if (IsTreeScanEligibleClause(clause, exec))
+            {
+                hasAnyTreeScan = true;
+                break;
+            }
+
+            // Check subclauses
+            if (clause.OrSubClauses != null)
+            {
+                for (int si = 0; si < clause.OrSubClauses.Count; si++)
+                {
+                    var subExec = exec?.OrSubExecutions?[si];
+                    if (IsTreeScanEligibleClause(clause.OrSubClauses[si], subExec))
+                    {
+                        hasAnyTreeScan = true;
+                        break;
+                    }
+                }
+            }
+            if (hasAnyTreeScan) break;
+
+            if (clause.AndSubClauses != null)
+            {
+                for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                {
+                    var subExec = exec?.AndSubExecutions?[si];
+                    if (IsTreeScanEligibleClause(clause.AndSubClauses[si], subExec))
+                    {
+                        hasAnyTreeScan = true;
+                        break;
+                    }
+                }
+            }
+            if (hasAnyTreeScan) break;
+        }
+
+        if (!hasAnyTreeScan)
+            return null;
+
+        int totalSlots = CountMatchSlots(clauses, execs, plan.IsAllEntries, plan.AllNegated);
+        var providers = new ITermsProvider[totalSlots];
+        int matchIdx = 0;
+
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            ClauseInfo clause = clauses[ci];
+            ClauseExecution exec = execs != null && ci < execs.Length ? execs[ci] : null;
+
+            switch (clause.ClauseType)
+            {
+                case ClauseType.OrGroup when clause.OrSubClauses is { Count: > 0 }:
+                    for (int si = 0; si < clause.OrSubClauses.Count; si++)
+                    {
+                        var sub = clause.OrSubClauses[si];
+                        var subExec = exec?.OrSubExecutions?[si];
+                        providers[matchIdx] = ResolveSingleTermsProvider(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                        matchIdx++;
+                    }
+                    break;
+
+                case ClauseType.AndGroup when clause.AndSubClauses is { Count: > 0 }:
+                    for (int si = 0; si < clause.AndSubClauses.Count; si++)
+                    {
+                        var sub = clause.AndSubClauses[si];
+                        var subExec = exec?.AndSubExecutions?[si];
+                        providers[matchIdx] = ResolveSingleTermsProvider(sub, subExec, indexSearcher, plan, parameters, builderParams);
+                        matchIdx++;
+                    }
+                    break;
+
+                case ClauseType.AllIn or ClauseType.In:
+                    // IN terms use PostingList dispatch, not TreeScan. +1 for null-term slot (always allocated).
+                    matchIdx += (exec?.InTermCount ?? 0) + 1;
+                    break;
+
+                default:
+                    providers[matchIdx] = ResolveSingleTermsProvider(clause, exec, indexSearcher, plan, parameters, builderParams);
+                    matchIdx++;
+                    break;
+            }
+        }
+
+        return providers;
+    }
+
+    /// <summary>Resolve a single TreeScan-eligible clause to its raw ITermsProvider.
+    /// Returns null for non-TreeScan clauses or when the field doesn't exist in the
+    /// index (factory method returned TermMatch.Empty instead of TermsProviderMatch).
+    /// Null slots cause the IL to fall through to the QueryMatch dispatch path.</summary>
+    private static ITermsProvider ResolveSingleTermsProvider(ClauseInfo clause, ClauseExecution exec,
+        IndexSearcher indexSearcher, QueryExecution plan, PlanParameters parameters, QueryBuilderParameters builderParams)
+    {
+        if (IsTreeScanEligibleClause(clause, exec) == false)
+            return null;
+
+        // Create the match via the existing factory methods, then extract the provider.
+        // The factory methods handle all complexity (analyzer, CompactKey, tree lookup).
+        var match = ResolveClause(clause, exec ?? new ClauseExecution(), indexSearcher, plan, parameters, builderParams);
+        if (match is TermsProviderMatch tpm)
+            return tpm.Provider;
+
+        // Factory returned something other than TermsProviderMatch (e.g. TermMatch.Empty
+        // when the field doesn't exist). Return an empty provider so the IL's TreeScan
+        // dispatch gets a valid (no-op) provider instead of null.
+        return EmptyTermsProviderInstance.Instance;
+    }
+
+    /// <summary>Resolve a single Equals / NotEquals clause to a posting-list ID and
+    /// decode it into a <see cref="PostingSource"/>. Returns Empty when the clause
+    /// is non-term-shaped or the term doesn't exist in the index.</summary>
+    private static PostingSource ResolveSingleTermSource(ClauseInfo clause, ClauseExecution exec, IndexSearcher indexSearcher,
+        QueryExecution plan, PlanParameters parameters, QueryBuilderParameters builderParams)
+    {
+        if (IsTermSourceEligibleClause(clause, exec) == false)
+            return default; // Kind == Empty
+
+        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, indexSearcher, parameters, builderParams);
+        long postingListId = GetTermPostingListIdFromParam(exec.PackedParamValue, fieldMeta, indexSearcher, plan);
+        return DecodePostingListId(postingListId, indexSearcher);
+    }
+
+    /// <summary>Resolve a single In/AllIn term to a posting-list ID.
+    /// Uses <paramref name="termIndex"/> into <see cref="ClauseInfo.InTerms"/> /
+    /// <see cref="ClauseInfo.InTermTypes"/> to pick the correct numeric vs. string
+    /// overload — avoids the long.TryParse false-positive on zero-padded string
+    /// values like "000001" (parses as 1L but is indexed as the string "000001").</summary>
+    private static PostingSource ResolveInTermSource(ClauseInfo clause, ClauseExecution exec, int termIndex, IndexSearcher indexSearcher,
+        QueryExecution plan, PlanParameters parameters, QueryBuilderParameters builderParams)
+    {
+        FieldMetadata fieldMeta = builderParams != null ?
+            QueryBuilderHelper.GetFieldMetadata(in builderParams, clause.FieldName, hasBoost: builderParams.HasBoost) :
+            indexSearcher.FieldMetadataBuilder(clause.FieldName, hasBoost: parameters?.HasBoost ?? false);
+
+        var p = exec.PackedParamValue;
+        int idx = p.Param1 + termIndex;
+        var termPacked = new PackedParam(p.ValueType, idx);
+        long postingListId = GetTermPostingListIdFromParam(termPacked, fieldMeta, indexSearcher, plan);
+        return DecodePostingListId(postingListId, indexSearcher);
+    }
+
+    /// <summary>Resolve field metadata for a term-source clause. Mirrors the
+    /// non-Spatial/Vector/Search branch of <see cref="ResolveClause"/>.</summary>
+    private static FieldMetadata ResolveFieldMetadata(ClauseInfo clause, IndexSearcher indexSearcher,
+        PlanParameters parameters, QueryBuilderParameters builderParams)
+    {
+        if (builderParams != null)
+        {
+            string resolvedFieldName = clause.FieldName;
+            if (clause.IsExact && builderParams.Metadata.IsDynamic)
+                resolvedFieldName = AutoIndexField.GetExactAutoIndexFieldName(resolvedFieldName);
+            return QueryBuilderHelper.GetFieldMetadata(in builderParams, resolvedFieldName, exact: clause.IsExact, hasBoost: builderParams.HasBoost);
+        }
+
+        return indexSearcher.FieldMetadataBuilder(clause.FieldName, hasBoost: parameters?.HasBoost ?? false);
+    }
+
+    /// <summary>Decode a raw posting-list ID (with TermIdMask bits) into a
+    /// <see cref="PostingSource"/>. Returns Empty when the term doesn't exist (-1).
+    /// For PostingList kind, opens a fresh iterator on the underlying set.</summary>
+    private static PostingSource DecodePostingListId(long postingListId, IndexSearcher indexSearcher)
+    {
+        if (postingListId == -1)
+        {
+            return default; // Kind == Empty
+        }
+
+        var termType = (global::Corax.Indexing.TermIdMask)postingListId & global::Corax.Indexing.TermIdMask.EnsureIsSingleMask;
+        switch (termType)
+        {
+            case global::Corax.Indexing.TermIdMask.Single:
+                return new PostingSource
+                {
+                    Kind = PostingSourceKind.Single,
+                    SingleEntryId = (long)EntryIdEncodings.GetContainerId(postingListId),
+                };
+
+            case global::Corax.Indexing.TermIdMask.SmallPostingList:
+                return new PostingSource
+                {
+                    Kind = PostingSourceKind.SmallPostingList,
+                    SmallPostingListId = (long)EntryIdEncodings.GetContainerId(postingListId),
+                };
+
+            case global::Corax.Indexing.TermIdMask.PostingList:
+            {
+                var postingList = indexSearcher.GetPostingList(postingListId);
+                return new PostingSource
+                {
+                    Kind = PostingSourceKind.PostingList,
+                    LargeIterator = postingList.Iterate(),
+                };
+            }
+
+            default:
+                return default;
+        }
+    }
+
+    // ── Scan parameter extraction ────────────────────────────────────────
+
+    /// <summary>Extract typed parameter values from clauses for entry scan.
+    /// Called per-query at execution time. The values populate the CompiledQueryMatch arrays.</summary>
+    private static void ExtractScanParameters(QueryExecution plan, IndexSearcher indexSearcher,
+        out long[] longParams, out double[] doubleParams, out Voron.Slice[] sliceParams, out long[] fieldRootPages)
+    {
+        var predicates = plan.ScanPredicateInfos;
+        if (predicates == null || predicates.Length == 0)
+        {
+            longParams = [];
+            doubleParams = [];
+            sliceParams = [];
+            fieldRootPages = [];
+            return;
+        }
+
+        var longs = new List<long>();
+        var doubles = new List<double>();
+        var slices = new List<Voron.Slice>();
+        var roots = new List<long>();
+
+        // Walk predicates and clauses in lock-step. BuildScanPredicateInfo skips non-eligible
+        // clauses (Search, In, AllIn, Exists, StartsWith, EndsWith, Regex, Spatial, Vector,
+        // AndGroup), so we must skip them here too to keep the 1:1 positional mapping.
+        int scanStart = plan.AllNegated ? 0 : 1;
+        int clauseIdx = scanStart;
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        int dummyL = 0, dummyD = 0, dummyS = 0;
+        foreach (ScanPredicateInfo pred in predicates)
+        {
+            // Advance past clauses that BuildScanPredicateInfo would have skipped (returned null).
+            while (clauseIdx < clauses.Count &&
+                   BuildScanPredicateInfo(clauses[clauseIdx], execs != null && clauseIdx < execs.Length ? execs[clauseIdx] : null,
+                       ref dummyL, ref dummyD, ref dummyS) == null)
+            {
+                clauseIdx++;
+            }
+
+            ClauseInfo matchingClause = clauseIdx < clauses.Count ? clauses[clauseIdx] : null;
+            ClauseExecution matchingExec = execs != null && clauseIdx < execs.Length ? execs[clauseIdx] : null;
+            clauseIdx++;
+            ExtractParamsFromPredicate(pred, matchingClause, matchingExec, indexSearcher, plan, longs, doubles, slices, roots);
+        }
+
+        longParams = longs.Count > 0 ? longs.ToArray() : [];
+        doubleParams = doubles.Count > 0 ? doubles.ToArray() : [];
+        sliceParams = slices.Count > 0 ? slices.ToArray() : [];
+        fieldRootPages = roots.Count > 0 ? roots.ToArray() : [];
+    }
+
+    private static void ExtractParamsFromPredicate(ScanPredicateInfo pred, ClauseInfo clause, ClauseExecution exec,
+        IndexSearcher indexSearcher, QueryExecution plan, List<long> longs, List<double> doubles,
+        List<Voron.Slice> slices, List<long> roots)
+    {
+        if (pred.SubPredicates != null)
+        {
+            // Each OrBranch corresponds to a subclause of the OrGroup.
+            // Pass subclauses positionally to avoid the same field-name ambiguity.
+            List<ClauseInfo> subClauses = clause?.OrSubClauses;
+            ClauseExecution[] subExecs = exec?.OrSubExecutions;
+            for (int b = 0; b < pred.SubPredicates.Length; b++)
+            {
+                ClauseInfo subClause = (subClauses != null && b < subClauses.Count) ? subClauses[b] : null;
+                ClauseExecution subExec = (subExecs != null && b < subExecs.Length) ? subExecs[b] : null;
+                ExtractParamsFromPredicate(pred.SubPredicates[b], subClause, subExec, indexSearcher, plan, longs, doubles, slices, roots);
+            }
+            return;
+        }
+
+        // Resolve field root page
+        roots.Add(indexSearcher.FieldCache.GetLookupRootPage(pred.FieldName));
+
+        if (clause == null || exec == null)
+            return;
+
+        // Read pre-resolved typed values from the plan's arrays via packed param.
+        var packed = exec.PackedParamValue;
+        if (packed.IsNone)
+            return;
+        int idx1 = packed.Param1;
+        int idx2 = packed.Param2;
+        bool hasBetween = idx2 != PackedParam.NoParamValue;
+
+        switch (pred.ValueType)
+        {
+            case ScanValueType.Long:
+                longs.Add(plan.LongValues[idx1]);
+                if (hasBetween)
+                    longs.Add(plan.LongValues[idx2]);
+                break;
+            case ScanValueType.Double:
+                doubles.Add(plan.DoubleValues[idx1]);
+                if (hasBetween)
+                    doubles.Add(plan.DoubleValues[idx2]);
+                break;
+            case ScanValueType.Slice:
+                var fieldMeta = indexSearcher.FieldMetadataBuilder(clause.FieldName);
+                slices.Add(indexSearcher.EncodeAndApplyAnalyzer(fieldMeta, plan.StringValues[idx1]));
+                if (hasBetween)
+                    slices.Add(indexSearcher.EncodeAndApplyAnalyzer(fieldMeta, plan.StringValues[idx2]));
+                break;
+        }
+    }
+
+    // ── Highlighting ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Populate the highlighting terms dictionary from the plan's clauses.
+    /// The old CoraxQueryBuilder did this as a side effect during query building.
+    /// The bitmap pipeline must do it explicitly after plan building.
+    /// </summary>
+    private static void PopulateHighlightingTerms(QueryExecution plan, Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms, QueryMetadata metadata)
+    {
+        if (highlightingTerms == null || plan.Clauses is not { Count: > 0 } clauses)
+            return;
+
+        var execs = plan.Executions;
+        for (int ci = 0; ci < clauses.Count; ci++)
+        {
+            var clauseObj = clauses[ci];
+            var exec = execs != null && ci < execs.Length ? execs[ci] : null;
+            if (clauseObj?.FieldName == null)
+                continue;
+
+            PopulateHighlightingForClause(clauseObj, exec, highlightingTerms, metadata, plan);
+
+            switch (clauseObj.ClauseType)
+            {
+                case ClauseType.OrGroup when clauseObj.OrSubClauses is { Count: > 0 }:
+                {
+                    for (int si = 0; si < clauseObj.OrSubClauses.Count; si++)
+                    {
+                        var subExec = exec?.OrSubExecutions != null && si < exec.OrSubExecutions.Length ? exec.OrSubExecutions[si] : null;
+                        PopulateHighlightingForClause(clauseObj.OrSubClauses[si], subExec, highlightingTerms, metadata, plan);
+                    }
+                    break;
+                }
+                case ClauseType.AndGroup when clauseObj.AndSubClauses is { Count: > 0 }:
+                {
+                    for (int si = 0; si < clauseObj.AndSubClauses.Count; si++)
+                    {
+                        var subExec = exec?.AndSubExecutions != null && si < exec.AndSubExecutions.Length ? exec.AndSubExecutions[si] : null;
+                        PopulateHighlightingForClause(clauseObj.AndSubClauses[si], subExec, highlightingTerms, metadata, plan);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    private static void PopulateHighlightingForClause(ClauseInfo clause, ClauseExecution exec, Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms, QueryMetadata metadata, QueryExecution plan)
+    {
+        string fieldName = clause.FieldName;
+        if (fieldName == null)
+            return;
+
+        if (highlightingTerms.TryGetValue(fieldName, out var existingTerm))
+        {
+            // Already populated (e.g., multiple clauses on same field) — update values if needed
+            existingTerm.Values ??= GetHighlightingValues(clause, exec, plan);
+            return;
+        }
+
+        var term = new CoraxHighlightingTermIndex
+        {
+            FieldName = fieldName,
+            Values = GetHighlightingValues(clause, exec, plan)
+        };
+
+        if (metadata.IsDynamic && clause.ClauseType == ClauseType.Search)
+            term.DynamicFieldName = AutoIndexField.GetSearchAutoIndexFieldName(fieldName);
+        else if (metadata.IsDynamic && clause.IsExact)
+            term.DynamicFieldName = AutoIndexField.GetExactAutoIndexFieldName(fieldName);
+
+        highlightingTerms[fieldName] = term;
+
+        // For dynamic indexes, also add the dynamic field name variant
+        if (term.DynamicFieldName != null)
+            highlightingTerms[term.DynamicFieldName] = term;
+    }
+
+    private static object GetHighlightingValues(ClauseInfo clause, ClauseExecution exec, QueryExecution plan)
+    {
+        var packed = exec?.PackedParamValue ?? PackedParam.None;
+        if (clause.ClauseType == ClauseType.Between)
+        {
+            return new Tuple<string, string>(
+                FormatValueFromPlan(packed, plan),
+                FormatValue2FromPlan(packed, plan));
+        }
+
+        int inTermCount = exec?.InTermCount ?? 0;
+        bool hasNullTerm = exec?.HasNullTerm ?? false;
+        if (clause.ClauseType is ClauseType.In or ClauseType.AllIn && (inTermCount > 0 || hasNullTerm))
+        {
+            var p = packed;
+            var terms = new List<string>(inTermCount + (hasNullTerm ? 1 : 0));
+            for (int t = 0; t < inTermCount; t++)
+                terms.Add(FormatValueFromPlan(new PackedParam(p.ValueType, p.Param1 + t), plan));
+            if (hasNullTerm)
+                terms.Add(null);
+            return terms;
+        }
+
+        return FormatValueFromPlan(packed, plan);
+    }
+
+    // ── Vector / Spatial resolution ──────────────────────────────────────
+
+    /// <summary>
+    /// Resolve vector select operations from the plan into CoraxVectorItem instances.
+    /// These are NOT materialized yet — the caller materializes them with the bitmap-producing
+    /// match as the filterQuery. Returns null if the plan has no vectors.
+    /// </summary>
+    private static CoraxVectorItem[] ResolveVectorItems(QueryExecution plan, QueryBuilderParameters builderParams = null)
+    {
+        if (plan.VectorSelects == null || plan.VectorSelects.Length == 0)
+            return null;
+
+        var items = new CoraxVectorItem[plan.VectorSelects.Length];
+        for (int i = 0; i < plan.VectorSelects.Length; i++)
+        {
+            var clause = plan.VectorSelects[i].Clause;
+            var exec = plan.VectorSelects[i].Exec;
+            if (clause == null || clause.ClauseType != ClauseType.Vector || builderParams == null)
+                throw new InvalidOperationException("Vector select references an invalid clause at index " + i);
+
+            items[i] = HandleVector(builderParams, clause, exec, false);
+        }
+        return items;
+    }
+
+    private static IQueryMatch HandleSpatial(QueryBuilderParameters builderParameters, ClauseInfo clause, ClauseExecution exec, SpatialOperationType spatialMethod)
+    {
+        var index = builderParameters.Index;
+        var allocator = builderParameters.Allocator;
+
+        // Field name was pre-resolved during parsing.
+        string fieldName = clause.FieldName
+            ?? throw new InvalidOperationException("Spatial clause has no pre-resolved field name.");
+
+        var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(allocator, fieldName, index, builderParameters.IndexFieldsMapping,
+            builderParameters.FieldsToFetch, builderParameters.HasDynamics, builderParameters.DynamicFields, hasBoost: builderParameters.HasBoost);
+
+        var sp = exec.Spatial;
+        var distanceErrorPct = sp.DistanceErrorPct >= 0
+            ? sp.DistanceErrorPct
+            : RavenConstants.Documents.Indexing.Spatial.DefaultDistanceErrorPct;
+
+        var spatialField = builderParameters.Factories.GetSpatialFieldFactory(fieldName);
+
+        // Build shape from pre-resolved parameters — no GetValue calls
+        IShape shape;
+        SpatialUnits? units = sp.Units.HasValue ? (SpatialUnits)sp.Units.Value : null;
+        if (sp.ShapeType == SpatialShapeType.Circle)
+        {
+            shape = spatialField.ReadCircle(sp.CircleRadius, sp.CircleLatitude, sp.CircleLongitude, units);
+        }
+        else if (sp.Wkt != null)
+        {
+            shape = spatialField.ReadShape(sp.Wkt, units);
+        }
+        else
+        {
+            throw new InvalidOperationException("Spatial clause has no pre-resolved shape parameters.");
+        }
+
+        return builderParameters.IndexSearcher.SpatialQuery(fieldMetadata, distanceErrorPct, shape, spatialField.GetContext(), (SpatialRelation)spatialMethod, token: builderParameters.Token);
+    }
+
+    private static CoraxVectorItem HandleVector(QueryBuilderParameters builderParameters, ClauseInfo clause, ClauseExecution exec, bool exact)
+    {
+        IndexField indexField;
+        string embeddingsGenerationTaskIdentifier;
+
+        var vec = exec.Vector;
+        var minimumMatch = vec.MinimumMatch >= 0
+            ? vec.MinimumMatch
+            : builderParameters.Index.Configuration.CoraxVectorSearchDefaultMinimumSimilarity;
+
+        int numberOfCandidates = vec.NumberOfCandidates >= 0
+            ? vec.NumberOfCandidates
+            : builderParameters.Index.Configuration.CoraxVectorDefaultNumberOfCandidatesForQuerying;
+
+        var fieldName = clause.FieldName
+            ?? throw new InvalidOperationException("Vector clause has no pre-resolved field name.");
+
+        var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(builderParameters, fieldName, hasBoost: builderParameters.HasBoost);
+
+        // Use pre-resolved vector value and method kind from parsing
+        object methodParameter = vec.ResolvedValue;
+        ValueTokenType valueTokenType = ToValueTokenType(vec.ResolvedValueType);
+
+        if (vec.Method != VectorSourceKind.Inline)
+        {
+            var method = vec.Method switch
+            {
+                VectorSourceKind.FromDocument => VectorHelpers.MethodVectorValue.ForDocument,
+                VectorSourceKind.FromText => VectorHelpers.MethodVectorValue.EmbeddingText,
+                _ => throw new InvalidDataException($"Unknown vector source kind: {vec.Method}")
+            };
+
+            if (method is not VectorHelpers.MethodVectorValue.EmbeddingText)
+            {
+                return (method, methodParameter) switch
+                {
+                    (method: VectorHelpers.MethodVectorValue.ForDocument, string docId) => CoraxVectorItem.BuildForDocVector(builderParameters, fieldMetadata, docId, numberOfCandidates, minimumMatch, exact),
+                    (method: VectorHelpers.MethodVectorValue.ForDocument, StringSegment docIdSegment) => CoraxVectorItem.BuildForDocVector(builderParameters, fieldMetadata, docIdSegment.Value, numberOfCandidates, minimumMatch, exact),
+                    (method: VectorHelpers.MethodVectorValue.ForRaw, string vectorAsBase64) => CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, vectorAsBase64), numberOfCandidates, minimumMatch, exact),
+                    (method: VectorHelpers.MethodVectorValue.ForRaw, StringSegment stringSegmentAsBase64) => CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, stringSegmentAsBase64.ToString()), numberOfCandidates, minimumMatch, exact),
+                    (_, BlittableJsonReaderArray { Length: > 0 }) => throw new InvalidDataException("Cannot perform search on empty value."),
+                    _ => throw new InvalidQueryException(
+                        $"Unknown method in value ({vec.Method}. Parameter type: {methodParameter?.GetType().FullName}, Value: {methodParameter}")
+                };
+            }
+
+            embeddingsGenerationTaskIdentifier = vec.AiTaskName;
+            var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
+            if (vectorOptions != null)
+            {
+                vectorOptions = new VectorOptions()
+                {
+                    DestinationEmbeddingType = vectorOptions.DestinationEmbeddingType,
+                    Dimensions = vectorOptions.Dimensions,
+                    SourceEmbeddingType = VectorEmbeddingType.Text,
+                    NumberOfCandidatesForIndexing = vectorOptions.NumberOfCandidatesForIndexing,
+                    NumberOfEdges = vectorOptions.NumberOfEdges
+                };
+            }
+
+            var vector = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueTokenType, methodParameter, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
+
+            if (vector.SingleVector != null)
+                return CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, vector.SingleVector.Value, numberOfCandidates, minimumMatch, exact);
+
+            return CoraxVectorItem.BuildMultiVector(builderParameters, fieldMetadata, vector.MultiVector, numberOfCandidates, minimumMatch, exact);
+        }
+
+        // Direct value (not a method call) — use pre-resolved value
+        var value = methodParameter;
+        var valueType = valueTokenType;
+
+        (VectorValue? SingleVector, VectorValue[] MultiVector) transformedEmbeddings = (null, null);
+        int numberOfDimensions;
+        if (VectorHelpers.TryRetrieveEmbeddingsGenerationTaskIdentifier(builderParameters, fieldName, out embeddingsGenerationTaskIdentifier))
+        {
+            var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
+            transformedEmbeddings = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueType, value, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
+        }
+        else
+        {
+            VectorOptions vectorOptions = VectorHelpers.GetOptions(builderParameters, fieldName, out indexField);
+
+            if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out numberOfDimensions) == false)
+                return CoraxVectorItem.BuildEmpty(builderParameters); // no vector indexed
+            if (vectorOptions.SourceEmbeddingType is VectorEmbeddingType.Text)
+            {
+                transformedEmbeddings = VectorHelpers.GetVectorValueForTextualInput(builderParameters, vectorOptions, valueType, value);
+            }
+            else
+            {
+                switch (value)
+                {
+                    case string s:
+                        transformedEmbeddings.SingleVector = GenerateEmbeddings.FromBase64Array(vectorOptions, builderParameters.Allocator, s);
+                        break;
+                    case StringSegment stringSegment:
+                        transformedEmbeddings.SingleVector = GenerateEmbeddings.FromBase64Array(vectorOptions, builderParameters.Allocator, stringSegment.ToString());
+                        break;
+                    case BlittableJsonReaderObject bjro:
+                        transformedEmbeddings.SingleVector = VectorHelpers.GetVectorValueFromRavenVector(builderParameters, bjro, vectorOptions);
+                        break;
+                    case BlittableJsonReaderArray { Length: > 0 } bjra:
+                    {
+                        var isRavenVector = bjra[0] is BlittableJsonReaderObject;
+                        var isStringArray = bjra[0] is string or StringSegment or LazyStringValue;
+                        var isArray = bjra[0] is BlittableJsonReaderArray;
+
+                        if (isRavenVector == false && isStringArray == false && isArray == false)
+                        {
+                            transformedEmbeddings.SingleVector = VectorHelpers.GetVectorValueFromNumericalBlittableArray(builderParameters, bjra, vectorOptions);
+                        }
+                        else
+                        {
+                            var embeddings = new VectorValue[bjra.Length];
+                            for (int i = 0; i < bjra.Length; ++i)
+                            {
+                                if (isRavenVector)
+                                    embeddings[i] = VectorHelpers.GetVectorValueFromRavenVector(builderParameters, (BlittableJsonReaderObject)bjra[i], vectorOptions);
+                                else if (isStringArray)
+                                    embeddings[i] = GenerateEmbeddings.FromBase64Array(vectorOptions, builderParameters.Allocator, bjra[i].ToString());
+                                else
+                                    embeddings[i] = VectorHelpers.GetVectorValueFromNumericalBlittableArray(builderParameters, (BlittableJsonReaderArray)bjra[i],
+                                        vectorOptions);
+                            }
+
+                            transformedEmbeddings.MultiVector = embeddings;
+                        }
+
+                        break;
+                    }
+                    default:
+                        PortableExceptions.Throw<InvalidDataException>("We expected to get vector(s), however got: " + value.GetType().Name);
+                        break;
+                }
+            }
+        }
+
+        if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out numberOfDimensions) == false)
+            return CoraxVectorItem.BuildEmpty(builderParameters); // no vector indexed
+
+        if (transformedEmbeddings.SingleVector != null)
+        {
+            var singleVector = transformedEmbeddings.SingleVector.Value;
+
+            if (indexField != null)
+                AssertDimensions(singleVector);
+            return CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, singleVector, numberOfCandidates, minimumMatch, exact);
+        }
+
+        if (transformedEmbeddings.MultiVector != null)
+        {
+            var multiVector = transformedEmbeddings.MultiVector;
+
+            if (indexField != null)
+            {
+                foreach (var vector in multiVector)
+                    AssertDimensions(vector);
+            }
+            return CoraxVectorItem.BuildMultiVector(builderParameters, fieldMetadata, multiVector, numberOfCandidates, minimumMatch, exact);
+        }
+
+        throw new InvalidDataException("Expected to get single or multiple embeddings of VectorValue type but none was provided");
+
+        void AssertDimensions(in VectorValue vector)
+        {
+            if (numberOfDimensions != vector.Length)
+            {
+                using (vector)
+                    VectorHelpers.ThrowDifferentNumberOfDimensions(indexField, fieldName, vector, numberOfDimensions);
+            }
+        }
+    }
+
+    private static class VectorHelpers
+    {
+        public enum MethodVectorValue
+        {
+            ForDocument,
+            ForRaw,
+            EmbeddingText
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryRetrieveEmbeddingsGenerationTaskIdentifier(QueryBuilderParameters builderParameters, in string fieldName, out string embeddingsGenerationTaskIdentifier)
+        {
+            var existsInPersistence =
+                builderParameters.Index.IndexFieldsPersistence.TryReadEmbeddingsGenerationTaskIdentifier(fieldName, out embeddingsGenerationTaskIdentifier);
+
+            if (builderParameters.Metadata.IsDynamic == false)
+                return existsInPersistence;
+
+            if (((builderParameters.FieldsToFetch != null && builderParameters.FieldsToFetch.IndexFields.TryGetValue(fieldName, out var indexField)) || (builderParameters.Index.Definition.IndexFields.TryGetValue(fieldName, out indexField))) && indexField.Vector is AutoVectorOptions avo)
+            {
+                embeddingsGenerationTaskIdentifier = avo.EmbeddingsGenerationTaskIdentifier;
+                return string.IsNullOrEmpty(avo.EmbeddingsGenerationTaskIdentifier) == false;
+            }
+
+            embeddingsGenerationTaskIdentifier = null;
+            return false;
+        }
+
+        internal static (VectorValue? SingleVector, VectorValue[] MultiVector) GetVectorValueForTextualInput(QueryBuilderParameters parameters, VectorOptions vectorOptions, ValueTokenType valueType, object value)
+        {
+            if (valueType is ValueTokenType.String)
+                return (GenerateEmbeddings.FromText(parameters.Allocator, vectorOptions, value.ToString()), null);
+
+            if (valueType is not ValueTokenType.Parameter)
+                PortableExceptions.Throw<InvalidDataException>($"Cannot use vector.search() on a text field with a non-string value. Got {valueType}");
+
+            if (value is BlittableJsonReaderArray valueAsList)
+            {
+                var embeddings = new VectorValue[valueAsList.Length];
+                for (var i = 0; i < valueAsList.Length; ++i)
+                    embeddings[i] = GenerateEmbeddings.FromText(parameters.Allocator, vectorOptions, valueAsList[i].ToString());
+
+                return (null, embeddings);
+            }
+
+            PortableExceptions.Throw<InvalidDataException>($"Cannot use vector.search() on a text field with a non-string value(s). Got {valueType}");
+            return (null, null);
+        }
+
+        internal static VectorValue GetVectorValueFromRavenVector(QueryBuilderParameters parameters, BlittableJsonReaderObject json, VectorOptions vectorOptions)
+        {
+            var vectorObjectFound = json.TryGetMember(Sparrow.Global.Constants.Naming.VectorPropertyName, out var vectorObject);
+            PortableExceptions.ThrowIfNot<InvalidDataException>(vectorObjectFound, "Cannot find vector property in the object.");
+
+            var vectorReader = (BlittableJsonReaderVector)vectorObject;
+            return QueryBuilderHelper.GetVectorValueFromBlittableJsonVectorReader(parameters.Allocator, vectorOptions, vectorReader);
+        }
+
+        internal static VectorValue GetVectorValueFromNumericalBlittableArray(QueryBuilderParameters parameters, BlittableJsonReaderArray array, VectorOptions vectorOptions)
+        {
+            var bytesUsed = array.Length * (vectorOptions.SourceEmbeddingType is VectorEmbeddingType.Single ? sizeof(float) : 1);
+            var memScope = parameters.Allocator.Allocate(bytesUsed, out Memory<byte> mem);
+            ref var floatRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, float>(mem.Span));
+            ref var sbyteRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, sbyte>(mem.Span));
+            ref var byteRef = ref MemoryMarshal.GetReference(mem.Span);
+
+            for (int i = 0; i < array.Length; ++i)
+            {
+                switch (vectorOptions.SourceEmbeddingType)
+                {
+                    case VectorEmbeddingType.Single:
+                        Unsafe.Add(ref floatRef, i) = array.GetByIndex<float>(i);
+                        break;
+                    case VectorEmbeddingType.Int8:
+                        Unsafe.Add(ref sbyteRef, i) = array.GetByIndex<sbyte>(i);
+                        break;
+                    default:
+                        Unsafe.AddByteOffset(ref byteRef, i) = array.GetByIndex<byte>(i);
+                        break;
+                }
+            }
+
+            return GenerateEmbeddings.FromArray(parameters.Allocator, memScope, mem, vectorOptions, bytesUsed);
+        }
+
+        internal static VectorOptions GetExplicitVectorOptions(QueryBuilderParameters builderParameters, in string fieldName, out IndexField indexField)
+        {
+            if ((builderParameters.FieldsToFetch != null && builderParameters.FieldsToFetch.IndexFields.TryGetValue(fieldName, out indexField)) == false
+                && (builderParameters.Index.Definition.IndexFields.TryGetValue(fieldName, out indexField)) == false)
+                PortableExceptions.Throw<InvalidDataException>($"Cannot find `{fieldName}` field in the index.");
+
+            return indexField.Vector;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static VectorOptions GetOptions(QueryBuilderParameters builderParameters, in string fieldName, out IndexField indexField)
+        {
+            if ((builderParameters.FieldsToFetch != null && builderParameters.FieldsToFetch.IndexFields.TryGetValue(fieldName, out indexField)) == false
+                && (builderParameters.Index.Definition.IndexFields.TryGetValue(fieldName, out indexField)) == false)
+                PortableExceptions.Throw<InvalidDataException>($"Cannot find `{fieldName}` field in the index.");
+
+            // VectorOptions can be null when a user does not specify the configuration.
+            // In such cases, we will choose the input depending on the value type (similar to how we handle it during indexing).
+            if (indexField.Vector != null)
+                return indexField.Vector;
+
+            builderParameters.Index.IndexFieldsPersistence.TryReadVectorSourceEmbeddingType(fieldName, out var vectorSourceEmbeddingType);
+
+            var defaultVectorOptions = vectorSourceEmbeddingType switch
+            {
+                VectorEmbeddingType.Single => VectorOptions.Default,
+                VectorEmbeddingType.Text => VectorOptions.DefaultText,
+                _ => throw new InvalidDataException(
+                    $"Unknown vector source embedding type: {vectorSourceEmbeddingType}. Implicit configuration support only single and text vector source embedding types.")
+            };
+
+            indexField.Vector = defaultVectorOptions;
+
+            return defaultVectorOptions;
+        }
+
+        internal static void ThrowDifferentNumberOfDimensions(in IndexField indexField, in string fieldName, in VectorValue transformedEmbedding,
+            in int numberOfDimensions)
+        {
+            var (storedDimensions, inputDimensions) = indexField.Vector.DestinationEmbeddingType switch
+            {
+                VectorEmbeddingType.Single => (numberOfDimensions / sizeof(float), transformedEmbedding.Length / sizeof(float)),
+                VectorEmbeddingType.Int8 => (numberOfDimensions - sizeof(float), transformedEmbedding.Length - sizeof(float)),
+                VectorEmbeddingType.Binary => (numberOfDimensions, transformedEmbedding.Length),
+                _ => throw new InvalidDataException($"Unexpected embedding type - {numberOfDimensions}.")
+            };
+
+            PortableExceptions.Throw<InvalidDataException>(
+                $"Vector field `{fieldName}` has {storedDimensions} dimensions, but the vector passed to vector.search() has {inputDimensions} dimensions.");
+        }
+
+        internal static (VectorValue? SingleVector, VectorValue[] MultiVector) GetEmbeddingsForQueryParameter(QueryBuilderParameters builderParameters, ValueTokenType valueType,
+            object value,
+            string embeddingsGenerationTaskIdentifier, VectorOptions vectorOptions, string fieldName)
+        {
+            var database = builderParameters.Index.DocumentDatabase;
+
+            var embeddingsTaskId = new EmbeddingsGenerationTaskIdentifier(embeddingsGenerationTaskIdentifier);
+
+            var embeddingsGenerator = database.EmbeddingsGeneratorQueries;
+
+            var sourceEmbeddingType = embeddingsGenerator.GetQuantizationOf(embeddingsTaskId);
+
+            // Quantized dynamic field indicates that the task generated embeddings with different quantization than requested in the index
+            // In this case we want to use quantization defined in dynamic field (which was set in CurrentIndexingScope.GetLoadVectorField)
+            VectorEmbeddingType destinationEmbeddingType;
+            if (builderParameters.Metadata.IsDynamic)
+            {
+                destinationEmbeddingType = sourceEmbeddingType is not VectorEmbeddingType.Single ? 
+                    sourceEmbeddingType : 
+                    vectorOptions!.DestinationEmbeddingType;
+            }
+            else
+            {
+                destinationEmbeddingType = vectorOptions?.DestinationEmbeddingType ?? sourceEmbeddingType;
+            }
+
+            ReadOnlyMemory<ReadOnlyMemory<byte>> embeddingValues;
+
+            switch (valueType)
+            {
+                case ValueTokenType.String:
+                    embeddingValues = embeddingsGenerator
+                        .GetEmbeddingsForQuery(builderParameters.DocumentsContext, embeddingsTaskId, value.ToString());
+                    break;
+                case ValueTokenType.Parameter:
+                {
+                    if (value is not BlittableJsonReaderArray bjra)
+                        throw new InvalidQueryException($"Expected array as parameter of vector.search({fieldName}) method, got '{value.GetType().FullName}' type instead.");
+
+                    var values = new string[bjra.Length];
+
+                    for (var i = 0; i < values.Length; i++)
+                        values[i] = bjra[i].ToString();
+
+                    embeddingValues = embeddingsGenerator
+                        .GetEmbeddingsForQuery(builderParameters.DocumentsContext, embeddingsTaskId, values);
+                    break;
+                }
+                default:
+                    throw new NotSupportedException($"Unexpected value type provided as parameter to vector.search({fieldName}) method. Got '{value.GetType().FullName}' type.");
+            }
+
+            var queryingVectorOption = new VectorOptions
+            {
+                SourceEmbeddingType = sourceEmbeddingType,
+                DestinationEmbeddingType = destinationEmbeddingType
+            };
+
+            if (embeddingValues.Length == 1)
+            {
+                var embeddingValue = embeddingValues.Span[0];
+
+                return (GenerateEmbeddings.FromArray(builderParameters.Allocator, embeddingValue.Span, queryingVectorOption), null);
+            }
+            else
+            {
+                var vectorValues = new VectorValue[embeddingValues.Length];
+
+                for (int i = 0; i < embeddingValues.Length; i++)
+                {
+                    var embeddingValue = embeddingValues.Span[i];
+
+                    vectorValues[i] = GenerateEmbeddings.FromArray(builderParameters.Allocator, embeddingValue.Span, queryingVectorOption);
+                }
+
+                return (null, vectorValues);
+            }
+        }
+    }
+
+    // ── Compound field merging (WHERE only, no ORDER BY) ──────────────────
+
+    // ── Compound field exact match (no ORDER BY) ─────────────────────────
+
+    /// <summary>Check if two Equals clauses on (field1, field2) match a compound field.
+    /// If so, build a single TermQuery on the compound tree with the composite key.
+    /// One tree lookup instead of two posting list intersections.</summary>
+    public static bool TryCreateCompoundExactMatch(
+        QueryExecution plan, PlanParameters planParams, QueryBuilderParameters builderParams,
+        out IQueryMatch compoundMatch)
+    {
+        compoundMatch = null;
+        if (plan.Clauses == null || plan.Clauses.Count < 2 || plan.AllNegated)
+            return false;
+        if (planParams.Index == null)
+            return false;
+
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        var index = planParams.Index;
+        var indexSearcher = planParams.IndexSearcher;
+        var allocator = planParams.Allocator;
+
+        // Find two unboosted Equals clauses that match a compound field
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            var c1 = clauses[i];
+            if (c1.ClauseType != ClauseType.Equals || c1.IsNegated || c1.HasBoost)
+                continue;
+            var e1 = execs[i];
+            if (e1.BoostFactor > 0 || e1.PackedParamValue.IsNone)
+                continue;
+
+            for (int j = i + 1; j < clauses.Count; j++)
+            {
+                var c2 = clauses[j];
+                if (c2.ClauseType != ClauseType.Equals || c2.IsNegated || c2.HasBoost)
+                    continue;
+                var e2 = execs[j];
+                if (e2.BoostFactor > 0 || e2.PackedParamValue.IsNone)
+                    continue;
+
+                // Check both orderings
+                string firstField = null, secondField = null;
+                ClauseExecution firstExec = null, secondExec = null;
+
+                using (Voron.Slice.From(allocator, c1.FieldName, out var s1))
+                using (Voron.Slice.From(allocator, c2.FieldName, out var s2))
+                {
+                    if (index.HasCompoundField(s1, s2, out _))
+                    {
+                        firstField = c1.FieldName; secondField = c2.FieldName;
+                        firstExec = e1; secondExec = e2;
+                    }
+                    else if (index.HasCompoundField(s2, s1, out _))
+                    {
+                        firstField = c2.FieldName; secondField = c1.FieldName;
+                        firstExec = e2; secondExec = e1;
+                    }
+                }
+
+                if (firstField == null) continue;
+
+                // Build field1 bytes
+                byte[] field1Bytes = BuildCompoundFieldBytes(firstField, firstExec, indexSearcher, plan);
+                if (field1Bytes == null || field1Bytes.Length > byte.MaxValue) continue;
+
+                // Build field2 bytes
+                byte[] field2Bytes = BuildCompoundFieldBytes(secondField, secondExec, indexSearcher, plan);
+                if (field2Bytes == null) continue;
+
+                // Build composite key
+                int totalLen = field1Bytes.Length + field2Bytes.Length + 1;
+                if (totalLen > Constants.Terms.MaxLength) continue;
+
+                var compositeKey = new byte[totalLen];
+                field1Bytes.CopyTo(compositeKey, 0);
+                field2Bytes.CopyTo(compositeKey.AsSpan(field1Bytes.Length));
+                compositeKey[^1] = (byte)field1Bytes.Length;
+
+                var compoundFieldName = $"compound({firstField},{secondField})";
+                var compoundFieldMeta = indexSearcher.FieldMetadataBuilder(compoundFieldName, hasBoost: false);
+                Voron.Slice.From(allocator, compositeKey, out var keySlice);
+
+                // Single exact-term lookup on the compound tree
+                compoundMatch = indexSearcher.TermQuery(compoundFieldMeta, keySlice);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static byte[] BuildCompoundFieldBytes(string fieldName, ClauseExecution exec,
+        IndexSearcher indexSearcher, QueryExecution plan)
+    {
+        var p = exec.PackedParamValue;
+        if (p.ValueType == PackedParam.TypeString)
+        {
+            var meta = indexSearcher.FieldMetadataBuilder(fieldName, hasBoost: false);
+            var analyzed = indexSearcher.EncodeAndApplyAnalyzer(meta, plan.StringValues[p.Param1]);
+            if (analyzed.Size > byte.MaxValue) return null;
+            var bytes = new byte[analyzed.Size];
+            analyzed.CopyTo(bytes);
+            return bytes;
+        }
+        if (p.ValueType == PackedParam.TypeLong)
+        {
+            var bytes = new byte[sizeof(long)];
+            System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                bytes, Sparrow.Binary.Bits.SwapBytes(plan.LongValues[p.Param1]));
+            return bytes;
+        }
+        if (p.ValueType == PackedParam.TypeDouble)
+        {
+            var bytes = new byte[sizeof(long)];
+            long sortable = Sparrow.Binary.Bits.DoubleToSortableLong(plan.DoubleValues[p.Param1]);
+            System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                bytes, Sparrow.Binary.Bits.SwapBytes(sortable));
+            return bytes;
+        }
+        return null;
+    }
+
+    // ── Compound field optimization (with ORDER BY) ─────────────────────
+
+    /// <summary>Check if WHERE + ORDER BY can be served by a compound tree scan.
+    /// Condition: an Equals clause on field1, ORDER BY on field2 (or field1, or both),
+    /// compound(field1, field2) exists in the index, and any residual clauses are
+    /// entry-scan eligible.
+    /// Returns a DirectScanMatch wrapping a compound tree StartsWith with optional
+    /// residual predicate checking.</summary>
+    public static bool TryCreateCompoundFieldMatch(
+        QueryExecution plan, OrderMetadata[] orderByFields,
+        PlanParameters planParams, QueryBuilderParameters builderParams,
+        CompiledPlan compiledPlan, out IQueryMatch compoundMatch)
+    {
+        compoundMatch = null;
+
+        if (orderByFields == null || orderByFields.Length == 0)
+            return false;
+        if (plan.Clauses == null || plan.Clauses.Count == 0 || plan.AllNegated)
+            return false;
+
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        var index = planParams.Index;
+        var indexSearcher = planParams.IndexSearcher;
+        var allocator = planParams.Allocator;
+
+        // Determine which field to pair with the Equals clause for compound lookup.
+        // Single ORDER BY: compound(equalsField, sortField)
+        // Two ORDER BY fields: compound(orderBy[0], orderBy[1]) — the Equals must be on orderBy[0]
+        string sortFieldName;
+        string compoundField1ForMultiSort = null;
+        if (orderByFields.Length == 1)
+        {
+            sortFieldName = orderByFields[0].Field.FieldName.ToString();
+        }
+        else if (orderByFields.Length == 2)
+        {
+            // Check if compound(orderBy[0], orderBy[1]) exists
+            string f1 = orderByFields[0].Field.FieldName.ToString();
+            string f2 = orderByFields[1].Field.FieldName.ToString();
+            using (Voron.Slice.From(allocator, f1, out var s1))
+            using (Voron.Slice.From(allocator, f2, out var s2))
+            {
+                if (index.HasCompoundField(s1, s2, out _))
+                {
+                    sortFieldName = f2; // The compound tree sorts by f1 then f2
+                    compoundField1ForMultiSort = f1; // The Equals clause must be on f1
+                }
+                else
+                {
+                    return false; // No compound field for this ORDER BY pair
+                }
+            }
+        }
+        else
+        {
+            return false; // >2 ORDER BY fields not supported
+        }
+
+        // Find an Equals clause that, paired with the ORDER BY field, matches a compound field
+        int drivingClauseIdx = -1;
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            var c = clauses[i];
+            if (c.ClauseType != ClauseType.Equals || c.IsNegated || c.HasBoost)
+                continue;
+            var e = execs[i];
+            if (e.BoostFactor > 0)
+                continue;
+
+            if (compoundField1ForMultiSort != null)
+            {
+                // Multi-field ORDER BY: the Equals must be on the first ORDER BY field
+                if (c.FieldName == compoundField1ForMultiSort)
+                {
+                    drivingClauseIdx = i;
+                    break;
+                }
+            }
+            else
+            {
+                // Single-field ORDER BY: check compound(equalsField, sortField)
+                using (Voron.Slice.From(allocator, c.FieldName, out var f1Slice))
+                using (Voron.Slice.From(allocator, sortFieldName, out var sortSlice))
+                {
+                    if (index.HasCompoundField(f1Slice, sortSlice, out _))
+                    {
+                        drivingClauseIdx = i;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (drivingClauseIdx == -1)
+            return false;
+
+        var drivingClause = clauses[drivingClauseIdx];
+        var drivingExec = execs[drivingClauseIdx];
+        var packed = drivingExec.PackedParamValue;
+        if (packed.IsNone)
+            return false;
+
+        // Look for an optional range clause on field2 (the sort field) — narrows the compound scan
+        int field2RangeIdx = -1;
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            if (i == drivingClauseIdx) continue;
+            if (clauses[i].FieldName != sortFieldName) continue;
+            if (clauses[i].ClauseType is ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual
+                or ClauseType.LessThan or ClauseType.LessThanOrEqual or ClauseType.Between)
+            {
+                field2RangeIdx = i;
+                break;
+            }
+        }
+
+        // Check residual clauses are entry-scan eligible
+        var residualPreds = new List<ScanPredicateInfo>();
+        int longIdx = 0, doubleIdx = 0, sliceIdx = 0;
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            if (i == drivingClauseIdx || i == field2RangeIdx)
+                continue;
+            if (clauses[i].HasBoost || (execs[i] is { BoostFactor: > 0 }))
+                return false; // boosted clauses need scoring — can't entry scan
+            var pred = BuildScanPredicateInfo(clauses[i], execs[i], ref longIdx, ref doubleIdx, ref sliceIdx);
+            if (pred == null)
+                return false; // non-scannable residual → fall back to bitmap
+            residualPreds.Add(pred.Value);
+        }
+
+        // Cost check: estimate scan count vs bitmap cost
+        long drivingCardinality = drivingExec.Cardinality > 0 ? drivingExec.Cardinality : indexSearcher.NumberOfEntries;
+        long bitmapCost = 0;
+        for (int i = 0; i < clauses.Count; i++)
+            bitmapCost += execs[i].Cardinality > 0 ? execs[i].Cardinality : indexSearcher.NumberOfEntries;
+
+        // Estimate entries to scan (accounting for residual selectivity)
+        long entriesToScan = drivingCardinality;
+        if (residualPreds.Count > 0)
+        {
+            long minResidualCardinality = long.MaxValue;
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (i == drivingClauseIdx) continue;
+                long card = execs[i].Cardinality > 0 ? execs[i].Cardinality : indexSearcher.NumberOfEntries;
+                if (card < minResidualCardinality)
+                    minResidualCardinality = card;
+            }
+            if (minResidualCardinality > 0 && minResidualCardinality < indexSearcher.NumberOfEntries)
+            {
+                double passRate = (double)minResidualCardinality / indexSearcher.NumberOfEntries;
+                if (passRate > 0)
+                    entriesToScan = (long)(drivingCardinality / passRate);
+            }
+        }
+
+        long directCost = entriesToScan > long.MaxValue / QueryPrimitives.EntryScanCostMultiplier ? long.MaxValue : entriesToScan * QueryPrimitives.EntryScanCostMultiplier;
+        if (directCost >= bitmapCost || entriesToScan > QueryPrimitives.EntryScanCountThreshold)
+            return false; // bitmap is cheaper
+
+        // Build the compound tree match
+        string field1Name = drivingClause.FieldName;
+        var compoundFieldName = $"compound({field1Name},{sortFieldName})";
+        var compoundFieldMeta = indexSearcher.FieldMetadataBuilder(compoundFieldName, hasBoost: false);
+
+        // Build the prefix bytes for field1's value.
+        // String: analyzed via field1's analyzer. Numeric: Bits.SwapBytes big-endian encoding.
+        Voron.Slice analyzedPrefix;
+        string field1ValueStr;
+        switch (packed.ValueType)
+        {
+            case PackedParam.TypeString:
+            {
+                field1ValueStr = plan.StringValues[packed.Param1];
+                var field1Meta = builderParams != null
+                    ? QueryBuilderHelper.GetFieldMetadata(in builderParams, field1Name, hasBoost: false)
+                    : indexSearcher.FieldMetadataBuilder(field1Name, hasBoost: false);
+                analyzedPrefix = indexSearcher.EncodeAndApplyAnalyzer(field1Meta, field1ValueStr);
+                break;
+            }
+            case PackedParam.TypeLong:
+            {
+                long longVal = plan.LongValues[packed.Param1];
+                field1ValueStr = longVal.ToString();
+                var bytes = new byte[sizeof(long)];
+                System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(bytes, Sparrow.Binary.Bits.SwapBytes(longVal));
+                Voron.Slice.From(allocator, bytes, out analyzedPrefix);
+                break;
+            }
+            case PackedParam.TypeDouble:
+            {
+                double dblVal = plan.DoubleValues[packed.Param1];
+                field1ValueStr = dblVal.ToString(CultureInfo.InvariantCulture);
+                long sortable = Sparrow.Binary.Bits.DoubleToSortableLong(dblVal);
+                var bytes = new byte[sizeof(long)];
+                System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(bytes, Sparrow.Binary.Bits.SwapBytes(sortable));
+                Voron.Slice.From(allocator, bytes, out analyzedPrefix);
+                break;
+            }
+            default:
+                return false;
+        }
+
+        // Compound key trailing byte stores field1 length as a single byte.
+        // If the analyzed prefix exceeds 255 bytes, the compound key format can't represent it.
+        // Fall back to the bitmap pipeline which queries individual fields normally.
+        if (analyzedPrefix.Size > byte.MaxValue)
+            return false;
+
+        IQueryMatch drivingMatch = null;
+        if (field2RangeIdx >= 0)
+        {
+            // Compound range: build composite low/high keys incorporating the field2 bound
+            var field2Exec = execs[field2RangeIdx];
+            var field2Clause = clauses[field2RangeIdx];
+            var field2Packed = field2Exec.PackedParamValue;
+
+            if (field2Packed.IsNone == false)
+            {
+                // Encode field2 bound value into bytes (same encoding as indexing).
+                // Long/Double: Bits.SwapBytes big-endian. String: analyze with field2's analyzer.
+                byte[] field2Bytes = null;
+                byte[] field2HighBytes = null;
+                bool usePrefix = false;
+
+                if (field2Packed.ValueType == PackedParam.TypeLong)
+                {
+                    field2Bytes = new byte[sizeof(long)];
+                    System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                        field2Bytes, Sparrow.Binary.Bits.SwapBytes(plan.LongValues[field2Packed.Param1]));
+                    if (field2Clause.ClauseType == ClauseType.Between)
+                    {
+                        field2HighBytes = new byte[sizeof(long)];
+                        System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                            field2HighBytes, Sparrow.Binary.Bits.SwapBytes(plan.LongValues[field2Packed.Param2]));
+                    }
+                }
+                else if (field2Packed.ValueType == PackedParam.TypeDouble)
+                {
+                    field2Bytes = new byte[sizeof(long)];
+                    long sortable = Sparrow.Binary.Bits.DoubleToSortableLong(plan.DoubleValues[field2Packed.Param1]);
+                    System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                        field2Bytes, Sparrow.Binary.Bits.SwapBytes(sortable));
+                    if (field2Clause.ClauseType == ClauseType.Between)
+                    {
+                        field2HighBytes = new byte[sizeof(long)];
+                        long highSortable = Sparrow.Binary.Bits.DoubleToSortableLong(plan.DoubleValues[field2Packed.Param2]);
+                        System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(
+                            field2HighBytes, Sparrow.Binary.Bits.SwapBytes(highSortable));
+                    }
+                }
+                else if (field2Packed.ValueType == PackedParam.TypeString)
+                {
+                    // Analyze field2's value with the sort field's analyzer (same as indexing)
+                    var field2Meta = builderParams != null
+                        ? QueryBuilderHelper.GetFieldMetadata(in builderParams, sortFieldName, hasBoost: false)
+                        : indexSearcher.FieldMetadataBuilder(sortFieldName, hasBoost: false);
+                    var analyzed = indexSearcher.EncodeAndApplyAnalyzer(field2Meta, plan.StringValues[field2Packed.Param1]);
+                    if (analyzed.Size > byte.MaxValue)
+                        usePrefix = true;
+                    else
+                    {
+                        field2Bytes = new byte[analyzed.Size];
+                        analyzed.CopyTo(field2Bytes);
+                        if (field2Clause.ClauseType == ClauseType.Between)
+                        {
+                            var analyzedHigh = indexSearcher.EncodeAndApplyAnalyzer(field2Meta, plan.StringValues[field2Packed.Param2]);
+                            if (analyzedHigh.Size > byte.MaxValue)
+                                usePrefix = true;
+                            else
+                            {
+                                field2HighBytes = new byte[analyzedHigh.Size];
+                                analyzedHigh.CopyTo(field2HighBytes);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    usePrefix = true;
+                }
+
+                if (usePrefix || field2Bytes == null)
+                {
+                    // Field2 value too long or unsupported type — fall back to prefix-only
+                    drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
+                        isNegated: false, forward: orderByFields[0].Ascending,
+                        validatePostfixLen: true);
+                }
+                else
+                {
+
+                    // Build low and high composite keys
+                    int prefixLen = analyzedPrefix.Size;
+                    int field2Len = field2Bytes.Length;
+                    int keyLen = prefixLen + field2Len + 1; // +1 for field1 length byte
+                    int highField2Len = field2HighBytes?.Length ?? field2Len;
+                    int highKeyLen = prefixLen + highField2Len + 1;
+
+                    // Check total key length against max
+                    if (keyLen > Constants.Terms.MaxLength || highKeyLen > Constants.Terms.MaxLength)
+                    {
+                        drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
+                            isNegated: false, forward: orderByFields[0].Ascending, validatePostfixLen: true);
+                        goto DrivingMatchReady;
+                    }
+
+                    byte[] lowKeyBytes = new byte[keyLen];
+                    byte[] highKeyBytes = new byte[highKeyLen];
+
+                    analyzedPrefix.CopyTo(lowKeyBytes);
+                    analyzedPrefix.CopyTo(highKeyBytes);
+
+                    // Low key: either the field2 bound or min value (0x00s)
+                    // High key: either the field2 bound or max value (0xFFs)
+                    bool isGt = field2Clause.ClauseType is ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual;
+                    if (isGt || field2Clause.ClauseType == ClauseType.Between)
+                    {
+                        field2Bytes.CopyTo(lowKeyBytes.AsSpan(prefixLen));
+                    }
+                    // else: low = field1 prefix + 0x00s (already zeroed)
+
+                    if (field2Clause.ClauseType is ClauseType.LessThan or ClauseType.LessThanOrEqual || field2Clause.ClauseType == ClauseType.Between)
+                    {
+                        var highBytes = field2HighBytes ?? field2Bytes;
+                        highBytes.CopyTo(highKeyBytes.AsSpan(prefixLen));
+                    }
+                    else
+                    {
+                        // GT/GTE: high = field1 prefix + 0xFF...FF
+                        highKeyBytes.AsSpan(prefixLen, highField2Len).Fill(0xFF);
+                    }
+
+                    // Trailing field1 length byte
+                    lowKeyBytes[^1] = (byte)prefixLen;
+                    highKeyBytes[^1] = (byte)prefixLen;
+
+                    Voron.Slice.From(allocator, lowKeyBytes, out var lowSlice);
+                    Voron.Slice.From(allocator, highKeyBytes, out var highSlice);
+
+                    drivingMatch = indexSearcher.RangeBuilder<global::Corax.Querying.Matches.Meta.Range.Inclusive, global::Corax.Querying.Matches.Meta.Range.Inclusive>(
+                        compoundFieldMeta, lowSlice, highSlice,
+                        forward: orderByFields[0].Ascending, CancellationToken.None);
+                }
+            }
+        }
+        else
+        {
+            // Pure prefix scan (no field2 constraint)
+            drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
+                isNegated: false, forward: orderByFields[0].Ascending,
+                validatePostfixLen: true);
+        }
+        DrivingMatchReady:
+
+        // Extract scan parameters for residual predicates
+        ScanPredicateInfo[] residualArray = residualPreds.Count > 0 ? residualPreds.ToArray() : null;
+        long[] longParams = null;
+        double[] doubleParams = null;
+        Voron.Slice[] sliceParams = null;
+        long[] fieldRootPages = null;
+
+        if (residualArray != null)
+        {
+            var longs = new List<long>();
+            var doubles = new List<double>();
+            var slices = new List<Voron.Slice>();
+            var roots = new List<long>();
+
+            int residualIdx = 0;
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (i == drivingClauseIdx || i == field2RangeIdx) continue;
+                var matchingExec = execs[i];
+
+                // Add field root page
+                roots.Add(indexSearcher.FieldCache.GetLookupRootPage(clauses[i].FieldName));
+
+                var predPacked = matchingExec.PackedParamValue;
+                if (predPacked.IsNone) { residualIdx++; continue; }
+
+                int idx1 = predPacked.Param1;
+                int idx2 = predPacked.Param2;
+                bool hasBetween = idx2 != PackedParam.NoParamValue;
+
+                switch (residualArray[residualIdx].ValueType)
+                {
+                    case ScanValueType.Long:
+                        longs.Add(plan.LongValues[idx1]);
+                        if (hasBetween) longs.Add(plan.LongValues[idx2]);
+                        break;
+                    case ScanValueType.Double:
+                        doubles.Add(plan.DoubleValues[idx1]);
+                        if (hasBetween) doubles.Add(plan.DoubleValues[idx2]);
+                        break;
+                    case ScanValueType.Slice:
+                    {
+                        Voron.Slice.From(allocator, plan.StringValues[idx1], out var s1);
+                        slices.Add(s1);
+                        if (hasBetween)
+                        {
+                            Voron.Slice.From(allocator, plan.StringValues[idx2], out var s2);
+                            slices.Add(s2);
+                        }
+                        break;
+                    }
+                }
+                residualIdx++;
+            }
+
+            longParams = longs.Count > 0 ? longs.ToArray() : null;
+            doubleParams = doubles.Count > 0 ? doubles.ToArray() : null;
+            sliceParams = slices.Count > 0 ? slices.ToArray() : null;
+            fieldRootPages = roots.Count > 0 ? roots.ToArray() : null;
+        }
+
+        var directScan = BuildDirectScan(
+            indexSearcher, drivingMatch, longParams, doubleParams, sliceParams, fieldRootPages,
+            compiledPlan.CompiledEntryPredicate, residualArray);
+        directScan.DrivingTreeName = compoundFieldName;
+        directScan.DrivingClause = $"{field1Name} = '{field1ValueStr}'";
+        directScan.SeekBound = $"'{field1ValueStr}' (prefix, validatePostfixLen)";
+        directScan.Direction = orderByFields[0].Ascending ? "Forward" : "Backward";
+        directScan.ResidualDescription = residualArray != null
+            ? string.Join(", ", residualPreds.ConvertAll(p => $"{p.FieldName} {p.CompareOp}"))
+            : null;
+        directScan.Reason = $"entries_to_scan({entriesToScan}) × {QueryPrimitives.EntryScanCostMultiplier} < bitmap_cost({bitmapCost})";
+
+        compoundMatch = directScan;
+        return true;
+    }
+
+    // ── Simple field direct scan ──────────────────────────────────────────
+
+    /// <summary>Check if a range clause on the ORDER BY field can be served by a direct
+    /// tree scan instead of the bitmap pipeline. The range query already walks the tree
+    /// in sort order, so no SortingMatch wrapper is needed.</summary>
+    public static bool TryCreateSimpleFieldDirectScan(
+        QueryExecution plan, OrderMetadata[] orderByFields,
+        PlanParameters planParams, QueryBuilderParameters builderParams,
+        CompiledPlan compiledPlan, out IQueryMatch directMatch)
+    {
+        directMatch = null;
+
+        if (orderByFields == null || orderByFields.Length == 0)
+            return false;
+
+        // Multi-field ORDER BY is only handled here as a tie-break optimization:
+        // primary field walked in tree order, secondary (numeric) values resolved per
+        // primary-term group and sorted in-place. >2 fields are out of scope — fall back
+        // to bitmap+sort which supports arbitrary depth.
+        if (orderByFields.Length > 2)
+            return false;
+
+        bool hasTieBreak = orderByFields.Length == 2;
+        if (hasTieBreak)
+        {
+            var tieBreakType = orderByFields[1].FieldType;
+            if (tieBreakType is not (MatchCompareFieldType.Integer or MatchCompareFieldType.Floating))
+                return false;
+        }
+
+        var indexSearcher = planParams.IndexSearcher;
+        string sortFieldName = orderByFields[0].Field.FieldName.ToString();
+        bool forward = orderByFields[0].Ascending;
+        var sortFieldType = orderByFields[0].FieldType;
+
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        bool isFullScan = clauses == null || clauses.Count == 0;
+
+        if (isFullScan && plan.AllNegated)
+            return false;
+
+        ITermsProvider provider;
+        Voron.Impl.LowLevelTransaction llt;
+        long drivingCardinality;
+        string drivingClauseDescription;
+        int drivingIdx = -1;
+
+        if (isFullScan)
+        {
+            // ── No WHERE at all, only ORDER BY ──
+            // Full field tree walk — use BetweenQuery for numeric fields (correct numeric
+            // comparison) and ExistsQuery for string/sequence fields.
+            // ExistsQuery uses CompactKeyLookup byte comparison which doesn't match numeric order.
+            // Only index-walkable field types qualify.
+            if (sortFieldType is not (MatchCompareFieldType.Sequence or MatchCompareFieldType.Integer or MatchCompareFieldType.Floating))
+                return false;
+            var fieldMeta = orderByFields[0].Field;
+            IQueryMatch fullScanMatch;
+            if (sortFieldType == MatchCompareFieldType.Integer)
+                fullScanMatch = indexSearcher.BetweenQuery(fieldMeta, long.MinValue, long.MaxValue, forward: forward);
+            else if (sortFieldType == MatchCompareFieldType.Floating)
+                fullScanMatch = indexSearcher.BetweenQuery(fieldMeta, double.MinValue, double.MaxValue, forward: forward);
+            else
+                fullScanMatch = indexSearcher.ExistsQuery(fieldMeta, forward: forward);
+            if (fullScanMatch is not TermsProviderMatch tpm)
+                return false;
+            provider = tpm.Provider;
+            llt = tpm.Llt;
+            drivingCardinality = 0; // not used (cost check skipped)
+            drivingClauseDescription = $"{sortFieldName} [all]";
+        }
+        else
+        {
+            // ── Find a range or equals clause on the sort field ──
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (clauses[i].FieldName != sortFieldName)
+                    continue;
+                if (clauses[i].ClauseType is not (ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual
+                    or ClauseType.LessThan or ClauseType.LessThanOrEqual or ClauseType.Between
+                    or ClauseType.Equals))
+                    continue;
+                if (clauses[i].HasBoost || (execs[i] is { BoostFactor: > 0 }))
+                    continue;
+                drivingIdx = i;
+                break;
+            }
+
+            if (drivingIdx == -1)
+                return false;
+
+            var drivingPacked = execs[drivingIdx].PackedParamValue;
+            if (drivingPacked.IsNone)
+                return false;
+
+            var drivingClause = clauses[drivingIdx];
+            var drivingExec = execs[drivingIdx];
+
+            TermsProviderMatch tpm;
+            if (drivingClause.ClauseType == ClauseType.Equals)
+            {
+                var eqMatch = ResolveEqualsClauseWithDirection(drivingClause, drivingExec, indexSearcher, plan, planParams, builderParams, forward);
+                if (eqMatch is not TermsProviderMatch eq)
+                    return false;
+                tpm = eq;
+            }
+            else
+            {
+                var match = ResolveRangeClauseWithDirection(drivingClause, drivingExec, indexSearcher, plan, planParams, builderParams, forward);
+                if (match is not TermsProviderMatch m)
+                    return false;
+                tpm = m;
+            }
+
+            provider = tpm.Provider;
+            llt = tpm.Llt;
+            drivingCardinality = drivingExec.Cardinality > 0 ? drivingExec.Cardinality : indexSearcher.NumberOfEntries;
+            drivingClauseDescription = $"{drivingClause.FieldName} {drivingClause.ClauseType}";
+        }
+
+        // ── Residual predicates ──
+        int longIdx = 0, doubleIdx = 0, sliceIdx = 0;
+        var residualPreds = new List<ScanPredicateInfo>();
+        if (isFullScan == false)
+        {
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (i == drivingIdx) continue;
+                if (clauses[i].HasBoost || (execs[i] is { BoostFactor: > 0 }))
+                    return false;
+                var pred = BuildScanPredicateInfo(clauses[i], execs[i], ref longIdx, ref doubleIdx, ref sliceIdx);
+                if (pred == null)
+                    return false;
+                residualPreds.Add(pred.Value);
+            }
+        }
+
+        // ── Cost check (skip for full scan — always beneficial) ──
+        long entriesToScan = 0, bitmapCost = 0;
+        if (isFullScan == false)
+        {
+            for (int i = 0; i < clauses.Count; i++)
+                bitmapCost += execs[i].Cardinality > 0 ? execs[i].Cardinality : indexSearcher.NumberOfEntries;
+
+            entriesToScan = drivingCardinality;
+            if (residualPreds.Count > 0)
+            {
+                long minResidual = long.MaxValue;
+                for (int i = 0; i < clauses.Count; i++)
+                {
+                    if (i == drivingIdx) continue;
+                    long c = execs[i].Cardinality > 0 ? execs[i].Cardinality : indexSearcher.NumberOfEntries;
+                    if (c < minResidual) minResidual = c;
+                }
+                if (minResidual > 0 && minResidual < indexSearcher.NumberOfEntries)
+                {
+                    double passRate = (double)minResidual / indexSearcher.NumberOfEntries;
+                    if (passRate > 0) entriesToScan = (long)(drivingCardinality / passRate);
+                }
+            }
+
+            long directCost = entriesToScan > long.MaxValue / QueryPrimitives.EntryScanCostMultiplier ? long.MaxValue : entriesToScan * QueryPrimitives.EntryScanCostMultiplier;
+            if (directCost >= bitmapCost || entriesToScan > QueryPrimitives.EntryScanCountThreshold)
+                return false;
+        }
+
+        // ── Create the driving match ──
+        bool nullIsSmallest = (orderByFields[0].NullsSortMode ?? builderParams.Index.Configuration.NullsSortMode) == NullsSortMode.NullsSmallest;
+        bool nullFirst = forward ? nullIsSmallest : !nullIsSmallest;
+        // BetweenQuery and StartWithQuery don't include nulls in their term output,
+        // so SortedDrivingMatch must drain them itself (respecting nullFirst direction).
+        bool drainNulls = true;
+        IQueryMatch drivingMatch;
+        if (hasTieBreak)
+        {
+            // Per-term group cap: bail if any single primary term could exceed the group
+            // buffer cap. Conservative gate: total driving cardinality must fit.
+            if (drivingCardinality > SortedDrivingWithTieBreakMatch.MaxGroupSize)
+                return false;
+            drivingMatch = new SortedDrivingWithTieBreakMatch(
+                provider, llt, planParams.Allocator, indexSearcher,
+                orderByFields[0].Field, orderByFields[1].Field,
+                orderByFields[1].FieldType, secondaryDescending: orderByFields[1].Ascending == false,
+                nullFirst: nullFirst, nullIsSmallest: nullIsSmallest, drainNulls: drainNulls);
+        }
+        else
+        {
+            drivingMatch = new SortedDrivingMatch(provider, llt, planParams.Allocator,
+                indexSearcher, orderByFields[0].Field, nullFirst, drainNulls);
+        }
+
+        // ── Residual scan parameters ──
+        ScanPredicateInfo[] residualArray = residualPreds.Count > 0 ? residualPreds.ToArray() : null;
+        long[] longParams = null;
+        double[] doubleParams = null;
+        Voron.Slice[] sliceParams = null;
+        long[] fieldRootPages = null;
+
+        if (residualArray != null && clauses != null)
+        {
+            var longs = new List<long>();
+            var doubles = new List<double>();
+            var slices = new List<Voron.Slice>();
+            var roots = new List<long>();
+
+            int residualIdx = 0;
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (i == drivingIdx) continue;
+                roots.Add(indexSearcher.FieldCache.GetLookupRootPage(clauses[i].FieldName));
+                var predPacked = execs[i].PackedParamValue;
+                if (predPacked.IsNone) { residualIdx++; continue; }
+                int idx1 = predPacked.Param1;
+                int idx2 = predPacked.Param2;
+                bool hasBetween = idx2 != PackedParam.NoParamValue;
+                switch (residualArray[residualIdx].ValueType)
+                {
+                    case ScanValueType.Long:
+                        longs.Add(plan.LongValues[idx1]);
+                        if (hasBetween) longs.Add(plan.LongValues[idx2]);
+                        break;
+                    case ScanValueType.Double:
+                        doubles.Add(plan.DoubleValues[idx1]);
+                        if (hasBetween) doubles.Add(plan.DoubleValues[idx2]);
+                        break;
+                    case ScanValueType.Slice:
+                        Voron.Slice.From(planParams.Allocator, plan.StringValues[idx1], out var s1);
+                        slices.Add(s1);
+                        if (hasBetween) { Voron.Slice.From(planParams.Allocator, plan.StringValues[idx2], out var s2); slices.Add(s2); }
+                        break;
+                }
+                residualIdx++;
+            }
+            longParams = longs.Count > 0 ? longs.ToArray() : null;
+            doubleParams = doubles.Count > 0 ? doubles.ToArray() : null;
+            sliceParams = slices.Count > 0 ? slices.ToArray() : null;
+            fieldRootPages = roots.Count > 0 ? roots.ToArray() : null;
+        }
+
+        var ds = BuildDirectScan(
+            indexSearcher, drivingMatch, longParams, doubleParams, sliceParams, fieldRootPages,
+            compiledPlan.CompiledEntryPredicate, residualArray);
+        ds.DrivingTreeName = sortFieldName;
+        ds.DrivingClause = drivingClauseDescription;
+        ds.Direction = orderByFields[0].Ascending ? "Forward" : "Backward";
+        ds.ResidualDescription = residualArray != null
+            ? string.Join(", ", residualPreds.ConvertAll(p => $"{p.FieldName} {p.CompareOp}"))
+            : null;
+        ds.Reason = isFullScan
+            ? "full index-only scan (no WHERE clause)"
+            : $"entries_to_scan({entriesToScan}) × {QueryPrimitives.EntryScanCostMultiplier} < bitmap_cost({bitmapCost})";
+        directMatch = ds;
+        return true;
+    }
+
+    // ── Sort seek hint ────────────────────────────────────────────────────
+
+    /// <summary>If the first clause is a range predicate on the same field as the first
+    /// ORDER BY field, set a seek hint on the CompiledQueryMatch so SortedIndexReader
+    /// can skip walking irrelevant tree terms.</summary>
+    public static void TrySetSortSeekHint(CompiledQueryMatch match,
+        QueryExecution plan, OrderMetadata[] orderByFields)
+    {
+        if (orderByFields == null || orderByFields.Length == 0)
+            return;
+
+        var clauses = plan.Clauses;
+        var execs = plan.Executions;
+        if (clauses == null || clauses.Count == 0 || execs == null || execs.Length == 0)
+            return;
+
+        // Only consider the first ORDER BY field
+        var sortField = orderByFields[0].Field.FieldName;
+
+        // Find a range clause on the same field (scan all clauses, not just first — the sort-eligible
+        // clause may not be the cheapest and thus not clause[0]).
+        for (int i = 0; i < clauses.Count; i++)
+        {
+            var clause = clauses[i];
+            var exec = execs[i];
+
+            if (clause.FieldName != sortField.ToString())
+                continue;
+
+            // Range clauses on the sort field — supports long, double, and string
+            if (clause.ClauseType is not (ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual
+                or ClauseType.LessThan or ClauseType.LessThanOrEqual or ClauseType.Between))
+                continue;
+
+            var packed = exec.PackedParamValue;
+            if (packed.IsNone)
+                continue;
+
+            // For ascending order: seek to the lower bound (GT/GTE value)
+            // For descending order: seek to the upper bound (LT/LTE value)
+            bool ascending = orderByFields[0].Ascending;
+            object seekValue = null;
+            bool inclusive = false;
+
+            if (ascending && clause.ClauseType is ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual)
+            {
+                seekValue = packed.ValueType switch
+                {
+                    PackedParam.TypeLong => plan.LongValues[packed.Param1],
+                    PackedParam.TypeDouble => plan.DoubleValues[packed.Param1],
+                    PackedParam.TypeString => plan.StringValues[packed.Param1],
+                    _ => null
+                };
+                inclusive = clause.ClauseType == ClauseType.GreaterThanOrEqual;
+            }
+            else if (ascending == false && clause.ClauseType is ClauseType.LessThan or ClauseType.LessThanOrEqual)
+            {
+                seekValue = packed.ValueType switch
+                {
+                    PackedParam.TypeLong => plan.LongValues[packed.Param1],
+                    PackedParam.TypeDouble => plan.DoubleValues[packed.Param1],
+                    PackedParam.TypeString => plan.StringValues[packed.Param1],
+                    _ => null
+                };
+                inclusive = clause.ClauseType == ClauseType.LessThanOrEqual;
+            }
+            else if (clause.ClauseType == ClauseType.Between)
+            {
+                // Between: seek to the lower bound for ASC, upper bound for DESC
+                int idx = ascending ? packed.Param1 : packed.Param2;
+                seekValue = packed.ValueType switch
+                {
+                    PackedParam.TypeLong => plan.LongValues[idx],
+                    PackedParam.TypeDouble => plan.DoubleValues[idx],
+                    PackedParam.TypeString => plan.StringValues[idx],
+                    _ => null
+                };
+                inclusive = true; // Between is always inclusive on both sides
+            }
+
+            if (seekValue != null)
+            {
+                match.SortHint = new SortHint(clause.FieldName, seekValue, inclusive);
+                return;
+            }
+        }
+    }
+
+    // ── Sorting / Ordering ───────────────────────────────────────────────
+
+    public static OrderMetadata[] GetSortMetadata(QueryBuilderParameters builderParameters, out bool hasEmpty)
+    {
+        hasEmpty = false;
+        var query = builderParameters.Query;
+        var index = builderParameters.Index;
+        var getSpatialField = builderParameters.Factories?.GetSpatialFieldFactory;
+        var indexMapping = builderParameters.IndexFieldsMapping;
+        var queryMapping = builderParameters.FieldsToFetch;
+        var allocator = builderParameters.Allocator;
+        if (query.PageSize == 0) // no need to sort when counting only
+        {
+            return null;
+        }
+
+        var orderByFields = query.Metadata.OrderBy;
+
+        if (orderByFields == null)
+        {
+            if (builderParameters.HasBoost && (
+                    index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved
+                    || index.Configuration.CoraxVectorSearchOrderByScoreAutomatically))
+            {
+                if (builderParameters.Metadata.HasVectorSearch == false)
+                    builderParameters.IndexReadOperation?.AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved();
+
+                return [new OrderMetadata(true, MatchCompareFieldType.Score)];
+            }
+
+            return null;
+        }
+
+        int sortIndex = 0;
+        var sortArray = new OrderMetadata[16];
+
+        if (orderByFields.Length > sortArray.Length)
+            throw new InvalidOperationException($"Corax does not support ordering by more than {sortArray.Length} properties.");
+
+        foreach (var field in orderByFields)
+        {
+            var nullsSortMode = (field.NullsOrdering, field.Ascending) switch
+            {
+                (NullsOrderingType.First, Ascending: true) => NullsSortMode.NullsSmallest,
+                (NullsOrderingType.First, Ascending: false) => NullsSortMode.NullsLargest,
+                (NullsOrderingType.Last, Ascending: true) => NullsSortMode.NullsLargest,
+                (NullsOrderingType.Last, Ascending: false) => NullsSortMode.NullsSmallest,
+                _ => (NullsSortMode?)null
+            };
+
+            if (field.OrderingType == OrderByFieldType.Random)
+            {
+                var seed = field.Arguments is { Length: > 0 } ?
+                    (int)Hashing.XXHash32.CalculateRaw(field.Arguments[0].NameOrValue) :
+                    Random.Shared.Next();
+                sortArray[sortIndex++] = new OrderMetadata(seed);
+                continue;
+            }
+
+            if (field.OrderingType == OrderByFieldType.Score)
+            {
+                // EntryComparerByScore.Compare is intentionally inverted (returns y.CompareTo(x)),
+                // so ascending=true -> highest scores first (the default "most relevant first" search engine order).
+                // ascending=false -> Descending<EntryComparerByScore> -> lowest scores first.
+                sortArray[sortIndex++] = new OrderMetadata(true, MatchCompareFieldType.Score, field.Ascending);
+
+                continue;
+            }
+
+            var fieldMetadata = QueryBuilderHelper.GetFieldIdForOrderBy(allocator, field.Name, index, builderParameters.HasDynamics,
+                builderParameters.DynamicFields, indexMapping, queryMapping, false);
+
+            bool fieldIsEmpty = builderParameters.IndexSearcher.GetTermAmountInField(fieldMetadata) == 0;
+            if (fieldIsEmpty)
+            {
+                if (builderParameters.IndexReadOperation.IsSharded == false)
+                    continue;
+                hasEmpty = true;
+            }
+
+            if (field.OrderingType == OrderByFieldType.Distance)
+            {
+                var spatialField = getSpatialField(field.Name);
+
+                int lastArgument;
+                IPoint point;
+                switch (field.Method)
+                {
+                    case MethodType.Spatial_Circle:
+                        var cLatitude = field.Arguments[1].GetDouble(query.QueryParameters);
+                        var cLongitude = field.Arguments[2].GetDouble(query.QueryParameters);
+                        lastArgument = 2;
+                        point = spatialField.ReadPoint(cLatitude, cLongitude).Center;
+                        break;
+                    case MethodType.Spatial_Wkt:
+                        var wkt = field.Arguments[0].GetString(query.QueryParameters);
+                        SpatialUnits? spatialUnits = null;
+                        lastArgument = 1;
+                        if (field.Arguments.Length > 1)
+                        {
+                            spatialUnits = Enum.Parse<SpatialUnits>(field.Arguments[1].GetString(query.QueryParameters), ignoreCase: true);
+                            lastArgument = 2;
+                        }
+
+                        point = spatialField.ReadShape(wkt, spatialUnits).Center;
+                        break;
+                    case MethodType.Spatial_Point:
+                        var pLatitude = field.Arguments[0].GetDouble(query.QueryParameters);
+                        var pLongitude = field.Arguments[1].GetDouble(query.QueryParameters);
+                        lastArgument = 2;
+                        point = spatialField.ReadPoint(pLatitude, pLongitude).Center;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                var roundTo = field.Arguments.Length > lastArgument
+                    ? field.Arguments[lastArgument].GetDouble(query.QueryParameters)
+                    : 0D;
+
+                sortArray[sortIndex++] = new OrderMetadata(fieldMetadata, field.Ascending, MatchCompareFieldType.Spatial, point, roundTo,
+                    spatialField.Units is SpatialUnits.Kilometers
+                        ? global::Corax.Utils.Spatial.SpatialUnits.Kilometers
+                        : global::Corax.Utils.Spatial.SpatialUnits.Miles, fieldIsEmpty, nullsSortMode);
+                continue;
+            }
+
+            var orderingType = field.OrderingType;
+            if (orderingType is OrderByFieldType.Implicit && index.Configuration.OrderByTicksAutomaticallyWhenDatesAreInvolved && index.IndexFieldsPersistence.HasTimeValues(field.Name.Value))
+                orderingType = OrderByFieldType.Long;
+
+            var metadataField = QueryBuilderHelper.GetFieldIdForOrderBy(allocator, field.Name.Value, index, builderParameters.HasDynamics,
+                builderParameters.DynamicFields,
+                indexMapping, queryMapping, false);
+            // Dynamic CreateField fields: no IndexFieldsMapping entry, FieldId == DynamicField (-2).
+            // Such fields are written per-document only when the index function emits CreateField;
+            // docs that don't emit the field have NO entry (not even a NonExisting marker) in the
+            // field's tree, so StreamAndIntersect (which walks tree + null/nonExisting lists) would
+            // silently drop them. Route through ExtractAndSort instead — see SortingMatch.Fill.
+            bool mayHaveMissingEntries = metadataField.FieldId == global::Corax.Constants.IndexWriter.DynamicField;
+            OrderMetadata? temporaryOrder = null;
+            switch (orderingType)
+            {
+                case OrderByFieldType.Custom:
+                    throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support Custom OrderBy.");
+                case OrderByFieldType.AlphaNumeric:
+                    sortArray[sortIndex++] = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Alphanumeric, fieldIsEmpty, nullsSortMode, mayHaveMissingEntries);
+                    continue;
+                case OrderByFieldType.Long:
+                    temporaryOrder = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Integer, fieldIsEmpty, nullsSortMode, mayHaveMissingEntries);
+                    break;
+                case OrderByFieldType.Double:
+                    temporaryOrder = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Floating, fieldIsEmpty, nullsSortMode, mayHaveMissingEntries);
+                    break;
+            }
+
+            sortArray[sortIndex++] = temporaryOrder ?? new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Sequence, fieldIsEmpty, nullsSortMode, mayHaveMissingEntries);
+        }
+
+        return sortArray[0..sortIndex];
+    }
+
+    public static IQueryMatch OrderBy(QueryBuilderParameters builderParameters, IQueryMatch match, in OrderMetadata[] orderMetadataSource, bool hasEmptySortingMatches)
+    {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+        var indexSearcher = builderParameters.IndexSearcher;
+        var take = builderParameters.Take;
+        OrderMetadata[] orderMetadata = null;
+        if (hasEmptySortingMatches == false)
+            orderMetadata = orderMetadataSource;
+        else
+        {
+            var currentIdx = 0;
+            foreach (var orderMetadataItem in orderMetadataSource)
+            {
+                if (orderMetadataItem.FieldHasNoTerms)
+                    continue;
+
+                orderMetadata ??= new OrderMetadata[orderMetadataSource.Length];
+                orderMetadata[currentIdx++] = orderMetadataItem;
+            }
+
+            orderMetadata = currentIdx == 0 ? [] : orderMetadata![..currentIdx];
+        }
+
+        switch (orderMetadata.Length)
+        {
+            case 0:
+                return match;
+            case 1:
+                return indexSearcher.OrderBy(match, orderMetadata[0], builderParameters.Index.Configuration.NullsSortMode, take, builderParameters.Token);
+            default:
+                return indexSearcher.OrderBy(match, orderMetadata, builderParameters.Index.Configuration.NullsSortMode, take, builderParameters.Token);
+        }
+    }
+
+    /// <summary>Apply ORDER BY from plan metadata when a full <see cref="QueryBuilderParameters"/> is not
+    /// available (e.g., direct tests). Handles <c>ORDER BY score()</c> only — callers that need
+    /// field / spatial / alphanumeric sorts must use the full
+    /// <see cref="OrderBy(QueryBuilderParameters,IQueryMatch,in OrderMetadata[],bool)"/> overload.</summary>
+    public static IQueryMatch ApplyScoreOrdering(PlanParameters planParams, IQueryMatch match, long take, CancellationToken token = default)
+    {
+        OrderByField[] orderByFields = planParams.Metadata.OrderBy;
+        if (orderByFields == null || orderByFields.Length == 0)
+            return match;
+
+        var indexSearcher = planParams.IndexSearcher;
+        int takeInt = take > int.MaxValue ? Constants.IndexSearcher.TakeAll : (int)take;
+
+        for (int i = 0; i < orderByFields.Length; i++)
+        {
+            if (orderByFields[i].OrderingType == OrderByFieldType.Score)
+            {
+                var meta = new OrderMetadata(true, MatchCompareFieldType.Score, orderByFields[i].Ascending);
+                return indexSearcher.OrderBy(match, meta, NullsSortMode.NullsLargest, take: takeInt, token: token);
+            }
+        }
+
+        return match;
+    }
+
+    // ── Search helpers (used by ResolveClause for Search clause type) ────
+
+    /// <summary>
+    /// Replaces the search analyzer with an appropriate wildcard analyzer.
+    /// LuceneAnalyzerAdapter wrapping KeywordAnalyzer has IsExactAnalyzer=false
+    /// (because LuceneAnalyzerAdapter passes NoTransformers), so the generic
+    /// CreateWildcardAnalyzer in the Legacy path would incorrectly lowercase the term.
+    /// This matches the old CoraxQueryBuilder.ReplaceAnalyzerForWildcardQueries logic.
+    /// </summary>
+    private static FieldMetadata ReplaceAnalyzerForWildcardQueries(
+        FieldMetadata searchMeta,
+        QueryBuilderParameters builderParams,
+        PlanParameters parameters)
+    {
+        var result = searchMeta;
+        var indexFieldsMapping = builderParams?.IndexFieldsMapping ?? parameters?.IndexFieldsMapping;
+
+        if (searchMeta.IsDynamic && indexFieldsMapping != null)
+            result = searchMeta.ChangeAnalyzer(searchMeta.Mode, indexFieldsMapping.SearchAnalyzer(searchMeta.FieldName.ToString()));
+
+        if (searchMeta.Analyzer is Lucene.LuceneAnalyzerAdapter laa && indexFieldsMapping != null)
+        {
+            global::Corax.Analyzers.Analyzer replacementAnalyzer = laa.Analyzer switch
+            {
+                global::Lucene.Net.Analysis.KeywordAnalyzer => indexFieldsMapping.ExactAnalyzer(searchMeta.FieldName.ToString()),
+                Lucene.Analyzers.RavenStandardAnalyzer
+                    or Lucene.Analyzers.NGramAnalyzer => indexFieldsMapping.DefaultAnalyzer,
+                global::Lucene.Net.Analysis.Standard.StandardAnalyzer when laa.Analyzer.GetType() == typeof(global::Lucene.Net.Analysis.Standard.StandardAnalyzer)
+                    => indexFieldsMapping.DefaultAnalyzer,
+                Lucene.Analyzers.LowerCaseKeywordAnalyzer
+                    or Lucene.Analyzers.Collation.CollationAnalyzer => indexFieldsMapping.DefaultAnalyzer,
+                _ => null
+            };
+
+            if (replacementAnalyzer != null)
+                result = searchMeta.ChangeAnalyzer(global::Corax.FieldIndexingMode.Search, replacementAnalyzer);
+        }
+
+        return result;
+    }
+
+    /// <summary>Split search term value respecting quoted phrases.
+    /// "nonexists \"second third\" nonexsts" -> ["nonexists", "second third", "nonexsts"]
+    /// Same logic as old CoraxQueryBuilder.GetValues().</summary>
+    private static IEnumerable<string> SplitSearchTerms(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            yield return value;
+            yield break;
+        }
+
+        bool quoted = false;
+        int lastStart = 0;
+
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            if (c == '"')
+            {
+                if (i > 0 && value[i - 1] == '\\')
+                    continue; // escaped quote
+
+                if (lastStart != i)
+                    yield return value.Substring(lastStart, i - lastStart);
+
+                quoted = !quoted;
+                lastStart = i + 1;
+            }
+            else if ((c == ' ' || c == '\t') && !quoted)
+            {
+                if (lastStart != i)
+                    yield return value.Substring(lastStart, i - lastStart);
+                lastStart = i + 1;
+            }
+        }
+
+        if (value.Length - lastStart > 0)
+            yield return value.Substring(lastStart, value.Length - lastStart);
+    }
+
+    /// <summary>Create the appropriate DirectScan match based on whether residual predicates exist.</summary>
+    private static DirectScanMatchBase BuildDirectScan(
+        IndexSearcher searcher, IQueryMatch drivingMatch,
+        long[] longParams, double[] doubleParams, Voron.Slice[] sliceParams, long[] fieldRootPages,
+        ResidualScanIlEmitter.ResidualScanPredicate residualDelegate,
+        ScanPredicateInfo[]? residualArray)
+    {
+        if (residualArray == null) 
+            return new DirectScanSimpleMatch(searcher, drivingMatch, take: -1);
+        
+        return new DirectScanFilteredMatch(
+            searcher, drivingMatch, longParams, doubleParams, sliceParams, fieldRootPages,
+            take: -1, precompiledDelegate: residualDelegate);
+    }
+
+    /// <summary>Singleton no-op ITermsProvider for TreeScan slots where the field doesn't exist.
+    /// FillPostingListIds returns 0 immediately, so the bitmap op is a no-op.</summary>
+    private sealed class EmptyTermsProviderInstance : ITermsProvider
+    {
+        public static readonly EmptyTermsProviderInstance Instance = new();
+        public bool IsFillSupported => false;
+        public int Fill(Span<long> containers) => 0;
+        public int FillPostingListIds(Span<long> postingListIds) => 0;
+        public void Reset() { }
+        public bool Next(out TermMatch term) { term = default; return false; }
+        public QueryInspectionNode Inspect() => new("EmptyTermsProvider");
+    }
+}

--- a/test/FastTests/Corax/CompiledQueryTests.cs
+++ b/test/FastTests/Corax/CompiledQueryTests.cs
@@ -1,0 +1,1301 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+public class CompiledQueryTests : RavenTestBase
+{
+    public CompiledQueryTests(Xunit.ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task SimpleTermQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Single term query
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status == "active")
+                .ToListAsync();
+
+            Assert.Equal(50, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task AndQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // AND query: Status=active AND Category=cat-0
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status == "active" && x.Category == "cat-0")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.Equal("cat-0", r.Category);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // OR query: Category=cat-0 OR Category=cat-1
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0" || x.Category == "cat-1")
+                .ToListAsync();
+
+            Assert.Equal(40, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task ThreeWayAnd_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 200; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // 3-way AND: Status=active AND Category=cat-0 AND Tag=tag-0
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status == "active" && x.Category == "cat-0" && x.Tag == "tag-0")
+                .ToListAsync();
+
+            // active (100/200) ∩ cat-0 (40/200) ∩ tag-0 (20/200)
+            // Expected: docs where i%2==0 AND i%5==0 AND i%10==0 → i%10==0
+            Assert.Equal(20, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.Equal("cat-0", r.Category);
+                Assert.Equal("tag-0", r.Tag);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task AndWithRange_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = i * 10
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // AND with range: Category=cat-0 AND Price > 200
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0" && x.Price > 200)
+                .ToListAsync();
+
+            // cat-0: indices 0,5,10,15,20,...,95 (20 total)
+            // Price > 200: i*10 > 200 → i > 20
+            // cat-0 indices > 20: 25,30,35,40,45,50,55,60,65,70,75,80,85,90,95 → 15
+            Assert.Equal(15, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("cat-0", r.Category);
+                Assert.True(r.Price > 200);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task InClause_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // IN clause: Category in (cat-0, cat-1, cat-2)
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category in ('cat-0', 'cat-1', 'cat-2')")
+                .ToListAsync();
+
+            // 3 categories × 20 each = 60
+            Assert.Equal(60, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotEquals_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Status != "active" — should get inactive docs
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status != "active")
+                .ToListAsync();
+
+            Assert.Equal(25, results.Count);
+            Assert.All(results, r => Assert.Equal("inactive", r.Status));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task BetweenQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = i * 10
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // BETWEEN: Category=cat-0 AND Price between 100 and 500
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' and Price between 100 and 500")
+                .ToListAsync();
+
+            // cat-0: 0,5,10,15,20,25,30,35,40,45,50,...
+            // Price 100-500: i=10..50 → cat-0 in that range: 10,15,20,25,30,35,40,45,50 → 9
+            Assert.Equal(9, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task LargeResultSet_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 3}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Large AND: 500 active ∩ 334 cat-0 = ~167
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status == "active" && x.Category == "cat-0")
+                .ToListAsync();
+
+            // active: even indices, cat-0: i%3==0
+            // Both: i%2==0 AND i%3==0 → i%6==0 → 0,6,12,...,996 → 167
+            Assert.Equal(167, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task StartsWith_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"alpha-{i}",
+                    Category = "cat-0",
+                    Status = "active"
+                });
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"beta-{i}",
+                    Category = "cat-1",
+                    Status = "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // startsWith
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where startsWith(Name, 'alpha')")
+                .ToListAsync();
+
+            Assert.Equal(50, results.Count);
+            Assert.All(results, r => Assert.StartsWith("alpha", r.Name));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task ExistsQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        // Store docs — all have Category, so exists(Category) should return all
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 3}",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // exists(Category) — all 30 docs have it
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where exists(Category)")
+                .ToListAsync();
+
+            Assert.Equal(30, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task AndWithStartsWith_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"item-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // AND with startsWith: Status=active AND startsWith(Name, 'item-0000')
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and startsWith(Name, 'item-0000')")
+                .ToListAsync();
+
+            // item-00000 to item-00009, active (even): 00000,00002,00004,00006,00008 → 5
+            Assert.Equal(5, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrderByScore_BitmapPath()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestDoc { Name = "hello world foo", Category = "cat-0", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "hello", Category = "cat-0", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "world", Category = "cat-1", Status = "inactive" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // ORDER BY score() should fall back to old path and work correctly
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where search(Name, 'hello') order by score()")
+                .ToListAsync();
+
+            // Should find docs with 'hello' in Name, ordered by relevance
+            Assert.True(results.Count >= 1);
+        }
+    }
+
+    /// <summary>
+    /// Verifies score ordering direction contracts:
+    ///   ORDER BY score()     → highest scores first  (default, search-engine convention)
+    ///   ORDER BY score() ASC → highest scores first  (ASC is idiomatic for "most relevant" in RavenDB)
+    ///   ORDER BY score() DESC → lowest scores first  (explicit reversal)
+    /// </summary>
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrderByScore_DirectionSemantics()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        // Three docs with different boost factors in the query give reliably distinct scores.
+        // Name values are unique so each doc matches exactly one boost() clause.
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestDoc { Name = "doc-a", Category = "cat-x", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "doc-b", Category = "cat-x", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "doc-c", Category = "cat-x", Status = "active" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // boost() factors ensure doc-a > doc-b > doc-c in score.
+        const string where = "boost(Name = 'doc-a', 100) OR boost(Name = 'doc-b', 10) OR boost(Name = 'doc-c', 1)";
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // No direction / default: highest score first.
+            var defaultOrder = await session.Advanced.AsyncRawQuery<TestDoc>(
+                $"from TestDocs where {where} order by score()")
+                .ToListAsync();
+            Assert.Equal(3, defaultOrder.Count);
+            Assert.Equal("doc-a", defaultOrder[0].Name);
+            Assert.Equal("doc-b", defaultOrder[1].Name);
+            Assert.Equal("doc-c", defaultOrder[2].Name);
+
+            // ASC: same as default — highest score first.
+            var ascOrder = await session.Advanced.AsyncRawQuery<TestDoc>(
+                $"from TestDocs where {where} order by score() asc")
+                .ToListAsync();
+            Assert.Equal(3, ascOrder.Count);
+            Assert.Equal("doc-a", ascOrder[0].Name);
+            Assert.Equal("doc-b", ascOrder[1].Name);
+            Assert.Equal("doc-c", ascOrder[2].Name);
+
+            // DESC: lowest score first.
+            var descOrder = await session.Advanced.AsyncRawQuery<TestDoc>(
+                $"from TestDocs where {where} order by score() desc")
+                .ToListAsync();
+            Assert.Equal(3, descOrder.Count);
+            Assert.Equal("doc-c", descOrder[0].Name);
+            Assert.Equal("doc-b", descOrder[1].Name);
+            Assert.Equal("doc-a", descOrder[2].Name);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task RegexQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = i % 2 == 0 ? $"alpha-{i}" : $"beta-{i}",
+                    Category = "cat-0",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // regex query
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where regex(Name, '^alpha')")
+                .ToListAsync();
+
+            Assert.Equal(25, results.Count);
+            Assert.All(results, r => Assert.StartsWith("alpha", r.Name));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotEqualsInAndChain_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // AND with !=: Category=cat-0 AND Status != 'active'
+        // First verify old path returns correct results
+        using (var session = store.OpenAsyncSession())
+        {
+            var oldPathResults = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' and Status = 'inactive'")
+                .ToListAsync();
+            Assert.Equal(10, oldPathResults.Count);
+            Assert.All(oldPathResults, r => Assert.Equal("inactive", r.Status));
+        }
+
+        // Now test != through bitmap path
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' and Status != 'active'")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            foreach (var r in results)
+            {
+                Assert.Equal("cat-0", r.Category);
+                Assert.Equal("inactive", r.Status);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task MixedAndOr_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Mixed: (Category=cat-0 OR Category=cat-1) AND Status=active
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where (Category = 'cat-0' or Category = 'cat-1') and Status = 'active'")
+                .ToListAsync();
+
+            // (cat-0 ∪ cat-1) = 40, active = 50, intersection = 20
+            Assert.Equal(20, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.True(r.Category is "cat-0" or "cat-1");
+                Assert.Equal("active", r.Status);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrderBy_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = (99 - i) * 10 // reverse order
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // ORDER BY Name LIMIT 10
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' order by Name limit 10")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            // Should be sorted by Name ascending
+            for (int i = 1; i < results.Count; i++)
+            {
+                Assert.True(string.Compare(results[i - 1].Name, results[i].Name, System.StringComparison.Ordinal) <= 0,
+                    $"Results not sorted: {results[i - 1].Name} should be before {results[i].Name}");
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task ComplexAndOrWithSort_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 200; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"item-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}",
+                    Price = i * 5
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Complex: (cat-0 OR cat-1) AND active, ORDER BY Name LIMIT 10
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where (Category = 'cat-0' or Category = 'cat-1') and Status = 'active' order by Name limit 10")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.True(r.Category is "cat-0" or "cat-1");
+                Assert.Equal("active", r.Status);
+            });
+            // Verify sorting
+            for (int i = 1; i < results.Count; i++)
+            {
+                Assert.True(string.Compare(results[i - 1].Name, results[i].Name, System.StringComparison.Ordinal) <= 0);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EndsWith_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = i % 2 == 0 ? $"item-{i}-alpha" : $"item-{i}-beta",
+                    Category = $"cat-{i % 5}",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where endsWith(Name, 'alpha')")
+                .ToListAsync();
+
+            Assert.Equal(25, results.Count);
+            Assert.All(results, r => Assert.EndsWith("alpha", r.Name));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task FiveWayAnd_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 500; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}",
+                    Price = i * 3
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // 5-way AND: Category=cat-0 AND Status=active AND Tag=tag-0 AND Price>500 AND startsWith(Name, 'doc-0')
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' and Status = 'active' and Tag = 'tag-0' and Price > 500 and startsWith(Name, 'doc-0')")
+                .ToListAsync();
+
+            // cat-0: i%5==0, active: i%2==0, tag-0: i%10==0 → i%10==0 AND i%2==0 → i%10==0
+            // Price > 500: i*3 > 500 → i > 166
+            // startsWith doc-0: i < 100000 (all match with 5-digit padding)
+            // Combined: i%10==0 AND i>166 → 170,180,190,...,490 → 33 items
+            Assert.Equal(33, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("cat-0", r.Category);
+                Assert.Equal("active", r.Status);
+                Assert.Equal("tag-0", r.Tag);
+                Assert.True(r.Price > 500);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedOrWithAnd_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // (cat-0 OR cat-1) AND (tag-0 OR tag-5)
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where (Category = 'cat-0' or Category = 'cat-1') and (Tag = 'tag-0' or Tag = 'tag-5')")
+                .ToListAsync();
+
+            // cat-0∪cat-1: 40 docs, tag-0∪tag-5: 20 docs
+            // Intersection: cat-0 or cat-1 AND tag-0 or tag-5
+            // cat-0 indices: 0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,85,90,95
+            // cat-1 indices: 1,6,11,16,21,26,31,36,41,46,51,56,61,66,71,76,81,86,91,96
+            // tag-0: i%10==0: 0,10,20,30,40,50,60,70,80,90
+            // tag-5: i%10==5: 5,15,25,35,45,55,65,75,85,95
+            // (cat-0∪cat-1) ∩ (tag-0∪tag-5):
+            //   cat-0 ∩ tag-0: 0,10,20,30,40,50,60,70,80,90 (all i%10==0 are cat-0 since 0%5==0) → 10
+            //   cat-0 ∩ tag-5: 5,15,25,35,45,55,65,75,85,95 (all i%10==5 are cat-0 since 5%5==0) → 10
+            //   cat-1 ∩ tag-0: none (cat-1 indices end in 1,6 — none mod 10 == 0)
+            //   cat-1 ∩ tag-5: none
+            // Wait — cat-1 is i%5==1: 1,6,11,16,21,26,...
+            // tag-0 is i%10==0: 0,10,20,30,...
+            // cat-1 ∩ tag-0: i%5==1 AND i%10==0 → no solution (i%10==0 means i%5==0)
+            // cat-1 ∩ tag-5: i%5==1 AND i%10==5 → i%10==5 means i%5==0 (5%5=0) → no
+            // Actually i%5==1 gives 1,6,11,16,... and i%10==5 gives 5,15,25,...
+            // 1,6,11,16,21,26,31,36,41,46 ∩ 5,15,25,35,45 = empty
+            // So total = 10 + 10 = 20
+            Assert.Equal(20, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EmptyResultSet_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = "cat-0",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // No matches — nonexistent term
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-999")
+                .ToListAsync();
+
+            Assert.Equal(0, results.Count);
+        }
+
+        // AND that produces empty result
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0" && x.Status == "inactive")
+                .ToListAsync();
+
+            Assert.Equal(0, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task Pagination_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = "cat-0",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Page 1: skip 0, take 10
+        using (var session = store.OpenAsyncSession())
+        {
+            var page1 = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0")
+                .Skip(0).Take(10)
+                .ToListAsync();
+            Assert.Equal(10, page1.Count);
+        }
+
+        // Page 2: skip 10, take 10 — verify no overlap with page 1
+        using (var session = store.OpenAsyncSession())
+        {
+            var allResults = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0")
+                .ToListAsync();
+
+            var page1 = allResults.Take(10).ToList();
+            var page2 = allResults.Skip(10).Take(10).ToList();
+            Assert.Equal(10, page1.Count);
+            Assert.Equal(10, page2.Count);
+            Assert.NotEqual(page1[0].Id, page2[0].Id);
+            Assert.All(page2, r => Assert.DoesNotContain(r.Name, page1.Select(p => p.Name)));
+        }
+
+        // Page 10: skip 90, take 10
+        using (var session = store.OpenAsyncSession())
+        {
+            var allResults = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0")
+                .OrderBy(r => r.Name)
+                .ToListAsync();
+
+            var page10 = allResults.Skip(90).Take(10).ToList();
+            Assert.Equal(10, page10.Count);
+            Assert.NotEqual(page10[0].Name, allResults[0].Name);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task TrueOrConstantFolding_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 3}",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // (true or Category='cat-0') → should return all 50 docs
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where true or Category = 'cat-0'")
+                .ToListAsync();
+
+            Assert.Equal(50, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrderByDesc_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = "cat-0",
+                    Status = "active",
+                    Price = i * 10
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // ORDER BY Price DESC LIMIT 5
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' order by Price as long desc limit 5")
+                .ToListAsync();
+
+            Assert.Equal(5, results.Count);
+            // Should be highest prices first
+            Assert.True(results[0].Price >= results[1].Price);
+            Assert.True(results[0].Price >= results[4].Price);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task SingleDocResult_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestDoc { Name = "unique-doc", Category = "unique-cat", Status = "active" });
+            for (int i = 0; i < 99; i++)
+                await session.StoreAsync(new TestDoc { Name = $"doc-{i}", Category = "common-cat", Status = "active" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Single result — tests cardinality-1 path
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "unique-cat")
+                .ToListAsync();
+
+            Assert.Equal(1, results.Count);
+            Assert.Equal("unique-doc", results[0].Name);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task SearchQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestDoc { Name = "hello world", Category = "cat-0", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "hello there", Category = "cat-0", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "goodbye world", Category = "cat-1", Status = "inactive" });
+            await session.StoreAsync(new TestDoc { Name = "foo bar", Category = "cat-2", Status = "active" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // search() query without boost — should use bitmap path
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where search(Name, 'hello')")
+                .ToListAsync();
+
+            Assert.Equal(2, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NoWhereClause_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 3}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // No WHERE clause — should return all documents
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs")
+                .ToListAsync();
+
+            Assert.Equal(30, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NoWhereClauseWithOrderBy_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D2}",
+                    Category = $"cat-{i % 5}",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // No WHERE clause with ORDER BY — bitmap path should handle sorting
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs order by Name")
+                .ToListAsync();
+
+            Assert.Equal(20, results.Count);
+            // Verify ordering
+            for (int i = 1; i < results.Count; i++)
+            {
+                Assert.True(string.Compare(results[i - 1].Name, results[i].Name, StringComparison.Ordinal) <= 0,
+                    $"Expected {results[i - 1].Name} <= {results[i].Name}");
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EntryScanWithSmallBitmapVsLargePostingList_Correctness()
+    {
+        // Verifies correctness of results when the entry-scan heuristic triggers.
+        // Entry scan fires when: bitmap.Count < 32K && bitmap.Count * 64 < nextMatch.Count.
+        // This test validates the result is correct under heuristic-triggering conditions
+        // (10 rare entries AND'd with ~2500 active entries).
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // 5000 docs, only 10 have Category='rare'
+            for (int i = 0; i < 5000; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = i < 10 ? "rare" : $"common-{i % 50}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = i
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Category='rare' produces ~10 entries, Status='active' has ~2500
+        // 10 * 64 = 640 < 2500 → entry scan should fire
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'rare' and Status = 'active'")
+                .ToListAsync();
+
+            Assert.Equal(5, results.Count); // indices 0,2,4,6,8
+            Assert.All(results, r =>
+            {
+                Assert.Equal("rare", r.Category);
+                Assert.Equal("active", r.Status);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EntryScanWithNotEquals_Correctness()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 5000; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = i < 10 ? "rare" : $"common-{i % 50}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = i
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Category='rare' AND Status != 'active'
+        // 10 rare entries, 5 active, 5 inactive → expect 5 inactive
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'rare' and Status != 'active'")
+                .ToListAsync();
+
+            Assert.Equal(5, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("rare", r.Category);
+                Assert.Equal("inactive", r.Status);
+            });
+        }
+    }
+
+    private class TestDoc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public string Status { get; set; }
+        public string Tag { get; set; }
+        public int Price { get; set; }
+    }
+}


### PR DESCRIPTION
**[Partial PR 8/9 — Corax 2.0 query engine. Apply all 9 to reproduce branch HEAD.]**

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25281

### Additional description

Adds the clause-resolution layer of the new plan parser — `QueryPlanBuilder.Resolution.cs` — together with the compiled-query test suite that pins its behaviour.

This is the half of the plan parser that turns parsed RQL clauses into resolved plan nodes: type/analyzer normalisation, BETWEEN sentinel handling, time-field string→ticks rewrites, IN cardinality handling, NOT-chain canonicalisation, default-search-analyzer threading for dynamic fields, plan-shape rewrites, and the cost-based direct-scan vs. bitmap dispatch.

`CompiledQueryTests` exercises plan-cache stability across parameter cardinalities, template-mutation safety, and the rewrite cases above.

This PR is partial and depends on PRs 1–7/9. It is part of a 9-PR stack that together reproduce the `RavenDB-25281` branch HEAD.

### Type of change

- [x] New feature

### How risky is the change?

- [ ] Low
- [ ] Moderate
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
