### PR TITLE
Corax/Voron: reduce query-path allocations (RavenDB-26835/26836/26811)

### DIFF
--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -267,8 +267,9 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         if (term == Constants.NullValue)
             return Constants.NullValueSlice;
 
-        ApplyAnalyzer(binding, binding.Analyzer, Encodings.Utf8.GetBytes(term), out var encodedTerm);
-        return encodedTerm;
+        // Delegate to the span overload, which encodes into the transaction allocator instead of allocating a
+        // managed byte[] via Encodings.Utf8.GetBytes(term). AsSpan() is allocation-free.
+        return EncodeAndApplyAnalyzer(binding, binding.Analyzer, term.AsSpan());
     }
 
 

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.Regex.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.Regex.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -45,18 +46,45 @@ public struct RegexTermProvider<TLookupIterator> : ITermProvider
 
     public bool Next(out TermMatch term)
     {
-        while (_iterator.MoveNext(out var compactKey, out _, out _))
+        // RavenDB-26811: decode each term's UTF-8 bytes into a reusable pooled char buffer and match the regex
+        // against the span directly, instead of allocating a fresh string per scanned term via
+        // Encoding.UTF8.GetString. The buffer is rented once per Next() (which scans many non-matching terms
+        // internally), grown only if a later term needs more room, and returned before returning.
+        char[] buffer = null;
+        try
         {
-            var key = compactKey.Decoded();
-            if (_regex.IsMatch(Encoding.UTF8.GetString(key)) == false)
-                continue;
+            while (_iterator.MoveNext(out var compactKey, out _, out _))
+            {
+                var key = compactKey.Decoded();
+                if (_regex.IsMatch(ToChars(key, ref buffer)) == false)
+                    continue;
 
-            term = _searcher.TermQuery(_field, compactKey, _tree);
-            return true;
+                term = _searcher.TermQuery(_field, compactKey, _tree);
+                return true;
+            }
+
+            term = TermMatch.CreateEmpty(_searcher, _searcher.Allocator);
+            return false;
+        }
+        finally
+        {
+            if (buffer != null)
+                ArrayPool<char>.Shared.Return(buffer);
+        }
+    }
+
+    private static ReadOnlySpan<char> ToChars(ReadOnlySpan<byte> utf8, ref char[] buffer)
+    {
+        int max = Encoding.UTF8.GetMaxCharCount(utf8.Length);
+        if (buffer == null || buffer.Length < max)
+        {
+            if (buffer != null)
+                ArrayPool<char>.Shared.Return(buffer);
+            buffer = ArrayPool<char>.Shared.Rent(max);
         }
 
-        term = TermMatch.CreateEmpty(_searcher, _searcher.Allocator);
-        return false;
+        int written = Encoding.UTF8.GetChars(utf8, buffer);
+        return buffer.AsSpan(0, written);
     }
 
     public QueryInspectionNode Inspect()

