### PR TITLE
RavenDB-25281 PR14: unify nested-group resolution with IL slot pipeline

### DIFF
--- a/src/Corax/Querying/Planning/ClauseInfo.cs
+++ b/src/Corax/Querying/Planning/ClauseInfo.cs
@@ -98,24 +98,6 @@ public sealed class ClauseInfo
         set { ThrowIfFrozen(); field = value; }
     }
 
-    /// <summary>For IN/AllIn clauses: true when ALL bindings are literals (no parameters).
-    /// When set, the dominant type and type-incompatible filtering are pre-computed at
-    /// template time, skipping per-execution work in ResolveInFromBindings.</summary>
-    public bool AllBindingsAreLiteral
-    {
-        get;
-        set { ThrowIfFrozen(); field = value; }
-    }
-
-    /// <summary>Pre-computed dominant type for all-literal IN/AllIn clauses. Only valid
-    /// when <see cref="AllBindingsAreLiteral"/> is true. The dominant type determines which typed
-    /// array (Long/Double/String) receives the resolved values.</summary>
-    public ParamValueType InDominantType
-    {
-        get;
-        set { ThrowIfFrozen(); field = value; }
-    }
-
     /// <summary>True if this clause is wrapped in boost(). When set, Bindings[^1] is the
     /// boost factor binding and exec.BoostFactor is resolved from it per-execution.</summary>
     public bool HasBoost

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1439,7 +1439,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 {
                     // moreLikeThis(id() = 'datas/4-A', ...) — build a query from just the
                     // inner binary expression (not the full WHERE which wraps it in moreLikeThis).
-                    baseDocumentQuery = BuildQueryFromExpression(builderParameters, be);
+                    baseDocumentQuery = QueryPlanBuilder.BuildQueryForMoreLikeThis(builderParameters, be);
                 }
                 else
                 {
@@ -1471,17 +1471,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                     Options = options
                 };
             }
-        }
-
-        /// <summary>
-        /// Build a query match from the inner BinaryExpression of a moreLikeThis clause,
-        /// e.g. the <c>id() = 'datas/4-A'</c> part of <c>moreLikeThis(id() = 'datas/4-A', ...)</c>.
-        /// Resolves the expression directly instead of going through the full plan pipeline
-        /// (which would see the moreLikeThis wrapper and produce AllEntries).
-        /// </summary>
-        private static IQueryMatch BuildQueryFromExpression(QueryBuilderParameters builderParameters, QueryExpression expression)
-        {
-            return QueryPlanBuilder.BuildFromSubExpression(builderParameters, expression);
         }
 
         private static IQueryMatch BuildCompiledQueryMatch(QueryBuilderParameters builderParameters)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryBuilderParameters.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryBuilderParameters.cs
@@ -36,22 +36,22 @@ public sealed class QueryBuilderParameters
     public readonly QueryTimeScope QueryTime;
 
     /// <summary>Direct-planner test constructor. Used by tests that exercise <c>QueryPlanBuilder</c>
-    /// without a full <see cref="Index"/> / <see cref="IndexQueryServerSide"/> stack — only the
-    /// fields needed by the planner's direct-test path are populated. <see cref="IndexFieldsMapping"/>
-    /// stays <c>null</c>, which is what resolvers (<c>ResolveFieldMetadata</c>, compound-exact /
-    /// compound-field branches) use as the discriminator to route through
-    /// <see cref="IndexSearcher.FieldMetadataBuilder"/> instead of the analyzer-aware
-    /// <see cref="QueryBuilderHelper.GetFieldMetadata"/>.</summary>
-    internal QueryBuilderParameters(IndexSearcher searcher, ByteStringContext allocator, QueryMetadata metadata, BlittableJsonReaderObject queryParameters, bool hasBoost = false)
+    /// without a full <see cref="Index"/> / <see cref="IndexQueryServerSide"/> stack. The supplied
+    /// <see cref="IndexFieldsMapping"/> is required so resolvers (<c>ResolveFieldMetadata</c>,
+    /// compound-exact / compound-field branches) can route through
+    /// <see cref="QueryBuilderHelper.GetFieldMetadata"/> uniformly — the production code no longer
+    /// branches on <c>IndexFieldsMapping == null</c>.</summary>
+    internal QueryBuilderParameters(IndexSearcher searcher, ByteStringContext allocator, QueryMetadata metadata, BlittableJsonReaderObject queryParameters, IndexFieldsMapping indexFieldsMapping, bool hasBoost = false)
     {
         IndexSearcher = searcher;
         Allocator = allocator;
         Metadata = metadata;
         QueryParameters = queryParameters;
+        IndexFieldsMapping = indexFieldsMapping ?? throw new ArgumentNullException(nameof(indexFieldsMapping));
         HasBoost = hasBoost;
         // HasDynamics and IsVectorSingleClause default to false; Index/Query and other
-        // production-only fields stay null — the planner's direct-test path guards on
-        // IndexFieldsMapping == null and avoids dereferencing them.
+        // production-only fields stay null — the planner's direct-test path does not exercise
+        // Search / Spatial / Vector / dynamic-field branches.
     }
 
     internal QueryBuilderParameters(IndexSearcher searcher, ByteStringContext allocator, TransactionOperationContext serverContext, DocumentsOperationContext documentsContext,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -129,6 +129,21 @@ internal static partial class QueryPlanBuilder
     /// strategies (CompoundExact / DirectScan / no ORDER BY), the compound match for CompoundField,
     /// or the bitmap CompiledQueryMatch for BitmapSort. The caller uses this for inspection-graph
     /// construction and deterministic disposal of the IL-emitted match.</param>
+    /// <summary>Per-execution context bundling the stable parameters that flow through
+    /// every Construct* / Try* call inside <see cref="Instantiate"/>. Stack-only;
+    /// zero allocation. <see cref="RejectReason"/> is written by Try* on failure
+    /// so the caller can record it on the <see cref="CompiledPlan.DecisionTrail"/>
+    /// without an extra out parameter.</summary>
+    private ref struct InstCtx
+    {
+        public CompiledPlan Plan;
+        public QueryExecution Exec;
+        public OrderMetadata[] OrderByFields; // may be null when PageSize == 0
+        public PlanParameters PlanParams;
+        public QueryBuilderParameters BuilderParams;
+        public string RejectReason;
+    }
+
     private static IQueryMatch Instantiate(
         CompiledPlan compiledPlan,
         QueryExecution exec,
@@ -142,86 +157,94 @@ internal static partial class QueryPlanBuilder
         out IQueryMatch innerMatch,
         CancellationToken token)
     {
-        
+        var ctx = new InstCtx
+        {
+            Plan = compiledPlan,
+            Exec = exec,
+            OrderByFields = orderByFields,
+            PlanParams = planParams,
+            BuilderParams = builderParameters,
+        };
+
+        if (compiledPlan.Strategy == ExecutionStrategy.NotEvaluated)
+            SelectExecutionStrategy(ref ctx);
+
         switch (compiledPlan.Strategy)
         {
-            case ExecutionStrategy.NotEvaluated:
-                SelectExecutionStrategy(); // select the right strategy 
-                RuntimeHelpers.EnsureSufficientExecutionStack(); // not retry...
-                return Instantiate(compiledPlan, exec, orderByFields, hasEmptySorts, planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, out innerMatch, token);
-            
             // ── Fast path: cached strategy, dispatch directly to Construct* ──
             case ExecutionStrategy.CompoundExact:
-                innerMatch = ConstructCompoundExact(exec, planParams);
-                if(innerMatch is null) goto default;
+                innerMatch = ConstructCompoundExact(ref ctx);
+                if (innerMatch is null) goto default;
                 return innerMatch;
-            case ExecutionStrategy.CompoundField when orderByFields != null:  // orderByFields can be null when PageSize is 0  
-                int f2 = FindCompoundFieldField2Range(exec.Executions, exec.Plan.CompoundFieldDrivingClause, exec.Plan.Template.CompoundFieldSortName);
-                innerMatch = ConstructCompoundField(exec, orderByFields, planParams, builderParameters, compiledPlan, f2, entriesToScan: 0, bitmapCost: 0);
-                if(innerMatch is null) goto default;
+            case ExecutionStrategy.CompoundField when orderByFields != null:
+                // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
+                // CompoundField plan — PageSize is not part of the plan cache key.
+                int f2 = FindCompoundFieldField2Range(exec.Executions, compiledPlan.CompoundFieldDrivingClause, compiledPlan.Template.CompoundFieldSortName);
+                innerMatch = ConstructCompoundField(ref ctx, f2, entriesToScan: 0, bitmapCost: 0);
+                if (innerMatch is null) goto default;
                 return OrderBy(builderParameters, innerMatch, orderByFields, hasEmptySorts);
             case ExecutionStrategy.DirectScan when orderByFields is { Length: <= 2 }:
                 // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
                 // DirectScan plan — PageSize is not part of the plan cache key.
-                if (exec.Executions is not { Count:> 0 } || 
+                var execs = exec.Executions;
+                if (execs is not { Count: > 0 } ||
                     exec.Plan.SortDrivingClauseIndex >= 0 && exec.Executions[exec.Plan.SortDrivingClauseIndex].PackedParamValue.IsNone is false)
                 {
-                    innerMatch = ConstructDirectScan(exec, orderByFields, planParams, builderParameters,
-                        compiledPlan, exec.Plan.SortDrivingClauseIndex, exec.Executions is not { Count:> 0 }, orderByFields.Length == 2, entriesToScan: 0, bitmapCost: 0);
+                    innerMatch = ConstructDirectScan(ref ctx, exec.Plan.SortDrivingClauseIndex,
+                        execs is not { Count: > 0 }, orderByFields.Length == 2, entriesToScan: 0, bitmapCost: 0);
                     if (innerMatch is not null) return innerMatch;
                 }
                 goto default;
             case ExecutionStrategy.BitmapSort:
-            default: // may either be the selected strategy or a one-off (because of bad parameters preventing a faster strategy) 
+            default:
+                // may either be the selected strategy, or a one-off (because of bad parameters preventing a faster strategy)
                 return InstantiateBitmapFallback(compiledPlan, exec, orderByFields, hasEmptySorts,
                     planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, out innerMatch, token);
         }
 
-
-        void SelectExecutionStrategy()
+        static void SelectExecutionStrategy(ref InstCtx ctx)
         {
             // ── Slow path: cache-miss, run Try* discovery chain ──
-            compiledPlan.DecisionTrail = new();
-            compiledPlan.Strategy = ExecutionStrategy.BitmapSort; // if nothing else overrides it 
+            ctx.Plan.DecisionTrail = new();
+            ctx.Plan.Strategy = ExecutionStrategy.BitmapSort; // if nothing else overrides it
 
-            if (compiledPlan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.CompoundExactCandidate))
+            if (ctx.Plan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.CompoundExactCandidate))
             {
-                if (TryCreateCompoundExactMatch(exec, planParams, builderParameters, out var ceReason))
+                if (TryCreateCompoundExactMatch(ref ctx))
                 {
-                    compiledPlan.Strategy = ExecutionStrategy.CompoundExact;
-                    compiledPlan.DecisionTrail.Record("CompoundExact", true, "compound exact-term lookup");
+                    ctx.Plan.Strategy = ExecutionStrategy.CompoundExact;
+                    ctx.Plan.DecisionTrail.Record("CompoundExact", true, "compound exact-term lookup");
                     return;
                 }
-
-                compiledPlan.DecisionTrail.Record("CompoundExact", false, ceReason ?? "rejected");
+                ctx.Plan.DecisionTrail.Record("CompoundExact", false, ctx.RejectReason ?? "rejected");
             }
 
-            if (orderByFields is null)
+            if (ctx.OrderByFields is null)
             {
-                compiledPlan.DecisionTrail.Record("NoOrderBy", true, "no ORDER BY");
+                ctx.Plan.DecisionTrail.Record("NoOrderBy", true, "no ORDER BY");
                 return;
             }
 
-            if (compiledPlan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.DirectScanCandidate))
+            if (ctx.Plan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.DirectScanCandidate))
             {
-                if (TryCreateCompoundFieldMatch(exec, orderByFields, planParams, builderParameters, compiledPlan, out var cfReason))
+                if (TryCreateCompoundFieldMatch(ref ctx))
                 {
-                    compiledPlan.Strategy = ExecutionStrategy.CompoundField;
-                    compiledPlan.DecisionTrail.Record("CompoundField", true, "compound tree scan with ORDER BY");
+                    ctx.Plan.Strategy = ExecutionStrategy.CompoundField;
+                    ctx.Plan.DecisionTrail.Record("CompoundField", true, "compound tree scan with ORDER BY");
                     return;
                 }
-                compiledPlan.DecisionTrail.Record("CompoundField", false, cfReason ?? "rejected");
+                ctx.Plan.DecisionTrail.Record("CompoundField", false, ctx.RejectReason ?? "rejected");
 
-                if (TryCreateSimpleFieldDirectScan(exec, orderByFields, planParams, builderParameters, compiledPlan, out _, out var dsReason))
+                if (TryCreateSimpleFieldDirectScan(ref ctx))
                 {
-                    compiledPlan.Strategy = ExecutionStrategy.DirectScan;
-                    compiledPlan.DecisionTrail.Record("DirectScan", true, "direct tree scan on sort field");
+                    ctx.Plan.Strategy = ExecutionStrategy.DirectScan;
+                    ctx.Plan.DecisionTrail.Record("DirectScan", true, "direct tree scan on sort field");
                     return;
                 }
-                compiledPlan.DecisionTrail.Record("DirectScan", false, dsReason ?? "rejected");
+                ctx.Plan.DecisionTrail.Record("DirectScan", false, ctx.RejectReason ?? "rejected");
             }
 
-            compiledPlan.DecisionTrail.Record("BitmapSort", true, "bitmap pipeline with SortingMatch fallback");
+            ctx.Plan.DecisionTrail.Record("BitmapSort", true, "bitmap pipeline with SortingMatch fallback");
         }
     }
 
@@ -3822,4 +3845,33 @@ internal static partial class QueryPlanBuilder
             _ => ScanValueType.Slice
         };
     }
+
+    // ── InstCtx overloads — thin wrappers so Instantiate callers pass one struct ──
+
+    private static bool TryCreateCompoundExactMatch(ref InstCtx ctx)
+    {
+        bool result = TryCreateCompoundExactMatch(ctx.Exec, ctx.PlanParams, ctx.BuilderParams, out ctx.RejectReason);
+        return result;
+    }
+
+    private static bool TryCreateCompoundFieldMatch(ref InstCtx ctx)
+    {
+        bool result = TryCreateCompoundFieldMatch(ctx.Exec, ctx.OrderByFields, ctx.PlanParams, ctx.BuilderParams, ctx.Plan, out ctx.RejectReason);
+        return result;
+    }
+
+    private static bool TryCreateSimpleFieldDirectScan(ref InstCtx ctx)
+    {
+        bool result = TryCreateSimpleFieldDirectScan(ctx.Exec, ctx.OrderByFields, ctx.PlanParams, ctx.BuilderParams, ctx.Plan, out _, out ctx.RejectReason);
+        return result;
+    }
+
+    private static IQueryMatch ConstructCompoundExact(ref InstCtx ctx)
+        => ConstructCompoundExact(ctx.Exec, ctx.PlanParams);
+
+    private static IQueryMatch ConstructCompoundField(ref InstCtx ctx, int field2RangeIdx, long entriesToScan, long bitmapCost)
+        => ConstructCompoundField(ctx.Exec, ctx.OrderByFields, ctx.PlanParams, ctx.BuilderParams, ctx.Plan, field2RangeIdx, entriesToScan, bitmapCost);
+
+    private static IQueryMatch ConstructDirectScan(ref InstCtx ctx, int drivingIdx, bool isFullScan, bool hasTieBreak, long entriesToScan, long bitmapCost)
+        => ConstructDirectScan(ctx.Exec, ctx.OrderByFields, ctx.PlanParams, ctx.BuilderParams, ctx.Plan, drivingIdx, isFullScan, hasTieBreak, entriesToScan, bitmapCost);
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1401,26 +1401,10 @@ internal static partial class QueryPlanBuilder
 
             case ClauseType.In:
             case ClauseType.AllIn:
-            {
-                // IN/AllIn inside an AndGroup reaches here as a single clause.
-                // Expand each term into a TermQuery and merge via bitmap, same as the
-                // top-level queryExec does with FillFromPostings/OrWithPostings/AndWithPostings.
-                if (cur.InTermCount == 0)
-                    return indexSearcher.EmptyMatch();
-                var bm = new BitmapMatch(indexSearcher.Allocator);
-                var temp = new RoaringBitmap(indexSearcher.Allocator);
-                for (int t = 0; t < cur.InTermCount; t++)
-                {
-                    var termMatch = ResolveInTerm(cur, t, root, walkerCtx);
-                    if (clause.ClauseType == ClauseType.AllIn && t > 0)
-                        QueryPrimitives.AndWithMatch(termMatch, ref bm.BitmapState, ref temp);
-                    else
-                        QueryPrimitives.OrWithMatch(termMatch, ref bm.BitmapState);
-                }
-
-                temp.Dispose();
-                return bm;
-            }
+                throw new InvalidOperationException(
+                    "In/AllIn should be expanded by ResolveMatches (per-term slot loop), " +
+                    "not resolved as a single clause. Use ResolveInPositiveBitmap when the " +
+                    "positive-form bitmap is needed (e.g. NOT IN inside an OR chain).");
 
             case ClauseType.Exists:
                 return indexSearcher.ExistsQuery(fieldMeta);
@@ -1521,6 +1505,34 @@ internal static partial class QueryPlanBuilder
         return TermQueryFromParam(termPacked, fieldMeta, walkerCtx.IndexSearcher, queryExec);
     }
 
+    /// <summary>Build the positive-form bitmap of an IN/AllIn clause: expand each term to a
+    /// TermQuery and OR-merge (IN) or AND-merge after the first (AllIn) into a
+    /// <see cref="BitmapMatch"/>. Mirrors the top-level
+    /// FillFromPostings/OrWithPostings/AndWithPostings sequence used by the IL emitter,
+    /// but produces a single <see cref="IQueryMatch"/> for callers that need the
+    /// materialized positive set (currently only <see cref="CreateNotEqualsOrMatch"/>
+    /// for NOT IN / NOT AllIn appearing inside an OR chain).</summary>
+    private static IQueryMatch ResolveInPositiveBitmap(ClauseExecution exec,
+        QueryExecution queryExec, ResolutionContext walkerCtx)
+    {
+        var indexSearcher = walkerCtx.IndexSearcher;
+        if (exec.InTermCount == 0)
+            return indexSearcher.EmptyMatch();
+        var isAllIn = exec.Clause.ClauseType == ClauseType.AllIn;
+        var bm = new BitmapMatch(indexSearcher.Allocator);
+        var temp = new RoaringBitmap(indexSearcher.Allocator);
+        for (int t = 0; t < exec.InTermCount; t++)
+        {
+            var termMatch = ResolveInTerm(exec, t, queryExec, walkerCtx);
+            if (isAllIn && t > 0)
+                QueryPrimitives.AndWithMatch(termMatch, ref bm.BitmapState, ref temp);
+            else
+                QueryPrimitives.OrWithMatch(termMatch, ref bm.BitmapState);
+        }
+        temp.Dispose();
+        return bm;
+    }
+
     /// <summary>Create a pre-materialized <see cref="BitmapMatch"/> for a negated clause
     /// appearing in an OR chain. OR(NOT X, NOT Y, ...) cannot use the raw term posting list
     /// (FillBitmapFromPostingSource would add entries WITH X, not WITHOUT X). Instead, we
@@ -1530,7 +1542,7 @@ internal static partial class QueryPlanBuilder
     private static IQueryMatch CreateNotEqualsOrMatch(ClauseExecution exec,
         QueryExecution queryExec, ResolutionContext walkerCtx)
     {
-        // Resolve the positive form of the match. For IN/AllIn clauses, ResolveClause
+        // Resolve the positive form of the match. For IN/AllIn clauses, ResolveInPositiveBitmap
         // handles multi-term expansion correctly. For simple Equals/NotEquals, the
         // single-term TermQueryFromParam suffices. EXISTS clauses carry no PackedParam.
         var clause = exec.Clause;
@@ -1538,7 +1550,7 @@ internal static partial class QueryPlanBuilder
         IQueryMatch termMatch;
         if (clause.ClauseType is ClauseType.In or ClauseType.AllIn)
         {
-            termMatch = ResolveClause(exec, queryExec, walkerCtx);
+            termMatch = ResolveInPositiveBitmap(exec, queryExec, walkerCtx);
         }
         else if (clause.ClauseType == ClauseType.Exists)
         {
@@ -1773,15 +1785,11 @@ internal static partial class QueryPlanBuilder
         var execs = exec.Executions;
         foreach (ScanPredicateInfo pred in predicates)
         {
-            // Advance past clauses that BuildScanPredicateInfo would have skipped (returned null).
-            while (clauseIdx < execs.Count && IsScanEligible(execs[clauseIdx]) == false)
-            {
+            // Advance past clauses that BuildScanPredicateInfo would have skipped.
+            while (IsScanEligible(execs[clauseIdx]) == false)
                 clauseIdx++;
-            }
 
-            ClauseExecution matchingExec = clauseIdx < execs.Count ? execs[clauseIdx] : null;
-            clauseIdx++;
-            ExtractParamsFromPredicate(pred, matchingExec, indexSearcher, exec, longs, doubles, slices, roots);
+            ExtractParamsFromPredicate(pred, execs[clauseIdx++], indexSearcher, exec, longs, doubles, slices, roots);
         }
 
         longParams = longs.Count > 0 ? longs.ToArray() : [];
@@ -1870,23 +1878,16 @@ internal static partial class QueryPlanBuilder
     {
         if (pred.SubPredicates != null)
         {
-            // Each OrBranch corresponds to a subclause of the OrGroup.
-            // Pass sub-executions positionally to maintain the predicate-to-clause mapping.
-            List<ClauseExecution> subExecs = exec?.SubExecutions;
+            // Each sub-predicate corresponds positionally to a sub-execution of the group.
+            // BuildScanPredicateInfoCore guarantees pred.SubPredicates.Length == exec.SubExecutions.Count.
+            var subExecs = exec.SubExecutions;
             for (int b = 0; b < pred.SubPredicates.Length; b++)
-            {
-                ClauseExecution subExec = (subExecs != null && b < subExecs.Count) ? subExecs[b] : null;
-                ExtractParamsFromPredicate(pred.SubPredicates[b], subExec, indexSearcher, queryExec, longs, doubles, slices, roots);
-            }
-
+                ExtractParamsFromPredicate(pred.SubPredicates[b], subExecs[b], indexSearcher, queryExec, longs, doubles, slices, roots);
             return;
         }
 
         // Resolve field root page
         roots.Add(indexSearcher.FieldCache.GetLookupRootPage(pred.FieldName));
-
-        if (exec == null)
-            return;
 
         // Read pre-resolved typed values from the queryExec's arrays via packed param.
         var packed = exec.PackedParamValue;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1345,15 +1345,12 @@ internal static partial class QueryPlanBuilder
     /// carries a non-zero BoostFactor.</summary>
     private readonly struct MatchResolver : ISlotResolver<MatchResolver, IQueryMatch>
     {
+        // Precondition: callers (ResolveClauseLeavesInto) only dispatch here for clauses
+        // where ClauseInfo.IsOrChainNotEquals is set.
         public static IQueryMatch ResolveSubClauseSlot(ClauseInfo sub, ClauseExecution subExec,
             QueryExecution exec, ResolutionContext ctx)
         {
-            // A negated direct child of a nested OrGroup carries IsOrChainNotEquals=true (set by
-            // PlanWalker.NotCanonicalize). Materialise as AllEntries ANDNOT(positive) so the
-            // surrounding OR step combines the complement set, not the positive posting list.
-            IQueryMatch match = sub.IsOrChainNotEquals
-                ? CreateNotEqualsOrMatch(sub, subExec, exec, ctx)
-                : ResolveClause(subExec, exec, ctx);
+            IQueryMatch match = CreateNotEqualsOrMatch(sub, subExec, exec, ctx);
             if (subExec.BoostFactor > 0)
                 match = ctx.IndexSearcher.Boost(match, subExec.BoostFactor);
             return match;
@@ -1392,15 +1389,12 @@ internal static partial class QueryPlanBuilder
     /// (the bitmap-path match wins).</summary>
     private readonly struct TermSourceResolver : ISlotResolver<TermSourceResolver, PostingSource>
     {
+        // Precondition: callers (ResolveClauseLeavesInto) only dispatch here for clauses
+        // where ClauseInfo.IsOrChainNotEquals is set. Such clauses use MatchDispatch.QueryMatch,
+        // so the PostingSource slot is never read — return default and skip the lookup.
         public static PostingSource ResolveSubClauseSlot(ClauseInfo sub, ClauseExecution subExec,
             QueryExecution exec, ResolutionContext ctx)
-        {
-            // Boosted slots are emitted through the IQueryMatch path so scoring works;
-            // the PostingSource stays Empty here.
-            return subExec.BoostFactor > 0
-                ? default
-                : ResolveSingleTermSource(sub, subExec, exec, ctx);
-        }
+            => default;
 
         public static PostingSource ResolveInTermSlot(ClauseInfo clause, ClauseExecution clauseExec, int termIndex,
             QueryExecution exec, ResolutionContext ctx)
@@ -1431,9 +1425,12 @@ internal static partial class QueryPlanBuilder
     /// Only Equals/range/prefix-like clauses populate.</summary>
     private readonly struct TermsProviderResolver : ISlotResolver<TermsProviderResolver, ITermsProvider>
     {
+        // Precondition: callers (ResolveClauseLeavesInto) only dispatch here for clauses
+        // where ClauseInfo.IsOrChainNotEquals is set. Such clauses use MatchDispatch.QueryMatch,
+        // so the ITermsProvider slot is never read.
         public static ITermsProvider ResolveSubClauseSlot(ClauseInfo sub, ClauseExecution subExec,
             QueryExecution exec, ResolutionContext ctx)
-            => ResolveSingleTermsProvider(sub, subExec, exec, ctx);
+            => null;
 
         public static ITermsProvider ResolveInTermSlot(ClauseInfo clause, ClauseExecution clauseExec, int termIndex,
             QueryExecution exec, ResolutionContext ctx) => null;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -142,170 +142,79 @@ internal static partial class QueryPlanBuilder
         out IQueryMatch innerMatch,
         CancellationToken token)
     {
-        // ── Fast path: cached strategy, dispatch directly to Construct* ──
-        var strategy = compiledPlan.Strategy;
-        if (strategy != ExecutionStrategy.NotEvaluated)
+        
+        switch (compiledPlan.Strategy)
         {
-            IQueryMatch built = null;
-            switch (strategy)
+            case ExecutionStrategy.NotEvaluated:
+                SelectExecutionStrategy(); // select the right strategy 
+                RuntimeHelpers.EnsureSufficientExecutionStack(); // not retry...
+                return Instantiate(compiledPlan, exec, orderByFields, hasEmptySorts, planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, out innerMatch, token);
+            
+            // ── Fast path: cached strategy, dispatch directly to Construct* ──
+            case ExecutionStrategy.CompoundExact:
+                innerMatch = ConstructCompoundExact(exec, planParams);
+                if(innerMatch is null) goto default;
+                return innerMatch;
+            case ExecutionStrategy.CompoundField when orderByFields != null:  // orderByFields can be null when PageSize is 0  
+                int f2 = FindCompoundFieldField2Range(exec.Executions, exec.Plan.CompoundFieldDrivingClause, exec.Plan.Template.CompoundFieldSortName);
+                innerMatch = ConstructCompoundField(exec, orderByFields, planParams, builderParameters, compiledPlan, f2, entriesToScan: 0, bitmapCost: 0);
+                if(innerMatch is null) goto default;
+                return OrderBy(builderParameters, innerMatch, orderByFields, hasEmptySorts);
+            case ExecutionStrategy.DirectScan 
+                when orderByFields is { Length: <= 2 } &&
+                     exec.Executions is { Count: > 0 } && 
+                     exec.Plan.SortDrivingClauseIndex >= 0 && 
+                     exec.Executions[exec.Plan.SortDrivingClauseIndex].PackedParamValue.IsNone is false:
+                bool hasTieBreak = orderByFields.Length == 2;
+                innerMatch = ConstructDirectScan(exec, orderByFields, planParams, builderParameters,
+                    compiledPlan, exec.Plan.SortDrivingClauseIndex, true, hasTieBreak, entriesToScan: 0, bitmapCost: 0);
+                if(innerMatch is null) goto default;
+                return innerMatch;
+            case ExecutionStrategy.BitmapSort:
+            default:
+                // may either be the selected strategy, or a one-off (because of bad parameters preventing a faster strategy) 
+                return InstantiateBitmapFallback(compiledPlan, exec, orderByFields, hasEmptySorts,
+                    planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, out innerMatch, token);
+        }
+
+
+        void SelectExecutionStrategy()
+        {
+            // ── Slow path: cache-miss, run Try* discovery chain ──
+            compiledPlan.DecisionTrail = new();
+            compiledPlan.Strategy = ExecutionStrategy.BitmapSort; // if nothing else overrides it 
+
+            if (compiledPlan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.CompoundExactCandidate))
             {
-                case ExecutionStrategy.CompoundExact:
-                    built = ConstructCompoundExact(exec, planParams);
-                    if (built != null)
-                    {
-                        innerMatch = built;
-                        return built;
-                    }
+                if (TryCreateCompoundExactMatch(exec, planParams, builderParameters, out var ceReason))
+                {
+                    compiledPlan.Strategy = ExecutionStrategy.CompoundExact;
+                    compiledPlan.DecisionTrail.Record("CompoundExact", true, "compound exact-term lookup");
+                    return;
+                }
 
-                    break;
-                case ExecutionStrategy.CompoundField:
-                    // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
-                    // CompoundField plan — PageSize is not part of the plan cache key.
-                    if (orderByFields != null)
-                    {
-                        int f2 = FindCompoundFieldField2Range(exec.Executions, exec.Plan.CompoundFieldDrivingClause, exec.Plan.Template.CompoundFieldSortName);
-                        // Cost facts (entriesToScan, bitmapCost) are diagnostic-only inside
-                        // Construct (used for the Reason string). Pass zeros — the cliff bit
-                        // in the cache key already segregates cost buckets.
-                        built = ConstructCompoundField(exec, orderByFields, planParams, builderParameters,
-                            compiledPlan, f2, entriesToScan: 0, bitmapCost: 0);
-                    }
-
-                    if (built != null)
-                    {
-                        innerMatch = built;
-                        return OrderBy(builderParameters, built, orderByFields, hasEmptySorts);
-                    }
-
-                    break;
-                case ExecutionStrategy.DirectScan:
-                    // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
-                    // DirectScan plan — PageSize is not part of the plan cache key.
-                    if (orderByFields is { Length: <= 2 })
-                    {
-                        var execs2 = exec.Executions;
-                        bool isFullScan = execs2 == null || execs2.Count == 0;
-                        bool hasTieBreak = orderByFields.Length == 2;
-                        // Re-resolve drivingIdx (cheap structural lookup; cached at template time
-                        // via SortDrivingClauseIndex). Skip cost gating — strategy cache encodes
-                        // the cost decision via cliff bit in Ordering.
-                        int drivingIdx = -1;
-                        if (!isFullScan)
-                        {
-                            drivingIdx = exec.Plan.SortDrivingClauseIndex;
-                            // BoostFactor cannot land here: ComputeOptFlags clears
-                            // DirectScanCandidate template-wide for any boost; only IsNone
-                            // (parameter resolved to null) can still invalidate at runtime.
-                            if (drivingIdx >= 0 && exec.Executions[drivingIdx].PackedParamValue.IsNone)
-                                drivingIdx = -1;
-                        }
-
-                        if (isFullScan || drivingIdx >= 0)
-                            built = ConstructDirectScan(exec, orderByFields, planParams, builderParameters,
-                                compiledPlan, drivingIdx, isFullScan, hasTieBreak,
-                                entriesToScan: 0, bitmapCost: 0);
-                    }
-
-                    if (built != null)
-                    {
-                        innerMatch = built;
-                        return built;
-                    }
-
-                    break;
+                compiledPlan.DecisionTrail.Record("CompoundExact", false, ceReason ?? "rejected");
             }
 
-            // Cached non-BitmapSort strategy failed at construction time (e.g. per-execution
-            // byte-length overflow). Fall back to bitmap+sort. The cached strategy stays valid
-            // for the next execution; this one had unlucky parameter values.
-            return InstantiateBitmapFallback(compiledPlan, exec, orderByFields, hasEmptySorts,
-                planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, out innerMatch, token);
-        }
-
-        // ── Slow path: cache-miss, run Try* discovery chain ──
-        // Each Try* method performs structural + cost checks and, on success, constructs the
-        // live match. We record the outcome on a DecisionTrail for diagnostics, then bake the
-        // winning strategy + *Data onto compiledPlan so future executions skip discovery.
-        bool needsFullChain = true;
-        var resultStrategy = ExecutionStrategy.BitmapSort;
-        var trail = new PlanDecisionTrail();
-        IQueryMatch queryMatch = null;
-        innerMatch = null;
-
-        if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.CompoundExactCandidate) == 0)
-            trail.Record("CompoundExact", false, "template has no compound-exact candidate");
-        else if (TryCreateCompoundExactMatch(exec, planParams, builderParameters, out var compoundExact, out var ceReason))
-        {
-            queryMatch = compoundExact;
-            innerMatch = compoundExact;
-            resultStrategy = ExecutionStrategy.CompoundExact;
-            needsFullChain = false;
-            trail.Record("CompoundExact", true, "compound exact-term lookup");
-        }
-        else
-            trail.Record("CompoundExact", false, ceReason ?? "rejected");
-
-        if (orderByFields != null)
-        {
-            if (needsFullChain)
+            if (orderByFields is null)
             {
-                if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.DirectScanCandidate) == 0)
-                    trail.Record("CompoundField", false, "template has no direct-scan candidate");
-                else if (TryCreateCompoundFieldMatch(exec, orderByFields, planParams, builderParameters, compiledPlan, out var compoundMatch, out var cfReason))
+                compiledPlan.DecisionTrail.Record("NoOrderBy", true, "no ORDER BY");
+                return;
+            }
+
+            if (compiledPlan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.DirectScanCandidate))
+            {
+                if (TryCreateCompoundFieldMatch(exec, orderByFields, planParams, builderParameters, compiledPlan, out var cfReason))
                 {
-                    innerMatch = compoundMatch;
-                    queryMatch = OrderBy(builderParameters, compoundMatch, orderByFields, hasEmptySorts);
-                    resultStrategy = ExecutionStrategy.CompoundField;
-                    needsFullChain = false;
-                    trail.Record("CompoundField", true, "compound tree scan with ORDER BY");
+                    compiledPlan.Strategy = ExecutionStrategy.CompoundField;
+                    compiledPlan.DecisionTrail.Record("CompoundField", true, "compound tree scan with ORDER BY");
                 }
                 else
-                    trail.Record("CompoundField", false, cfReason ?? "rejected");
-            }
-
-            if (needsFullChain)
-            {
-                if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.DirectScanCandidate) == 0)
-                    trail.Record("DirectScan", false, "template has no direct-scan candidate");
-                else if (TryCreateSimpleFieldDirectScan(exec, orderByFields, planParams, builderParameters, compiledPlan, out var directMatch, out var dsReason))
                 {
-                    queryMatch = directMatch;
-                    innerMatch = directMatch;
-                    resultStrategy = ExecutionStrategy.DirectScan;
-                    needsFullChain = false;
-                    trail.Record("DirectScan", true, "direct tree scan on sort field");
+                    compiledPlan.DecisionTrail.Record("CompoundField", false, cfReason ?? "rejected");
                 }
-                else
-                    trail.Record("DirectScan", false, dsReason ?? "rejected");
-            }
-
-            if (needsFullChain)
-            {
-                // All Try* failed → fall back to bitmap pipeline.
-                var bitmapMatch = InstantiateBitmapPipeline(compiledPlan, exec, planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, token);
-                innerMatch = bitmapMatch;
-                if (bitmapMatch is CompiledQueryMatch seekMatch)
-                    TrySetSortSeekHint(seekMatch, exec, orderByFields);
-                queryMatch = OrderBy(builderParameters, bitmapMatch, orderByFields, hasEmptySorts);
-                resultStrategy = ExecutionStrategy.BitmapSort;
-                trail.Record("BitmapSort", true, "bitmap pipeline with SortingMatch fallback");
             }
         }
-        else
-        {
-            trail.Record("NoOrderBy", true, "no ORDER BY");
-            if (queryMatch == null)
-            {
-                // No ORDER BY and no Try* winner — use bitmap match.
-                queryMatch = InstantiateBitmapPipeline(compiledPlan, exec, planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, token);
-                innerMatch = queryMatch;
-            }
-        }
-
-        compiledPlan.Strategy = resultStrategy;
-        compiledPlan.DecisionTrail = trail;
-
-        return queryMatch;
     }
 
     /// <summary>Bitmap-pipeline fallback used when a cached non-BitmapSort strategy fails at
@@ -2060,36 +1969,38 @@ internal static partial class QueryPlanBuilder
     // ── Compound field exact match (no ORDER BY) ─────────────────────────
 
     public static bool TryCreateCompoundExactMatch(
-        QueryExecution exec, PlanParameters planParams, QueryBuilderParameters builderParams,
-        out IQueryMatch compoundMatch, out string rejectReason)
+        QueryExecution exec, PlanParameters planParams, QueryBuilderParameters builderParams, out string rejectReason)
     {
-        rejectReason = null;
-        bool result = TryCreateCompoundExactMatch(exec, planParams, builderParams, out compoundMatch);
-        if (!result)
+        if (planParams.Index is null || exec is not { 
+                Executions: { Count: >= 2 } executions, 
+                Plan: { 
+                    AllNegated: false, 
+                    CompoundExactClauseA: var a and >= 0, 
+                    CompoundExactClauseB: var b and >= 0 
+                } 
+            } || a >= executions.Count || b >= executions.Count)
         {
-            if (exec.Executions == null || exec.Executions.Count < 2)
-                rejectReason = $"fewer than 2 clauses ({exec.Executions?.Count ?? 0})";
-            else if (exec.Plan.AllNegated)
-                rejectReason = "all clauses are negated";
-            else if (planParams.Index == null)
-                rejectReason = "no index available";
-            else if (exec.Plan.CompoundExactClauseA < 0 || exec.Plan.CompoundExactClauseB < 0)
-                rejectReason = "no compound-exact clause pair identified at template time";
-            else
-                rejectReason = "composite key encoding failed or exceeded max term length";
+            rejectReason = "no compound-exact clause pair identified at template time";
+            return false;
         }
 
-        return result;
+        if (IsClauseBoosted(executions[a]) || executions[a].PackedParamValue.IsNone || 
+            IsClauseBoosted(executions[b]) || executions[b].PackedParamValue.IsNone)
+        {
+            rejectReason = "composite key encoding failed or exceeded max term length, or clause is boosted";
+            return false;
+        }
+
+        rejectReason = null;
+        return true;
     }
 
     /// <summary>Check if two Equals clauses on (field1, field2) match a compound field.
     /// If so, build a single TermQuery on the compound tree with the composite key.
     /// One tree lookup instead of two posting list intersections.</summary>
     public static bool TryCreateCompoundExactMatch(
-        QueryExecution exec, PlanParameters planParams, QueryBuilderParameters builderParams,
-        out IQueryMatch compoundMatch)
+        QueryExecution exec, PlanParameters planParams, QueryBuilderParameters builderParams)
     {
-        compoundMatch = null;
         // Discovery: structural rejection. All structural facts (CompoundExactClauseA/B,
         // CompoundExactAFirst) were pre-classified at template time; this method only
         // confirms the runtime state is compatible.
@@ -2109,9 +2020,7 @@ internal static partial class QueryPlanBuilder
             return false;
         if (IsClauseBoosted(eB) || eB.PackedParamValue.IsNone)
             return false;
-
-        compoundMatch = ConstructCompoundExact(exec, planParams);
-        return compoundMatch != null;
+        return true;
     }
 
     /// <summary>Phase 5 bake: construction-only path for the CompoundExact hint.
@@ -2202,29 +2111,6 @@ internal static partial class QueryPlanBuilder
         return null;
     }
 
-    /// <summary>Check if WHERE + ORDER BY can be served by a compound tree scan.
-    /// Condition: an Equals clause on field1, ORDER BY on field2 (or field1, or both),
-    /// </summary>
-    public static bool TryCreateCompoundFieldMatch(
-        QueryExecution exec, OrderMetadata[] orderByFields,
-        PlanParameters planParams, QueryBuilderParameters builderParams,
-        CompiledPlan compiledPlan, out IQueryMatch compoundMatch, out string rejectReason)
-    {
-        if (TryCreateCompoundFieldMatch(exec, orderByFields, planParams, builderParams, compiledPlan, out compoundMatch))
-        {
-            rejectReason = null;
-            return true;
-        }
-
-        if (exec.Plan.CompoundFieldDrivingClause < 0 || exec.Plan.Template.CompoundFieldSortName == null)
-            rejectReason = "no compound-field candidate identified at template time";
-        else if (exec.Plan.AllNegated)
-            rejectReason = "all clauses are negated";
-        else
-            rejectReason = "cost check failed (bitmap is cheaper), non-scannable residual, or prefix too long";
-        return false;
-    }
-
     /// <summary>compound(field1, field2) exists in the index, and any residual clauses are
     /// entry-scan eligible.
     /// Returns a DirectScanMatch wrapping a compound tree StartsWith with optional
@@ -2232,32 +2118,32 @@ internal static partial class QueryPlanBuilder
     public static bool TryCreateCompoundFieldMatch(
         QueryExecution exec, OrderMetadata[] orderByFields,
         PlanParameters planParams, QueryBuilderParameters builderParams,
-        CompiledPlan compiledPlan, out IQueryMatch compoundMatch)
+        CompiledPlan compiledPlan, out string rejectReason)
     {
-        compoundMatch = null;
-
-        // Discovery: structural rejection + cost gate. Structural facts
-        // (CompoundFieldDrivingClause, CompoundFieldSortName) were pre-classified at
-        // template time. This method runs cost estimation and residual-scannability
-        // checks that are deterministic for the cache key (cardinality cliff bit 31
-        // in Ordering segregates cliff buckets, so cost outcome is stable per key).
-        int drivingClauseIdx = exec.Plan.CompoundFieldDrivingClause;
-        string sortFieldName = exec.Plan.Template.CompoundFieldSortName;
-        if (drivingClauseIdx < 0 || sortFieldName == null)
+        if (exec.Plan.CompoundFieldDrivingClause < 0 || exec.Plan.Template.CompoundFieldSortName is null)
+        {
+            rejectReason = "no compound-field candidate identified at template time";
             return false;
+        }
         var execs = exec.Executions;
-        if (execs == null || drivingClauseIdx >= execs.Count || exec.Plan.AllNegated)
+        if (exec.Plan.CompoundFieldDrivingClause >= execs.Count || exec.Plan.AllNegated)
+        {
+            rejectReason = "all clauses are negated";   
             return false;
+        }
 
         var indexSearcher = planParams.IndexSearcher;
 
-        var drivingExec = execs[drivingClauseIdx];
+        var drivingExec = execs[exec.Plan.CompoundFieldDrivingClause];
         if (drivingExec.PackedParamValue.IsNone)
+        {
+            rejectReason = "driving clause has no packed param value";
             return false;
+        }
 
         // Find optional field2 range narrowing clause (structural — same for all
         // executions of this template).
-        int field2RangeIdx = FindCompoundFieldField2Range(execs, drivingClauseIdx, sortFieldName);
+        int field2RangeIdx = FindCompoundFieldField2Range(execs, exec.Plan.CompoundFieldDrivingClause, exec.Plan.Template.CompoundFieldSortName);
 
         // Residual scannability + cost check
         int longIdx = 0, doubleIdx = 0, sliceIdx = 0;
@@ -2266,27 +2152,36 @@ internal static partial class QueryPlanBuilder
         for (int i = 0; i < execs.Count; i++)
         {
             bitmapCost += EffectiveCardinality(execs[i], indexSearcher);
-            if (i == drivingClauseIdx || i == field2RangeIdx)
+            if (i == exec.Plan.CompoundFieldDrivingClause || i == field2RangeIdx)
                 continue;
             if (IsClauseBoosted(execs[i]))
+            {
+                rejectReason = "boosted clause found";
                 return false;
-            var pred = BuildScanPredicateInfo(execs[i], ref longIdx, ref doubleIdx, ref sliceIdx);
-            if (pred == null)
+            }
+
+            if (BuildScanPredicateInfo(execs[i], ref longIdx, ref doubleIdx, ref sliceIdx) is null)
+            {
+                rejectReason = "scan predicate info is null";
                 return false;
+            }
             residualCount++;
         }
 
         long drivingCardinality = EffectiveCardinality(drivingExec, indexSearcher);
         long entriesToScan = residualCount > 0
-            ? AdjustEntriesToScanByMinResidual(execs, drivingClauseIdx, drivingCardinality, indexSearcher)
+            ? AdjustEntriesToScanByMinResidual(execs, exec.Plan.CompoundFieldDrivingClause, drivingCardinality, indexSearcher)
             : drivingCardinality;
 
         if (IsDirectScanCostEffective(entriesToScan, bitmapCost) == false)
-            return false;
+        {
+            rejectReason = "cost check failed (bitmap is cheaper), non-scannable residual, or prefix too long";
 
-        compoundMatch = ConstructCompoundField(exec, orderByFields, planParams, builderParams, compiledPlan,
-            field2RangeIdx, entriesToScan, bitmapCost);
-        return compoundMatch != null;
+            return false;
+        }
+
+        rejectReason = null;
+        return true;
     }
 
     /// <summary>Locate an optional GT/GTE/LT/LTE/Between clause on the sort field

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -160,16 +160,30 @@ internal static partial class QueryPlanBuilder
                 innerMatch = ConstructCompoundField(exec, orderByFields, planParams, builderParameters, compiledPlan, f2, entriesToScan: 0, bitmapCost: 0);
                 if(innerMatch is null) goto default;
                 return OrderBy(builderParameters, innerMatch, orderByFields, hasEmptySorts);
-            case ExecutionStrategy.DirectScan 
-                when orderByFields is { Length: <= 2 } &&
-                     exec.Executions is { Count: > 0 } && 
-                     exec.Plan.SortDrivingClauseIndex >= 0 && 
-                     exec.Executions[exec.Plan.SortDrivingClauseIndex].PackedParamValue.IsNone is false:
-                bool hasTieBreak = orderByFields.Length == 2;
-                innerMatch = ConstructDirectScan(exec, orderByFields, planParams, builderParameters,
-                    compiledPlan, exec.Plan.SortDrivingClauseIndex, true, hasTieBreak, entriesToScan: 0, bitmapCost: 0);
-                if(innerMatch is null) goto default;
-                return innerMatch;
+            case ExecutionStrategy.DirectScan when orderByFields is { Length: <= 2 }:
+                // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
+                // DirectScan plan — PageSize is not part of the plan cache key.
+                {
+                    var execs = exec.Executions;
+                    bool isFullScan = execs is null or { Count: 0 };
+                    int drivingIdx = -1;
+                    if (!isFullScan)
+                    {
+                        drivingIdx = exec.Plan.SortDrivingClauseIndex;
+                        // BoostFactor cannot land here: ComputeOptFlags clears
+                        // DirectScanCandidate template-wide for any boost; only IsNone
+                        // (parameter resolved to null) can still invalidate at runtime.
+                        if (drivingIdx >= 0 && exec.Executions[drivingIdx].PackedParamValue.IsNone)
+                            drivingIdx = -1;
+                    }
+                    if (isFullScan || drivingIdx >= 0)
+                    {
+                        innerMatch = ConstructDirectScan(exec, orderByFields, planParams, builderParameters,
+                            compiledPlan, drivingIdx, isFullScan, orderByFields.Length == 2, entriesToScan: 0, bitmapCost: 0);
+                        if (innerMatch is not null) return innerMatch;
+                    }
+                    goto default;
+                }
             case ExecutionStrategy.BitmapSort:
             default:
                 // may either be the selected strategy, or a one-off (because of bad parameters preventing a faster strategy) 
@@ -208,12 +222,20 @@ internal static partial class QueryPlanBuilder
                 {
                     compiledPlan.Strategy = ExecutionStrategy.CompoundField;
                     compiledPlan.DecisionTrail.Record("CompoundField", true, "compound tree scan with ORDER BY");
+                    return;
                 }
-                else
+                compiledPlan.DecisionTrail.Record("CompoundField", false, cfReason ?? "rejected");
+
+                if (TryCreateSimpleFieldDirectScan(exec, orderByFields, planParams, builderParameters, compiledPlan, out _, out var dsReason))
                 {
-                    compiledPlan.DecisionTrail.Record("CompoundField", false, cfReason ?? "rejected");
+                    compiledPlan.Strategy = ExecutionStrategy.DirectScan;
+                    compiledPlan.DecisionTrail.Record("DirectScan", true, "direct tree scan on sort field");
+                    return;
                 }
+                compiledPlan.DecisionTrail.Record("DirectScan", false, dsReason ?? "rejected");
             }
+
+            compiledPlan.DecisionTrail.Record("BitmapSort", true, "bitmap pipeline with SortingMatch fallback");
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -17,6 +17,7 @@ using Corax.Querying.Planning;
 using Corax.Querying.Primitives;
 using Corax.Utils;
 using Raven.Client.Exceptions;
+using Raven.Server.Documents.Indexes.Persistence.Corax.QueryOptimizer;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
 using Sparrow.Binary;
@@ -113,166 +114,15 @@ internal static partial class QueryPlanBuilder
         return new BuildCompileAndOptimizeResult(queryMatch, innerMatch, queryMatch == innerMatch ? null : queryMatch, plan, builderParameters, orderByFields);
     }
 
-    /// <summary>
-    /// Phase 3 dispatcher: produce the final <see cref="IQueryMatch"/> for a compiled plan,
-    /// applying ORDER BY when present. On the first execution (<see cref="ExecutionStrategy.NotEvaluated"/>)
-    /// runs the Try* discovery chain — CompoundExact → CompoundField → DirectScan — and caches
-    /// the winner's strategy + structural facts on <paramref name="compiledPlan"/>. Subsequent
-    /// executions read the cached <see cref="CompiledPlan.Strategy"/> and dispatch straight to
-    /// the matching Construct* helper, skipping discovery.
-    ///
-    /// The bitmap pipeline (<see cref="InstantiateBitmapPipeline"/>) is the last fallback —
-    /// reached either when all Try* methods reject (cache-miss path) or when a cached Construct*
-    /// returns null on per-execution rejection (e.g. byte-length overflow for CompoundExact).
-    /// </summary>
-    /// <param name="innerMatch">Pre-wrap inner match: same as the return value for the no-wrap
-    /// strategies (CompoundExact / DirectScan / no ORDER BY), the compound match for CompoundField,
-    /// or the bitmap CompiledQueryMatch for BitmapSort. The caller uses this for inspection-graph
-    /// construction and deterministic disposal of the IL-emitted match.</param>
-    /// <summary>Per-execution context bundling the stable parameters that flow through
-    /// every Construct* / Try* call inside <see cref="Instantiate"/>. Stack-only;
-    /// zero allocation. <see cref="RejectReason"/> is written by Try* on failure
-    /// so the caller can record it on the <see cref="CompiledPlan.DecisionTrail"/>
-    /// without an extra out parameter.</summary>
-    private ref struct InstCtx
+    private ref struct InstCtx(CompiledPlan plan, QueryExecution exec, OrderMetadata[] orderByFields, PlanParameters planParams, QueryBuilderParameters builderParams)
     {
-        public CompiledPlan Plan;
-        public QueryExecution Exec;
-        public OrderMetadata[] OrderByFields; // may be null when PageSize == 0
-        public PlanParameters PlanParams;
-        public QueryBuilderParameters BuilderParams;
+        public CompiledPlan Plan = plan;
+        public QueryExecution Exec = exec;
+        public OrderMetadata[] OrderByFields = orderByFields; // may be null when PageSize == 0
+        public PlanParameters PlanParams = planParams;
+        public QueryBuilderParameters BuilderParams = builderParams;
+
         public string RejectReason;
-    }
-
-    private static IQueryMatch Instantiate(
-        CompiledPlan compiledPlan,
-        QueryExecution exec,
-        OrderMetadata[] orderByFields,
-        bool hasEmptySorts,
-        PlanParameters planParams,
-        QueryBuilderParameters builderParameters,
-        ResolutionContext walkerCtx,
-        Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms,
-        bool wantTimings,
-        out IQueryMatch innerMatch,
-        CancellationToken token)
-    {
-        var ctx = new InstCtx
-        {
-            Plan = compiledPlan,
-            Exec = exec,
-            OrderByFields = orderByFields,
-            PlanParams = planParams,
-            BuilderParams = builderParameters,
-        };
-
-        if (compiledPlan.Strategy == ExecutionStrategy.NotEvaluated)
-            SelectExecutionStrategy(ref ctx);
-
-        switch (compiledPlan.Strategy)
-        {
-            // ── Fast path: cached strategy, dispatch directly to Construct* ──
-            case ExecutionStrategy.CompoundExact:
-                innerMatch = ConstructCompoundExact(ref ctx);
-                if (innerMatch is null) goto default;
-                return innerMatch;
-            case ExecutionStrategy.CompoundField when orderByFields != null:
-                // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
-                // CompoundField plan — PageSize is not part of the plan cache key.
-                int f2 = FindCompoundFieldField2Range(exec.Executions, compiledPlan.CompoundFieldDrivingClause, compiledPlan.Template.CompoundFieldSortName);
-                innerMatch = ConstructCompoundField(ref ctx, f2, entriesToScan: 0, bitmapCost: 0);
-                if (innerMatch is null) goto default;
-                return OrderBy(builderParameters, innerMatch, orderByFields, hasEmptySorts);
-            case ExecutionStrategy.DirectScan when orderByFields is { Length: <= 2 }:
-                // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
-                // DirectScan plan — PageSize is not part of the plan cache key.
-                var execs = exec.Executions;
-                if (execs is not { Count: > 0 } ||
-                    exec.Plan.SortDrivingClauseIndex >= 0 && exec.Executions[exec.Plan.SortDrivingClauseIndex].PackedParamValue.IsNone is false)
-                {
-                    innerMatch = ConstructDirectScan(ref ctx, exec.Plan.SortDrivingClauseIndex,
-                        execs is not { Count: > 0 }, orderByFields.Length == 2, entriesToScan: 0, bitmapCost: 0);
-                    if (innerMatch is not null) return innerMatch;
-                }
-                goto default;
-            case ExecutionStrategy.BitmapSort:
-            default:
-                // may either be the selected strategy, or a one-off (because of bad parameters preventing a faster strategy)
-                return InstantiateBitmapFallback(compiledPlan, exec, orderByFields, hasEmptySorts,
-                    planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, out innerMatch, token);
-        }
-
-        static void SelectExecutionStrategy(ref InstCtx ctx)
-        {
-            // ── Slow path: cache-miss, run Try* discovery chain ──
-            ctx.Plan.DecisionTrail = new();
-            ctx.Plan.Strategy = ExecutionStrategy.BitmapSort; // if nothing else overrides it
-
-            if (ctx.Plan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.CompoundExactCandidate))
-            {
-                if (TryCreateCompoundExactMatch(ref ctx, out ctx.RejectReason))
-                {
-                    ctx.Plan.Strategy = ExecutionStrategy.CompoundExact;
-                    ctx.Plan.DecisionTrail.Record("CompoundExact", true, "compound exact-term lookup");
-                    return;
-                }
-                ctx.Plan.DecisionTrail.Record("CompoundExact", false, ctx.RejectReason ?? "rejected");
-            }
-
-            if (ctx.OrderByFields is null)
-            {
-                ctx.Plan.DecisionTrail.Record("NoOrderBy", true, "no ORDER BY");
-                return;
-            }
-
-            if (ctx.Plan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.DirectScanCandidate))
-            {
-                if (TryCreateCompoundFieldMatch(ref ctx, out ctx.RejectReason))
-                {
-                    ctx.Plan.Strategy = ExecutionStrategy.CompoundField;
-                    ctx.Plan.DecisionTrail.Record("CompoundField", true, "compound tree scan with ORDER BY");
-                    return;
-                }
-                ctx.Plan.DecisionTrail.Record("CompoundField", false, ctx.RejectReason ?? "rejected");
-
-                if (TryCreateSimpleFieldDirectScan(ref ctx, out _, out ctx.RejectReason))
-                {
-                    ctx.Plan.Strategy = ExecutionStrategy.DirectScan;
-                    ctx.Plan.DecisionTrail.Record("DirectScan", true, "direct tree scan on sort field");
-                    return;
-                }
-                ctx.Plan.DecisionTrail.Record("DirectScan", false, ctx.RejectReason ?? "rejected");
-            }
-
-            ctx.Plan.DecisionTrail.Record("BitmapSort", true, "bitmap pipeline with SortingMatch fallback");
-        }
-    }
-
-    /// <summary>Bitmap-pipeline fallback used when a cached non-BitmapSort strategy fails at
-    /// construction time (per-execution rejection, not a structural rejection). Applies ORDER BY
-    /// when present and sets the seek hint on the inner CompiledQueryMatch. The cached strategy
-    /// is intentionally NOT downgraded — the next execution's parameters may construct
-    /// successfully.</summary>
-    private static IQueryMatch InstantiateBitmapFallback(
-        CompiledPlan compiledPlan, QueryExecution exec,
-        OrderMetadata[] orderByFields, bool hasEmptySorts,
-        PlanParameters planParams, QueryBuilderParameters builderParameters,
-        ResolutionContext walkerCtx,
-        Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms,
-        bool wantTimings,
-        out IQueryMatch innerMatch,
-        CancellationToken token)
-    {
-        var fallbackMatch = InstantiateBitmapPipeline(compiledPlan, exec, planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, token);
-        innerMatch = fallbackMatch;
-        if (orderByFields != null)
-        {
-            if (fallbackMatch is CompiledQueryMatch seekMatch)
-                TrySetSortSeekHint(seekMatch, exec, orderByFields);
-            return OrderBy(builderParameters, fallbackMatch, orderByFields, hasEmptySorts);
-        }
-
-        return fallbackMatch;
     }
 
     /// <summary>
@@ -405,6 +255,122 @@ internal static partial class QueryPlanBuilder
             AttachSpatialAndVectorClauses(exec, template, planParams, builderParameters, writer);
             writer.SetValues(exec);
             return (compiledPlan, exec);
+        }
+    }
+    
+    
+    /// <summary>
+    /// Phase 3 dispatcher: produce the final <see cref="IQueryMatch"/> for a compiled plan,
+    /// applying ORDER BY when present. On the first execution (<see cref="ExecutionStrategy.NotEvaluated"/>)
+    /// runs the Try* discovery chain — CompoundExact → CompoundField → DirectScan — and caches
+    /// the winner's strategy + structural facts on <paramref name="compiledPlan"/>. Subsequent
+    /// executions read the cached <see cref="CompiledPlan.Strategy"/> and dispatch straight to
+    /// the matching Construct* helper, skipping discovery.
+    ///
+    /// The bitmap pipeline (<see cref="InstantiateBitmapPipeline"/>) is the last fallback —
+    /// reached either when all Try* methods reject (cache-miss path) or when a cached Construct*
+    /// returns null on per-execution rejection (e.g. byte-length overflow for CompoundExact).
+    /// </summary>
+    /// <param name="innerMatch">Pre-wrap inner match: same as the return value for the no-wrap
+    /// strategies (CompoundExact / DirectScan / no ORDER BY), the compound match for CompoundField,
+    /// or the bitmap CompiledQueryMatch for BitmapSort. The caller uses this for inspection-graph
+    /// construction and deterministic disposal of the IL-emitted match.</param>
+    private static IQueryMatch Instantiate(
+        CompiledPlan compiledPlan,
+        QueryExecution exec,
+        OrderMetadata[] orderByFields,
+        bool hasEmptySorts,
+        PlanParameters planParams,
+        QueryBuilderParameters builderParameters,
+        ResolutionContext walkerCtx,
+        Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms,
+        bool wantTimings,
+        out IQueryMatch innerMatch,
+        CancellationToken token)
+    {
+        var ctx = new InstCtx(compiledPlan, exec, orderByFields, planParams, builderParameters);
+
+        if (compiledPlan.Strategy == ExecutionStrategy.NotEvaluated)
+            SelectExecutionStrategy(ref ctx);
+
+        switch (compiledPlan.Strategy)
+        {
+            // ── Fast path: cached strategy, dispatch directly to Construct* ──
+            case ExecutionStrategy.CompoundExact:
+                innerMatch = ConstructCompoundExact(ref ctx);
+                if (innerMatch is null) goto default;
+                return innerMatch;
+            case ExecutionStrategy.CompoundField when orderByFields != null:
+                // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
+                // CompoundField plan — PageSize is not part of the plan cache key.
+                innerMatch = ConstructCompoundField(ref ctx, FindCompoundFieldField2Range(ref ctx), entriesToScan: 0, bitmapCost: 0);
+                if (innerMatch is null) goto default;
+                return OrderBy(builderParameters, innerMatch, orderByFields, hasEmptySorts);
+            case ExecutionStrategy.DirectScan when orderByFields is { Length: <= 2 }:
+                // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
+                // DirectScan plan — PageSize is not part of the plan cache key.
+                var execs = exec.Executions;
+                bool isFullScan = execs is not { Count: > 0 };
+                if (isFullScan ||
+                    exec.Plan.SortDrivingClauseIndex >= 0 && exec.Executions[exec.Plan.SortDrivingClauseIndex].PackedParamValue.IsNone is false)
+                {
+                    bool hasTieBreak = orderByFields.Length == 2;
+                    innerMatch = ConstructDirectScan(ref ctx, exec.Plan.SortDrivingClauseIndex, isFullScan, hasTieBreak, entriesToScan: 0, bitmapCost: 0);
+                    if (innerMatch is not null) return innerMatch;
+                }
+                goto default;
+            case ExecutionStrategy.BitmapSort:
+            default: // may either be the selected strategy, or a one-off (because of bad parameters preventing a faster strategy)
+                innerMatch = InstantiateBitmapPipeline(ctx.Plan, ctx.Exec, ctx.PlanParams, ctx.BuilderParams, walkerCtx, highlightingTerms, wantTimings, token);
+                if (ctx.OrderByFields == null) return innerMatch;
+                if (innerMatch is CompiledQueryMatch seekMatch)
+                    TrySetSortSeekHint(seekMatch, ctx.Exec, ctx.OrderByFields);
+                return OrderBy(ctx.BuilderParams, innerMatch, ctx.OrderByFields, hasEmptySorts);
+        }
+
+        static void SelectExecutionStrategy(ref InstCtx ctx)
+        {
+            // ── Slow path: cache-miss, run Try* discovery chain ──
+            ctx.Plan.DecisionTrail = new();
+            ctx.Plan.Strategy = ExecutionStrategy.BitmapSort; // if nothing else overrides it
+
+            if (ctx.Plan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.CompoundExactCandidate))
+            {
+                if (TryCreateCompoundExactMatch(ref ctx, out ctx.RejectReason))
+                {
+                    ctx.Plan.Strategy = ExecutionStrategy.CompoundExact;
+                    ctx.Plan.DecisionTrail.Record("CompoundExact", true, "compound exact-term lookup");
+                    return;
+                }
+                ctx.Plan.DecisionTrail.Record("CompoundExact", false, ctx.RejectReason ?? "rejected");
+            }
+
+            if (ctx.OrderByFields is null)
+            {
+                ctx.Plan.DecisionTrail.Record("NoOrderBy", true, "no ORDER BY");
+                return;
+            }
+
+            if (ctx.Plan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.DirectScanCandidate))
+            {
+                if (TryCreateCompoundFieldMatch(ref ctx, out ctx.RejectReason))
+                {
+                    ctx.Plan.Strategy = ExecutionStrategy.CompoundField;
+                    ctx.Plan.DecisionTrail.Record("CompoundField", true, "compound tree scan with ORDER BY");
+                    return;
+                }
+                ctx.Plan.DecisionTrail.Record("CompoundField", false, ctx.RejectReason ?? "rejected");
+
+                if (TryCreateSimpleFieldDirectScan(ref ctx, out ctx.RejectReason))
+                {
+                    ctx.Plan.Strategy = ExecutionStrategy.DirectScan;
+                    ctx.Plan.DecisionTrail.Record("DirectScan", true, "direct tree scan on sort field");
+                    return;
+                }
+                ctx.Plan.DecisionTrail.Record("DirectScan", false, ctx.RejectReason ?? "rejected");
+            }
+
+            ctx.Plan.DecisionTrail.Record("BitmapSort", true, "bitmap pipeline with SortingMatch fallback");
         }
     }
 
@@ -566,8 +532,7 @@ internal static partial class QueryPlanBuilder
         // Vector: each vector wraps the (possibly null) filter so far.
         if (exec.VectorSelects is { Length: > 0 })
         {
-            var vectorItems = ResolveVectorItems(exec, builderParameters);
-            foreach (var item in vectorItems)
+            foreach (var item in ResolveVectorItems(exec, builderParameters))
             {
                 result = item.Materialize(result);
             }
@@ -581,7 +546,7 @@ internal static partial class QueryPlanBuilder
     /// of a moreLikeThis clause). Parses and resolves the expression directly
     /// without going through the full plan/compile pipeline.
     /// </summary>
-    public static IQueryMatch BuildFromSubExpression(QueryBuilderParameters builderParams, QueryExpression expression)
+    public static IQueryMatch BuildQueryForMoreLikeThis(QueryBuilderParameters builderParams, QueryExpression expression)
     {
         // Sub-expression entry point: run the same phases as ParseTemplate.
         // Validation is inline in the Parse methods; errors accumulate in walkerCtx.Errors.
@@ -615,25 +580,18 @@ internal static partial class QueryPlanBuilder
             return ResolveClause(subExecs[0], subPlan, walkerCtx);
 
         // Multiple clauses (AND chain) — resolve each and AND them via bitmap.
-        // RoaringBitmap is passed as `ref` to AndWithMatch, so using var is not legal here;
-        // use try/finally to guarantee disposal.
         var bitmap = new BitmapMatch(indexSearcher.Allocator);
+        if (walkerCtx.Clauses.Count == 0)
+            return bitmap;
+        
+        QueryPrimitives.OrWithMatch(ResolveClause(subExecs[0], subPlan, walkerCtx), ref bitmap.BitmapState);
+
         var temp = new RoaringBitmap(indexSearcher.Allocator);
         try
         {
-            bool first = true;
-            for (int ci2 = 0; ci2 < walkerCtx.Clauses.Count; ci2++)
+            for (int i = 1; i < walkerCtx.Clauses.Count; i++)
             {
-                var match = ResolveClause(subExecs[ci2], subPlan, walkerCtx);
-                if (first)
-                {
-                    QueryPrimitives.OrWithMatch(match, ref bitmap.BitmapState);
-                    first = false;
-                }
-                else
-                {
-                    QueryPrimitives.AndWithMatch(match, ref bitmap.BitmapState, ref temp);
-                }
+                QueryPrimitives.AndWithMatch(ResolveClause(subExecs[i], subPlan, walkerCtx), ref bitmap.BitmapState, ref temp);
             }
         }
         finally
@@ -708,12 +666,11 @@ internal static partial class QueryPlanBuilder
     /// Equals-shaped IL that would silently drop terms on subsequent N&gt;1 executions
     /// (RavenDB-17423). The uniform IN shape lets EmitInOps emit a single OrRange whose
     /// term count is read from InRangeCounts at runtime.</summary>
-    private static void PropagateBetweenContradictions(
-        List<ClauseExecution> execList, ValueWriter writer)
+    private static void PropagateBetweenContradictions(List<ClauseExecution> execList, ValueWriter writer)
     {
-        for (int ci = execList.Count - 1; ci >= 0; ci--)
+        for (int i = execList.Count - 1; i >= 0; i--)
         {
-            var e = execList[ci];
+            var e = execList[i];
             var c = e.Clause;
 
             var p = e.PackedParamValue;
@@ -878,7 +835,7 @@ internal static partial class QueryPlanBuilder
             _ => clause.ClauseType.ToString()
         };
         throw new InvalidQueryException(
-            $"Method {methodName}() expects to get an argument of type String while it got Null");
+            $"Method {methodName}() expects to get an argument of type String while it got null");
     }
 
     private static void ResolveBoostFactor(ClauseExecution exec, BlittableJsonReaderObject queryParameters)
@@ -2026,34 +1983,6 @@ internal static partial class QueryPlanBuilder
         return true;
     }
 