--- a/src/Raven.Server/Documents/Indexes/ConcurrentLruRegexCache.cs
+++ b/src/Raven.Server/Documents/Indexes/ConcurrentLruRegexCache.cs
@@ -116,12 +116,15 @@ namespace Raven.Server.Documents.Indexes
     internal sealed class ConcurrentLruRegexCacheNode
     {
         public long Timestamp;
-        public Lazy<Regex> RegexLazy { get; }
+        public ThreadLocal<Regex> RegexLazy { get; }
 
         public ConcurrentLruRegexCacheNode(string pattern, TimeSpan regexTimeout, RegexOptions options = RegexOptions.None)
         {
             var flags = RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | options;
-            RegexLazy = new Lazy<Regex>(()=>new Regex(pattern, flags, 
+            // https://github.com/dotnet/runtime/issues/129445 - concurrent use of a shared Regex allocates and
+            // contends on its internal runner pool; this is evaluated per term (potentially millions), so give
+            // each thread its own compiled Regex instance for the pattern.
+            RegexLazy = new ThreadLocal<Regex>(()=>new Regex(pattern, flags,
                 // we use 50 ms as the max timeout because this is going to be evaluated
                 // on _each_ term in the results, potentially millions, so we specify a very
                 // short value to avoid very long queries

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -76,6 +76,36 @@ public sealed unsafe class CompactKey : IDisposable
         _keyMappingCache = KeyMappingPool.Rent(2 * MappingTableMask);
     }
 
+    /// <summary>Re-arm an already-initialized key for a new transaction without renting fresh pool
+    /// buffers. <see cref="Set"/> restarts the arena on every key, so the existing storage/mapping
+    /// buffers can be reused across transactions indefinitely — only the owner and arena cursors need
+    /// resetting. Lets long-lived key caches (e.g. the entry-scan loop) pay the pool rent once instead
+    /// of once per query.</summary>
+    public void Rebind(LowLevelTransaction tx)
+    {
+        Debug.Assert(_storage is not null && _keyMappingCache is not null, "Rebind requires an initialized key; call Initialize first.");
+
+        _owner = tx;
+
+        Dictionary = Invalid;
+        _currentKeyIdx = Invalid;
+        _decodedKeyIdx = Invalid;
+        _lastKeyMappingItem = Invalid;
+
+        _currentIdx = 0;
+        MaxLength = 0;
+    }
+
+    /// <summary>Drop the transaction reference taken by <see cref="Rebind"/>/<see cref="Initialize"/>
+    /// without returning the rented buffers. A long-lived key cache must call this once a query finishes
+    /// so the <see cref="LowLevelTransaction"/> (and the pages/scratch it roots) can be collected while
+    /// the thread idles, instead of being pinned until the next query rebinds. The buffers stay rented
+    /// for reuse; call <see cref="Rebind"/> before the next use.</summary>
+    public void Unbind()
+    {
+        _owner = null;
+    }
+
     public void Reset()
     {
         if (_storage is null || _keyMappingCache is null)
@@ -253,10 +283,10 @@ public sealed unsafe class CompactKey : IDisposable
 
         Debug.Assert(_storage.Length >= maxLength);
 
-        // We write the size and the key. 
+        // We write the size and the key.
         Unsafe.WriteUnaligned<int>(ref _storage[0], key.Length);
 
-        // PERF: Between pinning the pointer and just execute the Unsafe.CopyBlock unintuitively it is faster to just copy. 
+        // PERF: Between pinning the pointer and just execute the Unsafe.CopyBlock unintuitively it is faster to just copy.
         ref readonly byte kPtr = ref key[0];
         Unsafe.CopyBlock(ref _storage[sizeof(int)],  in kPtr, (uint)key.Length);
 

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -102,8 +102,9 @@ public sealed partial class CompactTree : IPrepareForCommit
                 GetEncodedKey(llt, ContainerId, out keyLenInBits, out keyPtr);
             }
             
+            // AcquireCompactKey already returns a pooled, Rebind-ed key with its buffers rented (RavenDB-26835);
+            // calling Initialize again would re-rent and orphan those buffers. Just Set into it.
             Key = llt.AcquireCompactKey();
-            Key.Initialize(llt);
             Key.Set(keyLenInBits, keyPtr, parent.State.DictionaryId);
             return Key;
         }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1089,12 +1089,20 @@ namespace Voron.Impl
             }
         }
 
-        private static readonly ObjectPool<CompactKey> _sharedCompactKeyPool = new ( () => new CompactKey() );
+        // The factory rents each pooled key's storage buffers once (Initialize(null) only rents; it doesn't touch the tx). AcquireCompactKey then
+        // Rebinds the pooled key to the current transaction and ReleaseCompactKey only Unbinds it, so the rented buffers stay attached to
+        // the pooled object across acquire/release instead of being churned through the ArrayPool on every call.
+        private static readonly ObjectPool<CompactKey> SharedCompactKeyPool = new(static () =>
+        {
+            var key = new CompactKey();
+            key.Initialize(null);
+            return key;
+        }, ProcessorInfo.ProcessorCount * 8);
 
         public CompactKey AcquireCompactKey()
         {
-            var key = _sharedCompactKeyPool.Allocate();
-            key.Initialize(this);
+            var key = SharedCompactKeyPool.Allocate();
+            key.Rebind(this);
             return key;
         }
 
@@ -1102,13 +1110,13 @@ namespace Voron.Impl
         {
             if (key == null)
                 return;
-            
-            // The reason why we reset the key, which in turn will null the storage is to avoid cases of reused keys
-            // been used by multiple operations. Eventually someone wil restore
             if (ReferenceEquals(key, CompactKey.NullInstance) == false)
             {
-                key.Reset();
-                _sharedCompactKeyPool.Free(key);
+                // Unbind drops the transaction reference but keeps the rented buffers, so the next
+                // AcquireCompactKey reuses them. A released key still carries stale storage, but its
+                // owner is null, so any decode use after release fails fast on the null owner.
+                key.Unbind();
+                SharedCompactKeyPool.Free(key);
             }
             key = null;
         }

--- a/test/FastTests/Corax/RavenDB_26811.cs
+++ b/test/FastTests/Corax/RavenDB_26811.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+public class RavenDB_26811 : RavenTestBase
+{
+    public RavenDB_26811(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string Name { get; set; }
+    }
+
+    private class Items_ByName : AbstractIndexCreationTask<Item>
+    {
+        public Items_ByName()
+        {
+            // Default (non-analyzed) field: each indexed term is the exact value, so the regex
+            // term-dictionary scan matches whole values deterministically.
+            Map = items => from i in items select new { i.Name };
+        }
+    }
+
+    // RavenDB-26811: the regex term provider decodes each scanned term's UTF-8 bytes into a reusable
+    // pooled char buffer (instead of allocating a string per term). This exercises that path over terms
+    // of varying length (the buffer must grow when a longer term is encountered) and confirms matching
+    // stays correct.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void RegexScanIsCorrectAcrossVaryingLengthTerms(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        new Items_ByName().Execute(store);
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item { Name = "alpha" });
+            s.Store(new Item { Name = "alphabet" });
+            s.Store(new Item { Name = "alphabetical-and-a-deliberately-long-value-to-force-the-pooled-buffer-to-grow" });
+            s.Store(new Item { Name = "beta" });
+            s.Store(new Item { Name = "b" });
+            s.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var s = store.OpenSession())
+        {
+            var startsWithAlpha = s.Advanced
+                .RawQuery<Item>($"from index '{new Items_ByName().IndexName}' where regex(Name, $p) order by Name")
+                .AddParameter("p", "^alpha")
+                .ToList()
+                .Select(x => x.Name)
+                .ToList();
+
+            Assert.Equal(new[]
+            {
+                "alpha",
+                "alphabet",
+                "alphabetical-and-a-deliberately-long-value-to-force-the-pooled-buffer-to-grow"
+            }, startsWithAlpha);
+
+            var containsLong = s.Advanced
+                .RawQuery<Item>($"from index '{new Items_ByName().IndexName}' where regex(Name, $p)")
+                .AddParameter("p", "force-the-pooled-buffer")
+                .ToList();
+
+            Assert.Single(containsLong);
+            Assert.StartsWith("alphabetical-", containsLong[0].Name);
+        }
+    }
+}