-    /// <summary>Check if two Equals clauses on (field1, field2) match a compound field.
-    /// If so, build a single TermQuery on the compound tree with the composite key.
-    /// One tree lookup instead of two posting list intersections.</summary>
-    private static bool TryCreateCompoundExactMatch(
-        ref InstCtx ctx)
-    {
-        // Discovery: structural rejection. All structural facts (CompoundExactClauseA/B,
-        // CompoundExactAFirst) were pre-classified at template time; this method only
-        // confirms the runtime state is compatible.
-        if (ctx.Exec.Executions == null || ctx.Exec.Executions.Count < 2 || ctx.Exec.Plan.AllNegated)
-            return false;
-        if (ctx.PlanParams.Index == null)
-            return false;
-
-        int idxA = ctx.Exec.Plan.CompoundExactClauseA;
-        int idxB = ctx.Exec.Plan.CompoundExactClauseB;
-        if (idxA < 0 || idxB < 0 || idxA >= ctx.Exec.Executions.Count || idxB >= ctx.Exec.Executions.Count)
-            return false;
-
-        var eA = ctx.Exec.Executions[idxA];
-        var eB = ctx.Exec.Executions[idxB];
-        if (IsClauseBoosted(eA) || eA.PackedParamValue.IsNone)
-            return false;
-        if (IsClauseBoosted(eB) || eB.PackedParamValue.IsNone)
-            return false;
-        return true;
-    }
-
     /// <summary>Phase 5 bake: construction-only path for the CompoundExact hint.
     /// Assumes structural discovery has already validated this optimization applies
     /// (called either right after <see cref="TryCreateCompoundExactMatch"/>'s checks pass
@@ -2146,8 +2075,7 @@ internal static partial class QueryPlanBuilder
     /// entry-scan eligible.
     /// Returns a DirectScanMatch wrapping a compound tree StartsWith with optional
     /// residual predicate checking.</summary>
-    private static bool TryCreateCompoundFieldMatch(
-        ref InstCtx ctx, out string rejectReason)
+    private static bool TryCreateCompoundFieldMatch(ref InstCtx ctx, out string rejectReason)
     {
         if (ctx.Exec.Plan.CompoundFieldDrivingClause < 0 || ctx.Exec.Plan.Template.CompoundFieldSortName is null)
         {
@@ -2172,7 +2100,7 @@ internal static partial class QueryPlanBuilder
 
         // Find optional field2 range narrowing clause (structural — same for all
         // executions of this template).
-        int field2RangeIdx = FindCompoundFieldField2Range(execs, ctx.Exec.Plan.CompoundFieldDrivingClause, ctx.Exec.Plan.Template.CompoundFieldSortName);
+        int field2RangeIdx = FindCompoundFieldField2Range(ref ctx);
 
         // Residual scannability + cost check
         int longIdx = 0, doubleIdx = 0, sliceIdx = 0;
@@ -2217,8 +2145,12 @@ internal static partial class QueryPlanBuilder
     /// that can narrow the compound prefix scan. Structural — same for all executions
     /// of a given template, but cheap enough to recompute on each Construct call
     /// rather than threading another field through QueryExecution.</summary>
-    private static int FindCompoundFieldField2Range(List<ClauseExecution> executions, int drivingClauseIdx, string sortFieldName)
+    private static int FindCompoundFieldField2Range(ref InstCtx ctx)
     {
+        var executions = ctx.Exec.Executions;
+        int drivingClauseIdx = ctx.Plan.CompoundFieldDrivingClause;
+        var sortFieldName = ctx.Plan.Template.CompoundFieldSortName;
+        
         for (int i = 0; i < executions.Count; i++)
         {
             if (i == drivingClauseIdx) continue;
@@ -2459,10 +2391,10 @@ internal static partial class QueryPlanBuilder
 
     /// <summary>Check if a range clause on the ORDER BY field can be served by a direct</summary>
     private static bool TryCreateSimpleFieldDirectScan(
-        ref InstCtx ctx, out IQueryMatch directMatch, out string rejectReason)
+        ref InstCtx ctx, out string rejectReason)
     {
         rejectReason = null;
-        bool result = TryCreateSimpleFieldDirectScan(ref ctx, out directMatch);
+        bool result = TryCreateSimpleFieldDirectScan(ref ctx, out IQueryMatch directMatch);
         if (!result)
         {
             if (ctx.OrderByFields == null || ctx.OrderByFields.Length == 0)
@@ -2482,8 +2414,7 @@ internal static partial class QueryPlanBuilder
 
     /// <summary>tree scan instead of the bitmap pipeline. The range query already walks the tree
     /// in sort order, so no SortingMatch wrapper is needed.</summary>
-    private static bool TryCreateSimpleFieldDirectScan(
-        ref InstCtx ctx, out IQueryMatch directMatch)
+    private static bool TryCreateSimpleFieldDirectScan(ref InstCtx ctx, out IQueryMatch directMatch)
     {
         directMatch = null;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -204,6 +204,12 @@ internal static partial class QueryPlanBuilder
 
         (int typeSignature, byte[] fullKinds) = ComputeTypeSignature(template, planParams);
 
+        // IN/AllIn clauses with QueryParameter bindings can expand to different term counts
+        // at runtime. The slot layout (ParamIndex constants baked into the compiled IL) depends
+        // on InTermCount, so different counts must produce different compiled plans. Fold a hash
+        // of all IN/AllIn InTermCounts into typeSignature so the cache treats them as distinct.
+        typeSignature ^= ComputeInTermSignature(executions);
+
         if(planCache.Get(queryText, operandOrdering, typeSignature, fullKinds, whenFlags) is {} compiledPlan)
             return FinalizePlan();
         
@@ -2837,13 +2843,13 @@ internal static partial class QueryPlanBuilder
 
         if (clause.ClauseType is ClauseType.In)
         {
-            EmitInLeaf(clause, cardinality, merge, ref matchIndex, ref maxScratchUsed, ops, rangeCounts);
+            EmitInLeaf(clause, exec, cardinality, merge, ref matchIndex, ref maxScratchUsed, ops, rangeCounts);
             return;
         }
 
         if (clause.ClauseType is ClauseType.AllIn)
         {
-            EmitAllInLeaf(clause, cardinality, merge, suppressEarlyExit,
+            EmitAllInLeaf(clause, exec, cardinality, merge, suppressEarlyExit,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
             return;
         }
@@ -2984,20 +2990,21 @@ internal static partial class QueryPlanBuilder
     /// via AndBitmaps/AndNotBitmaps. OrRange ignores SkipEarlyExit so suppression
     /// doesn't need to propagate here.</summary>
     private static void EmitInLeaf(
-        ClauseInfo clause, long cardinality, MergeKind merge,
+        ClauseInfo clause, ClauseExecution exec, long cardinality, MergeKind merge,
         ref int matchIndex, ref int maxScratchUsed,
         List<PlanOp> ops, List<int> rangeCounts)
     {
+        int inTermCount = exec?.InTermCount > 0 ? exec.InTermCount : clause.Bindings?.Length ?? 0;
         if (merge is MergeKind.Fill or MergeKind.OrInto)
         {
-            EmitInOps(ops, clause, cardinality, bitmapLocal: 0, isSeed: merge == MergeKind.Fill, ref matchIndex, rangeCounts);
+            EmitInOps(ops, inTermCount, cardinality, bitmapLocal: 0, isSeed: merge == MergeKind.Fill, ref matchIndex, rangeCounts);
             return;
         }
 
         // AndInto / AndNotInto: union IN terms in slot 1, then merge with slot 0.
         if (1 > maxScratchUsed) maxScratchUsed = 1;
         ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 1 });
-        EmitInOps(ops, clause, cardinality, bitmapLocal: 1, isSeed: false, ref matchIndex, rangeCounts);
+        EmitInOps(ops, inTermCount, cardinality, bitmapLocal: 1, isSeed: false, ref matchIndex, rangeCounts);
         ops.Add(new PlanOp
         {
             Kind = merge == MergeKind.AndInto ? PlanOpKind.AndBitmaps : PlanOpKind.AndNotBitmaps,
@@ -3012,14 +3019,15 @@ internal static partial class QueryPlanBuilder
     /// AndRange op honors SkipEarlyExit; in a saved context we must set it so the loop
     /// doesn't jump to doneLabel mid-intersection.</summary>
     private static void EmitAllInLeaf(
-        ClauseInfo clause, long cardinality, MergeKind merge,
+        ClauseInfo clause, ClauseExecution exec, long cardinality, MergeKind merge,
         bool suppressEarlyExit,
         ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
         List<PlanOp> ops, List<int> rangeCounts)
     {
+        int inTermCount = exec?.InTermCount > 0 ? exec.InTermCount : clause.Bindings?.Length ?? 0;
         if (merge == MergeKind.Fill)
         {
-            EmitAllInOps(ops, clause, cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
+            EmitAllInOps(ops, inTermCount, cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
             if (suppressEarlyExit)
                 SetLastAndRangeSkipEarlyExit(ops);
             return;
@@ -3030,7 +3038,7 @@ internal static partial class QueryPlanBuilder
 
         ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = saveSlot });
         ops.Add(new PlanOp { Kind = PlanOpKind.SwapBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
-        EmitAllInOps(ops, clause, cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
+        EmitAllInOps(ops, inTermCount, cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
         // Inside save-swap: AndRange must not jump to doneLabel — that would skip
         // the merge-back and leak the saved accumulator.
         SetLastAndRangeSkipEarlyExit(ops);
@@ -3272,11 +3280,23 @@ internal static partial class QueryPlanBuilder
     {
         var counts = new int[slotCount];
         int rangeIdx = 0;
+        AccumulateInRangeCounts(executions, counts, ref rangeIdx);
+        return counts;
+    }
+
+    private static void AccumulateInRangeCounts(List<ClauseExecution> executions, int[] counts, ref int rangeIdx)
+    {
         for (int ci = 0; ci < executions.Count && rangeIdx < counts.Length; ci++)
         {
             ClauseExecution execution = executions[ci];
             switch (execution.Clause.ClauseType)
             {
+                case ClauseType.OrGroup:
+                case ClauseType.AndGroup:
+                    if (execution.SubExecutions is not null)
+                        AccumulateInRangeCounts(execution.SubExecutions, counts, ref rangeIdx);
+                    break;
+
                 // IN: EmitInOps emits Fill + OrRange. Fill consumed slot 0,
                 // range = InTermCount (ORing with empty null slot is a no-op).
                 case ClauseType.In:
@@ -3290,7 +3310,6 @@ internal static partial class QueryPlanBuilder
                     break;
             }
         }
-        return counts;
     }
 
     private static bool AreAllScanEligible(List<ClauseExecution> executions, int startIndex)
@@ -3313,16 +3332,17 @@ internal static partial class QueryPlanBuilder
 
     // ── Plan helpers ─────────────────────────────────────────────────────
 
-    /// <summary>Emit ops for an IN clause: Fill the first term + OrRange for the rest, plus null-term if needed.</summary>
     /// <summary>Emit ops for an IN clause: Fill slot 0 + OrRange for the rest.
     /// Fixed 2-op shape regardless of term count or presence of null. Slot 0 holds
     /// the null-term posting list when HasNullTerm, else the first typed term, else
-    /// an empty PostingSource. Slots 1..N-1 hold remaining typed terms, dispatched
-    /// via OrRange whose count comes from <c>ctx.InRangeCounts[rangeIdx]</c> at
-    /// runtime.</summary>
-    private static void EmitInOps(List<PlanOp> ops, ClauseInfo clause, long cardinality, int bitmapLocal, bool isSeed, ref int matchIndex, List<int> rangeCounts)
+    /// an empty PostingSource. Slots 1..inTermCount hold remaining typed terms and
+    /// the null-term, dispatched via OrRange whose count comes from
+    /// <c>ctx.InRangeCounts[rangeIdx]</c> at runtime. <paramref name="inTermCount"/>
+    /// must match <c>exec.InTermCount</c> so the emitter slot layout agrees with the
+    /// resolver's <see cref="ResolveClauseLeavesInto{TResolver,TSlot}"/> walk.</summary>
+    private static void EmitInOps(List<PlanOp> ops, int inTermCount, long cardinality, int bitmapLocal, bool isSeed, ref int matchIndex, List<int> rangeCounts)
     {
-        int totalSlots = (clause.Bindings?.Length ?? 0) + 1;
+        int totalSlots = inTermCount + 1; // inTermCount non-null terms + 1 null-term slot
         // Range iterates over the slots AFTER slot 0 (which Fill handles). When the parameter
         // list has no null, the trailing null slot is Empty — ORing with Empty is a no-op, so
         // we can safely include it (rangeCount = totalSlots - 1). When the list HAS a null
@@ -3352,10 +3372,12 @@ internal static partial class QueryPlanBuilder
 
     /// <summary>Emit ops for an AllIn clause (as a seed): Fill slot 0 + AndRange for the rest.
     /// Same fixed shape rationale as <see cref="EmitInOps"/> — the count of remaining
-    /// terms lives in <c>ctx.InRangeCounts</c> rather than the op shape itself.</summary>
-    private static void EmitAllInOps(List<PlanOp> ops, ClauseInfo clause, long cardinality, int bitmapLocal, ref int matchIndex, List<int> rangeCounts)
+    /// terms lives in <c>ctx.InRangeCounts</c> rather than the op shape itself.
+    /// <paramref name="inTermCount"/> must match <c>exec.InTermCount</c> so the slot
+    /// layout agrees with the resolver walk.</summary>
+    private static void EmitAllInOps(List<PlanOp> ops, int inTermCount, long cardinality, int bitmapLocal, ref int matchIndex, List<int> rangeCounts)
     {
-        int totalSlots = (clause.Bindings?.Length ?? 0) + 1;
+        int totalSlots = inTermCount + 1; // inTermCount non-null terms + 1 null-term slot
         // Fill consumes slot 0, AndRange iterates the rest. The range count
         // covers all slots after slot 0 (including the null-term slot).
         int rangeCount = totalSlots - 1;
@@ -3699,6 +3721,28 @@ internal static partial class QueryPlanBuilder
             typeSignature |= kind << (i * 2); 
         }
         return (typeSignature, fullKinds);
+    }
+
+    /// <summary>Compute a hash over the InTermCount of every IN/AllIn execution in the tree.
+    /// When a QueryParameter IN binding expands to N values at runtime (N may differ per
+    /// execution), the compiled plan's slot-layout constants depend on N. Folding this hash
+    /// into the typeSignature cache key ensures different expansion sizes get different plans,
+    /// preventing slot-index mismatches between the emitter (uses InTermCount at build time)
+    /// and the resolver (uses InTermCount at execution time).</summary>
+    private static int ComputeInTermSignature(List<ClauseExecution> executions)
+    {
+        int sig = 0;
+        foreach (var exec in executions ?? [])
+            AccumulateInTermCounts(exec, ref sig);
+        return sig;
+    }
+
+    private static void AccumulateInTermCounts(ClauseExecution exec, ref int sig)
+    {
+        if (exec.Clause.ClauseType is ClauseType.In or ClauseType.AllIn)
+            sig = (sig * 397) ^ exec.InTermCount;
+        foreach (var sub in exec.SubExecutions ?? [])
+            AccumulateInTermCounts(sub, ref sig);
     }
 
     /// <summary>Classify a query parameter's runtime type from the blittable JSON value.

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -150,8 +150,7 @@ internal static partial class QueryPlanBuilder
             switch (strategy)
             {
                 case ExecutionStrategy.CompoundExact:
-                    if (exec != null)
-                        built = ConstructCompoundExact(exec, planParams);
+                    built = ConstructCompoundExact(exec, planParams);
                     if (built != null)
                     {
                         innerMatch = built;
@@ -160,7 +159,9 @@ internal static partial class QueryPlanBuilder
 
                     break;
                 case ExecutionStrategy.CompoundField:
-                    if (exec != null && orderByFields != null)
+                    // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
+                    // CompoundField plan — PageSize is not part of the plan cache key.
+                    if (orderByFields != null)
                     {
                         int f2 = FindCompoundFieldField2Range(exec.Executions, exec.Plan.CompoundFieldDrivingClause, exec.Plan.Template.CompoundFieldSortName);
                         // Cost facts (entriesToScan, bitmapCost) are diagnostic-only inside
@@ -178,7 +179,9 @@ internal static partial class QueryPlanBuilder
 
                     break;
                 case ExecutionStrategy.DirectScan:
-                    if (exec != null && orderByFields is { Length: <= 2 })
+                    // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
+                    // DirectScan plan — PageSize is not part of the plan cache key.
+                    if (orderByFields is { Length: <= 2 })
                     {
                         var execs2 = exec.Executions;
                         bool isFullScan = execs2 == null || execs2.Count == 0;
@@ -229,9 +232,7 @@ internal static partial class QueryPlanBuilder
         IQueryMatch queryMatch = null;
         innerMatch = null;
 
-        if (exec == null)
-            trail.Record("CompoundExact", false, "no exec available");
-        else if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.CompoundExactCandidate) == 0)
+        if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.CompoundExactCandidate) == 0)
             trail.Record("CompoundExact", false, "template has no compound-exact candidate");
         else if (TryCreateCompoundExactMatch(exec, planParams, builderParameters, out var compoundExact, out var ceReason))
         {
@@ -248,9 +249,7 @@ internal static partial class QueryPlanBuilder
         {
             if (needsFullChain)
             {
-                if (exec == null)
-                    trail.Record("CompoundField", false, "no exec available");
-                else if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.DirectScanCandidate) == 0)
+                if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.DirectScanCandidate) == 0)
                     trail.Record("CompoundField", false, "template has no direct-scan candidate");
                 else if (TryCreateCompoundFieldMatch(exec, orderByFields, planParams, builderParameters, compiledPlan, out var compoundMatch, out var cfReason))
                 {
@@ -266,9 +265,7 @@ internal static partial class QueryPlanBuilder
 
             if (needsFullChain)
             {
-                if (exec == null)
-                    trail.Record("DirectScan", false, "no exec available");
-                else if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.DirectScanCandidate) == 0)
+                if ((compiledPlan.Template.OptimizationFlags & PlanOptimizationFlags.DirectScanCandidate) == 0)
                     trail.Record("DirectScan", false, "template has no direct-scan candidate");
                 else if (TryCreateSimpleFieldDirectScan(exec, orderByFields, planParams, builderParameters, compiledPlan, out var directMatch, out var dsReason))
                 {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1278,50 +1278,51 @@ internal static partial class QueryPlanBuilder
         };
     }
 
-    /// <summary>
-    /// Produces a slot per position from QueryExecution's clauses. Slot layout matches
-    /// <see cref="CountMatchSlots"/> exactly, produces identical parallel arrays indexed. 
-    /// </summary>
+    /// <summary>Produces a slot per LEAF position from QueryExecution's clauses. Slot layout
+    /// matches <see cref="CountMatchSlots"/> exactly — both walk the clause tree via the
+    /// same recursion (<see cref="ResolveClauseLeavesInto{TResolver, TSlot}"/> here,
+    /// <see cref="CountClauseLeaves"/> there). The emit helpers consume leaves in the
+    /// same order, keeping IL slot indices end-to-end consistent.</summary>
     private static TSlot[] ResolveSlots<TResolver, TSlot>(QueryExecution exec, ResolutionContext walkerCtx)
         where TResolver : ISlotResolver<TResolver, TSlot>
     {
         var execs = exec.Executions;
         var slots = new TSlot[CountMatchSlots(execs, exec.IsAllEntries)];
         int matchIdx = 0;
-
         foreach (var clauseExec in execs)
-        {
-            ClauseInfo clause = clauseExec.Clause;
-
-            if (TryGetGroupFanOut(clause, clauseExec, out var subClauses, out var subExecs))
-            {
-                for (int si = 0; si < subClauses.Count; si++)
-                {
-                    slots[matchIdx++] = TResolver.ResolveSubClauseSlot(subClauses[si], subExecs[si], exec, walkerCtx);
-                }
-
-                continue;
-            }
-
-            switch (clause.ClauseType)
-            {
-                case ClauseType.AllIn or ClauseType.In:
-                    for (int t = 0; t < clauseExec.InTermCount; t++)
-                    {
-                        slots[matchIdx++] = TResolver.ResolveInTermSlot(clause, clauseExec, t, exec, walkerCtx);
-                    }
-
-                    // Null-term slot is always allocated; resolver decides whether to populate.
-                    slots[matchIdx++] = TResolver.ResolveNullTermSlot(clause, clauseExec, walkerCtx);
-                    break;
-
-                default:
-                    slots[matchIdx++] = TResolver.ResolveDefaultSlot(clause, clauseExec, exec, walkerCtx);
-                    break;
-            }
-        }
-
+            ResolveClauseLeavesInto<TResolver, TSlot>(clauseExec.Clause, clauseExec, exec, walkerCtx, slots, ref matchIdx);
         return slots;
+    }
+
+    /// <summary>Recursive leaf walker shared by all three <see cref="ISlotResolver{TSelf, TSlot}"/>
+    /// implementations. Groups expand to their leaves; <see cref="ClauseInfo.IsOrChainNotEquals"/>
+    /// short-circuits to <see cref="ISlotResolver{TSelf, TSlot}.ResolveSubClauseSlot"/> so the
+    /// AllEntries-ANDNOT materialisation kicks in at any nesting depth.</summary>
+    private static void ResolveClauseLeavesInto<TResolver, TSlot>(
+        ClauseInfo clause, ClauseExecution clauseExec, QueryExecution exec, ResolutionContext walkerCtx,
+        TSlot[] slots, ref int matchIdx)
+        where TResolver : ISlotResolver<TResolver, TSlot>
+    {
+        if (clause.IsOrChainNotEquals)
+        {
+            slots[matchIdx++] = TResolver.ResolveSubClauseSlot(clause, clauseExec, exec, walkerCtx);
+            return;
+        }
+        if (TryGetGroupFanOut(clause, clauseExec, out var subClauses, out var subExecs))
+        {
+            for (int si = 0; si < subClauses.Count; si++)
+                ResolveClauseLeavesInto<TResolver, TSlot>(subClauses[si], subExecs?[si], exec, walkerCtx, slots, ref matchIdx);
+            return;
+        }
+        if (clause.ClauseType is ClauseType.AllIn or ClauseType.In)
+        {
+            for (int t = 0; t < clauseExec.InTermCount; t++)
+                slots[matchIdx++] = TResolver.ResolveInTermSlot(clause, clauseExec, t, exec, walkerCtx);
+            // Null-term slot is always allocated; resolver decides whether to populate.
+            slots[matchIdx++] = TResolver.ResolveNullTermSlot(clause, clauseExec, walkerCtx);
+            return;
+        }
+        slots[matchIdx++] = TResolver.ResolveDefaultSlot(clause, clauseExec, exec, walkerCtx);
     }
 
     /// <summary>Per-slot resolver contract; one implementation per output array shape.
@@ -3021,16 +3022,308 @@ internal static partial class QueryPlanBuilder
         };
     }
 
+    // ── Phase D unified recursive emit ─────────────────────────────────────────
+    //
+    // EmitOrPlan / EmitAndPlan invoke EmitClauseInto per top-level clause; nested
+    // groups recurse and slot allocation stays in lock-step with the recursive
+    // resolver in ResolveSlots / CountMatchSlots (one match slot per LEAF, not
+    // per direct sub-clause). The emitter consumes leaves in identical order so
+    // ParamIndex values line up with ResolvedMatches / PostingSources entries.
+    //
+    // Bitmap slots:
+    //   Slot 0 = main accumulator
+    //   Slot 1 = AND-primitive temp (clobbered by AndWithPostings/AndNotWithPostings
+    //            for SmallPostingList/PostingList sources via MaterializeTermSourceIntoBitmap)
+    //            and as the direct scratch for IN AndInto leaves.
+    //   Slot 2+ = save slots for non-Fill group merges. Allocated LIFO via
+    //             nextScratch; RequiredBitmaps grows with nesting depth.
+    //
+    // SkipEarlyExit propagation: AndWithPostings and AndRange normally emit a
+    // goto-doneLabel when the bitmap empties — that early-exit is correct at the
+    // top of an AND chain (whole query is empty), but inside a saved-swap context
+    // it would jump past the merge-back and leak the saved accumulator. The
+    // suppressEarlyExit flag is propagated through the recursion: top-level
+    // EmitOrPlan always suppresses (the OR chain continues regardless), top-level
+    // EmitAndPlan does not (early-exit is desired), and EmitGroupInto's non-Fill
+    // path turns suppression ON before emitting the inner contents.
+
+    /// <summary>How a clause's result is folded into slot 0 by the recursive emitter.</summary>
+    private enum MergeKind
+    {
+        /// <summary>Slot 0 ← clause result. First op of an OR chain or first
+        /// non-negated element of an AND chain.</summary>
+        Fill,
+        /// <summary>slot 0 ← slot 0 ∪ clause. Subsequent OR-chain elements.</summary>
+        OrInto,
+        /// <summary>slot 0 ← slot 0 ∩ clause. Subsequent positive AND-chain elements.</summary>
+        AndInto,
+        /// <summary>slot 0 ← slot 0 \ clause. Negated AND-chain elements.</summary>
+        AndNotInto
+    }
+
+    /// <summary>Recursive emit entry point. Emit ops that fold <paramref name="clause"/>'s
+    /// result into slot 0 per <paramref name="merge"/>. Groups recurse; IN/AllIn/leaf
+    /// route to specialised helpers.</summary>
+    private static void EmitClauseInto(
+        ClauseInfo clause, ClauseExecution exec,
+        MergeKind merge, long cardinality,
+        bool suppressEarlyExit,
+        ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
+        List<PlanOp> ops, List<int> rangeCounts)
+    {
+        // OR-chain NotEquals materialised by MatchResolver into ResolvedMatches[matchIndex].
+        if (clause.IsOrChainNotEquals)
+        {
+            EmitLeafMergeOp(merge, matchIndex, cardinality, MatchDispatch.QueryMatch, suppressEarlyExit, ops);
+            matchIndex++;
+            return;
+        }
+
+        if (TryGetGroupFanOut(clause, exec, out var subs, out var subExecs))
+        {
+            EmitGroupInto(clause, exec, subs, subExecs, merge, suppressEarlyExit,
+                ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
+            return;
+        }
+
+        if (clause.ClauseType is ClauseType.In)
+        {
+            EmitInLeaf(clause, cardinality, merge, ref matchIndex, ref maxScratchUsed, ops, rangeCounts);
+            return;
+        }
+
+        if (clause.ClauseType is ClauseType.AllIn)
+        {
+            EmitAllInLeaf(clause, cardinality, merge, suppressEarlyExit,
+                ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
+            return;
+        }
+
+        EmitLeafMergeOp(merge, matchIndex, cardinality, GetDispatch(clause), suppressEarlyExit, ops);
+        matchIndex++;
+    }
+
+    /// <summary>Emit a group (OrGroup or AndGroup) merged into slot 0. For Fill merge,
+    /// build directly in slot 0. For non-Fill, save slot 0 to a scratch slot, build
+    /// the group fresh in slot 0, then merge with the saved accumulator via the
+    /// matching bitmap-pair op.</summary>
+    private static void EmitGroupInto(
+        ClauseInfo clause, ClauseExecution exec,
+        List<ClauseInfo> subs, List<ClauseExecution> subExecs,
+        MergeKind merge, bool suppressEarlyExit,
+        ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
+        List<PlanOp> ops, List<int> rangeCounts)
+    {
+        if (merge == MergeKind.Fill)
+        {
+            EmitGroupContentsInSlot0(clause, exec, subs, subExecs, suppressEarlyExit,
+                ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
+            return;
+        }
+
+        int saveSlot = nextScratch++;
+        if (saveSlot > maxScratchUsed) maxScratchUsed = saveSlot;
+
+        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = saveSlot });
+        ops.Add(new PlanOp { Kind = PlanOpKind.SwapBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+
+        // Inside the saved context, AndWithPostings/AndRange MUST NOT early-exit to
+        // doneLabel — that would skip the merge-back below and leak the saved value.
+        EmitGroupContentsInSlot0(clause, exec, subs, subExecs, suppressEarlyExit: true,
+            ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
+
+        switch (merge)
+        {
+            case MergeKind.OrInto:
+                ops.Add(new PlanOp { Kind = PlanOpKind.OrBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+                break;
+            case MergeKind.AndInto:
+                ops.Add(new PlanOp { Kind = PlanOpKind.AndBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+                break;
+            case MergeKind.AndNotInto:
+                // AndNotBitmaps[0, saveSlot] = slot 0 \ saveSlot. After build,
+                // slot 0 = group result, saveSlot = original accumulator. We
+                // want (orig \ group) so swap operands back first.
+                ops.Add(new PlanOp { Kind = PlanOpKind.SwapBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+                ops.Add(new PlanOp { Kind = PlanOpKind.AndNotBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+                break;
+        }
+
+        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = saveSlot });
+        nextScratch--;
+    }
+
+    /// <summary>Build a group's complete result in slot 0 (slot 0 must be empty/usable
+    /// on entry; the caller arranges this either by being the seed Fill or by swapping
+    /// the live accumulator out). OrGroup: Fill first sub, OR rest. AndGroup: Fill
+    /// first sub (or FillAllEntries if first is negated), AND/ANDNOT rest.</summary>
+    private static void EmitGroupContentsInSlot0(
+        ClauseInfo clause, ClauseExecution exec,
+        List<ClauseInfo> subs, List<ClauseExecution> subExecs,
+        bool suppressEarlyExit,
+        ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
+        List<PlanOp> ops, List<int> rangeCounts)
+    {
+        int subCount = subs.Count;
+        long subCard = (exec?.Cardinality ?? 0) / Math.Max(1, subCount);
+        bool isOr = clause.ClauseType == ClauseType.OrGroup;
+
+        if (isOr)
+        {
+            for (int si = 0; si < subCount; si++)
+            {
+                EmitClauseInto(subs[si], subExecs?[si],
+                    si == 0 ? MergeKind.Fill : MergeKind.OrInto,
+                    subCard, suppressEarlyExit,
+                    ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
+            }
+            return;
+        }
+
+        // AndGroup
+        bool firstIsNeg = subs[0].IsNegated || subs[0].ClauseType == ClauseType.NotEquals;
+        int start;
+        if (firstIsNeg)
+        {
+            ops.Add(new PlanOp { Kind = PlanOpKind.FillAllEntries, EstimatedCardinality = long.MaxValue });
+            start = 0;
+        }
+        else
+        {
+            EmitClauseInto(subs[0], subExecs?[0], MergeKind.Fill, subCard, suppressEarlyExit,
+                ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
+            start = 1;
+        }
+        for (int si = start; si < subCount; si++)
+        {
+            bool subNeg = subs[si].IsNegated || subs[si].ClauseType == ClauseType.NotEquals;
+            EmitClauseInto(subs[si], subExecs?[si],
+                subNeg ? MergeKind.AndNotInto : MergeKind.AndInto,
+                subCard, suppressEarlyExit,
+                ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
+        }
+    }
+
+    /// <summary>Emit one PlanOp for a simple leaf clause according to <paramref name="merge"/>.
+    /// Sets SkipEarlyExit on AndWithPostings when inside a saved-swap context.</summary>
+    private static void EmitLeafMergeOp(
+        MergeKind merge, int matchIndex, long cardinality, MatchDispatch dispatch,
+        bool suppressEarlyExit, List<PlanOp> ops)
+    {
+        PlanOpKind kind = merge switch
+        {
+            MergeKind.Fill => PlanOpKind.FillFromPostings,
+            MergeKind.OrInto => PlanOpKind.OrWithPostings,
+            MergeKind.AndInto => PlanOpKind.AndWithPostings,
+            MergeKind.AndNotInto => PlanOpKind.AndNotWithPostings,
+            _ => throw new InvalidOperationException($"Unhandled MergeKind: {merge}")
+        };
+        ops.Add(new PlanOp
+        {
+            Kind = kind,
+            ParamIndex = matchIndex,
+            BitmapLocal = 0,
+            EstimatedCardinality = cardinality,
+            Dispatch = dispatch,
+            SkipEarlyExit = kind == PlanOpKind.AndWithPostings && suppressEarlyExit
+        });
+    }
+
+    /// <summary>IN clause leaf — logically (term0 ∪ term1 ∪ … ∪ termN). For Fill/OrInto
+    /// merges, build directly in slot 0 via EmitInOps. For AndInto/AndNotInto, build
+    /// the union in slot 1 (slot 1 is freshly cleared first), then merge into slot 0
+    /// via AndBitmaps/AndNotBitmaps. OrRange ignores SkipEarlyExit so suppression
+    /// doesn't need to propagate here.</summary>
+    private static void EmitInLeaf(
+        ClauseInfo clause, long cardinality, MergeKind merge,
+        ref int matchIndex, ref int maxScratchUsed,
+        List<PlanOp> ops, List<int> rangeCounts)
+    {
+        if (merge is MergeKind.Fill or MergeKind.OrInto)
+        {
+            EmitInOps(ops, clause, cardinality, bitmapLocal: 0, isSeed: merge == MergeKind.Fill, ref matchIndex, rangeCounts);
+            return;
+        }
+
+        // AndInto / AndNotInto: union IN terms in slot 1, then merge with slot 0.
+        if (1 > maxScratchUsed) maxScratchUsed = 1;
+        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 1 });
+        EmitInOps(ops, clause, cardinality, bitmapLocal: 1, isSeed: false, ref matchIndex, rangeCounts);
+        ops.Add(new PlanOp
+        {
+            Kind = merge == MergeKind.AndInto ? PlanOpKind.AndBitmaps : PlanOpKind.AndNotBitmaps,
+            BitmapLocal = 0,
+            ParamIndex2 = 1
+        });
+    }
+
+    /// <summary>AllIn clause leaf — logically (term0 ∩ term1 ∩ … ∩ termN). For Fill merge,
+    /// build directly in slot 0. For OrInto/AndInto/AndNotInto, save slot 0 to a scratch
+    /// slot, build the intersection in slot 0 (Fill + AndRange), then merge back. The
+    /// AndRange op honors SkipEarlyExit; in a saved context we must set it so the loop
+    /// doesn't jump to doneLabel mid-intersection.</summary>
+    private static void EmitAllInLeaf(
+        ClauseInfo clause, long cardinality, MergeKind merge,
+        bool suppressEarlyExit,
+        ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
+        List<PlanOp> ops, List<int> rangeCounts)
+    {
+        if (merge == MergeKind.Fill)
+        {
+            EmitAllInOps(ops, clause, cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
+            if (suppressEarlyExit)
+                SetLastAndRangeSkipEarlyExit(ops);
+            return;
+        }
+
+        int saveSlot = nextScratch++;
+        if (saveSlot > maxScratchUsed) maxScratchUsed = saveSlot;
+
+        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = saveSlot });
+        ops.Add(new PlanOp { Kind = PlanOpKind.SwapBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+        EmitAllInOps(ops, clause, cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
+        // Inside save-swap: AndRange must not jump to doneLabel — that would skip
+        // the merge-back and leak the saved accumulator.
+        SetLastAndRangeSkipEarlyExit(ops);
+
+        switch (merge)
+        {
+            case MergeKind.OrInto:
+                ops.Add(new PlanOp { Kind = PlanOpKind.OrBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+                break;
+            case MergeKind.AndInto:
+                ops.Add(new PlanOp { Kind = PlanOpKind.AndBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+                break;
+            case MergeKind.AndNotInto:
+                ops.Add(new PlanOp { Kind = PlanOpKind.SwapBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+                ops.Add(new PlanOp { Kind = PlanOpKind.AndNotBitmaps, BitmapLocal = 0, ParamIndex2 = saveSlot });
+                break;
+        }
+        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = saveSlot });
+        nextScratch--;
+    }
+
+    /// <summary>Set <see cref="PlanOp.SkipEarlyExit"/>=true on the most recent
+    /// <see cref="PlanOpKind.AndRange"/> in <paramref name="ops"/>. The op was emitted
+    /// by <see cref="EmitAllInOps"/> as the last entry of the AllIn pair; mutating it
+    /// here avoids threading the flag through that helper's signature.</summary>
+    private static void SetLastAndRangeSkipEarlyExit(List<PlanOp> ops)
+    {
+        for (int i = ops.Count - 1; i >= 0; i--)
+        {
+            if (ops[i].Kind == PlanOpKind.AndRange)
+            {
+                var op = ops[i];
+                op.SkipEarlyExit = true;
+                ops[i] = op;
+                return;
+            }
+        }
+    }
+
     /// <summary>Translate sorted clauses into a linear PlanOp[] sequence for IL emission.
     /// Dispatches to <see cref="EmitOrPlan"/> or <see cref="EmitAndPlan"/> after shared
-    /// empty-IN handling.
-    ///
-    /// Bitmap slots:
-    ///   Slot 0 = main result bitmap (accumulates the final answer).
-    ///   Slot 1 = scratch bitmap (used for AND-chain non-seed IN terms and OR-group accumulation).
-    ///   Slot 2 = save slot (only allocated when an OR chain contains multiple AND-groups;
-    ///            used to save the prior OR accumulation while building a new AND sub-chain
-    ///            in slot 0 via SwapBitmaps(0,2), then ORed back).</summary>
+    /// empty-IN handling.</summary>
     private static (PlanOp[] Ops, int RequiredBitmaps, int[] InRangeCounts) EmitPlan(bool isOr, List<ClauseExecution> executions)
     {
         if (executions.Count is 0)
@@ -3051,215 +3344,41 @@ internal static partial class QueryPlanBuilder
         return isOr ? EmitOrPlan(executions) : EmitAndPlan(executions);
     }
 
-    /// <summary>Emit the PlanOp sequence for an OR chain. All terms are ORed into slot 0.
-    /// AND-groups within an OR use the three-bitmap swap pattern: save slot 0 to slot 2,
-    /// build AND result in slot 0, OR slot 2 back. Returns RequiredBitmaps = 2 unless
-    /// nested AndGroups require 3.</summary>
+    /// <summary>Emit the PlanOp sequence for an OR chain. All clauses are merged into
+    /// slot 0: the first via Fill, the rest via OrInto. Groups recurse through
+    /// <see cref="EmitClauseInto"/>, allocating scratch slots on demand. SkipEarlyExit
+    /// is forced on every AND-step because remaining OR terms may still match.
+    /// Returns RequiredBitmaps = max(2, deepest scratch slot used + 1).</summary>
     private static (PlanOp[] Ops, int RequiredBitmaps, int[] InRangeCounts) EmitOrPlan(List<ClauseExecution> executions)
     {
         List<PlanOp> ops = [];
         List<int> rangeCounts = [];
-        bool needsThreeBitmaps = false;
-
         int matchIndex = 0;
-        foreach (var exec in executions)
+        int nextScratch = 2;
+        int maxScratchUsed = 1;
+
+        for (int i = 0; i < executions.Count; i++)
         {
-            var it = exec.Clause;
-
-            // Negated clause in an OR chain: emit a single QueryMatch slot whose match
-            // is materialized at resolution time as AllEntries ANDNOT(positive form).
-            // Covers NotEquals, NOT IN, NOT AllIn, NOT exists(), NOT startsWith(), etc.
-            // The raw posting list / range / tree-scan can't deliver the complement,
-            // so dispatch is forced to QueryMatch and CreateNotEqualsOrMatch produces
-            // a pre-materialized BitmapMatch. The IsOrChainNotEquals flag is set at
-            // template build time by PlanWalker.NotCanonicalize.
-            if (it.IsNegated || it.ClauseType == ClauseType.NotEquals)
-            {
-                Debug.Assert(it.IsOrChainNotEquals,
-                    "PlanWalker.NotCanonicalize must mark every negated OR-chain clause with IsOrChainNotEquals=true before template freeze.");
-                ops.Add(new PlanOp
-                {
-                    Kind = matchIndex == 0 ? PlanOpKind.FillFromPostings : PlanOpKind.OrWithPostings,
-                    ParamIndex = matchIndex,
-                    EstimatedCardinality = exec.Cardinality,
-                    Dispatch = MatchDispatch.QueryMatch
-                });
-                matchIndex++;
-                continue;
-            }
-
-            switch (it.ClauseType)
-            {
-                case ClauseType.In:
-                {
-                    EmitInOps(ops, it, exec.Cardinality, bitmapLocal: 0, isSeed: matchIndex == 0, ref matchIndex, rangeCounts);
-                    break;
-                }
-                case ClauseType.AllIn:
-                {
-                    // AllIn requires AND semantics (match docs with ALL values), so we
-                    // intersect in a scratch bitmap then OR the result into the main bitmap.
-                    if (matchIndex == 0)
-                    {
-                        // Seed: build directly in slot 0 with Fill + AndRange.
-                        EmitAllInOps(ops, it, exec.Cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
-                    }
-                    else
-                    {
-                        // Non-seed: swap slot 0 to slot 2, build AllIn intersection in
-                        // fresh slot 0, then OR slot 2 back.
-                        needsThreeBitmaps = true;
-                        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 1 });
-                        ops.Add(new PlanOp
-                        {
-                            Kind = PlanOpKind.SwapBitmaps,
-                            BitmapLocal = 0,
-                            ParamIndex2 = 2
-                        });
-                        EmitAllInOps(ops, it, exec.Cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
-                        ops.Add(new PlanOp
-                        {
-                            Kind = PlanOpKind.OrBitmaps,
-                            BitmapLocal = 0,
-                            ParamIndex2 = 2
-                        });
-                        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 2 });
-                    }
-                    break;
-                }
-                case ClauseType.OrGroup when it.SubClauses is { Count: > 0 }:
-                {
-                    int subCount = it.SubClauses.Count;
-                    for (int si = 0; si < subCount; si++)
-                    {
-                        var sub = it.SubClauses[si];
-                        // Negated direct children of this nested OrGroup carry
-                        // IsOrChainNotEquals=true (PlanWalker.NotCanonicalize). Force
-                        // QueryMatch dispatch so the IL reads the pre-materialized
-                        // AllEntries-ANDNOT bitmap that MatchResolver.ResolveSubClauseSlot
-                        // produces, not the raw positive posting list.
-                        ops.Add(new PlanOp
-                        {
-                            Kind = matchIndex == 0 ? PlanOpKind.FillFromPostings : PlanOpKind.OrWithPostings,
-                            ParamIndex = matchIndex,
-                            EstimatedCardinality = exec.Cardinality / subCount,
-                            Dispatch = sub.IsOrChainNotEquals ? MatchDispatch.QueryMatch : GetDispatch(sub)
-                        });
-                        matchIndex++;
-                    }
-
-                    break;
-                }
-                case ClauseType.AndGroup when it.SubClauses is { Count: > 0 }:
-                {
-                    // AND sub-expression inside an OR chain.
-                    // Only supported when the AND group is the first element (matchIndex == 0)
-                    // or can be merged into slot 0 via OrBitmaps after computing into slot 1.
-                    var subClauses = it.SubClauses;
-                    int subCount = subClauses.Count;
-                    long subCardinality = exec.Cardinality / Math.Max(1, subCount);
-                    if (matchIndex == 0)
-                    {
-                        // First element: build the AND chain directly in slot 0.
-                        // Slot 1 is free (unused), so AndWithPostings can use it as scratch.
-                        // Suppress early-exit on AND steps — the OR chain continues regardless.
-                        ops.Add(new PlanOp
-                        {
-                            Kind = PlanOpKind.FillFromPostings,
-                            ParamIndex = matchIndex,
-                            EstimatedCardinality = subCardinality,
-                            Dispatch = GetDispatch(subClauses[0])
-                        });
-                        for (int s = 1; s < subClauses.Count; s++)
-                        {
-                            // Mirror EmitAndPlan's firstIsNegated predicate: a bare NotEquals
-                            // sub-clause must subtract via AndNot. Pre-tactical-fix this branch
-                            // only checked IsNegated, silently AND-merging NotEquals subs as positives.
-                            bool subIsNegated = subClauses[s].IsNegated || subClauses[s].ClauseType == ClauseType.NotEquals;
-                            ops.Add(new PlanOp
-                            {
-                                Kind = subIsNegated ? PlanOpKind.AndNotWithPostings : PlanOpKind.AndWithPostings,
-                                ParamIndex = matchIndex + s,
-                                EstimatedCardinality = subCardinality,
-                                Dispatch = GetDispatch(subClauses[s]),
-                                SkipEarlyExit = true // don't abort on empty — remaining OR terms may still match
-                            });
-                        }
-                    }
-                    else
-                    {
-                        // Non-first AND group: save the accumulated OR result (slot 0) to slot 2,
-                        // build this AND sub-chain fresh in slot 0, then OR slot 2 back.
-                        needsThreeBitmaps = true;
-                        // Uses SwapBitmaps(0, 2): slot 0 ↔ slot 2.
-                        // Slot 2 must have been cleared before the swap (it's either the initial
-                        // empty state or was cleared at the end of the previous iteration).
-                        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 1 });
-                        ops.Add(new PlanOp
-                        {
-                            Kind = PlanOpKind.SwapBitmaps,
-                            BitmapLocal = 0,
-                            ParamIndex2 = 2
-                        });
-                        // Slot 0 is now fresh (was slot 2 = cleared); slot 2 = prior OR accumulation.
-                        ops.Add(new PlanOp
-                        {
-                            Kind = PlanOpKind.FillFromPostings,
-                            ParamIndex = matchIndex,
-                            EstimatedCardinality = subCardinality,
-                            Dispatch = GetDispatch(subClauses[0])
-                        });
-                        for (int s = 1; s < subClauses.Count; s++)
-                        {
-                            // Same predicate alignment as the matchIndex==0 branch above.
-                            bool subIsNegated = subClauses[s].IsNegated || subClauses[s].ClauseType == ClauseType.NotEquals;
-                            ops.Add(new PlanOp
-                            {
-                                Kind = subIsNegated ? PlanOpKind.AndNotWithPostings : PlanOpKind.AndWithPostings,
-                                ParamIndex = matchIndex + s,
-                                BitmapLocal = 0,
-                                EstimatedCardinality = subCardinality,
-                                Dispatch = GetDispatch(subClauses[s]),
-                                SkipEarlyExit = true // don't abort — OR chain continues
-                            });
-                        }
-
-                        ops.Add(new PlanOp
-                        {
-                            Kind = PlanOpKind.OrBitmaps,
-                            BitmapLocal = 0,
-                            ParamIndex2 = 2
-                        });
-                        ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 2 });
-                    }
-
-                    matchIndex += subClauses.Count;
-                    break;
-                }
-                default:
-                {
-                    ops.Add(new PlanOp
-                    {
-                        Kind = matchIndex == 0 ? PlanOpKind.FillFromPostings : PlanOpKind.OrWithPostings,
-                        ParamIndex = matchIndex,
-                        EstimatedCardinality = exec.Cardinality,
-                        Dispatch = GetDispatch(it)
-                    });
-                    matchIndex++;
-                    break;
-                }
-            }
+            var exec = executions[i];
+            EmitClauseInto(exec.Clause, exec,
+                i == 0 ? MergeKind.Fill : MergeKind.OrInto,
+                exec.Cardinality, suppressEarlyExit: true,
+                ref matchIndex, ref nextScratch, ref maxScratchUsed,
+                ops, rangeCounts);
         }
 
         ops.Add(new PlanOp { Kind = PlanOpKind.IterateInto });
 
-        return (ops.ToArray(), needsThreeBitmaps ? 3 : 2, rangeCounts.Count > 0 ? rangeCounts.ToArray() : null);
+        return (ops.ToArray(), Math.Max(2, maxScratchUsed + 1), rangeCounts.Count > 0 ? rangeCounts.ToArray() : null);
     }
 
-    /// <summary>Emit the PlanOp sequence for an AND chain. The first clause seeds slot 0
-    /// (FillFromPostings), the following clauses narrow it (AndWithPostings/AndNotWithPostings).
-    /// IN terms are ORed into slot 1, then ANDed with slot 0. Includes single-clause special
-    /// cases: DirectIterate for Equals, FillAllEntries+AndNot for NotEquals.</summary>
+    /// <summary>Emit the PlanOp sequence for an AND chain. Single-clause Equals/NotEquals
+    /// retain their specialised plans (DirectIterate, FillAllEntries+AndNot). Otherwise
+    /// the first non-negated clause seeds slot 0 (Fill) and each subsequent clause is
+    /// merged via AndInto or AndNotInto through <see cref="EmitClauseInto"/>. When every
+    /// clause is negated we seed with FillAllEntries instead and AndNot all of them.
+    /// CheckAndMaybeEntryScan is emitted before each iteration when remaining clauses
+    /// are scan-eligible; CheckEmpty follows each non-negated step.</summary>
     private static (PlanOp[] Ops, int RequiredBitmaps, int[] InRangeCounts) EmitAndPlan(List<ClauseExecution> executions)
     {
         List<PlanOp> ops = [];
@@ -3303,90 +3422,40 @@ internal static partial class QueryPlanBuilder
                 return (ops.ToArray(), 2, null);
         }
 
-        // AND chain: Fill the smallest non-negated, then AndWith/AndNotWith remaining.
-        // If the first clause is negated (all clauses are negated), we need to
-        // start from AllEntries and ANDNOT each one.
+        int matchIndex = 0;
+        int nextScratch = 2;
+        int maxScratchUsed = 1;
+
+        // AND chain: Fill the smallest non-negated, then AndWith/AndNotWith the rest.
+        // If the first clause is negated (cardinality sort puts negated clauses last,
+        // so first-negated ⇒ all-negated) we seed with FillAllEntries instead and
+        // AndNot every clause. FillAllEntries calls indexSearcher.AllEntries() directly,
+        // avoiding the structural-vs-runtime slot-index mismatch that bites IN with a
+        // parameter-bound array of different length.
         bool firstIsNegated = e0.IsNegated || e0.ClauseType == ClauseType.NotEquals;
         int startIndex;
 
         if (firstIsNegated)
         {
-            // All clauses are negated — start from all entries.
-            // FillAllEntries doesn't need a slot index — it calls indexSearcher.AllEntries()
-            // directly. This sidesteps the structural-vs-runtime slot-index mismatch that
-            // occurs when an IN clause's runtime InTermCount differs from its template
-            // Bindings.Length (e.g. NOT IN with a parameter that expands to an array).
-            ops.Add(new PlanOp
-            {
-                Kind = PlanOpKind.FillAllEntries,
-                EstimatedCardinality = long.MaxValue
-            });
-            startIndex = 0; // Process all clauses as ANDNOT
+            ops.Add(new PlanOp { Kind = PlanOpKind.FillAllEntries, EstimatedCardinality = long.MaxValue });
+            startIndex = 0;
         }
         else
         {
+            EmitClauseInto(c0, e0, MergeKind.Fill, e0.Cardinality, suppressEarlyExit: false,
+                ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
             startIndex = 1;
         }
 
-        int matchIndex = 0;
-        if (!firstIsNegated)
-        {
-            switch (e0.ClauseType)
-            {
-                case ClauseType.OrGroup when c0.SubClauses != null:
-                {
-                    var subClauses = c0.SubClauses;
-                    int subCount = subClauses.Count;
-                    for (int s = 0; s < subCount; s++)
-                    {
-                        var sub = subClauses[s];
-                        // Negated direct children of this OrGroup carry IsOrChainNotEquals=true
-                        // (PlanWalker.NotCanonicalize). Force QueryMatch dispatch so the IL reads
-                        // the AllEntries-ANDNOT bitmap from MatchResolver.ResolveSubClauseSlot.
-                        ops.Add(new PlanOp
-                        {
-                            Kind = s == 0 ? PlanOpKind.FillFromPostings : PlanOpKind.OrWithPostings,
-                            ParamIndex = matchIndex + s,
-                            BitmapLocal = 0,
-                            EstimatedCardinality = executions[0].Cardinality / Math.Max(1, subCount),
-                            Dispatch = sub.IsOrChainNotEquals ? MatchDispatch.QueryMatch : GetDispatch(sub)
-                        });
-                    }
-
-                    matchIndex += subCount;
-                    break;
-                }
-                case ClauseType.In:
-                {
-                    EmitInOps(ops, c0, executions[0].Cardinality, bitmapLocal: 0, isSeed: true, ref matchIndex, rangeCounts);
-                    break;
-                }
-                // Use the fixed-shape EmitAllInOps path for AllIn clauses.
-                case ClauseType.AllIn:
-                {
-                    EmitAllInOps(ops, c0, executions[0].Cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
-                    break;
-                }
-                default:
-                    ops.Add(new PlanOp
-                    {
-                        Kind = PlanOpKind.FillFromPostings,
-                        ParamIndex = 0,
-                        EstimatedCardinality = executions[0].Cardinality,
-                        Dispatch = GetDispatch(c0)
-                    });
-                    matchIndex = 1;
-                    break;
-            }
-        }
-
-        // Precheck: can all remaining clauses be converted to entry scan predicates?
+        // Precheck: can every remaining clause be evaluated by an entry-scan predicate?
         bool allScanEligible = AreAllScanEligible(executions, startIndex);
 
         for (int i = startIndex; i < executions.Count; i++)
         {
-            // Goto check before each AND step — only if all remaining clauses
-            // can be handled by entry scan predicates
+            // CheckAndMaybeEntryScan emits a runtime branch into the entry-scan
+            // fallback when bitmap[0] is small relative to remaining IQueryMatch
+            // counts. Only safe to emit when AreAllScanEligible reports every
+            // remaining clause has a scan predicate.
             if (allScanEligible)
             {
                 ops.Add(new PlanOp
@@ -3396,116 +3465,26 @@ internal static partial class QueryPlanBuilder
                 });
             }
 
-            var ci2 = executions[i].Clause;
-            switch (ci2.ClauseType)
+            var execI = executions[i];
+            var clauseI = execI.Clause;
+            bool stepNegated = clauseI.IsNegated || clauseI.ClauseType == ClauseType.NotEquals;
+            MergeKind merge = stepNegated ? MergeKind.AndNotInto : MergeKind.AndInto;
+
+            EmitClauseInto(clauseI, execI, merge, execI.Cardinality, suppressEarlyExit: false,
+                ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
+
+            // CheckEmpty: short-circuit when slot 0 became empty after a positive
+            // intersection. Negated steps don't justify the check — they remove
+            // entries, so an empty result still represents a valid finished plan.
+            if (!stepNegated)
             {
-                case ClauseType.OrGroup when ci2.SubClauses != null:
-                {
-                    // OrGroup: OR subclauses into bitmap[1], then AND with bitmap[0]
-                    var subClauses = ci2.SubClauses;
-                    int subCount = subClauses.Count;
-
-                    // Clear bitmap[1] (OR accumulator)
-                    ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 1 });
-
-                    // Fill each subclause into bitmap[1]
-                    for (int s = 0; s < subCount; s++)
-                    {
-                        var sub = subClauses[s];
-                        // Negated direct children of this OrGroup carry IsOrChainNotEquals=true
-                        // (PlanWalker.NotCanonicalize). Force QueryMatch dispatch so the IL reads
-                        // the AllEntries-ANDNOT bitmap from MatchResolver.ResolveSubClauseSlot.
-                        ops.Add(new PlanOp
-                        {
-                            Kind = PlanOpKind.OrWithPostings,
-                            ParamIndex = matchIndex + s,
-                            BitmapLocal = 1, // target bitmap[1]
-                            EstimatedCardinality = executions[i].Cardinality / Math.Max(1, subCount),
-                            Dispatch = sub.IsOrChainNotEquals ? MatchDispatch.QueryMatch : GetDispatch(sub)
-                        });
-                    }
-
-                    // AND bitmap[1] into bitmap[0]
-                    ops.Add(new PlanOp
-                    {
-                        Kind = PlanOpKind.AndBitmaps,
-                        BitmapLocal = 0, // target
-                        ParamIndex2 = 1 // source (reuse ParamIndex2 for source bitmap)
-                    });
-
-                    // Early exit check
-                    ops.Add(new PlanOp { Kind = PlanOpKind.CheckEmpty, BitmapLocal = 0 });
-
-                    matchIndex += subCount;
-                    break;
-                }
-                case ClauseType.In:
-                {
-                    // OR all IN terms into bitmap[1], then AND (or ANDNOT) with bitmap[0].
-                    // isSeed: false — FillFromPostings always targets bitmap[0], so we use
-                    // OrRange which respects bitmapLocal. Bitmap[1] is freshly cleared.
-                    ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 1 });
-                    EmitInOps(ops, ci2, executions[i].Cardinality, bitmapLocal: 1, isSeed: false, ref matchIndex, rangeCounts);
-                    ops.Add(new PlanOp
-                    {
-                        Kind = ci2.IsNegated ? PlanOpKind.AndNotBitmaps : PlanOpKind.AndBitmaps,
-                        BitmapLocal = 0,
-                        ParamIndex2 = 1
-                    });
-                    if (!ci2.IsNegated)
-                    {
-                        ops.Add(new PlanOp { Kind = PlanOpKind.CheckEmpty, BitmapLocal = 0 });
-                    }
-
-                    break;
-                }
-                case ClauseType.AllIn:
-                {
-                    // AllIn: intersect all terms in bitmap[1], then AND (or ANDNOT) with bitmap[0].
-                    // Same pattern as non-seed IN, but uses EmitAllInOps (Fill + AndRange) instead
-                    // of EmitInOps (Fill + OrRange) — AllIn requires ALL terms to match.
-                    ops.Add(new PlanOp { Kind = PlanOpKind.ClearBitmap, BitmapLocal = 1 });
-                    EmitAllInOps(ops, ci2, executions[i].Cardinality, bitmapLocal: 1, ref matchIndex, rangeCounts);
-                    ops.Add(new PlanOp
-                    {
-                        Kind = ci2.IsNegated ? PlanOpKind.AndNotBitmaps : PlanOpKind.AndBitmaps,
-                        BitmapLocal = 0,
-                        ParamIndex2 = 1
-                    });
-                    if (ci2.IsNegated == false)
-                    {
-                        ops.Add(new PlanOp { Kind = PlanOpKind.CheckEmpty, BitmapLocal = 0 });
-                    }
-                    break;
-                }
-                default:
-                {
-                    // Simple clause: AND or ANDNOT with bitmap[0]
-                    var isNegated = ci2.IsNegated || ci2.ClauseType == ClauseType.NotEquals;
-                    var andKind = isNegated ? PlanOpKind.AndNotWithPostings : PlanOpKind.AndWithPostings;
-                    ops.Add(new PlanOp
-                    {
-                        Kind = andKind,
-                        ParamIndex = matchIndex,
-                        BitmapLocal = 0,
-                        EstimatedCardinality = executions[i].Cardinality,
-                        Dispatch = GetDispatch(ci2)
-                    });
-
-                    if (!isNegated)
-                    {
-                        ops.Add(new PlanOp { Kind = PlanOpKind.CheckEmpty, BitmapLocal = 0 });
-                    }
-
-                    matchIndex++;
-                    break;
-                }
+                ops.Add(new PlanOp { Kind = PlanOpKind.CheckEmpty, BitmapLocal = 0 });
             }
         }
 
         ops.Add(new PlanOp { Kind = PlanOpKind.IterateInto });
 
-        return (ops.ToArray(), 2, rangeCounts.Count > 0 ? rangeCounts.ToArray() : null);
+        return (ops.ToArray(), Math.Max(2, maxScratchUsed + 1), rangeCounts.Count > 0 ? rangeCounts.ToArray() : null);
     }
 
     /// <summary>True when all clauses are negated (1+ clauses, first is negated after
@@ -3735,27 +3714,33 @@ internal static partial class QueryPlanBuilder
         return directCost < bitmapCost && entriesToScan <= QueryPrimitives.EntryScanCountThreshold;
     }
 
+    /// <summary>Count IL match slots a query consumes. Nested groups expand to one slot
+    /// PER LEAF (recursively); the recursive walk is shared with <see cref="ResolveSlots"/>
+    /// and the emit helpers so slot indices stay aligned end-to-end.</summary>
     internal static int CountMatchSlots(List<ClauseExecution> executions, bool isAllEntries)
     {
         int count = isAllEntries ? 1 : 0;
         foreach (var exec in executions ?? [])
-        {
-            var clause = exec.Clause;
-            if (clause.IsOrChainNotEquals)
-            {
-                count += 1;
-                continue;
-            }
-
-            count += clause.ClauseType switch
-            {
-                ClauseType.OrGroup or ClauseType.AndGroup => clause.SubClauses?.Count ?? 1,
-                ClauseType.In or ClauseType.AllIn => (exec.InTermCount > 0 ? exec.InTermCount : clause.Bindings?.Length ?? 0) + 1,
-                _ => 1
-            };
-        }
-
+            count += CountClauseLeaves(exec.Clause, exec);
         return count;
+    }
+
+    /// <summary>Recursive leaf counter. <see cref="ClauseInfo.IsOrChainNotEquals"/>
+    /// short-circuits to a single AllEntries-ANDNOT slot regardless of group shape.</summary>
+    private static int CountClauseLeaves(ClauseInfo clause, ClauseExecution exec)
+    {
+        if (clause.IsOrChainNotEquals)
+            return 1;
+        if (TryGetGroupFanOut(clause, exec, out var subClauses, out var subExecs))
+        {
+            int sum = 0;
+            for (int i = 0; i < subClauses.Count; i++)
+                sum += CountClauseLeaves(subClauses[i], subExecs?[i]);
+            return sum;
+        }
+        if (clause.ClauseType is ClauseType.In or ClauseType.AllIn)
+            return ((exec?.InTermCount ?? 0) > 0 ? exec.InTermCount : clause.Bindings?.Length ?? 0) + 1;
+        return 1;
     }
 
     /// <summary>For an OrGroup or AndGroup clause, returns the parallel (sub-clauses, sub-executions)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1506,71 +1506,9 @@ internal static partial class QueryPlanBuilder
         var clause = cur.Clause;
         var indexSearcher = walkerCtx.IndexSearcher;
         var builderParams = walkerCtx.BuilderParams;
-        if (clause.ClauseType == ClauseType.OrGroup && clause.SubClauses != null)
-        {
-            // Mirror MatchResolver.ResolveSubClauseSlot: a sub-clause flagged with
-            // IsOrChainNotEquals (negated direct child of this OrGroup, per PlanWalker
-            // .NotCanonicalize) must contribute its complement (AllEntries ANDNOT positive),
-            // not the raw positive posting list. Without this the OrGroup collapse path
-            // silently OR-merges the positive form for `... or X != y`.
-            var bm = new BitmapMatch(indexSearcher.Allocator);
-            var temp = new RoaringBitmap(indexSearcher.Allocator);
-            for (int si = 0; si < clause.SubClauses.Count; si++)
-            {
-                var sub = clause.SubClauses[si];
-                var subExec = cur.SubExecutions[si];
-                var subMatch = sub.IsOrChainNotEquals
-                    ? CreateNotEqualsOrMatch(sub, subExec, root, walkerCtx)
-                    : ResolveClause(subExec, root, walkerCtx);
-                QueryPrimitives.OrWithMatch(subMatch, ref bm.BitmapState);
-            }
-
-            temp.Dispose();
-            return bm;
-        }
-
-        if (clause.ClauseType == ClauseType.AndGroup && clause.SubClauses != null)
-        {
-            // NOTE: This collapse path is a known dual-path issue tracked by ayende/ravendb#4847.
-            // The IL slot pipeline (EmitOrPlan / EmitAndPlan) handles AND/OR composition with
-            // correct semantics for both `IsNegated` and `ClauseType == NotEquals` (see
-            // EmitAndPlan line ~3434). This collapse path historically only checked `IsNegated`,
-            // which silently AND-merged NotEquals sub-clauses as positive matches. Mirror the
-            // emitter's predicate here so the dual paths agree until #4847 retires this branch.
-            var bm = new BitmapMatch(indexSearcher.Allocator);
-            var temp = new RoaringBitmap(indexSearcher.Allocator);
-            bool first = true;
-            for (int si = 0; si < clause.SubClauses.Count; si++)
-            {
-                var sub = clause.SubClauses[si];
-                var subExec = cur.SubExecutions[si];
-                var subMatch = ResolveClause(subExec, root, walkerCtx);
-                bool isNegated = sub.IsNegated || sub.ClauseType == ClauseType.NotEquals;
-                if (first)
-                {
-                    if (isNegated)
-                    {
-                        // First clause is negated: seed from AllEntries, then ANDNOT.
-                        // Mirrors EmitAndPlan's firstIsNegated handling (line ~3270).
-                        var allEntries = indexSearcher.AllEntries();
-                        QueryPrimitives.OrWithMatch(allEntries, ref bm.BitmapState);
-                        QueryPrimitives.AndNotWithMatch(subMatch, ref bm.BitmapState, ref temp);
-                    }
-                    else
-                    {
-                        QueryPrimitives.OrWithMatch(subMatch, ref bm.BitmapState);
-                    }
-                    first = false;
-                }
-                else if (isNegated)
-                    QueryPrimitives.AndNotWithMatch(subMatch, ref bm.BitmapState, ref temp);
-                else
-                    QueryPrimitives.AndWithMatch(subMatch, ref bm.BitmapState, ref temp);
-            }
-
-            temp.Dispose();
-            return bm;
-        }
+        // ResolveClause is invoked per leaf only. OrGroup/AndGroup are decomposed
+        // by ResolveClauseLeavesInto / EmitClauseInto upstream; if one reaches here
+        // it falls through to the switch default which throws "Unexpected ClauseType".
 
         // Spatial/Vector/Search have their own field resolution paths.
         FieldMetadata fieldMeta = default;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1771,11 +1771,10 @@ internal static partial class QueryPlanBuilder
         int scanStart = exec.Plan.AllNegated ? 0 : 1;
         int clauseIdx = scanStart;
         var execs = exec.Executions;
-        int dummyL = 0, dummyD = 0, dummyS = 0;
         foreach (ScanPredicateInfo pred in predicates)
         {
             // Advance past clauses that BuildScanPredicateInfo would have skipped (returned null).
-            while (clauseIdx < execs.Count && BuildScanPredicateInfo(execs[clauseIdx], ref dummyL, ref dummyD, ref dummyS) == null)
+            while (clauseIdx < execs.Count && IsScanEligible(execs[clauseIdx]) == false)
             {
                 clauseIdx++;
             }
@@ -2068,7 +2067,6 @@ internal static partial class QueryPlanBuilder
         int field2RangeIdx = FindCompoundFieldField2Range(ref ctx);
 
         // Residual scannability + cost check
-        int longIdx = 0, doubleIdx = 0, sliceIdx = 0;
         long bitmapCost = 0;
         int residualCount = 0;
         for (int i = 0; i < execs.Count; i++)
@@ -2082,7 +2080,7 @@ internal static partial class QueryPlanBuilder
                 return false;
             }
 
-            if (BuildScanPredicateInfo(execs[i], ref longIdx, ref doubleIdx, ref sliceIdx) is null)
+            if (IsScanEligible(execs[i]) == false)
             {
                 rejectReason = "scan predicate info is null";
                 return false;
@@ -3302,16 +3300,10 @@ internal static partial class QueryPlanBuilder
     private static bool AreAllScanEligible(List<ClauseExecution> executions, int startIndex)
     {
         // If any clause (In, AllIn, Spatial, Vector, Search, etc.) can't be scanned, we must not emit CheckAndMaybeEntryScan — entry scan would skip them entirely.
-        int dummyL = 0, dummyD = 0, dummyS = 0;
         for (int j = startIndex; j < executions.Count; j++)
         {
-            ParamValueType termType = executions[j].TermValueType;
-            if (BuildScanPredicateInfoCore(executions[j], termType,ref dummyL, ref dummyD, ref dummyS) != null)
-            {
-                continue;
-            }
-
-            return false;
+            if (IsScanEligible(executions[j]) == false)
+                return false;
         }
 
         return true;
@@ -3579,6 +3571,48 @@ internal static partial class QueryPlanBuilder
     /// types are available (per-execution, after PopulateClauseValues).</summary>
     internal static ScanPredicateInfo? BuildScanPredicateInfo(ClauseExecution exec, ref int longIndex, ref int doubleIndex, ref int sliceIndex)
         => BuildScanPredicateInfoCore(exec, exec?.TermValueType ?? ParamValueType.String, ref longIndex, ref doubleIndex, ref sliceIndex);
+
+    /// <summary>Eligibility-only probe: returns whether <see cref="BuildScanPredicateInfo"/>
+    /// would have produced a non-null result for this execution, without allocating a
+    /// <see cref="ScanPredicateInfo"/> or accumulating parameter indices. Use this when the
+    /// caller only needs the null/non-null signal (gating loops, skip-filters).</summary>
+    private static bool IsScanEligible(ClauseExecution exec)
+        => IsScanEligibleCore(exec, exec.TermValueType);
+
+    private static bool IsScanEligibleCore(ClauseExecution exec, ParamValueType termType)
+    {
+        var clause = exec.Clause;
+        switch (clause.ClauseType)
+        {
+            case ClauseType.Search:
+            case ClauseType.Regex:
+            case ClauseType.Spatial:
+            case ClauseType.Vector:
+            case ClauseType.In:
+            case ClauseType.AllIn:
+                return false;
+
+            case ClauseType.StartsWith:
+            case ClauseType.EndsWith:
+                return termType == ParamValueType.String;
+
+            case ClauseType.AndGroup:
+            case ClauseType.OrGroup:
+            {
+                if (clause.SubClauses is not { Count: > 0 } subs)
+                    return false;
+                var subExecs = exec.SubExecutions;
+                for (int si = 0; si < subs.Count; si++)
+                {
+                    if (IsScanEligibleCore(subExecs[si], subExecs[si].TermValueType) == false)
+                        return false;
+                }
+                return true;
+            }
+        }
+        // Equals / NotEquals / Range / Between / Exists → eligible.
+        return true;
+    }
 
     /// <summary>Single walker shared by both overloads. <paramref name="exec"/> is non-null on
     /// the resolution path and supplies per-sub TermValueType during group recursion; on the

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -2810,45 +2810,45 @@ internal static partial class QueryPlanBuilder
         AndNotInto
     }
 
-    /// <summary>Recursive emit entry point. Emit ops that fold <paramref name="clause"/>'s
+    /// <summary>Recursive emit entry point. Emit ops that fold <paramref name="exec"/>'s
     /// result into slot 0 per <paramref name="merge"/>. Groups recurse; IN/AllIn/leaf
     /// route to specialised helpers.</summary>
     private static void EmitClauseInto(
-        ClauseInfo clause, ClauseExecution exec,
+        ClauseExecution exec,
         MergeKind merge, long cardinality,
         bool suppressEarlyExit,
         ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
         List<PlanOp> ops, List<int> rangeCounts)
     {
         // OR-chain NotEquals materialised by MatchResolver into ResolvedMatches[matchIndex].
-        if (clause.IsOrChainNotEquals)
+        if (exec.Clause.IsOrChainNotEquals)
         {
             EmitLeafMergeOp(merge, matchIndex, cardinality, MatchDispatch.QueryMatch, suppressEarlyExit, ops);
             matchIndex++;
             return;
         }
 
-        if (TryGetGroupFanOut(clause, exec, out var subs, out var subExecs))
+        if (TryGetGroupFanOut(exec.Clause, exec, out _, out var subExecs))
         {
-            EmitGroupInto(clause, exec, subs, subExecs, merge, suppressEarlyExit,
+            EmitGroupInto(exec, subExecs, merge, suppressEarlyExit,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
             return;
         }
 
-        if (clause.ClauseType is ClauseType.In)
+        if (exec.ClauseType is ClauseType.In)
         {
-            EmitInLeaf(clause, exec, cardinality, merge, ref matchIndex, ref maxScratchUsed, ops, rangeCounts);
+            EmitInLeaf(exec, cardinality, merge, ref matchIndex, ref maxScratchUsed, ops, rangeCounts);
             return;
         }
 
-        if (clause.ClauseType is ClauseType.AllIn)
+        if (exec.ClauseType is ClauseType.AllIn)
         {
-            EmitAllInLeaf(clause, exec, cardinality, merge, suppressEarlyExit,
+            EmitAllInLeaf(exec, cardinality, merge, suppressEarlyExit,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
             return;
         }
 
-        EmitLeafMergeOp(merge, matchIndex, cardinality, GetDispatch(clause), suppressEarlyExit, ops);
+        EmitLeafMergeOp(merge, matchIndex, cardinality, GetDispatch(exec.Clause), suppressEarlyExit, ops);
         matchIndex++;
     }
 
@@ -2857,15 +2857,15 @@ internal static partial class QueryPlanBuilder
     /// the group fresh in slot 0, then merge with the saved accumulator via the
     /// matching bitmap-pair op.</summary>
     private static void EmitGroupInto(
-        ClauseInfo clause, ClauseExecution exec,
-        List<ClauseInfo> subs, List<ClauseExecution> subExecs,
+        ClauseExecution exec,
+        List<ClauseExecution> subExecs,
         MergeKind merge, bool suppressEarlyExit,
         ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
         List<PlanOp> ops, List<int> rangeCounts)
     {
         if (merge == MergeKind.Fill)
         {
-            EmitGroupContentsInSlot0(clause, exec, subs, subExecs, suppressEarlyExit,
+            EmitGroupContentsInSlot0(exec, subExecs, suppressEarlyExit,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
             return;
         }
@@ -2878,7 +2878,7 @@ internal static partial class QueryPlanBuilder
 
         // Inside the saved context, AndWithPostings/AndRange MUST NOT early-exit to
         // doneLabel — that would skip the merge-back below and leak the saved value.
-        EmitGroupContentsInSlot0(clause, exec, subs, subExecs, suppressEarlyExit: true,
+        EmitGroupContentsInSlot0(exec, subExecs, suppressEarlyExit: true,
             ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
 
         switch (merge)
@@ -2907,21 +2907,21 @@ internal static partial class QueryPlanBuilder
     /// the live accumulator out). OrGroup: Fill first sub, OR rest. AndGroup: Fill
     /// first sub (or FillAllEntries if first is negated), AND/ANDNOT rest.</summary>
     private static void EmitGroupContentsInSlot0(
-        ClauseInfo clause, ClauseExecution exec,
-        List<ClauseInfo> subs, List<ClauseExecution> subExecs,
+        ClauseExecution exec,
+        List<ClauseExecution> subExecs,
         bool suppressEarlyExit,
         ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
         List<PlanOp> ops, List<int> rangeCounts)
     {
-        int subCount = subs.Count;
-        long subCard = (exec?.Cardinality ?? 0) / Math.Max(1, subCount);
-        bool isOr = clause.ClauseType == ClauseType.OrGroup;
+        int subCount = subExecs.Count;
+        long subCard = exec.Cardinality / Math.Max(1, subCount);
+        bool isOr = exec.ClauseType == ClauseType.OrGroup;
 
         if (isOr)
         {
             for (int si = 0; si < subCount; si++)
             {
-                EmitClauseInto(subs[si], subExecs?[si],
+                EmitClauseInto(subExecs[si],
                     si == 0 ? MergeKind.Fill : MergeKind.OrInto,
                     subCard, suppressEarlyExit,
                     ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
@@ -2930,7 +2930,7 @@ internal static partial class QueryPlanBuilder
         }
 
         // AndGroup
-        bool firstIsNeg = subs[0].IsNegated || subs[0].ClauseType == ClauseType.NotEquals;
+        bool firstIsNeg = subExecs[0].IsNegated || subExecs[0].ClauseType == ClauseType.NotEquals;
         int start;
         if (firstIsNeg)
         {
@@ -2939,14 +2939,14 @@ internal static partial class QueryPlanBuilder
         }
         else
         {
-            EmitClauseInto(subs[0], subExecs?[0], MergeKind.Fill, subCard, suppressEarlyExit,
+            EmitClauseInto(subExecs[0], MergeKind.Fill, subCard, suppressEarlyExit,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
             start = 1;
         }
         for (int si = start; si < subCount; si++)
         {
-            bool subNeg = subs[si].IsNegated || subs[si].ClauseType == ClauseType.NotEquals;
-            EmitClauseInto(subs[si], subExecs?[si],
+            bool subNeg = subExecs[si].IsNegated || subExecs[si].ClauseType == ClauseType.NotEquals;
+            EmitClauseInto(subExecs[si],
                 subNeg ? MergeKind.AndNotInto : MergeKind.AndInto,
                 subCard, suppressEarlyExit,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
@@ -2984,11 +2984,11 @@ internal static partial class QueryPlanBuilder
     /// via AndBitmaps/AndNotBitmaps. OrRange ignores SkipEarlyExit so suppression
     /// doesn't need to propagate here.</summary>
     private static void EmitInLeaf(
-        ClauseInfo clause, ClauseExecution exec, long cardinality, MergeKind merge,
+        ClauseExecution exec, long cardinality, MergeKind merge,
         ref int matchIndex, ref int maxScratchUsed,
         List<PlanOp> ops, List<int> rangeCounts)
     {
-        int inTermCount = exec?.InTermCount > 0 ? exec.InTermCount : clause.Bindings?.Length ?? 0;
+        int inTermCount = exec.InTermCount;
         if (merge is MergeKind.Fill or MergeKind.OrInto)
         {
             EmitInOps(ops, inTermCount, cardinality, bitmapLocal: 0, isSeed: merge == MergeKind.Fill, ref matchIndex, rangeCounts);
@@ -3013,12 +3013,12 @@ internal static partial class QueryPlanBuilder
     /// AndRange op honors SkipEarlyExit; in a saved context we must set it so the loop
     /// doesn't jump to doneLabel mid-intersection.</summary>
     private static void EmitAllInLeaf(
-        ClauseInfo clause, ClauseExecution exec, long cardinality, MergeKind merge,
+        ClauseExecution exec, long cardinality, MergeKind merge,
         bool suppressEarlyExit,
         ref int matchIndex, ref int nextScratch, ref int maxScratchUsed,
         List<PlanOp> ops, List<int> rangeCounts)
     {
-        int inTermCount = exec?.InTermCount > 0 ? exec.InTermCount : clause.Bindings?.Length ?? 0;
+        int inTermCount = exec.InTermCount;
         if (merge == MergeKind.Fill)
         {
             EmitAllInOps(ops, inTermCount, cardinality, bitmapLocal: 0, ref matchIndex, rangeCounts);
@@ -3111,7 +3111,7 @@ internal static partial class QueryPlanBuilder
         for (int i = 0; i < executions.Count; i++)
         {
             var exec = executions[i];
-            EmitClauseInto(exec.Clause, exec,
+            EmitClauseInto(exec,
                 i == 0 ? MergeKind.Fill : MergeKind.OrInto,
                 exec.Cardinality, suppressEarlyExit: true,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed,
@@ -3135,7 +3135,6 @@ internal static partial class QueryPlanBuilder
         List<PlanOp> ops = [];
         List<int> rangeCounts = [];
 
-        var c0 = executions[0].Clause;
         var e0 = executions[0];
         switch (executions.Count)
         {
@@ -3145,7 +3144,7 @@ internal static partial class QueryPlanBuilder
                     Kind = PlanOpKind.DirectIterate,
                     ParamIndex = 0,
                     EstimatedCardinality = e0.Cardinality,
-                    Dispatch = GetDispatch(c0)
+                    Dispatch = GetDispatch(e0.Clause)
                 });
                 return (ops.ToArray(), 2, null);
             case 1 when e0.ClauseType == ClauseType.NotEquals
@@ -3159,7 +3158,7 @@ internal static partial class QueryPlanBuilder
                 {
                     Kind = PlanOpKind.AndNotWithPostings,
                     EstimatedCardinality = e0.Cardinality,
-                    Dispatch = GetDispatch(c0)
+                    Dispatch = GetDispatch(e0.Clause)
                 });
                 ops.Add(new PlanOp { Kind = PlanOpKind.IterateInto });
 
@@ -3193,7 +3192,7 @@ internal static partial class QueryPlanBuilder
         }
         else
         {
-            EmitClauseInto(c0, e0, MergeKind.Fill, e0.Cardinality, suppressEarlyExit: false,
+            EmitClauseInto(e0, MergeKind.Fill, e0.Cardinality, suppressEarlyExit: false,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
             startIndex = 1;
         }
@@ -3217,11 +3216,10 @@ internal static partial class QueryPlanBuilder
             }
 
             var execI = executions[i];
-            var clauseI = execI.Clause;
-            bool stepNegated = clauseI.IsNegated || clauseI.ClauseType == ClauseType.NotEquals;
+            bool stepNegated = execI.IsNegated || execI.ClauseType == ClauseType.NotEquals;
             MergeKind merge = stepNegated ? MergeKind.AndNotInto : MergeKind.AndInto;
 
-            EmitClauseInto(clauseI, execI, merge, execI.Cardinality, suppressEarlyExit: false,
+            EmitClauseInto(execI, merge, execI.Cardinality, suppressEarlyExit: false,
                 ref matchIndex, ref nextScratch, ref maxScratchUsed, ops, rangeCounts);
 
             // CheckEmpty: short-circuit when slot 0 became empty after a positive
@@ -3486,25 +3484,25 @@ internal static partial class QueryPlanBuilder
     {
         int count = isAllEntries ? 1 : 0;
         foreach (var exec in executions ?? [])
-            count += CountClauseLeaves(exec.Clause, exec);
+            count += CountClauseLeaves(exec);
         return count;
     }
 
     /// <summary>Recursive leaf counter. <see cref="ClauseInfo.IsOrChainNotEquals"/>
     /// short-circuits to a single AllEntries-ANDNOT slot regardless of group shape.</summary>
-    private static int CountClauseLeaves(ClauseInfo clause, ClauseExecution exec)
+    private static int CountClauseLeaves(ClauseExecution exec)
     {
-        if (clause.IsOrChainNotEquals)
+        if (exec.Clause.IsOrChainNotEquals)
             return 1;
-        if (TryGetGroupFanOut(clause, exec, out var subClauses, out var subExecs))
+        if (TryGetGroupFanOut(exec.Clause, exec, out _, out var subExecs))
         {
             int sum = 0;
-            for (int i = 0; i < subClauses.Count; i++)
-                sum += CountClauseLeaves(subClauses[i], subExecs?[i]);
+            for (int i = 0; i < subExecs.Count; i++)
+                sum += CountClauseLeaves(subExecs[i]);
             return sum;
         }
-        if (clause.ClauseType is ClauseType.In or ClauseType.AllIn)
-            return ((exec?.InTermCount ?? 0) > 0 ? exec.InTermCount : clause.Bindings?.Length ?? 0) + 1;
+        if (exec.ClauseType is ClauseType.In or ClauseType.AllIn)
+            return exec.InTermCount + 1;
         return 1;
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -204,12 +204,6 @@ internal static partial class QueryPlanBuilder
 
         (int typeSignature, byte[] fullKinds) = ComputeTypeSignature(template, planParams);
 
-        // IN/AllIn clauses with QueryParameter bindings can expand to different term counts
-        // at runtime. The slot layout (ParamIndex constants baked into the compiled IL) depends
-        // on InTermCount, so different counts must produce different compiled plans. Fold a hash
-        // of all IN/AllIn InTermCounts into typeSignature so the cache treats them as distinct.
-        typeSignature ^= ComputeInTermSignature(executions);
-
         if(planCache.Get(queryText, operandOrdering, typeSignature, fullKinds, whenFlags) is {} compiledPlan)
             return FinalizePlan();
         
@@ -3721,28 +3715,6 @@ internal static partial class QueryPlanBuilder
             typeSignature |= kind << (i * 2); 
         }
         return (typeSignature, fullKinds);
-    }
-
-    /// <summary>Compute a hash over the InTermCount of every IN/AllIn execution in the tree.
-    /// When a QueryParameter IN binding expands to N values at runtime (N may differ per
-    /// execution), the compiled plan's slot-layout constants depend on N. Folding this hash
-    /// into the typeSignature cache key ensures different expansion sizes get different plans,
-    /// preventing slot-index mismatches between the emitter (uses InTermCount at build time)
-    /// and the resolver (uses InTermCount at execution time).</summary>
-    private static int ComputeInTermSignature(List<ClauseExecution> executions)
-    {
-        int sig = 0;
-        foreach (var exec in executions ?? [])
-            AccumulateInTermCounts(exec, ref sig);
-        return sig;
-    }
-
-    private static void AccumulateInTermCounts(ClauseExecution exec, ref int sig)
-    {
-        if (exec.Clause.ClauseType is ClauseType.In or ClauseType.AllIn)
-            sig = (sig * 397) ^ exec.InTermCount;
-        foreach (var sub in exec.SubExecutions ?? [])
-            AccumulateInTermCounts(sub, ref sig);
     }
 
     /// <summary>Classify a query parameter's runtime type from the blittable JSON value.

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -807,7 +807,7 @@ internal static partial class QueryPlanBuilder
             }
             case ClauseType.In or ClauseType.AllIn:
                 // IN/AllIn: each binding is a term (literal or parameter, possibly array-expanding)
-                ResolveInFromBindings(exec.Clause, exec, queryParameters, writer, bindings);
+                ResolveInFromBindings(exec.Clause, exec, queryParameters, writer, bindings, builderParameters);
                 break;
             default:
                 // Simple clause (Equals, Range, Search, Regex, etc.): single value at Bindings[0]
@@ -856,20 +856,15 @@ internal static partial class QueryPlanBuilder
     }
 
     /// <summary>Populate <paramref name="exec"/>'s typed-parameter slot for an IN/AllIn
-    /// clause. Two paths share the same tail (<see cref="EmitInTerms"/>): the
-    /// allocation-free literal fast path reads directly from <see cref="ParameterBinding"/>
-    /// when <see cref="ClauseInfo.AllBindingsAreLiteral"/> is set (dominantType was pre-computed
-    /// by InPreClassify at template time); the parameter-bound slow path resolves each
-    /// binding (potentially array-expanding) into <see cref="List{T}"/> buffers, infers
-    /// the dominant type at runtime, and then runs the same emit logic.</summary>
-    private static void ResolveInFromBindings(ClauseInfo clause, ClauseExecution exec, BlittableJsonReaderObject queryParameters, ValueWriter writer, ParameterBinding[] bindings)
+    /// clause. Resolves each binding (literal, query parameter, or deferred method such as
+    /// today()/now()/cmpxchg()) into typed value buffers, then calls <see cref="EmitInTerms"/>.
+    /// Array-expanding query parameters (e.g. <c>@ids</c> bound to a JSON array) are
+    /// flattened inline. Null values are never added to the buffers — they set
+    /// <c>hasNullTerm</c> so the posting-list resolver queries the null-term list separately.</summary>
+    private static void ResolveInFromBindings(ClauseInfo clause, ClauseExecution exec,
+        BlittableJsonReaderObject queryParameters, ValueWriter writer, ParameterBinding[] bindings,
+        QueryBuilderParameters builderParameters)
     {
-        if (clause.AllBindingsAreLiteral)
-        {
-            EmitInTerms(exec, writer, clause.InDominantType, bindings, hasNullTerm: false);
-            return;
-        }
-
         var resolvedValues = new List<object>(bindings.Length);
         var termTypes = new List<ParamValueType>(bindings.Length);
         bool hasNullTerm = false;
@@ -910,20 +905,21 @@ internal static partial class QueryPlanBuilder
                     {
                         hasNullTerm = true;
                     }
-
                     break;
                 }
 
                 case BindingSource.DeferredMethod:
-                    // Deferred bindings (cmpxchg, now, today) shouldn't appear in IN lists,
-                    // but handle gracefully: treat as null.
-                    hasNullTerm = true;
+                {
+                    var (val, type) = ResolveBindingScalar(it, queryParameters, builderParameters);
+                    if (val == null) { hasNullTerm = true; break; }
+                    resolvedValues.Add(val);
+                    termTypes.Add(type);
                     break;
+                }
             }
         }
 
         ParamValueType dominantType = resolvedValues.Count > 0 ? termTypes[0] : ParamValueType.String;
-
         EmitInTerms(exec, writer, dominantType, resolvedValues, termTypes, hasNullTerm);
     }
 
@@ -962,39 +958,10 @@ internal static partial class QueryPlanBuilder
         return true;
     }
 
-    /// <summary>All-literal fast-path emit: read values straight from
-    /// <paramref name="bindings"/>, write each dominantType-compatible non-null
-    /// value into <paramref name="writer"/>, then stamp the exec slot.</summary>
-    private static void EmitInTerms(ClauseExecution exec, ValueWriter writer, ParamValueType dominantType,
-        ParameterBinding[] bindings, bool hasNullTerm)
-    {
-        var (packedType, startIdx) = ResolveInWriterSlot(writer, dominantType);
-        var dominantTokenType = ToValueTokenType(dominantType);
-
-        int nonNullCount = 0;
-        foreach (var it in bindings)
-        {
-            var value = it.LiteralValue;
-            if (value == null)
-            {
-                hasNullTerm = true;
-                continue;
-            }
-
-            if (TryEmitInTermValue(writer, value, it.LiteralType, dominantType, dominantTokenType))
-                nonNullCount++;
-        }
-
-        exec.PackedParamValue = new PackedParam(packedType, startIdx);
-        exec.InTermCount = nonNullCount;
-        exec.HasNullTerm = hasNullTerm;
-    }
-
-    /// <summary>Parameter-bound slow-path emit: iterate the pre-resolved
-    /// <paramref name="values"/> / <paramref name="types"/> buffers, filter to the
-    /// inferred dominant type, write into <paramref name="writer"/>, then stamp the
-    /// exec slot. <paramref name="hasNullTerm"/> is supplied by the caller because
-    /// nulls are resolved upstream in this path (unlike the literal fast-path).</summary>
+    /// <summary>Write the resolved non-null IN/AllIn term values into <paramref name="writer"/>
+    /// and stamp the exec slot. Null values are not in <paramref name="values"/> — they are
+    /// signalled via <paramref name="hasNullTerm"/> so the resolver queries the null posting
+    /// list separately. Values whose type is incompatible with the dominant type are dropped.</summary>
     private static void EmitInTerms(ClauseExecution exec, ValueWriter writer, ParamValueType dominantType,
         List<object> values, List<ParamValueType> types, bool hasNullTerm)
     {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -163,30 +163,16 @@ internal static partial class QueryPlanBuilder
             case ExecutionStrategy.DirectScan when orderByFields is { Length: <= 2 }:
                 // orderByFields can be null on a per-execution PageSize==0 reuse of a cached
                 // DirectScan plan — PageSize is not part of the plan cache key.
+                if (exec.Executions is not { Count:> 0 } || 
+                    exec.Plan.SortDrivingClauseIndex >= 0 && exec.Executions[exec.Plan.SortDrivingClauseIndex].PackedParamValue.IsNone is false)
                 {
-                    var execs = exec.Executions;
-                    bool isFullScan = execs is null or { Count: 0 };
-                    int drivingIdx = -1;
-                    if (!isFullScan)
-                    {
-                        drivingIdx = exec.Plan.SortDrivingClauseIndex;
-                        // BoostFactor cannot land here: ComputeOptFlags clears
-                        // DirectScanCandidate template-wide for any boost; only IsNone
-                        // (parameter resolved to null) can still invalidate at runtime.
-                        if (drivingIdx >= 0 && exec.Executions[drivingIdx].PackedParamValue.IsNone)
-                            drivingIdx = -1;
-                    }
-                    if (isFullScan || drivingIdx >= 0)
-                    {
-                        innerMatch = ConstructDirectScan(exec, orderByFields, planParams, builderParameters,
-                            compiledPlan, drivingIdx, isFullScan, orderByFields.Length == 2, entriesToScan: 0, bitmapCost: 0);
-                        if (innerMatch is not null) return innerMatch;
-                    }
-                    goto default;
+                    innerMatch = ConstructDirectScan(exec, orderByFields, planParams, builderParameters,
+                        compiledPlan, exec.Plan.SortDrivingClauseIndex, exec.Executions is not { Count:> 0 }, orderByFields.Length == 2, entriesToScan: 0, bitmapCost: 0);
+                    if (innerMatch is not null) return innerMatch;
                 }
+                goto default;
             case ExecutionStrategy.BitmapSort:
-            default:
-                // may either be the selected strategy, or a one-off (because of bad parameters preventing a faster strategy) 
+            default: // may either be the selected strategy or a one-off (because of bad parameters preventing a faster strategy) 
                 return InstantiateBitmapFallback(compiledPlan, exec, orderByFields, hasEmptySorts,
                     planParams, builderParameters, walkerCtx, highlightingTerms, wantTimings, out innerMatch, token);
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1517,6 +1517,12 @@ internal static partial class QueryPlanBuilder
 
         if (clause.ClauseType == ClauseType.AndGroup && clause.SubClauses != null)
         {
+            // NOTE: This collapse path is a known dual-path issue tracked by ayende/ravendb#4847.
+            // The IL slot pipeline (EmitOrPlan / EmitAndPlan) handles AND/OR composition with
+            // correct semantics for both `IsNegated` and `ClauseType == NotEquals` (see
+            // EmitAndPlan line ~3434). This collapse path historically only checked `IsNegated`,
+            // which silently AND-merged NotEquals sub-clauses as positive matches. Mirror the
+            // emitter's predicate here so the dual paths agree until #4847 retires this branch.
             var bm = new BitmapMatch(indexSearcher.Allocator);
             var temp = new RoaringBitmap(indexSearcher.Allocator);
             bool first = true;
@@ -1525,12 +1531,24 @@ internal static partial class QueryPlanBuilder
                 var sub = clause.SubClauses[si];
                 var subExec = cur.SubExecutions[si];
                 var subMatch = ResolveClause(subExec, root, walkerCtx);
+                bool isNegated = sub.IsNegated || sub.ClauseType == ClauseType.NotEquals;
                 if (first)
                 {
-                    QueryPrimitives.OrWithMatch(subMatch, ref bm.BitmapState);
+                    if (isNegated)
+                    {
+                        // First clause is negated: seed from AllEntries, then ANDNOT.
+                        // Mirrors EmitAndPlan's firstIsNegated handling (line ~3270).
+                        var allEntries = indexSearcher.AllEntries();
+                        QueryPrimitives.OrWithMatch(allEntries, ref bm.BitmapState);
+                        QueryPrimitives.AndNotWithMatch(subMatch, ref bm.BitmapState, ref temp);
+                    }
+                    else
+                    {
+                        QueryPrimitives.OrWithMatch(subMatch, ref bm.BitmapState);
+                    }
                     first = false;
                 }
-                else if (sub.IsNegated)
+                else if (isNegated)
                     QueryPrimitives.AndNotWithMatch(subMatch, ref bm.BitmapState, ref temp);
                 else
                     QueryPrimitives.AndWithMatch(subMatch, ref bm.BitmapState, ref temp);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1347,7 +1347,12 @@ internal static partial class QueryPlanBuilder
         public static IQueryMatch ResolveSubClauseSlot(ClauseInfo sub, ClauseExecution subExec,
             QueryExecution exec, ResolutionContext ctx)
         {
-            var match = ResolveClause(subExec, exec, ctx);
+            // A negated direct child of a nested OrGroup carries IsOrChainNotEquals=true (set by
+            // PlanWalker.NotCanonicalize). Materialise as AllEntries ANDNOT(positive) so the
+            // surrounding OR step combines the complement set, not the positive posting list.
+            IQueryMatch match = sub.IsOrChainNotEquals
+                ? CreateNotEqualsOrMatch(sub, subExec, exec, ctx)
+                : ResolveClause(subExec, exec, ctx);
             if (subExec.BoostFactor > 0)
                 match = ctx.IndexSearcher.Boost(match, subExec.BoostFactor);
             return match;
@@ -1502,12 +1507,20 @@ internal static partial class QueryPlanBuilder
         var builderParams = walkerCtx.BuilderParams;
         if (clause.ClauseType == ClauseType.OrGroup && clause.SubClauses != null)
         {
+            // Mirror MatchResolver.ResolveSubClauseSlot: a sub-clause flagged with
+            // IsOrChainNotEquals (negated direct child of this OrGroup, per PlanWalker
+            // .NotCanonicalize) must contribute its complement (AllEntries ANDNOT positive),
+            // not the raw positive posting list. Without this the OrGroup collapse path
+            // silently OR-merges the positive form for `... or X != y`.
             var bm = new BitmapMatch(indexSearcher.Allocator);
             var temp = new RoaringBitmap(indexSearcher.Allocator);
             for (int si = 0; si < clause.SubClauses.Count; si++)
             {
+                var sub = clause.SubClauses[si];
                 var subExec = cur.SubExecutions[si];
-                var subMatch = ResolveClause(subExec, root, walkerCtx);
+                var subMatch = sub.IsOrChainNotEquals
+                    ? CreateNotEqualsOrMatch(sub, subExec, root, walkerCtx)
+                    : ResolveClause(subExec, root, walkerCtx);
                 QueryPrimitives.OrWithMatch(subMatch, ref bm.BitmapState);
             }
 
@@ -3120,12 +3133,17 @@ internal static partial class QueryPlanBuilder
                     for (int si = 0; si < subCount; si++)
                     {
                         var sub = it.SubClauses[si];
+                        // Negated direct children of this nested OrGroup carry
+                        // IsOrChainNotEquals=true (PlanWalker.NotCanonicalize). Force
+                        // QueryMatch dispatch so the IL reads the pre-materialized
+                        // AllEntries-ANDNOT bitmap that MatchResolver.ResolveSubClauseSlot
+                        // produces, not the raw positive posting list.
                         ops.Add(new PlanOp
                         {
                             Kind = matchIndex == 0 ? PlanOpKind.FillFromPostings : PlanOpKind.OrWithPostings,
                             ParamIndex = matchIndex,
                             EstimatedCardinality = exec.Cardinality / subCount,
-                            Dispatch = GetDispatch(sub)
+                            Dispatch = sub.IsOrChainNotEquals ? MatchDispatch.QueryMatch : GetDispatch(sub)
                         });
                         matchIndex++;
                     }
@@ -3154,9 +3172,13 @@ internal static partial class QueryPlanBuilder
                         });
                         for (int s = 1; s < subClauses.Count; s++)
                         {
+                            // Mirror EmitAndPlan's firstIsNegated predicate: a bare NotEquals
+                            // sub-clause must subtract via AndNot. Pre-tactical-fix this branch
+                            // only checked IsNegated, silently AND-merging NotEquals subs as positives.
+                            bool subIsNegated = subClauses[s].IsNegated || subClauses[s].ClauseType == ClauseType.NotEquals;
                             ops.Add(new PlanOp
                             {
-                                Kind = subClauses[s].IsNegated ? PlanOpKind.AndNotWithPostings : PlanOpKind.AndWithPostings,
+                                Kind = subIsNegated ? PlanOpKind.AndNotWithPostings : PlanOpKind.AndWithPostings,
                                 ParamIndex = matchIndex + s,
                                 EstimatedCardinality = subCardinality,
                                 Dispatch = GetDispatch(subClauses[s]),
@@ -3189,9 +3211,11 @@ internal static partial class QueryPlanBuilder
                         });
                         for (int s = 1; s < subClauses.Count; s++)
                         {
+                            // Same predicate alignment as the matchIndex==0 branch above.
+                            bool subIsNegated = subClauses[s].IsNegated || subClauses[s].ClauseType == ClauseType.NotEquals;
                             ops.Add(new PlanOp
                             {
-                                Kind = subClauses[s].IsNegated ? PlanOpKind.AndNotWithPostings : PlanOpKind.AndWithPostings,
+                                Kind = subIsNegated ? PlanOpKind.AndNotWithPostings : PlanOpKind.AndWithPostings,
                                 ParamIndex = matchIndex + s,
                                 BitmapLocal = 0,
                                 EstimatedCardinality = subCardinality,
@@ -3315,13 +3339,17 @@ internal static partial class QueryPlanBuilder
                     int subCount = subClauses.Count;
                     for (int s = 0; s < subCount; s++)
                     {
+                        var sub = subClauses[s];
+                        // Negated direct children of this OrGroup carry IsOrChainNotEquals=true
+                        // (PlanWalker.NotCanonicalize). Force QueryMatch dispatch so the IL reads
+                        // the AllEntries-ANDNOT bitmap from MatchResolver.ResolveSubClauseSlot.
                         ops.Add(new PlanOp
                         {
                             Kind = s == 0 ? PlanOpKind.FillFromPostings : PlanOpKind.OrWithPostings,
                             ParamIndex = matchIndex + s,
                             BitmapLocal = 0,
                             EstimatedCardinality = executions[0].Cardinality / Math.Max(1, subCount),
-                            Dispatch = GetDispatch(subClauses[s])
+                            Dispatch = sub.IsOrChainNotEquals ? MatchDispatch.QueryMatch : GetDispatch(sub)
                         });
                     }
 
@@ -3383,13 +3411,17 @@ internal static partial class QueryPlanBuilder
                     // Fill each subclause into bitmap[1]
                     for (int s = 0; s < subCount; s++)
                     {
+                        var sub = subClauses[s];
+                        // Negated direct children of this OrGroup carry IsOrChainNotEquals=true
+                        // (PlanWalker.NotCanonicalize). Force QueryMatch dispatch so the IL reads
+                        // the AllEntries-ANDNOT bitmap from MatchResolver.ResolveSubClauseSlot.
                         ops.Add(new PlanOp
                         {
                             Kind = PlanOpKind.OrWithPostings,
                             ParamIndex = matchIndex + s,
                             BitmapLocal = 1, // target bitmap[1]
                             EstimatedCardinality = executions[i].Cardinality / Math.Max(1, subCount),
-                            Dispatch = GetDispatch(subClauses[s])
+                            Dispatch = sub.IsOrChainNotEquals ? MatchDispatch.QueryMatch : GetDispatch(sub)
                         });
                     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -1151,7 +1151,7 @@ internal static partial class QueryPlanBuilder
         int matchIdx = 0;
         foreach (var clauseExec in execs)
         {
-            ResolveClauseLeavesInto<TResolver, TSlot>(clauseExec.Clause, clauseExec, exec, walkerCtx, slots, ref matchIdx);
+            ResolveClauseLeavesInto<TResolver, TSlot>(clauseExec, exec, walkerCtx, slots, ref matchIdx);
         }
 
         return slots;
@@ -1162,30 +1162,30 @@ internal static partial class QueryPlanBuilder
     /// short-circuits to <see cref="ISlotResolver{TSelf, TSlot}.ResolveSubClauseSlot"/> so the
     /// AllEntries-ANDNOT materialisation kicks in at any nesting depth.</summary>
     private static void ResolveClauseLeavesInto<TResolver, TSlot>(
-        ClauseInfo clause, ClauseExecution clauseExec, QueryExecution exec, ResolutionContext walkerCtx,
+        ClauseExecution clauseExec, QueryExecution exec, ResolutionContext walkerCtx,
         TSlot[] slots, ref int matchIdx)
         where TResolver : ISlotResolver<TResolver, TSlot>
     {
-        if (clause.IsOrChainNotEquals)
+        if (clauseExec.Clause.IsOrChainNotEquals)
         {
-            slots[matchIdx++] = TResolver.ResolveSubClauseSlot(clause, clauseExec, exec, walkerCtx);
+            slots[matchIdx++] = TResolver.ResolveSubClauseSlot(clauseExec, exec, walkerCtx);
             return;
         }
-        if (TryGetGroupFanOut(clause, clauseExec, out var subClauses, out var subExecs))
+        if (TryGetGroupFanOut(clauseExec.Clause, clauseExec, out _, out var subExecs))
         {
-            for (int si = 0; si < subClauses.Count; si++)
-                ResolveClauseLeavesInto<TResolver, TSlot>(subClauses[si], subExecs?[si], exec, walkerCtx, slots, ref matchIdx);
+            for (int si = 0; si < subExecs.Count; si++)
+                ResolveClauseLeavesInto<TResolver, TSlot>(subExecs[si], exec, walkerCtx, slots, ref matchIdx);
             return;
         }
-        if (clause.ClauseType is ClauseType.AllIn or ClauseType.In)
+        if (clauseExec.ClauseType is ClauseType.AllIn or ClauseType.In)
         {
             for (int t = 0; t < clauseExec.InTermCount; t++)
-                slots[matchIdx++] = TResolver.ResolveInTermSlot(clause, clauseExec, t, exec, walkerCtx);
+                slots[matchIdx++] = TResolver.ResolveInTermSlot(clauseExec, t, exec, walkerCtx);
             // Null-term slot is always allocated; resolver decides whether to populate.
-            slots[matchIdx++] = TResolver.ResolveNullTermSlot(clause, clauseExec, walkerCtx);
+            slots[matchIdx++] = TResolver.ResolveNullTermSlot(clauseExec, walkerCtx);
             return;
         }
-        slots[matchIdx++] = TResolver.ResolveDefaultSlot(clause, clauseExec, exec, walkerCtx);
+        slots[matchIdx++] = TResolver.ResolveDefaultSlot(clauseExec, exec, walkerCtx);
     }
 
     /// <summary>Per-slot resolver contract; one implementation per output array shape.
@@ -1194,13 +1194,13 @@ internal static partial class QueryPlanBuilder
     private interface ISlotResolver<TSelf, out TSlot>
         where TSelf : ISlotResolver<TSelf, TSlot>
     {
-        static abstract TSlot ResolveSubClauseSlot(ClauseInfo sub, ClauseExecution subExec, QueryExecution exec, ResolutionContext ctx);
+        static abstract TSlot ResolveSubClauseSlot(ClauseExecution subExec, QueryExecution exec, ResolutionContext ctx);
 
-        static abstract TSlot ResolveInTermSlot(ClauseInfo clause, ClauseExecution clauseExec, int termIndex, QueryExecution exec, ResolutionContext ctx);
+        static abstract TSlot ResolveInTermSlot(ClauseExecution clauseExec, int termIndex, QueryExecution exec, ResolutionContext ctx);
 
-        static abstract TSlot ResolveNullTermSlot(ClauseInfo clause, ClauseExecution clauseExec, ResolutionContext ctx);
+        static abstract TSlot ResolveNullTermSlot(ClauseExecution clauseExec, ResolutionContext ctx);
 
-        static abstract TSlot ResolveDefaultSlot(ClauseInfo clause, ClauseExecution clauseExec, QueryExecution exec, ResolutionContext ctx);
+        static abstract TSlot ResolveDefaultSlot(ClauseExecution clauseExec, QueryExecution exec, ResolutionContext ctx);
     }
 
     /// <summary>Resolver for the IQueryMatch[] output — the bitmap-path matches consumed
@@ -1210,37 +1210,35 @@ internal static partial class QueryPlanBuilder
     {
         // Precondition: callers (ResolveClauseLeavesInto) only dispatch here for clauses
         // where ClauseInfo.IsOrChainNotEquals is set.
-        public static IQueryMatch ResolveSubClauseSlot(ClauseInfo sub, ClauseExecution subExec,
+        public static IQueryMatch ResolveSubClauseSlot(ClauseExecution subExec,
             QueryExecution exec, ResolutionContext ctx)
         {
-            IQueryMatch match = CreateNotEqualsOrMatch(sub, subExec, exec, ctx);
+            IQueryMatch match = CreateNotEqualsOrMatch(subExec, exec, ctx);
             if (subExec.BoostFactor > 0)
                 match = ctx.IndexSearcher.Boost(match, subExec.BoostFactor);
             return match;
         }
 
-        public static IQueryMatch ResolveInTermSlot(ClauseInfo clause, ClauseExecution clauseExec, int termIndex,
+        public static IQueryMatch ResolveInTermSlot(ClauseExecution clauseExec, int termIndex,
             QueryExecution exec, ResolutionContext ctx)
-            => ResolveInTerm(clause, clauseExec, termIndex, exec, ctx);
+            => ResolveInTerm(clauseExec, termIndex, exec, ctx);
 
-        public static IQueryMatch ResolveNullTermSlot(ClauseInfo clause, ClauseExecution clauseExec, ResolutionContext ctx)
+        public static IQueryMatch ResolveNullTermSlot(ClauseExecution clauseExec, ResolutionContext ctx)
         {
             // Always emit a match for the null-term slot: TermQuery(null) when the
             // clause actually carries a null term, otherwise CreateEmpty so the OR/AND
             // step the IL emits against this slot is a no-op.
             var indexSearcher = ctx.IndexSearcher;
-            FieldMetadata nullMeta = ResolveFieldMetadata(clause, ctx);
+            FieldMetadata nullMeta = ResolveFieldMetadata(clauseExec.Clause, ctx);
             return clauseExec.HasNullTerm
                 ? indexSearcher.TermQuery(nullMeta, null)
                 : TermMatch.CreateEmpty(indexSearcher, indexSearcher.Allocator);
         }
 
-        public static IQueryMatch ResolveDefaultSlot(ClauseInfo clause, ClauseExecution clauseExec,
+        public static IQueryMatch ResolveDefaultSlot(ClauseExecution clauseExec,
             QueryExecution exec, ResolutionContext ctx)
         {
-            IQueryMatch match = clause.IsOrChainNotEquals
-                ? CreateNotEqualsOrMatch(clause, clauseExec, exec, ctx)
-                : ResolveClause(clauseExec, exec, ctx);
+            IQueryMatch match = ResolveClause(clauseExec, exec, ctx);
             if (clauseExec.BoostFactor > 0)
                 match = ctx.IndexSearcher.Boost(match, clauseExec.BoostFactor);
             return match;
@@ -1255,31 +1253,31 @@ internal static partial class QueryPlanBuilder
         // Precondition: callers (ResolveClauseLeavesInto) only dispatch here for clauses
         // where ClauseInfo.IsOrChainNotEquals is set. Such clauses use MatchDispatch.QueryMatch,
         // so the PostingSource slot is never read — return default and skip the lookup.
-        public static PostingSource ResolveSubClauseSlot(ClauseInfo sub, ClauseExecution subExec,
+        public static PostingSource ResolveSubClauseSlot(ClauseExecution subExec,
             QueryExecution exec, ResolutionContext ctx)
             => default;
 
-        public static PostingSource ResolveInTermSlot(ClauseInfo clause, ClauseExecution clauseExec, int termIndex,
+        public static PostingSource ResolveInTermSlot(ClauseExecution clauseExec, int termIndex,
             QueryExecution exec, ResolutionContext ctx)
-            => ResolveInTermSource(clause, clauseExec, termIndex, exec, ctx);
+            => ResolveInTermSource(clauseExec, termIndex, exec, ctx);
 
-        public static PostingSource ResolveNullTermSlot(ClauseInfo clause, ClauseExecution clauseExec, ResolutionContext ctx)
+        public static PostingSource ResolveNullTermSlot(ClauseExecution clauseExec, ResolutionContext ctx)
         {
             if (!clauseExec.HasNullTerm)
                 return default;
 
-            FieldMetadata nullMeta = ResolveFieldMetadata(clause, ctx);
+            FieldMetadata nullMeta = ResolveFieldMetadata(clauseExec.Clause, ctx);
             return ctx.IndexSearcher.TryGetPostingListForNull(in nullMeta, out long nullPlId)
                 ? DecodePostingListId(nullPlId, ctx.IndexSearcher)
                 : default;
         }
 
-        public static PostingSource ResolveDefaultSlot(ClauseInfo clause, ClauseExecution clauseExec,
+        public static PostingSource ResolveDefaultSlot(ClauseExecution clauseExec,
             QueryExecution exec, ResolutionContext ctx)
         {
             return clauseExec.BoostFactor > 0
                 ? default
-                : ResolveSingleTermSource(clause, clauseExec, exec, ctx);
+                : ResolveSingleTermSource(clauseExec, exec, ctx);
         }
     }
 
@@ -1291,31 +1289,31 @@ internal static partial class QueryPlanBuilder
         // Precondition: callers (ResolveClauseLeavesInto) only dispatch here for clauses
         // where ClauseInfo.IsOrChainNotEquals is set. Such clauses use MatchDispatch.QueryMatch,
         // so the ITermsProvider slot is never read.
-        public static ITermsProvider ResolveSubClauseSlot(ClauseInfo sub, ClauseExecution subExec,
+        public static ITermsProvider ResolveSubClauseSlot(ClauseExecution subExec,
             QueryExecution exec, ResolutionContext ctx)
             => null;
 
-        public static ITermsProvider ResolveInTermSlot(ClauseInfo clause, ClauseExecution clauseExec, int termIndex,
+        public static ITermsProvider ResolveInTermSlot(ClauseExecution clauseExec, int termIndex,
             QueryExecution exec, ResolutionContext ctx) => null;
 
-        public static ITermsProvider ResolveNullTermSlot(ClauseInfo clause, ClauseExecution clauseExec, ResolutionContext ctx) => null;
+        public static ITermsProvider ResolveNullTermSlot(ClauseExecution clauseExec, ResolutionContext ctx) => null;
 
-        public static ITermsProvider ResolveDefaultSlot(ClauseInfo clause, ClauseExecution clauseExec,
+        public static ITermsProvider ResolveDefaultSlot(ClauseExecution clauseExec,
             QueryExecution exec, ResolutionContext ctx)
-            => ResolveSingleTermsProvider(clause, clauseExec, exec, ctx);
+            => ResolveSingleTermsProvider(clauseExec, exec, ctx);
     }
 
-    private static IQueryMatch ResolveRangeClauseWithDirection(ClauseInfo clause, ClauseExecution exec,
+    private static IQueryMatch ResolveRangeClauseWithDirection(ClauseExecution exec,
         QueryExecution queryExec, bool forward, ResolutionContext walkerCtx)
     {
         var indexSearcher = walkerCtx.IndexSearcher;
-        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, walkerCtx);
+        FieldMetadata fieldMeta = ResolveFieldMetadata(exec.Clause, walkerCtx);
         var packed = exec.PackedParamValue;
 
-        return clause.ClauseType switch
+        return exec.ClauseType switch
         {
             ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual or ClauseType.LessThan or ClauseType.LessThanOrEqual
-                => RangeQueryFromParam(clause.ClauseType, packed, fieldMeta, indexSearcher, queryExec, forward),
+                => RangeQueryFromParam(exec.ClauseType, packed, fieldMeta, indexSearcher, queryExec, forward),
             ClauseType.Between when exec.SentinelRewriteType != null =>
                 ResolveSentinelRewrittenBetween(exec, fieldMeta, indexSearcher, queryExec),
             ClauseType.Between => BetweenQueryFromParam(packed, fieldMeta, indexSearcher, queryExec, forward),
@@ -1347,11 +1345,11 @@ internal static partial class QueryPlanBuilder
 
     /// <summary>Converts an Equals clause into a BetweenQuery(low==high==value) so
     /// it produces a TermsProviderMatch that SortedDrivingMatch can walk in sort order.</summary>
-    private static IQueryMatch ResolveEqualsClauseWithDirection(ClauseInfo clause, ClauseExecution exec,
+    private static IQueryMatch ResolveEqualsClauseWithDirection(ClauseExecution exec,
         QueryExecution queryExec, bool forward, ResolutionContext walkerCtx)
     {
         var indexSearcher = walkerCtx.IndexSearcher;
-        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, walkerCtx);
+        FieldMetadata fieldMeta = ResolveFieldMetadata(exec.Clause, walkerCtx);
         var packed = exec.PackedParamValue;
         return packed.ValueType switch
         {
@@ -1413,7 +1411,7 @@ internal static partial class QueryPlanBuilder
                 var temp = new RoaringBitmap(indexSearcher.Allocator);
                 for (int t = 0; t < cur.InTermCount; t++)
                 {
-                    var termMatch = ResolveInTerm(clause, cur, t, root, walkerCtx);
+                    var termMatch = ResolveInTerm(cur, t, root, walkerCtx);
                     if (clause.ClauseType == ClauseType.AllIn && t > 0)
                         QueryPrimitives.AndWithMatch(termMatch, ref bm.BitmapState, ref temp);
                     else
@@ -1481,7 +1479,7 @@ internal static partial class QueryPlanBuilder
 
             case ClauseType.Spatial:
             {
-                return HandleSpatial(builderParams, clause, cur, clause.SpatialMethodType);
+                return HandleSpatial(builderParams, cur, clause.SpatialMethodType);
             }
 
             case ClauseType.Vector:
@@ -1507,19 +1505,19 @@ internal static partial class QueryPlanBuilder
     /// Shared by <see cref="ResolveInTerm"/> (bitmap path) and <see cref="ResolveInTermSource"/>
     /// (posting-list path) to ensure field resolution and index arithmetic stay in sync.</summary>
     private static (FieldMetadata FieldMeta, PackedParam TermPacked) ResolveInTermParam(
-        ClauseInfo clause, ClauseExecution exec, int termIndex, ResolutionContext walkerCtx)
+        ClauseExecution exec, int termIndex, ResolutionContext walkerCtx)
     {
-        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, walkerCtx);
+        FieldMetadata fieldMeta = ResolveFieldMetadata(exec.Clause, walkerCtx);
         return (fieldMeta, exec.PackedParamValue.WithTermOffset(termIndex));
     }
 
     /// <summary>Resolve a single IN term to a typed TermQuery (bitmap path).
     /// IN terms are stored contiguously: PackedParamValue.Param1 = start index, InTermCount = count.
     /// Only non-null terms are in the typed array. Null is handled separately via HasNullTerm.</summary>
-    private static IQueryMatch ResolveInTerm(ClauseInfo clause, ClauseExecution exec, int termIndex,
+    private static IQueryMatch ResolveInTerm(ClauseExecution exec, int termIndex,
         QueryExecution queryExec, ResolutionContext walkerCtx)
     {
-        var (fieldMeta, termPacked) = ResolveInTermParam(clause, exec, termIndex, walkerCtx);
+        var (fieldMeta, termPacked) = ResolveInTermParam(exec, termIndex, walkerCtx);
         return TermQueryFromParam(termPacked, fieldMeta, walkerCtx.IndexSearcher, queryExec);
     }
 
@@ -1529,12 +1527,13 @@ internal static partial class QueryPlanBuilder
     /// pre-compute AllEntries ANDNOT (positive form) into a BitmapMatch so that OrWithMatch
     /// during execution correctly ORs in the set of entries NOT matching the positive predicate.
     /// Handles NOT EQUALS (single term), NOT EXISTS (ExistsQuery), and single-term NOT IN/AllIn.</summary>
-    private static IQueryMatch CreateNotEqualsOrMatch(ClauseInfo clause, ClauseExecution exec,
+    private static IQueryMatch CreateNotEqualsOrMatch(ClauseExecution exec,
         QueryExecution queryExec, ResolutionContext walkerCtx)
     {
         // Resolve the positive form of the match. For IN/AllIn clauses, ResolveClause
         // handles multi-term expansion correctly. For simple Equals/NotEquals, the
         // single-term TermQueryFromParam suffices. EXISTS clauses carry no PackedParam.
+        var clause = exec.Clause;
         var indexSearcher = walkerCtx.IndexSearcher;
         IQueryMatch termMatch;
         if (clause.ClauseType is ClauseType.In or ClauseType.AllIn)
@@ -1623,10 +1622,10 @@ internal static partial class QueryPlanBuilder
     /// Returns null for non-TreeScan clauses or when the field doesn't exist in the
     /// index (factory method returned TermMatch.Empty instead of TermsProviderMatch).
     /// Null slots cause the IL to fall through to the QueryMatch dispatch path.</summary>
-    private static ITermsProvider ResolveSingleTermsProvider(ClauseInfo clause, ClauseExecution exec,
+    private static ITermsProvider ResolveSingleTermsProvider(ClauseExecution exec,
         QueryExecution queryExec, ResolutionContext walkerCtx)
     {
-        if (IsTreeScanEligibleClause(clause) == false)
+        if (IsTreeScanEligibleClause(exec.Clause) == false)
             return null;
 
         // Create the match via the existing factory methods, then extract the provider.
@@ -1644,23 +1643,23 @@ internal static partial class QueryPlanBuilder
     /// <summary>Resolve a single Equals / NotEquals clause to a posting-list ID and
     /// decode it into a <see cref="PostingSource"/>. Returns Empty when the clause
     /// is non-term-shaped or the term doesn't exist in the index.</summary>
-    private static PostingSource ResolveSingleTermSource(ClauseInfo clause, ClauseExecution exec,
+    private static PostingSource ResolveSingleTermSource(ClauseExecution exec,
         QueryExecution queryExec, ResolutionContext walkerCtx)
     {
-        if (IsTermSourceEligibleClause(clause) == false)
+        if (IsTermSourceEligibleClause(exec.Clause) == false)
             return default; // Kind == Empty
 
-        FieldMetadata fieldMeta = ResolveFieldMetadata(clause, walkerCtx);
+        FieldMetadata fieldMeta = ResolveFieldMetadata(exec.Clause, walkerCtx);
         long postingListId = GetTermPostingListIdFromParam(exec.PackedParamValue, fieldMeta, walkerCtx.IndexSearcher, queryExec);
         return DecodePostingListId(postingListId, walkerCtx.IndexSearcher);
     }
 
     /// <summary>Resolve a single In/AllIn term to a posting-list source (posting-list path).
     /// Uses <see cref="ResolveInTermParam"/> for field resolution and index arithmetic.</summary>
-    private static PostingSource ResolveInTermSource(ClauseInfo clause, ClauseExecution exec, int termIndex,
+    private static PostingSource ResolveInTermSource(ClauseExecution exec, int termIndex,
         QueryExecution queryExec, ResolutionContext walkerCtx)
     {
-        var (fieldMeta, termPacked) = ResolveInTermParam(clause, exec, termIndex, walkerCtx);
+        var (fieldMeta, termPacked) = ResolveInTermParam(exec, termIndex, walkerCtx);
         return DecodePostingListId(GetTermPostingListIdFromParam(termPacked, fieldMeta, walkerCtx.IndexSearcher, queryExec), walkerCtx.IndexSearcher);
     }
 
@@ -1781,10 +1780,9 @@ internal static partial class QueryPlanBuilder
                 clauseIdx++;
             }
 
-            ClauseInfo matchingClause = clauseIdx < execs.Count ? execs[clauseIdx].Clause : null;
             ClauseExecution matchingExec = clauseIdx < execs.Count ? execs[clauseIdx] : null;
             clauseIdx++;
-            ExtractParamsFromPredicate(pred, matchingClause, matchingExec, indexSearcher, exec, longs, doubles, slices, roots);
+            ExtractParamsFromPredicate(pred, matchingExec, indexSearcher, exec, longs, doubles, slices, roots);
         }
 
         longParams = longs.Count > 0 ? longs.ToArray() : [];
@@ -1867,21 +1865,19 @@ internal static partial class QueryPlanBuilder
         fieldRootPages = roots.Count > 0 ? roots.ToArray() : null;
     }
 
-    private static void ExtractParamsFromPredicate(ScanPredicateInfo pred, ClauseInfo clause, ClauseExecution exec,
+    private static void ExtractParamsFromPredicate(ScanPredicateInfo pred, ClauseExecution exec,
         IndexSearcher indexSearcher, QueryExecution queryExec, List<long> longs, List<double> doubles,
         List<Slice> slices, List<long> roots)
     {
         if (pred.SubPredicates != null)
         {
             // Each OrBranch corresponds to a subclause of the OrGroup.
-            // Pass subclauses positionally to avoid the same field-name ambiguity.
-            List<ClauseInfo> subClauses = clause?.SubClauses;
+            // Pass sub-executions positionally to maintain the predicate-to-clause mapping.
             List<ClauseExecution> subExecs = exec?.SubExecutions;
             for (int b = 0; b < pred.SubPredicates.Length; b++)
             {
-                ClauseInfo subClause = (subClauses != null && b < subClauses.Count) ? subClauses[b] : null;
                 ClauseExecution subExec = (subExecs != null && b < subExecs.Count) ? subExecs[b] : null;
-                ExtractParamsFromPredicate(pred.SubPredicates[b], subClause, subExec, indexSearcher, queryExec, longs, doubles, slices, roots);
+                ExtractParamsFromPredicate(pred.SubPredicates[b], subExec, indexSearcher, queryExec, longs, doubles, slices, roots);
             }
 
             return;
@@ -1890,7 +1886,7 @@ internal static partial class QueryPlanBuilder
         // Resolve field root page
         roots.Add(indexSearcher.FieldCache.GetLookupRootPage(pred.FieldName));
 
-        if (clause == null || exec == null)
+        if (exec == null)
             return;
 
         // Read pre-resolved typed values from the queryExec's arrays via packed param.
@@ -1915,7 +1911,7 @@ internal static partial class QueryPlanBuilder
                 break;
             case ScanValueType.Slice:
             case ScanValueType.SliceLong:
-                var fieldMeta = indexSearcher.FieldMetadataBuilder(clause.FieldName);
+                var fieldMeta = indexSearcher.FieldMetadataBuilder(exec.Clause.FieldName);
                 slices.Add(indexSearcher.EncodeAndApplyAnalyzer(fieldMeta, queryExec.StringValues[idx1]));
                 if (hasBetween)
                     slices.Add(indexSearcher.EncodeAndApplyAnalyzer(fieldMeta, queryExec.StringValues[idx2]));
@@ -2529,20 +2525,19 @@ internal static partial class QueryPlanBuilder
         }
         else
         {
-            var drivingClause = execs[drivingIdx].Clause;
             var drivingExec = execs[drivingIdx];
 
             TermsProviderMatch tpm;
-            if (drivingClause.ClauseType == ClauseType.Equals)
+            if (drivingExec.ClauseType == ClauseType.Equals)
             {
-                var eqMatch = ResolveEqualsClauseWithDirection(drivingClause, drivingExec, ctx.Exec, forward, walkerCtx);
+                var eqMatch = ResolveEqualsClauseWithDirection(drivingExec, ctx.Exec, forward, walkerCtx);
                 if (eqMatch is not TermsProviderMatch eq)
                     return null;
                 tpm = eq;
             }
             else
             {
-                var match = ResolveRangeClauseWithDirection(drivingClause, drivingExec, ctx.Exec, forward, walkerCtx);
+                var match = ResolveRangeClauseWithDirection(drivingExec, ctx.Exec, forward, walkerCtx);
                 if (match is not TermsProviderMatch m)
                     return null;
                 tpm = m;
@@ -2550,7 +2545,7 @@ internal static partial class QueryPlanBuilder
 
             provider = tpm.Provider;
             llt = tpm.Llt;
-            drivingClauseDescription = $"{drivingClause.FieldName} {drivingClause.ClauseType}";
+            drivingClauseDescription = $"{drivingExec.Clause.FieldName} {drivingExec.ClauseType}";
         }
 
         // Residual predicates: reuse the list built during discovery when available;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -885,8 +885,7 @@ internal static partial class QueryPlanBuilder
                 case BindingSource.QueryParameter:
                 {
                     // Parameter — resolve from blittable. May be scalar or array.
-                    object inRaw = null;
-                    queryParameters?.TryGet(it.ParameterName, out inRaw);
+                    queryParameters.TryGet(it.ParameterName, out object inRaw);
                     if (inRaw is BlittableJsonReaderArray arr)
                     {
                         foreach (var elem in arr)
@@ -1001,7 +1000,7 @@ internal static partial class QueryPlanBuilder
     {
         if (binding.LiteralType != ParamValueType.Parameter)
             return (binding.LiteralValue, binding.LiteralType);
-        if (queryParameters != null && queryParameters.TryGet(binding.ParameterName, out object raw) && raw != null)
+        if (queryParameters.TryGet(binding.ParameterName, out object raw) && raw != null)
             return (raw, ParamValueType.Parameter); // raw from blittable — caller decides how to interpret
         return (null, ParamValueType.Null);
     }
@@ -1027,7 +1026,7 @@ internal static partial class QueryPlanBuilder
 
             case BindingSource.QueryParameter:
             default:
-                if (queryParameters != null && queryParameters.TryGet(binding.ParameterName, out object raw) && raw != null)
+                if (queryParameters.TryGet(binding.ParameterName, out object raw) && raw != null)
                 {
                     var (val, type) = ResolveParameterValue(raw);
                     return (val, ToParamValueType(type));
@@ -2759,9 +2758,9 @@ internal static partial class QueryPlanBuilder
         // Bounds-check before indexing — return null to indicate "no displayable value".
         return packed.ValueType switch
         {
-            PackedParam.TypeLong => idx < exec.LongValues?.Length ? exec.LongValues[idx].ToString() : null,
-            PackedParam.TypeDouble => idx < exec.DoubleValues?.Length ? exec.DoubleValues[idx].ToString(CultureInfo.InvariantCulture) : null,
-            _ => idx < exec.StringValues?.Length ? exec.StringValues[idx] : null
+            PackedParam.TypeLong => idx < exec.LongValues.Length ? exec.LongValues[idx].ToString() : null,
+            PackedParam.TypeDouble => idx < exec.DoubleValues.Length ? exec.DoubleValues[idx].ToString(CultureInfo.InvariantCulture) : null,
+            _ => idx < exec.StringValues.Length ? exec.StringValues[idx] : null
         };
     }
 
@@ -3496,15 +3495,14 @@ internal static partial class QueryPlanBuilder
 
     /// <summary>For an OrGroup or AndGroup clause, returns the parallel (sub-clauses, sub-executions)
     /// arrays that callers iterate to fan out one match slot per sub-term. Returns false for any
-    /// other clause type, or for empty groups. <paramref name="subExecs"/> is null when
-    /// <paramref name="exec"/> is null (TermsProviders path tolerates that).</summary>
+    /// other clause type, or for empty groups.</summary>
     internal static bool TryGetGroupFanOut(ClauseInfo clause, ClauseExecution exec,
         out List<ClauseInfo> subClauses, out List<ClauseExecution> subExecs)
     {
         if (clause.ClauseType is ClauseType.OrGroup or ClauseType.AndGroup && clause.SubClauses is { Count: > 0 })
         {
             subClauses = clause.SubClauses;
-            subExecs = exec?.SubExecutions;
+            subExecs = exec.SubExecutions;
             return true;
         }
 
@@ -3528,7 +3526,7 @@ internal static partial class QueryPlanBuilder
     /// from the direct dispatch (it walks the full tree regardless).</summary>
     internal static bool IsTreeScanEligibleClause(ClauseInfo clause)
     {
-        if (clause is null or { HasBoost: true })
+        if (clause.HasBoost)
             return false;
 
         if (clause.ClauseType is ClauseType.StartsWith or ClauseType.EndsWith
@@ -3571,7 +3569,7 @@ internal static partial class QueryPlanBuilder
     /// and recurses into subclauses using sub-execution types. Used when actual resolved
     /// types are available (per-execution, after PopulateClauseValues).</summary>
     internal static ScanPredicateInfo? BuildScanPredicateInfo(ClauseExecution exec, ref int longIndex, ref int doubleIndex, ref int sliceIndex)
-        => BuildScanPredicateInfoCore(exec, exec?.TermValueType ?? ParamValueType.String, ref longIndex, ref doubleIndex, ref sliceIndex);
+        => BuildScanPredicateInfoCore(exec, exec.TermValueType, ref longIndex, ref doubleIndex, ref sliceIndex);
 
     /// <summary>Eligibility-only probe: returns whether <see cref="BuildScanPredicateInfo"/>
     /// would have produced a non-null result for this execution, without allocating a
@@ -3752,7 +3750,7 @@ internal static partial class QueryPlanBuilder
     /// without walking the full clause/execution list.</summary>
     private static ScanValueType ClassifyParamType(BlittableJsonReaderObject queryParams, string name)
     {
-        if (queryParams == null || queryParams.TryGet(name, out object raw) == false || raw == null)
+        if (queryParams.TryGet(name, out object raw) == false || raw == null)
             return ScanValueType.Slice;
         return raw switch
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -210,7 +210,7 @@ internal static partial class QueryPlanBuilder
 
             if (ctx.Plan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.CompoundExactCandidate))
             {
-                if (TryCreateCompoundExactMatch(ref ctx))
+                if (TryCreateCompoundExactMatch(ref ctx, out ctx.RejectReason))
                 {
                     ctx.Plan.Strategy = ExecutionStrategy.CompoundExact;
                     ctx.Plan.DecisionTrail.Record("CompoundExact", true, "compound exact-term lookup");
@@ -227,7 +227,7 @@ internal static partial class QueryPlanBuilder
 
             if (ctx.Plan.Template.OptimizationFlags.HasFlag(PlanOptimizationFlags.DirectScanCandidate))
             {
-                if (TryCreateCompoundFieldMatch(ref ctx))
+                if (TryCreateCompoundFieldMatch(ref ctx, out ctx.RejectReason))
                 {
                     ctx.Plan.Strategy = ExecutionStrategy.CompoundField;
                     ctx.Plan.DecisionTrail.Record("CompoundField", true, "compound tree scan with ORDER BY");
@@ -235,7 +235,7 @@ internal static partial class QueryPlanBuilder
                 }
                 ctx.Plan.DecisionTrail.Record("CompoundField", false, ctx.RejectReason ?? "rejected");
 
-                if (TryCreateSimpleFieldDirectScan(ref ctx))
+                if (TryCreateSimpleFieldDirectScan(ref ctx, out _, out ctx.RejectReason))
                 {
                     ctx.Plan.Strategy = ExecutionStrategy.DirectScan;
                     ctx.Plan.DecisionTrail.Record("DirectScan", true, "direct tree scan on sort field");
@@ -1999,23 +1999,23 @@ internal static partial class QueryPlanBuilder
 
     // ── Compound field exact match (no ORDER BY) ─────────────────────────
 
-    public static bool TryCreateCompoundExactMatch(
-        QueryExecution exec, PlanParameters planParams, QueryBuilderParameters builderParams, out string rejectReason)
+    private static bool TryCreateCompoundExactMatch(
+        ref InstCtx ctx, out string rejectReason)
     {
-        if (planParams.Index is null || exec is not { 
-                Executions: { Count: >= 2 } executions, 
-                Plan: { 
-                    AllNegated: false, 
-                    CompoundExactClauseA: var a and >= 0, 
-                    CompoundExactClauseB: var b and >= 0 
-                } 
+        if (ctx.PlanParams.Index is null || ctx.Exec is not {
+                Executions: { Count: >= 2 } executions,
+                Plan: {
+                    AllNegated: false,
+                    CompoundExactClauseA: var a and >= 0,
+                    CompoundExactClauseB: var b and >= 0
+                }
             } || a >= executions.Count || b >= executions.Count)
         {
             rejectReason = "no compound-exact clause pair identified at template time";
             return false;
         }
 
-        if (IsClauseBoosted(executions[a]) || executions[a].PackedParamValue.IsNone || 
+        if (IsClauseBoosted(executions[a]) || executions[a].PackedParamValue.IsNone ||
             IsClauseBoosted(executions[b]) || executions[b].PackedParamValue.IsNone)
         {
             rejectReason = "composite key encoding failed or exceeded max term length, or clause is boosted";
@@ -2029,24 +2029,24 @@ internal static partial class QueryPlanBuilder
     /// <summary>Check if two Equals clauses on (field1, field2) match a compound field.
     /// If so, build a single TermQuery on the compound tree with the composite key.
     /// One tree lookup instead of two posting list intersections.</summary>
-    public static bool TryCreateCompoundExactMatch(
-        QueryExecution exec, PlanParameters planParams, QueryBuilderParameters builderParams)
+    private static bool TryCreateCompoundExactMatch(
+        ref InstCtx ctx)
     {
         // Discovery: structural rejection. All structural facts (CompoundExactClauseA/B,
         // CompoundExactAFirst) were pre-classified at template time; this method only
         // confirms the runtime state is compatible.
-        if (exec.Executions == null || exec.Executions.Count < 2 || exec.Plan.AllNegated)
+        if (ctx.Exec.Executions == null || ctx.Exec.Executions.Count < 2 || ctx.Exec.Plan.AllNegated)
             return false;
-        if (planParams.Index == null)
-            return false;
-
-        int idxA = exec.Plan.CompoundExactClauseA;
-        int idxB = exec.Plan.CompoundExactClauseB;
-        if (idxA < 0 || idxB < 0 || idxA >= exec.Executions.Count || idxB >= exec.Executions.Count)
+        if (ctx.PlanParams.Index == null)
             return false;
 
-        var eA = exec.Executions[idxA];
-        var eB = exec.Executions[idxB];
+        int idxA = ctx.Exec.Plan.CompoundExactClauseA;
+        int idxB = ctx.Exec.Plan.CompoundExactClauseB;
+        if (idxA < 0 || idxB < 0 || idxA >= ctx.Exec.Executions.Count || idxB >= ctx.Exec.Executions.Count)
+            return false;
+
+        var eA = ctx.Exec.Executions[idxA];
+        var eB = ctx.Exec.Executions[idxB];
         if (IsClauseBoosted(eA) || eA.PackedParamValue.IsNone)
             return false;
         if (IsClauseBoosted(eB) || eB.PackedParamValue.IsNone)
@@ -2061,18 +2061,18 @@ internal static partial class QueryPlanBuilder
     /// Returns null when a per-execution byte-length check fails — the caller must fall
     /// back to the next optimization (or bitmap). No cost gates here — those are encoded
     /// in the plan-cache key (cardinality cliff bit 31 of Ordering).</summary>
-    private static IQueryMatch ConstructCompoundExact(QueryExecution exec, PlanParameters planParams)
+    private static IQueryMatch ConstructCompoundExact(ref InstCtx ctx)
     {
-        var execs = exec.Executions;
-        var indexSearcher = planParams.IndexSearcher;
-        int idxA = exec.Plan.CompoundExactClauseA;
-        int idxB = exec.Plan.CompoundExactClauseB;
+        var execs = ctx.Exec.Executions;
+        var indexSearcher = ctx.PlanParams.IndexSearcher;
+        int idxA = ctx.Exec.Plan.CompoundExactClauseA;
+        int idxB = ctx.Exec.Plan.CompoundExactClauseB;
         var eA = execs[idxA];
         var eB = execs[idxB];
 
         string firstField, secondField;
         ClauseExecution firstExec, secondExec;
-        if (exec.Plan.Template.CompoundExactAFirst)
+        if (ctx.Exec.Plan.Template.CompoundExactAFirst)
         {
             firstField = eA.Clause.ResolvedFieldName ?? eA.Clause.FieldName;
             secondField = eB.Clause.ResolvedFieldName ?? eB.Clause.FieldName;
@@ -2087,10 +2087,10 @@ internal static partial class QueryPlanBuilder
             secondExec = eA;
         }
 
-        byte[] field1Bytes = BuildCompoundFieldBytes(firstField, firstExec, indexSearcher, exec);
+        byte[] field1Bytes = BuildCompoundFieldBytes(firstField, firstExec, indexSearcher, ctx.Exec);
         if (field1Bytes == null || field1Bytes.Length > byte.MaxValue) return null;
 
-        byte[] field2Bytes = BuildCompoundFieldBytes(secondField, secondExec, indexSearcher, exec);
+        byte[] field2Bytes = BuildCompoundFieldBytes(secondField, secondExec, indexSearcher, ctx.Exec);
         if (field2Bytes == null) return null;
 
         int totalLen = field1Bytes.Length + field2Bytes.Length + 1;
@@ -2103,7 +2103,7 @@ internal static partial class QueryPlanBuilder
 
         var compoundFieldName = $"compound({firstField},{secondField})";
         var compoundFieldMeta = indexSearcher.FieldMetadataBuilder(compoundFieldName, hasBoost: false);
-        Slice.From(planParams.Allocator, compositeKey, out var keySlice);
+        Slice.From(ctx.PlanParams.Allocator, compositeKey, out var keySlice);
 
         return indexSearcher.TermQuery(compoundFieldMeta, keySlice);
     }
@@ -2146,26 +2146,24 @@ internal static partial class QueryPlanBuilder
     /// entry-scan eligible.
     /// Returns a DirectScanMatch wrapping a compound tree StartsWith with optional
     /// residual predicate checking.</summary>
-    public static bool TryCreateCompoundFieldMatch(
-        QueryExecution exec, OrderMetadata[] orderByFields,
-        PlanParameters planParams, QueryBuilderParameters builderParams,
-        CompiledPlan compiledPlan, out string rejectReason)
+    private static bool TryCreateCompoundFieldMatch(
+        ref InstCtx ctx, out string rejectReason)
     {
-        if (exec.Plan.CompoundFieldDrivingClause < 0 || exec.Plan.Template.CompoundFieldSortName is null)
+        if (ctx.Exec.Plan.CompoundFieldDrivingClause < 0 || ctx.Exec.Plan.Template.CompoundFieldSortName is null)
         {
             rejectReason = "no compound-field candidate identified at template time";
             return false;
         }
-        var execs = exec.Executions;
-        if (exec.Plan.CompoundFieldDrivingClause >= execs.Count || exec.Plan.AllNegated)
+        var execs = ctx.Exec.Executions;
+        if (ctx.Exec.Plan.CompoundFieldDrivingClause >= execs.Count || ctx.Exec.Plan.AllNegated)
         {
-            rejectReason = "all clauses are negated";   
+            rejectReason = "all clauses are negated";
             return false;
         }
 
-        var indexSearcher = planParams.IndexSearcher;
+        var indexSearcher = ctx.PlanParams.IndexSearcher;
 
-        var drivingExec = execs[exec.Plan.CompoundFieldDrivingClause];
+        var drivingExec = execs[ctx.Exec.Plan.CompoundFieldDrivingClause];
         if (drivingExec.PackedParamValue.IsNone)
         {
             rejectReason = "driving clause has no packed param value";
@@ -2174,7 +2172,7 @@ internal static partial class QueryPlanBuilder
 
         // Find optional field2 range narrowing clause (structural — same for all
         // executions of this template).
-        int field2RangeIdx = FindCompoundFieldField2Range(execs, exec.Plan.CompoundFieldDrivingClause, exec.Plan.Template.CompoundFieldSortName);
+        int field2RangeIdx = FindCompoundFieldField2Range(execs, ctx.Exec.Plan.CompoundFieldDrivingClause, ctx.Exec.Plan.Template.CompoundFieldSortName);
 
         // Residual scannability + cost check
         int longIdx = 0, doubleIdx = 0, sliceIdx = 0;
@@ -2183,7 +2181,7 @@ internal static partial class QueryPlanBuilder
         for (int i = 0; i < execs.Count; i++)
         {
             bitmapCost += EffectiveCardinality(execs[i], indexSearcher);
-            if (i == exec.Plan.CompoundFieldDrivingClause || i == field2RangeIdx)
+            if (i == ctx.Exec.Plan.CompoundFieldDrivingClause || i == field2RangeIdx)
                 continue;
             if (IsClauseBoosted(execs[i]))
             {
@@ -2201,7 +2199,7 @@ internal static partial class QueryPlanBuilder
 
         long drivingCardinality = EffectiveCardinality(drivingExec, indexSearcher);
         long entriesToScan = residualCount > 0
-            ? AdjustEntriesToScanByMinResidual(execs, exec.Plan.CompoundFieldDrivingClause, drivingCardinality, indexSearcher)
+            ? AdjustEntriesToScanByMinResidual(execs, ctx.Exec.Plan.CompoundFieldDrivingClause, drivingCardinality, indexSearcher)
             : drivingCardinality;
 
         if (IsDirectScanCostEffective(entriesToScan, bitmapCost) == false)
@@ -2240,15 +2238,14 @@ internal static partial class QueryPlanBuilder
     /// Returns null on per-execution failure (e.g. analyzed prefix exceeds 255 bytes);
     /// caller falls back to the next optimization or bitmap.</summary>
     private static IQueryMatch ConstructCompoundField(
-        QueryExecution exec, OrderMetadata[] orderByFields,
-        PlanParameters planParams, QueryBuilderParameters builderParams, CompiledPlan compiledPlan,
+        ref InstCtx ctx,
         int field2RangeIdx, long entriesToScan, long bitmapCost)
     {
-        var execs = exec.Executions;
-        var indexSearcher = planParams.IndexSearcher;
-        var allocator = planParams.Allocator;
-        int drivingClauseIdx = exec.Plan.CompoundFieldDrivingClause;
-        string sortFieldName = exec.Plan.Template.CompoundFieldSortName;
+        var execs = ctx.Exec.Executions;
+        var indexSearcher = ctx.PlanParams.IndexSearcher;
+        var allocator = ctx.PlanParams.Allocator;
+        int drivingClauseIdx = ctx.Exec.Plan.CompoundFieldDrivingClause;
+        string sortFieldName = ctx.Exec.Plan.Template.CompoundFieldSortName;
 
         var drivingClause = execs[drivingClauseIdx].Clause;
         var drivingExec = execs[drivingClauseIdx];
@@ -2280,14 +2277,14 @@ internal static partial class QueryPlanBuilder
         {
             case PackedParam.TypeString:
             {
-                field1ValueStr = exec.StringValues[packed.Param1];
-                var field1Meta = GetCompoundFieldMetadata(builderParams, indexSearcher, field1Name);
+                field1ValueStr = ctx.Exec.StringValues[packed.Param1];
+                var field1Meta = GetCompoundFieldMetadata(ctx.BuilderParams, indexSearcher, field1Name);
                 analyzedPrefix = indexSearcher.EncodeAndApplyAnalyzer(field1Meta, field1ValueStr);
                 break;
             }
             case PackedParam.TypeLong:
             {
-                long longVal = exec.LongValues[packed.Param1];
+                long longVal = ctx.Exec.LongValues[packed.Param1];
                 field1ValueStr = longVal.ToString();
                 var bytes = new byte[sizeof(long)];
                 BinaryPrimitives.WriteInt64BigEndian(bytes, Bits.SwapBytes(longVal));
@@ -2296,7 +2293,7 @@ internal static partial class QueryPlanBuilder
             }
             case PackedParam.TypeDouble:
             {
-                double dblVal = exec.DoubleValues[packed.Param1];
+                double dblVal = ctx.Exec.DoubleValues[packed.Param1];
                 field1ValueStr = dblVal.ToString(CultureInfo.InvariantCulture);
                 long sortable = Bits.DoubleToSortableLong(dblVal);
                 var bytes = new byte[sizeof(long)];
@@ -2332,15 +2329,15 @@ internal static partial class QueryPlanBuilder
 
                 if (field2Packed.ValueType is PackedParam.TypeLong or PackedParam.TypeDouble)
                 {
-                    field2Bytes = EncodeNumericBoundBigEndian(exec, field2Packed.ValueType, field2Packed.Param1);
+                    field2Bytes = EncodeNumericBoundBigEndian(ctx.Exec, field2Packed.ValueType, field2Packed.Param1);
                     if (field2Clause.ClauseType == ClauseType.Between)
-                        field2HighBytes = EncodeNumericBoundBigEndian(exec, field2Packed.ValueType, field2Packed.Param2);
+                        field2HighBytes = EncodeNumericBoundBigEndian(ctx.Exec, field2Packed.ValueType, field2Packed.Param2);
                 }
                 else if (field2Packed.ValueType == PackedParam.TypeString)
                 {
                     // Analyze field2's value with the sort field's analyzer (same as indexing)
-                    var field2Meta = GetCompoundFieldMetadata(builderParams, indexSearcher, sortFieldName);
-                    var analyzed = indexSearcher.EncodeAndApplyAnalyzer(field2Meta, exec.StringValues[field2Packed.Param1]);
+                    var field2Meta = GetCompoundFieldMetadata(ctx.BuilderParams, indexSearcher, sortFieldName);
+                    var analyzed = indexSearcher.EncodeAndApplyAnalyzer(field2Meta, ctx.Exec.StringValues[field2Packed.Param1]);
                     if (analyzed.Size > byte.MaxValue)
                         usePrefix = true;
                     else
@@ -2349,7 +2346,7 @@ internal static partial class QueryPlanBuilder
                         analyzed.CopyTo(field2Bytes);
                         if (field2Clause.ClauseType == ClauseType.Between)
                         {
-                            var analyzedHigh = indexSearcher.EncodeAndApplyAnalyzer(field2Meta, exec.StringValues[field2Packed.Param2]);
+                            var analyzedHigh = indexSearcher.EncodeAndApplyAnalyzer(field2Meta, ctx.Exec.StringValues[field2Packed.Param2]);
                             if (analyzedHigh.Size > byte.MaxValue)
                                 usePrefix = true;
                             else
@@ -2369,7 +2366,7 @@ internal static partial class QueryPlanBuilder
                 {
                     // Field2 value too long or unsupported type — fall back to prefix-only
                     drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
-                        isNegated: false, forward: orderByFields[0].Ascending,
+                        isNegated: false, forward: ctx.OrderByFields[0].Ascending,
                         validatePostfixLen: true);
                 }
                 else
@@ -2386,7 +2383,7 @@ internal static partial class QueryPlanBuilder
                     if (keyLen > Constants.Terms.MaxLength || highKeyLen > Constants.Terms.MaxLength)
                     {
                         drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
-                            isNegated: false, forward: orderByFields[0].Ascending, validatePostfixLen: true);
+                            isNegated: false, forward: ctx.OrderByFields[0].Ascending, validatePostfixLen: true);
                         goto DrivingMatchReady;
                     }
 
@@ -2425,7 +2422,7 @@ internal static partial class QueryPlanBuilder
 
                     drivingMatch = indexSearcher.RangeBuilder<Range.Inclusive, Range.Inclusive>(
                         compoundFieldMeta, lowSlice, highSlice,
-                        forward: orderByFields[0].Ascending, CancellationToken.None);
+                        forward: ctx.OrderByFields[0].Ascending, CancellationToken.None);
                 }
             }
         }
@@ -2433,7 +2430,7 @@ internal static partial class QueryPlanBuilder
         {
             // Pure prefix scan (no field2 constraint)
             drivingMatch = indexSearcher.StartWithQuery(compoundFieldMeta, analyzedPrefix,
-                isNegated: false, forward: orderByFields[0].Ascending,
+                isNegated: false, forward: ctx.OrderByFields[0].Ascending,
                 validatePostfixLen: true);
         }
 
@@ -2441,17 +2438,17 @@ internal static partial class QueryPlanBuilder
 
         // Extract scan parameters for residual predicates
         ScanPredicateInfo[] residualArray = residualPreds.Count > 0 ? residualPreds.ToArray() : null;
-        BuildResidualScanParams(exec, indexSearcher, allocator, residualArray,
+        BuildResidualScanParams(ctx.Exec, indexSearcher, allocator, residualArray,
             drivingClauseIdx, field2RangeIdx,
             out var longParams, out var doubleParams, out var sliceParams, out var fieldRootPages);
 
         var directScan = BuildDirectScan(
             indexSearcher, drivingMatch, longParams, doubleParams, sliceParams, fieldRootPages,
-            compiledPlan.CompiledEntryPredicate, residualArray);
+            ctx.Plan.CompiledEntryPredicate, residualArray);
         directScan.DrivingTreeName = compoundFieldName;
         directScan.DrivingClause = $"{field1Name} = '{field1ValueStr}'";
         directScan.SeekBound = $"'{field1ValueStr}' (prefix, validatePostfixLen)";
-        directScan.Direction = orderByFields[0].Ascending ? "Forward" : "Backward";
+        directScan.Direction = ctx.OrderByFields[0].Ascending ? "Forward" : "Backward";
         directScan.ResidualDescription = residualArray != null
             ? string.Join(", ", residualPreds.ConvertAll(p => $"{p.FieldName} {p.CompareOp}"))
             : null;
@@ -2461,23 +2458,21 @@ internal static partial class QueryPlanBuilder
     }
 
     /// <summary>Check if a range clause on the ORDER BY field can be served by a direct</summary>
-    public static bool TryCreateSimpleFieldDirectScan(
-        QueryExecution exec, OrderMetadata[] orderByFields,
-        PlanParameters planParams, QueryBuilderParameters builderParams,
-        CompiledPlan compiledPlan, out IQueryMatch directMatch, out string rejectReason)
+    private static bool TryCreateSimpleFieldDirectScan(
+        ref InstCtx ctx, out IQueryMatch directMatch, out string rejectReason)
     {
         rejectReason = null;
-        bool result = TryCreateSimpleFieldDirectScan(exec, orderByFields, planParams, builderParams, compiledPlan, out directMatch);
+        bool result = TryCreateSimpleFieldDirectScan(ref ctx, out directMatch);
         if (!result)
         {
-            if (orderByFields == null || orderByFields.Length == 0)
+            if (ctx.OrderByFields == null || ctx.OrderByFields.Length == 0)
                 rejectReason = "no ORDER BY fields";
-            else if (orderByFields.Length > 2)
-                rejectReason = $"ORDER BY has {orderByFields.Length} fields (max 2 for direct scan)";
-            else if (orderByFields.Length == 2 && orderByFields[1].FieldType is not (MatchCompareFieldType.Integer or MatchCompareFieldType.Floating))
-                rejectReason = $"tie-break field type {orderByFields[1].FieldType} is not numeric";
-            else if (exec.Executions is { Count: > 0 } && exec.Plan.SortDrivingClauseIndex < 0)
-                rejectReason = $"no range/equals clause on sort field '{orderByFields[0].Field.FieldName}'";
+            else if (ctx.OrderByFields.Length > 2)
+                rejectReason = "ORDER BY has too many fields (max 2 for direct scan)";
+            else if (ctx.OrderByFields.Length == 2 && ctx.OrderByFields[1].FieldType is not (MatchCompareFieldType.Integer or MatchCompareFieldType.Floating))
+                rejectReason = "tie-break field type is not numeric (must be Integer or Floating)";
+            else if (ctx.Exec.Executions is { Count: > 0 } && ctx.Exec.Plan.SortDrivingClauseIndex < 0)
+                rejectReason = "no range/equals clause on sort field";
             else
                 rejectReason = "cost check failed (bitmap is cheaper), non-scannable residual, or cardinality too high for tie-break";
         }
@@ -2487,10 +2482,8 @@ internal static partial class QueryPlanBuilder
 
     /// <summary>tree scan instead of the bitmap pipeline. The range query already walks the tree
     /// in sort order, so no SortingMatch wrapper is needed.</summary>
-    public static bool TryCreateSimpleFieldDirectScan(
-        QueryExecution exec, OrderMetadata[] orderByFields,
-        PlanParameters planParams, QueryBuilderParameters builderParams,
-        CompiledPlan compiledPlan, out IQueryMatch directMatch)
+    private static bool TryCreateSimpleFieldDirectScan(
+        ref InstCtx ctx, out IQueryMatch directMatch)
     {
         directMatch = null;
 
@@ -2498,28 +2491,28 @@ internal static partial class QueryPlanBuilder
         // scannability + cost check. Per Phase 5, all per-execution rebuilds of
         // the live match are routed through ConstructDirectScan; this method
         // only validates the runtime state is compatible and then delegates.
-        if (orderByFields == null || orderByFields.Length == 0)
+        if (ctx.OrderByFields == null || ctx.OrderByFields.Length == 0)
             return false;
 
-        if (orderByFields.Length > 2)
+        if (ctx.OrderByFields.Length > 2)
             return false;
 
-        bool hasTieBreak = orderByFields.Length == 2;
+        bool hasTieBreak = ctx.OrderByFields.Length == 2;
         if (hasTieBreak)
         {
-            var tieBreakType = orderByFields[1].FieldType;
+            var tieBreakType = ctx.OrderByFields[1].FieldType;
             if (tieBreakType is not (MatchCompareFieldType.Integer or MatchCompareFieldType.Floating or MatchCompareFieldType.Sequence))
                 return false;
         }
 
-        var indexSearcher = planParams.IndexSearcher;
-        string sortFieldName = orderByFields[0].Field.FieldName.ToString();
-        var sortFieldType = orderByFields[0].FieldType;
+        var indexSearcher = ctx.PlanParams.IndexSearcher;
+        string sortFieldName = ctx.OrderByFields[0].Field.FieldName.ToString();
+        var sortFieldType = ctx.OrderByFields[0].FieldType;
 
-        var execs = exec.Executions;
+        var execs = ctx.Exec.Executions;
         bool isFullScan = execs == null || execs.Count == 0;
 
-        if (isFullScan && exec.Plan.AllNegated)
+        if (isFullScan && ctx.Exec.Plan.AllNegated)
             return false;
 
         // ── Discovery: drivingIdx + cost gate ──
@@ -2530,7 +2523,7 @@ internal static partial class QueryPlanBuilder
         {
             // SortDrivingClauseIndex pre-identified at template time and remapped to
             // post-sort index during Build — skip the per-execution clause scan.
-            drivingIdx = exec.Plan.SortDrivingClauseIndex;
+            drivingIdx = ctx.Exec.Plan.SortDrivingClauseIndex;
             if (drivingIdx == -1)
             {
                 // Fallback: template didn't identify a candidate (e.g. WHEN eliminated the
@@ -2567,7 +2560,7 @@ internal static partial class QueryPlanBuilder
                 bitmapCost += EffectiveCardinality(execs[i], indexSearcher);
                 if (i == drivingIdx) continue;
                 // Boost is ruled out at template time (see ComputeOptFlags).
-                var pred = BuildScanPredicateInfo( execs[i], ref rlongIdx, ref rdoubleIdx, ref rsliceIdx);
+                var pred = BuildScanPredicateInfo(execs[i], ref rlongIdx, ref rdoubleIdx, ref rsliceIdx);
                 if (pred == null)
                     return false;
                 preBuiltResiduals ??= new List<ScanPredicateInfo>();
@@ -2585,14 +2578,13 @@ internal static partial class QueryPlanBuilder
         else
         {
             // Full-scan structural eligibility checks (would-cause-empty paths).
-            if (orderByFields[0].MayHaveMissingEntries)
+            if (ctx.OrderByFields[0].MayHaveMissingEntries)
                 return false;
             if (sortFieldType is not (MatchCompareFieldType.Sequence or MatchCompareFieldType.Integer or MatchCompareFieldType.Floating))
                 return false;
         }
 
-        directMatch = ConstructDirectScan(exec, orderByFields, planParams, builderParams, compiledPlan,
-            drivingIdx, isFullScan, hasTieBreak, entriesToScan, bitmapCost, preBuiltResiduals);
+        directMatch = ConstructDirectScan(ref ctx, drivingIdx, isFullScan, hasTieBreak, entriesToScan, bitmapCost, preBuiltResiduals);
         return directMatch != null;
     }
 
@@ -2603,18 +2595,17 @@ internal static partial class QueryPlanBuilder
     /// runtime check fails (e.g. driving match resolution returns non-TermsProviderMatch
     /// or tie-break group cap exceeded by current parameter cardinality).</summary>
     private static IQueryMatch ConstructDirectScan(
-        QueryExecution exec, OrderMetadata[] orderByFields,
-        PlanParameters planParams, QueryBuilderParameters builderParams, CompiledPlan compiledPlan,
+        ref InstCtx ctx,
         int drivingIdx, bool isFullScan, bool hasTieBreak,
         long entriesToScan, long bitmapCost,
         List<ScanPredicateInfo> preBuiltResiduals = null)
     {
-        var indexSearcher = planParams.IndexSearcher;
-        var walkerCtx = new ResolutionContext(builderParams);
-        string sortFieldName = orderByFields[0].Field.FieldName.ToString();
-        bool forward = orderByFields[0].Ascending;
-        var sortFieldType = orderByFields[0].FieldType;
-        var execs = exec.Executions;
+        var indexSearcher = ctx.PlanParams.IndexSearcher;
+        var walkerCtx = new ResolutionContext(ctx.BuilderParams);
+        string sortFieldName = ctx.OrderByFields[0].Field.FieldName.ToString();
+        bool forward = ctx.OrderByFields[0].Ascending;
+        var sortFieldType = ctx.OrderByFields[0].FieldType;
+        var execs = ctx.Exec.Executions;
 
         ITermsProvider provider;
         LowLevelTransaction llt;
@@ -2622,7 +2613,7 @@ internal static partial class QueryPlanBuilder
 
         if (isFullScan)
         {
-            var fieldMeta = orderByFields[0].Field;
+            var fieldMeta = ctx.OrderByFields[0].Field;
             IQueryMatch fullScanMatch;
             if (sortFieldType == MatchCompareFieldType.Integer)
                 fullScanMatch = indexSearcher.BetweenQuery(fieldMeta, long.MinValue, long.MaxValue, forward: forward);
@@ -2644,14 +2635,14 @@ internal static partial class QueryPlanBuilder
             TermsProviderMatch tpm;
             if (drivingClause.ClauseType == ClauseType.Equals)
             {
-                var eqMatch = ResolveEqualsClauseWithDirection(drivingClause, drivingExec, exec, forward, walkerCtx);
+                var eqMatch = ResolveEqualsClauseWithDirection(drivingClause, drivingExec, ctx.Exec, forward, walkerCtx);
                 if (eqMatch is not TermsProviderMatch eq)
                     return null;
                 tpm = eq;
             }
             else
             {
-                var match = ResolveRangeClauseWithDirection(drivingClause, drivingExec, exec, forward, walkerCtx);
+                var match = ResolveRangeClauseWithDirection(drivingClause, drivingExec, ctx.Exec, forward, walkerCtx);
                 if (match is not TermsProviderMatch m)
                     return null;
                 tpm = m;
@@ -2671,7 +2662,7 @@ internal static partial class QueryPlanBuilder
             for (int i = 0; i < execs.Count; i++)
             {
                 if (i == drivingIdx) continue;
-                var pred = BuildScanPredicateInfo( execs[i], ref longIdx, ref doubleIdx, ref sliceIdx);
+                var pred = BuildScanPredicateInfo(execs[i], ref longIdx, ref doubleIdx, ref sliceIdx);
                 if (pred == null)
                     return null;
                 residualPreds ??= new List<ScanPredicateInfo>();
@@ -2682,39 +2673,39 @@ internal static partial class QueryPlanBuilder
         // ── Create the driving match ──
         // BetweenQuery and StartWithQuery don't include nulls in their term output,
         // so SortedDrivingMatch must drain them itself (respecting nullFirst direction).
-        bool nullIsSmallest = (orderByFields[0].NullsSortMode ?? builderParams.Index.Configuration.NullsSortMode) == NullsSortMode.NullsSmallest;
+        bool nullIsSmallest = (ctx.OrderByFields[0].NullsSortMode ?? ctx.BuilderParams.Index.Configuration.NullsSortMode) == NullsSortMode.NullsSmallest;
         bool nullFirst = forward ? nullIsSmallest : !nullIsSmallest;
         IQueryMatch drivingMatch;
         if (hasTieBreak)
         {
             // Secondary field uses its own NullsSortMode — distinct from the primary field's.
-            bool secondaryNullIsSmallest = (orderByFields[1].NullsSortMode ?? builderParams.Index.Configuration.NullsSortMode) == NullsSortMode.NullsSmallest;
-            int take = builderParams?.Take ?? Constants.IndexSearcher.TakeAll;
+            bool secondaryNullIsSmallest = (ctx.OrderByFields[1].NullsSortMode ?? ctx.BuilderParams.Index.Configuration.NullsSortMode) == NullsSortMode.NullsSmallest;
+            int take = ctx.BuilderParams?.Take ?? Constants.IndexSearcher.TakeAll;
             drivingMatch = new SortedDrivingWithTieBreakMatch(
-                provider, llt, planParams.Allocator, indexSearcher,
-                orderByFields[0].Field, orderByFields[1].Field,
-                orderByFields[1].FieldType, secondaryDescending: !orderByFields[1].Ascending,
+                provider, llt, ctx.PlanParams.Allocator, indexSearcher,
+                ctx.OrderByFields[0].Field, ctx.OrderByFields[1].Field,
+                ctx.OrderByFields[1].FieldType, secondaryDescending: !ctx.OrderByFields[1].Ascending,
                 nullFirst: nullFirst, nullIsSmallest: secondaryNullIsSmallest,
                 take: take);
         }
         else
         {
-            drivingMatch = new SortedDrivingMatch(provider, llt, planParams.Allocator,
-                indexSearcher, orderByFields[0].Field, nullFirst);
+            drivingMatch = new SortedDrivingMatch(provider, llt, ctx.PlanParams.Allocator,
+                indexSearcher, ctx.OrderByFields[0].Field, nullFirst);
         }
 
         // ── Residual scan parameters ──
         ScanPredicateInfo[] residualArray = residualPreds is { Count: > 0 } ? residualPreds.ToArray() : null;
-        BuildResidualScanParams(exec, indexSearcher, planParams.Allocator, residualArray,
+        BuildResidualScanParams(ctx.Exec, indexSearcher, ctx.PlanParams.Allocator, residualArray,
             drivingIdx, -1,
             out var longParams, out var doubleParams, out var sliceParams, out var fieldRootPages);
 
         var ds = BuildDirectScan(
             indexSearcher, drivingMatch, longParams, doubleParams, sliceParams, fieldRootPages,
-            compiledPlan.CompiledEntryPredicate, residualArray);
+            ctx.Plan.CompiledEntryPredicate, residualArray);
         ds.DrivingTreeName = sortFieldName;
         ds.DrivingClause = drivingClauseDescription;
-        ds.Direction = orderByFields[0].Ascending ? "Forward" : "Backward";
+        ds.Direction = ctx.OrderByFields[0].Ascending ? "Forward" : "Backward";
         ds.ResidualDescription = residualArray != null
             ? string.Join(", ", residualPreds.ConvertAll(p => $"{p.FieldName} {p.CompareOp}"))
             : null;
@@ -3846,32 +3837,4 @@ internal static partial class QueryPlanBuilder
         };
     }
 
-    // ── InstCtx overloads — thin wrappers so Instantiate callers pass one struct ──
-
-    private static bool TryCreateCompoundExactMatch(ref InstCtx ctx)
-    {
-        bool result = TryCreateCompoundExactMatch(ctx.Exec, ctx.PlanParams, ctx.BuilderParams, out ctx.RejectReason);
-        return result;
-    }
-
-    private static bool TryCreateCompoundFieldMatch(ref InstCtx ctx)
-    {
-        bool result = TryCreateCompoundFieldMatch(ctx.Exec, ctx.OrderByFields, ctx.PlanParams, ctx.BuilderParams, ctx.Plan, out ctx.RejectReason);
-        return result;
-    }
-
-    private static bool TryCreateSimpleFieldDirectScan(ref InstCtx ctx)
-    {
-        bool result = TryCreateSimpleFieldDirectScan(ctx.Exec, ctx.OrderByFields, ctx.PlanParams, ctx.BuilderParams, ctx.Plan, out _, out ctx.RejectReason);
-        return result;
-    }
-
-    private static IQueryMatch ConstructCompoundExact(ref InstCtx ctx)
-        => ConstructCompoundExact(ctx.Exec, ctx.PlanParams);
-
-    private static IQueryMatch ConstructCompoundField(ref InstCtx ctx, int field2RangeIdx, long entriesToScan, long bitmapCost)
-        => ConstructCompoundField(ctx.Exec, ctx.OrderByFields, ctx.PlanParams, ctx.BuilderParams, ctx.Plan, field2RangeIdx, entriesToScan, bitmapCost);
-
-    private static IQueryMatch ConstructDirectScan(ref InstCtx ctx, int drivingIdx, bool isFullScan, bool hasTieBreak, long entriesToScan, long bitmapCost)
-        => ConstructDirectScan(ctx.Exec, ctx.OrderByFields, ctx.PlanParams, ctx.BuilderParams, ctx.Plan, drivingIdx, isFullScan, hasTieBreak, entriesToScan, bitmapCost);
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -807,7 +807,7 @@ internal static partial class QueryPlanBuilder
             }
             case ClauseType.In or ClauseType.AllIn:
                 // IN/AllIn: each binding is a term (literal or parameter, possibly array-expanding)
-                ResolveInFromBindings(exec.Clause, exec, queryParameters, writer, bindings, builderParameters);
+                ResolveInFromBindings(exec, queryParameters, writer, bindings, builderParameters);
                 break;
             default:
                 // Simple clause (Equals, Range, Search, Regex, etc.): single value at Bindings[0]
@@ -861,9 +861,8 @@ internal static partial class QueryPlanBuilder
     /// Array-expanding query parameters (e.g. <c>@ids</c> bound to a JSON array) are
     /// flattened inline. Null values are never added to the buffers — they set
     /// <c>hasNullTerm</c> so the posting-list resolver queries the null-term list separately.</summary>
-    private static void ResolveInFromBindings(ClauseInfo clause, ClauseExecution exec,
-        BlittableJsonReaderObject queryParameters, ValueWriter writer, ParameterBinding[] bindings,
-        QueryBuilderParameters builderParameters)
+    private static void ResolveInFromBindings(ClauseExecution exec, BlittableJsonReaderObject queryParameters, ValueWriter writer, 
+        ParameterBinding[] bindings, QueryBuilderParameters builderParameters)
     {
         var resolvedValues = new List<object>(bindings.Length);
         var termTypes = new List<ParamValueType>(bindings.Length);
@@ -874,7 +873,11 @@ internal static partial class QueryPlanBuilder
             switch (it.Source)
             {
                 case BindingSource.Literal:
-                    if (it.LiteralValue == null) { hasNullTerm = true; break; }
+                    if (it.LiteralValue == null)
+                    {
+                        hasNullTerm = true; 
+                        continue;
+                    }
                     resolvedValues.Add(it.LiteralValue);
                     termTypes.Add(it.LiteralType);
                     break;
@@ -889,7 +892,11 @@ internal static partial class QueryPlanBuilder
                         foreach (var elem in arr)
                         {
                             var (elemVal, elemType) = ResolveParameterValue(elem);
-                            if (elemVal == null) { hasNullTerm = true; continue; }
+                            if (elemVal == null)
+                            {
+                                hasNullTerm = true; 
+                                continue;
+                            }
                             resolvedValues.Add(elemVal);
                             termTypes.Add(ToParamValueType(elemType));
                         }
@@ -897,7 +904,11 @@ internal static partial class QueryPlanBuilder
                     else if (inRaw != null)
                     {
                         var (singleVal, singleType) = ResolveParameterValue(inRaw);
-                        if (singleVal == null) { hasNullTerm = true; break; }
+                        if (singleVal == null)
+                        {
+                            hasNullTerm = true; 
+                            continue;
+                        }
                         resolvedValues.Add(singleVal);
                         termTypes.Add(ToParamValueType(singleType));
                     }
@@ -911,7 +922,11 @@ internal static partial class QueryPlanBuilder
                 case BindingSource.DeferredMethod:
                 {
                     var (val, type) = ResolveBindingScalar(it, queryParameters, builderParameters);
-                    if (val == null) { hasNullTerm = true; break; }
+                    if (val == null)
+                    {
+                        hasNullTerm = true; 
+                        continue;
+                    }
                     resolvedValues.Add(val);
                     termTypes.Add(type);
                     break;
@@ -1135,7 +1150,10 @@ internal static partial class QueryPlanBuilder
         var slots = new TSlot[CountMatchSlots(execs, exec.IsAllEntries)];
         int matchIdx = 0;
         foreach (var clauseExec in execs)
+        {
             ResolveClauseLeavesInto<TResolver, TSlot>(clauseExec.Clause, clauseExec, exec, walkerCtx, slots, ref matchIdx);
+        }
+
         return slots;
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -183,7 +183,7 @@ internal static partial class QueryPlanBuilder
         CollectionsMarshal.AsSpan(executions).Sort();
 
         var exec = new QueryExecution { Executions = executions };
- 
+
         if(executions.Count is 0)
         {
             if (template.Clauses.Count > 0)
@@ -198,6 +198,10 @@ internal static partial class QueryPlanBuilder
             // FROM Post - i.e, query with no where clauses, still needs a compiled delegate, so we go generate a cached exec for it
             exec.IsAllEntries = true;
         }
+
+        // Populate typed-arrays before BuildInspectionTemplate reads them via FormatValueFromPlan
+        // and before any downstream consumer (FinalizePlan/AttachSpatialAndVectorClauses) needs them.
+        writer.SetValues(exec);
 
         // ── Step 6: Compute cache key components (cheap) ────────────────────
         int operandOrdering = ComputeOperandOrdering(template, planParams, executions);
@@ -253,6 +257,9 @@ internal static partial class QueryPlanBuilder
                 exec.InRangeCounts = BuildInRangeCounts(executions, compiledPlan.InRangeSlotCount);
 
             AttachSpatialAndVectorClauses(exec, template, planParams, builderParameters, writer);
+            // Re-snapshot typed arrays into exec: AttachSpatialAndVectorClauses appended
+            // spatial/vector clause values to the writer after the initial SetValues call
+            // (which had to run early so BuildInspectionTemplate could format them).
             writer.SetValues(exec);
             return (compiledPlan, exec);
         }
@@ -1421,8 +1428,11 @@ internal static partial class QueryPlanBuilder
                 // pre-resolved by the DynamicFieldNameResolve walker step at template time.
                 string searchFieldName = clause.ResolvedFieldName ?? clause.FieldName;
                 {
+                    // Search clause is unreachable from the direct-test path (tests that use
+                    // the test-only QueryBuilderParameters ctor never construct Search clauses),
+                    // so Index is always non-null here.
                     bool forceSearch = builderParams.HasDynamics
-                                       && (builderParams.Index?.Configuration?.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery ?? false);
+                                       && builderParams.Index.Configuration.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery;
                     searchMeta = QueryBuilderHelper.GetFieldMetadata(
                         builderParams.Allocator, searchFieldName, builderParams.Index,
                         builderParams.IndexFieldsMapping,
@@ -1431,11 +1441,11 @@ internal static partial class QueryPlanBuilder
                         forceDefaultSearchAnalyzer: forceSearch);
                 }
 
-                var indexDef = builderParams.Index?.Definition;
+                var indexDef = builderParams.Index.Definition;
                 IndexSearcher.SearchQueryOptions searchQueryOptions;
-                if (indexDef != null && IndexDefinitionBaseServerSide.IndexVersion.IsCoraxSearchWildcardAdjustmentSupported(indexDef.Version))
+                if (IndexDefinitionBaseServerSide.IndexVersion.IsCoraxSearchWildcardAdjustmentSupported(indexDef.Version))
                     searchQueryOptions = IndexSearcher.SearchQueryOptions.PhraseQueryWithWildcardAdjustments;
-                else if (indexDef is { Version: >= IndexDefinitionBaseServerSide.IndexVersion.PhraseQuerySupportInCoraxIndexes })
+                else if (indexDef.Version >= IndexDefinitionBaseServerSide.IndexVersion.PhraseQuerySupportInCoraxIndexes)
                     searchQueryOptions = IndexSearcher.SearchQueryOptions.PhraseQuery;
                 else
                     searchQueryOptions = IndexSearcher.SearchQueryOptions.Legacy;
@@ -1675,16 +1685,13 @@ internal static partial class QueryPlanBuilder
     }
 
     /// <summary>Resolve simple field metadata (no analyzer-aware logic) routing
-    /// through the IndexFieldsMapping when available, otherwise the IndexSearcher's
-    /// direct factory. Used by compound-field key construction where the caller just
-    /// needs a metadata to feed <c>EncodeAndApplyAnalyzer</c>.</summary>
+    /// through the IndexFieldsMapping. Used by compound-field key construction where the
+    /// caller just needs a metadata to feed <c>EncodeAndApplyAnalyzer</c>.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static FieldMetadata GetCompoundFieldMetadata(QueryBuilderParameters builderParams,
         IndexSearcher indexSearcher, string fieldName)
     {
-        return builderParams?.IndexFieldsMapping != null
-            ? QueryBuilderHelper.GetFieldMetadata(in builderParams, fieldName, hasBoost: false)
-            : indexSearcher.FieldMetadataBuilder(fieldName, hasBoost: false);
+        return QueryBuilderHelper.GetFieldMetadata(in builderParams, fieldName, hasBoost: false);
     }
 
     /// <summary>Resolve field metadata for a term-source clause. Mirrors the
@@ -1695,19 +1702,13 @@ internal static partial class QueryPlanBuilder
         // Dynamic field name variants are pre-resolved by DynamicFieldNameResolve at template time.
         string resolvedFieldName = clause.ResolvedFieldName ?? clause.FieldName;
 
-        if (builderParams?.IndexFieldsMapping == null)
-        {
-            // Direct-test path (no QueryBuilderParameters, or test-constructed one with no
-            // IndexFieldsMapping): use IndexSearcher's FieldMetadataBuilder directly.
-            return walkerCtx.IndexSearcher.FieldMetadataBuilder(resolvedFieldName, hasBoost: walkerCtx.HasBoost);
-        }
-
         // When forceDefaultSearchAnalyzer is enabled for indexes with dynamic fields (CreateField),
         // non-exact non-search clauses should use the search analyzer (#4778 fix).
+        // HasDynamics short-circuits the Index dereference for the direct-test path.
         bool forceSearchAnalyzer = builderParams.HasDynamics
                                    && !clause.IsExact
                                    && clause.ClauseType != ClauseType.Search
-                                   && (builderParams.Index?.Configuration?.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery ?? false);
+                                   && builderParams.Index.Configuration.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery;
         return QueryBuilderHelper.GetFieldMetadata(in builderParams, resolvedFieldName, exact: clause.IsExact,
             hasBoost: builderParams.HasBoost, forceDefaultSearchAnalyzer: forceSearchAnalyzer);
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Resolution.cs
@@ -879,10 +879,9 @@ internal static partial class QueryPlanBuilder
             switch (it.Source)
             {
                 case BindingSource.Literal:
+                    if (it.LiteralValue == null) { hasNullTerm = true; break; }
                     resolvedValues.Add(it.LiteralValue);
                     termTypes.Add(it.LiteralType);
-                    if (it.LiteralValue == null)
-                        hasNullTerm = true;
                     break;
 
                 case BindingSource.QueryParameter:
@@ -895,22 +894,20 @@ internal static partial class QueryPlanBuilder
                         foreach (var elem in arr)
                         {
                             var (elemVal, elemType) = ResolveParameterValue(elem);
+                            if (elemVal == null) { hasNullTerm = true; continue; }
                             resolvedValues.Add(elemVal);
                             termTypes.Add(ToParamValueType(elemType));
-                            if (elemVal == null)
-                                hasNullTerm = true;
                         }
                     }
                     else if (inRaw != null)
                     {
                         var (singleVal, singleType) = ResolveParameterValue(inRaw);
+                        if (singleVal == null) { hasNullTerm = true; break; }
                         resolvedValues.Add(singleVal);
                         termTypes.Add(ToParamValueType(singleType));
                     }
                     else
                     {
-                        resolvedValues.Add(null);
-                        termTypes.Add(ParamValueType.Null);
                         hasNullTerm = true;
                     }
 
@@ -919,24 +916,13 @@ internal static partial class QueryPlanBuilder
 
                 case BindingSource.DeferredMethod:
                     // Deferred bindings (cmpxchg, now, today) shouldn't appear in IN lists,
-                    // but handle gracefully: resolve as null.
-                    resolvedValues.Add(null);
-                    termTypes.Add(ParamValueType.Null);
+                    // but handle gracefully: treat as null.
                     hasNullTerm = true;
                     break;
             }
         }
 
-        ParamValueType dominantType = ParamValueType.Null;
-        for (int i = 0; i < resolvedValues.Count; i++)
-        {
-            if (resolvedValues[i] == null) continue;
-            dominantType = termTypes[i];
-            break;
-        }
-
-        if (dominantType == ParamValueType.Null)
-            dominantType = ParamValueType.String;
+        ParamValueType dominantType = resolvedValues.Count > 0 ? termTypes[0] : ParamValueType.String;
 
         EmitInTerms(exec, writer, dominantType, resolvedValues, termTypes, hasNullTerm);
     }
@@ -1018,9 +1004,7 @@ internal static partial class QueryPlanBuilder
         int nonNullCount = 0;
         for (int i = 0; i < values.Count; i++)
         {
-            var value = values[i];
-            if (value == null) continue;
-            if (TryEmitInTermValue(writer, value, types[i], dominantType, dominantTokenType))
+            if (TryEmitInTermValue(writer, values[i], types[i], dominantType, dominantTokenType))
                 nonNullCount++;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.SpatialVector.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.SpatialVector.cs
@@ -251,13 +251,13 @@ internal static partial class QueryPlanBuilder
         return items;
     }
 
-    private static IQueryMatch HandleSpatial(QueryBuilderParameters builderParameters, ClauseInfo clause, ClauseExecution exec, SpatialOperationType spatialMethod)
+    private static IQueryMatch HandleSpatial(QueryBuilderParameters builderParameters, ClauseExecution exec, SpatialOperationType spatialMethod)
     {
         var index = builderParameters.Index;
         var allocator = builderParameters.Allocator;
 
         // Field name was pre-resolved during parsing.
-        string fieldName = clause.FieldName
+        string fieldName = exec.Clause.FieldName
                            ?? throw new InvalidOperationException("Spatial clause has no pre-resolved field name.");
 
         var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(allocator, fieldName, index, builderParameters.IndexFieldsMapping,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Walker.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Walker.cs
@@ -130,8 +130,7 @@ internal static partial class QueryPlanBuilder
             BoostPropagate(ctx);
             NotCanonicalize(clauses, ctx);
             BetweenRewriteSentinels(clauses, ctx.IsOr);
-            InPreClassify(clauses);
-            if (ctx.Metadata.IsDynamic) 
+            if (ctx.Metadata.IsDynamic)
                 DynamicFieldNameResolve(clauses);
             GroupCollapse(clauses, ctx);
             WhenRegister(clauses, ctx);
@@ -175,56 +174,6 @@ internal static partial class QueryPlanBuilder
             throw new NotSupportedException(
                 $"Query has {ctx.WhenCount} WHEN-guarded clauses; the plan template supports at most " +
                 $"{PlanTemplate.MaxWhenClauses}. Split the query into multiple smaller queries.");
-        }
-
-        /// <summary>
-        /// For IN/AllIn clauses where ALL bindings are literals (no parameters), pre-compute
-        /// the dominant type at template time. Sets <see cref="ClauseInfo.AllBindingsAreLiteral"/> and
-        /// <see cref="ClauseInfo.InDominantType"/>. At execution time, <see cref="ResolveInFromBindings"/>
-        /// skips the dominant-type scan and type-incompatible filtering for these clauses.
-        /// Recurses into OrGroup/AndGroup sub-clauses.
-        /// </summary>
-        private static void InPreClassify(List<ClauseInfo> clauses)
-        {
-            foreach (var t in clauses)
-            {
-                InPreClassifyRecursive(t);
-            }
-        }
-
-        private static void InPreClassifyRecursive(ClauseInfo clause)
-        {
-            foreach (var t in clause.SubClauses ?? [])
-            {
-                InPreClassifyRecursive(t);
-            }
-            
-            if (clause.ClauseType is not (ClauseType.In or ClauseType.AllIn) || clause.Bindings is not { Length: not 0 })
-                return;
-
-            // Check if all bindings are literals
-            foreach (var t in clause.Bindings)
-            {
-                if (t.Source != BindingSource.Literal)
-                    return; // has parameter bindings — can't pre-classify
-            }
-
-            // All literal: compute dominant type
-            ParamValueType dominant = ParamValueType.Null;
-            foreach (var t in clause.Bindings)
-            {
-                if (t.LiteralValue == null)
-                    continue;
-                if (dominant == ParamValueType.Null) 
-                    dominant = t.LiteralType;
-            }
-            if (dominant == ParamValueType.Null)
-            {
-                dominant = ParamValueType.String;
-            }
-
-            clause.AllBindingsAreLiteral = true;
-            clause.InDominantType = dominant;
         }
 
         /// <summary>

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Walker.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Walker.cs
@@ -242,15 +242,51 @@ internal static partial class QueryPlanBuilder
         /// </summary>
         private static void NotCanonicalize(List<ClauseInfo> clauses, ResolutionContext ctx)
         {
-            if (ctx.IsOr == false)
-                return;
+            if (ctx.IsOr)
+            {
+                foreach (var c in clauses)
+                {
+                    if (c.IsNegated || c.ClauseType == ClauseType.NotEquals)
+                    {
+                        c.IsOrChainNotEquals = true;
+                    }
+                }
+            }
 
+            // Recurse into nested groups. Negation polarity on a direct child of any OrGroup
+            // (top-level or nested) must be materialized as AllEntries ANDNOT(positive); the
+            // raw posting list / range / tree-scan can't deliver the complement. Direct
+            // children of an AndGroup don't get the flag — AND-rooted negation is handled
+            // by the firstIsNegated / AndNotWith path which subtracts the positive form.
             foreach (var c in clauses)
             {
-                if (c.IsNegated || c.ClauseType == ClauseType.NotEquals)
+                if (c.SubClauses is not { Count: > 0 } subs)
+                    continue;
+                bool subIsOr = c.ClauseType == ClauseType.OrGroup;
+                foreach (var sub in subs)
                 {
-                    c.IsOrChainNotEquals = true;
+                    if (subIsOr && (sub.IsNegated || sub.ClauseType == ClauseType.NotEquals))
+                        sub.IsOrChainNotEquals = true;
                 }
+                NotCanonicalizeRecursive(subs);
+            }
+        }
+
+        /// <summary>Recursive helper for <see cref="NotCanonicalize"/>. Walks each clause's
+        /// SubClauses and flags negated direct children of any OrGroup with IsOrChainNotEquals.</summary>
+        private static void NotCanonicalizeRecursive(List<ClauseInfo> clauses)
+        {
+            foreach (var c in clauses)
+            {
+                if (c.SubClauses is not { Count: > 0 } subs)
+                    continue;
+                bool subIsOr = c.ClauseType == ClauseType.OrGroup;
+                foreach (var sub in subs)
+                {
+                    if (subIsOr && (sub.IsNegated || sub.ClauseType == ClauseType.NotEquals))
+                        sub.IsOrChainNotEquals = true;
+                }
+                NotCanonicalizeRecursive(subs);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Walker.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder.Walker.cs
@@ -80,7 +80,7 @@ internal static partial class QueryPlanBuilder
         }
 
         /// <summary>Construct from raw bag/metadata. Used by sub-expression entry points
-        /// (e.g. <see cref="BuildFromSubExpression"/>) that do not have a full
+        /// (e.g. <see cref="QueryPlanBuilder.BuildQueryForMoreLikeThis"/>) that do not have a full
         /// <see cref="PlanParameters"/> available.</summary>
         private ResolutionContext(BlittableJsonReaderObject queryParameters, QueryMetadata metadata, IndexSearcher indexSearcher)
         {

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -294,7 +294,7 @@ namespace FastTests.Corax
                 HasBoost = true,
                 Allocator = Allocator
             };
-            var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, hasBoost: true), out _, out _, null, false, default);
+            var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields, hasBoost: true), out _, out _, null, false, default);
             match = QueryPlanBuilder.ApplyScoreOrdering(planParams, match, take);
             var list = new List<string>();
             Span<long> ids = stackalloc long[256];
@@ -317,7 +317,7 @@ namespace FastTests.Corax
                 HasBoost = true,
                 Allocator = Allocator
             };
-            var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, hasBoost: true), out _, out _, null, false, default);
+            var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields, hasBoost: true), out _, out _, null, false, default);
             match = QueryPlanBuilder.ApplyScoreOrdering(planParams, match, long.MaxValue);
             var list = new List<long>();
             var termsReader = searcher.TermsReaderFor("Content1");

--- a/test/FastTests/Corax/CompiledQueryNestedGroupTests.cs
+++ b/test/FastTests/Corax/CompiledQueryNestedGroupTests.cs
@@ -274,6 +274,64 @@ public class CompiledQueryNestedGroupTests : RavenTestBase
         }
     }
 
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedWithNegation_NotEqualsDirectInsideOrGroup()
+    {
+        // Probe for an asymmetry: NotEquals as a DIRECT sub-clause of a nested OrGroup
+        // (not wrapped in an inner AndGroup). NotCanonicalize only marks top-level
+        // OR-chain clauses with IsOrChainNotEquals=true; nested OrGroup sub-clauses
+        // are not marked. If the OrGroup collapse path (or the IL pipeline's nested
+        // OrGroup case in EmitAndPlan) doesn't handle the negation, the positive form
+        // leaks through and the result set is wrong.
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Category = "a b c d".Split(' ')[i % 4],
+                    Priority = (i % 5) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // active AND (Priority != 1 OR Category = 'b')
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and " +
+                "(Priority != 1 or Category = 'b')")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.True(
+                    r.Priority != 1 || r.Category == "b",
+                    $"Unexpected match: Category={r.Category}, Priority={r.Priority}");
+            });
+
+            var expected = 0;
+            for (int i = 0; i < 100; i++)
+            {
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                var cat = "a b c d".Split(' ')[i % 4];
+                var pri = (i % 5) + 1;
+                if (sta == "active" && (pri != 1 || cat == "b"))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
     private class TestDoc
     {
         public string Id { get; set; }

--- a/test/FastTests/Corax/CompiledQueryNestedGroupTests.cs
+++ b/test/FastTests/Corax/CompiledQueryNestedGroupTests.cs
@@ -1,0 +1,286 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// Regression suite for nested boolean groups in the Corax query planner.
+///
+/// These shapes exercise queries where a sub-clause of an OrGroup or AndGroup is
+/// itself a group with non-leaf children — the path that today falls through to
+/// <c>ResolveClause</c>'s recursive bitmap-collapse (lines 1503-1541) instead of
+/// staying in the IL slot pipeline.
+///
+/// Each test asserts result correctness only. Inspect/EXPLAIN structure assertions
+/// are added in a separate verification step once the IL pipeline owns the full tree.
+/// </summary>
+public class CompiledQueryNestedGroupTests : RavenTestBase
+{
+    public CompiledQueryNestedGroupTests(Xunit.ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedAndInsideOr_TwoConjuncts()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // Layout: 100 docs, Category cycles a/b/c/d, Priority 1..5
+            // - cat='a' AND pri=1 → docs at i % 4 == 0 AND i % 5 == 0 → i ∈ {0,20,40,60,80} = 5
+            // - cat='b' AND pri=2 → i % 4 == 1 AND i % 5 == 1 → i ∈ {1,21,41,61,81} = 5
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = "a b c d".Split(' ')[i % 4],
+                    Priority = (i % 5) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where (Category = 'a' and Priority = 1) or (Category = 'b' and Priority = 2)")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            Assert.All(results, r =>
+                Assert.True((r.Category == "a" && r.Priority == 1) || (r.Category == "b" && r.Priority == 2),
+                    $"Unexpected match: Category={r.Category}, Priority={r.Priority}"));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedAndInsideOr_ThreeConjuncts()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 120; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = "a b c d".Split(' ')[i % 4],
+                    Priority = (i % 5) + 1,
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where " +
+                "(Category = 'a' and Priority = 1) or " +
+                "(Category = 'b' and Priority = 2) or " +
+                "(Category = 'c' and Status = 'active')")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+                Assert.True(
+                    (r.Category == "a" && r.Priority == 1) ||
+                    (r.Category == "b" && r.Priority == 2) ||
+                    (r.Category == "c" && r.Status == "active"),
+                    $"Unexpected match: Category={r.Category}, Priority={r.Priority}, Status={r.Status}"));
+
+            // Verify count is non-zero and matches expected predicate over the fixture
+            var expected = 0;
+            for (int i = 0; i < 120; i++)
+            {
+                var cat = "a b c d".Split(' ')[i % 4];
+                var pri = (i % 5) + 1;
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                if ((cat == "a" && pri == 1) || (cat == "b" && pri == 2) || (cat == "c" && sta == "active"))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedOrInsideAnd_LeafAndAndGroups()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 200; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = "alpha beta gamma delta".Split(' ')[i % 4],
+                    Priority = (i % 6) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // Active items that are EITHER (alpha,pri=1) OR (beta,pri=2)
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and " +
+                "((Tag = 'alpha' and Priority = 1) or (Tag = 'beta' and Priority = 2))")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.True(
+                    (r.Tag == "alpha" && r.Priority == 1) ||
+                    (r.Tag == "beta" && r.Priority == 2),
+                    $"Unexpected match: Tag={r.Tag}, Priority={r.Priority}");
+            });
+
+            var expected = 0;
+            for (int i = 0; i < 200; i++)
+            {
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                var tag = "alpha beta gamma delta".Split(' ')[i % 4];
+                var pri = (i % 6) + 1;
+                if (sta == "active" && ((tag == "alpha" && pri == 1) || (tag == "beta" && pri == 2)))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedTripleDepth_AndWithOrWithAnd()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 150; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Category = "x y z".Split(' ')[i % 3],
+                    Tag = "hot cold warm".Split(' ')[i % 3],
+                    Priority = (i % 5) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // Three-level: active AND (cat=x OR (tag=hot AND priority=1))
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and " +
+                "(Category = 'x' or (Tag = 'hot' and Priority = 1))")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.True(
+                    r.Category == "x" || (r.Tag == "hot" && r.Priority == 1),
+                    $"Unexpected match: Category={r.Category}, Tag={r.Tag}, Priority={r.Priority}");
+            });
+
+            var expected = 0;
+            for (int i = 0; i < 150; i++)
+            {
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                var cat = "x y z".Split(' ')[i % 3];
+                var tag = "hot cold warm".Split(' ')[i % 3];
+                var pri = (i % 5) + 1;
+                if (sta == "active" && (cat == "x" || (tag == "hot" && pri == 1)))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedWithNegation_AndNotInsideOrGroup()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Category = "a b c d".Split(' ')[i % 4],
+                    Priority = (i % 5) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // active AND ((category=a AND priority != 1) OR (category=b AND priority = 2))
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and " +
+                "((Category = 'a' and Priority != 1) or (Category = 'b' and Priority = 2))")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.True(
+                    (r.Category == "a" && r.Priority != 1) ||
+                    (r.Category == "b" && r.Priority == 2),
+                    $"Unexpected match: Category={r.Category}, Priority={r.Priority}");
+            });
+
+            var expected = 0;
+            for (int i = 0; i < 100; i++)
+            {
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                var cat = "a b c d".Split(' ')[i % 4];
+                var pri = (i % 5) + 1;
+                if (sta == "active" && ((cat == "a" && pri != 1) || (cat == "b" && pri == 2)))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    private class TestDoc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Status { get; set; }
+        public string Category { get; set; }
+        public string Tag { get; set; }
+        public int Priority { get; set; }
+    }
+}

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -289,7 +289,7 @@ namespace FastTests.Corax
                 QueryParameters = null,
                 Allocator = Allocator
             };
-            var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null), out _, out _, null, false, default);
+            var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, _knownFields), out _, out _, null, false, default);
 
             var list = new List<string>();
             Span<long> ids = stackalloc long[256];

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -1290,7 +1290,8 @@ namespace FastTests.Corax
 
             const string rql = "FROM TestIndex WHERE Content IN ($p0)";
 
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
+            using var fields = CreateKnownFields(Allocator);
+            using var searcher = new IndexSearcher(Env, fields);
             using var ctx = global::Sparrow.Json.JsonOperationContext.ShortTermSingleUse();
 
             // Execution 1: $p0 = [] (empty array) → should return 0 results
@@ -1302,7 +1303,7 @@ namespace FastTests.Corax
                     IndexSearcher = searcher, Metadata = queryMetadata,
                     QueryParameters = emptyParams, Allocator = Allocator
                 };
-                var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, emptyParams), out _, out _, null, false, default);
+                var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, emptyParams, fields), out _, out _, null, false, default);
                 Span<long> buf = stackalloc long[64];
                 Assert.Equal(0, match.Fill(buf));
             }
@@ -1316,7 +1317,7 @@ namespace FastTests.Corax
                     IndexSearcher = searcher, Metadata = queryMetadata,
                     QueryParameters = realParams, Allocator = Allocator
                 };
-                var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, realParams), out _, out _, null, false, default);
+                var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, realParams, fields), out _, out _, null, false, default);
                 Span<long> buf = stackalloc long[64];
                 Assert.Equal(1, match.Fill(buf));
             }
@@ -1530,7 +1531,8 @@ namespace FastTests.Corax
 
             // when($p = true, Content = 'road') with $p = false → clause eliminated.
             // With all clauses removed, there is no selection, distinct from no filter, we always filter out all entries.
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
+            using var fields = CreateKnownFields(Allocator);
+            using var searcher = new IndexSearcher(Env, fields);
             var rql = "FROM TestIndex WHERE when($p = true, Content = 'road')";
             var queryMetadata = new QueryMetadata(rql, null, 0);
 
@@ -1545,7 +1547,7 @@ namespace FastTests.Corax
                 Allocator = Allocator
             };
 
-            var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, paramsJson), out _, out _, null, false, default);
+            var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, paramsJson, fields), out _, out _, null, false, default);
             Span<long> buffer = stackalloc long[256];
             int count = match.Fill(buffer);
             Assert.Equal(0, count);
@@ -1557,7 +1559,8 @@ namespace FastTests.Corax
         /// </summary>
         private List<long> ExecuteRQLQuery(string rqlQuery)
         {
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
+            using var fields = CreateKnownFields(Allocator);
+            using var searcher = new IndexSearcher(Env, fields);
 
             // Parse RQL query string into AST via QueryMetadata
             var queryMetadata = new QueryMetadata(rqlQuery, null, 0);
@@ -1574,7 +1577,7 @@ namespace FastTests.Corax
             // BuildAndCompile: RQL → QueryExecution → IL compilation → CompiledQueryMatch
             var compiledMatch = QueryPlanBuilder.BuildAndCompile(
                 planParams,
-                new QueryBuilderParameters(searcher, Allocator, queryMetadata, null),
+                new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, fields),
                 out var debugPlan,
                 out _,
                 highlightingTerms: null,

--- a/test/FastTests/Corax/Ranking/RankingFunctionTests.cs
+++ b/test/FastTests/Corax/Ranking/RankingFunctionTests.cs
@@ -172,7 +172,7 @@ public class RankingFunctionTests : StorageTest
             HasBoost = true,
             Allocator = Allocator
         };
-        var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, hasBoost: true), out _, out _, null, false, default);
+        var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, _mapping, hasBoost: true), out _, out _, null, false, default);
         match = QueryPlanBuilder.ApplyScoreOrdering(planParams, match, long.MaxValue);
         var list = new List<string>();
         Span<long> ids = stackalloc long[256];

--- a/test/FastTests/Corax/RavenDB_22603.cs
+++ b/test/FastTests/Corax/RavenDB_22603.cs
@@ -436,7 +436,7 @@ public class RavenDB_22603_Primitive : StorageTest
             QueryParameters = null,
             Allocator = Allocator
         };
-        var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null), out _, out _, null, false, default);
+        var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, _knownFields), out _, out _, null, false, default);
 
         var list = new List<string>();
         Span<long> ids = stackalloc long[256];

--- a/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
+++ b/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
@@ -601,7 +601,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
                     QueryParameters = blittableParameters,
                     Allocator = bsc
                 };
-                var coraxQuery = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(indexSearcher, bsc, indexQueryServerSide.Metadata, blittableParameters), out _, out _, null, false, default);
+                var coraxQuery = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(indexSearcher, bsc, indexQueryServerSide.Metadata, blittableParameters, mapping), out _, out _, null, false, default);
 
                 return coraxQuery;
             }

--- a/test/SlowTests.Issues/Issues/RavenDB-22703_LowLevel.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-22703_LowLevel.cs
@@ -147,7 +147,7 @@ public class RavenDB_22703_LowLevel : StorageTest
             QueryParameters = null,
             Allocator = Allocator
         };
-        var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null), out _, out _, null, false, default);
+        var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields), out _, out _, null, false, default);
         var list = new List<string>();
         Span<long> ids = stackalloc long[256];
         int count;

--- a/test/SlowTests/Corax/RavenDB_23631.cs
+++ b/test/SlowTests/Corax/RavenDB_23631.cs
@@ -140,7 +140,7 @@ public class RavenDB_23631(ITestOutputHelper output) : StorageTest(output)
             QueryParameters = null,
             Allocator = Allocator
         };
-        var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null), out _, out _, null, false, default);
+        var match = QueryPlanBuilder.BuildAndCompile(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, mapping), out _, out _, null, false, default);
         var list = new List<string>();
         Span<long> ids = stackalloc long[256];
         int count;


### PR DESCRIPTION
Implements #4847.

**Stacked on `worktree-pr13-arch-audit` (PR13).** Merge after PR13.

## Goal

Eliminate the recursive bitmap-collapse path in `ResolveClause` (`QueryPlanBuilder.Resolution.cs:1503-1541`) — currently the only way nested groups (group inside another group) are evaluated — and route every leaf through the same IL slot pipeline as flat queries. This eliminates:

- Loss of EXPLAIN/Inspect visibility for clauses inside nested groups.
- Missing per-clause timing hooks inside the collapse path.
- No cancellation between sub-clauses of a nested group.
- Code duplication between the IL emitter and the collapse path (same bug class as the recent `CheckAllNegated` and `AllNegated` tail-slot fixes).

## Approach

No new PlanOps needed — existing ops (`ClearBitmap` / `OrBitmaps` / `AndBitmaps` / `AndNotBitmaps` / `OrWithPostings BitmapLocal=N`) already support multi-slot composition. Work is in the plan-builder:

1. **Recursive slot allocation** — `CountMatchSlots`, `ResolveSlots`, and the three `ISlotResolver` impls recurse into nested groups, assigning every leaf at any depth a unique slot index.
2. **Recursive emitters** — `EmitOrPlan` / `EmitAndPlan` recognize group-shaped sub-clauses, allocate a fresh bitmap slot, recurse into the inner sub-tree, then fold back via `OrBitmaps` / `AndBitmaps` / `AndNotBitmaps`.
3. **Delete the recursive collapse path** — the OrGroup/AndGroup branches at the top of `ResolveClause` go away; the switch arms at 1663-1670 become reachable defensive asserts.

## Phases

- [x] **Phase A** — failing regression tests for nested-group shapes (this commit).
- [ ] **Phase B** — recursive slot allocation.
- [ ] **Phase C** — recursive emitters.
- [ ] **Phase D** — delete `ResolveClause` 1503-1541.
- [ ] **Phase E** — Inspect/timing/cancellation verification.

## Phase A status

5 nested-group regression tests added in `test/FastTests/Corax/CompiledQueryNestedGroupTests.cs`:

| Test | Status on current code |
|---|---|
| `NestedAndInsideOr_TwoConjuncts` — `(a∧b) ∨ (c∧d)` | pass |
| `NestedAndInsideOr_ThreeConjuncts` — `(a∧b) ∨ (c∧d) ∨ (e∧f)` | pass |
| `NestedOrInsideAnd_LeafAndAndGroups` — `leaf ∧ ((a∧b) ∨ (c∧d))` | pass |
| `NestedTripleDepth_AndWithOrWithAnd` — `leaf ∧ (leaf ∨ (a∧b))` (3 levels) | pass |
| `NestedWithNegation_AndNotInsideOrGroup` — `leaf ∧ ((a∧¬b) ∨ (c∧d))` | **fail** |

The failing test reveals a latent correctness bug in `ResolveClause`'s AndGroup branch: it checks `sub.IsNegated` to choose between `AndWithMatch` / `AndNotWithMatch`, but a `NotEquals` clause encodes negation in `ClauseType`, not the `IsNegated` flag. Result: `Priority != 1` inside a nested AndGroup is resolved as `Priority = 1` (returns the complement of intended).

Phases B-D will route these shapes through the IL pipeline and fix this bug as a side effect of eliminating the divergent path.

## Test plan

- [ ] All 5 nested-group regression tests pass after Phase C.
- [ ] FastTests Corax suite remains green (no regressions on existing nested-group test `CompiledQueryTests.cs:659-674`).
- [ ] `ResolveClause` switch arms 1663-1670 remain reachable (defensive asserts), no group reaches the bottom of the function in normal operation.
- [ ] EXPLAIN output shows individual leaves for nested-group queries (Phase E verification).