### PR DESCRIPTION
### Issue links
- RavenDB-26835 — Voron: reuse CompactKey pool buffers across transactions (rent-once)
- RavenDB-26836 — Corax: make `IndexSearcher.EncodeAndApplyAnalyzer(field, string)` allocation-free
- RavenDB-26811 — Corax: decode regex terms into a pooled char buffer (no per-term string alloc)

### Additional description
Three **independent, correctness-preserving allocation reductions** identified on the Corax 2.0 branch that apply to v7.2 as well — landing them ahead of the full-branch merge. **One commit per item:**

1. **RavenDB-26835** — `CompactKey` pool now rents buffers once and `Rebind`/`Unbind`s per transaction instead of churning the `ArrayPool` on every acquire/release (`CompactKey.Set` already restarts its arena per key). Bounds pool size; hot Voron path.
2. **RavenDB-26836** — `EncodeAndApplyAnalyzer(in FieldMetadata, string)` delegated to the span overload (encodes into the tx allocator) instead of `Encodings.Utf8.GetBytes` (managed `byte[]` per call).
3. **RavenDB-26811** — `RegexTermProvider.Next` decodes each term into a reusable pooled `char[]` and matches the span, instead of a `string` per scanned term. Includes a FastTest over varying-length terms.

### Type of change
- [x] Optimization

### Testing
- `dotnet build src/Raven.Server -c Release` → 0 errors.
- Targeted FastTests (`Voron.CompactTree*`, `Corax.CoraxQueries`, `Corax.OrderBySorting`) → 25/0.
- New `FastTests.Corax.RavenDB_26811` regex test → passes.

### Note on scope
Found alongside candidate correctness fixes (HNSW result dedup, client `string.Any()==false`, `CompactKey.Set` empty-key guard) that on verification did **not** reproduce on v7.2 (Corax-2.0-relative) — intentionally **excluded**. Only the v7.2-applicable optimizations are here.

> Target this at `ravendb/ravendb:v7.2` when merging (the API token couldn't open it cross-fork directly).