### PR TITLE
RavenDB-25281 [stack 02/13] Voron: RoaringBitmaps

### DIFF
--- a/src/Voron/Data/RoaringBitmaps/ContainerEntry.cs
+++ b/src/Voron/Data/RoaringBitmaps/ContainerEntry.cs
@@ -7,9 +7,7 @@ public unsafe struct ContainerEntry
 {
     /// <summary>
     /// Direct pointer to container data for Array, ArrayUnsorted, and Bitmap containers; for Range
-    /// containers it stores RangeStart encoded as (RangeStart + 1), keeping Range allocation-free.
-    /// Cached here (8 bytes/entry, negligible vs 64B–8KB of container data) to avoid the double
-    /// dereference through Storage.Ptr on every Contains/Add/iterator step, and a Range null check.
+    /// containers it stores RangeStart encoded as (RangeStart + 1) to avoid an allocation.
     /// </summary>
     public byte* Data;
 

--- a/src/Voron/Data/RoaringBitmaps/ContainerEntry.cs
+++ b/src/Voron/Data/RoaringBitmaps/ContainerEntry.cs
@@ -1,0 +1,60 @@
+﻿using System.Runtime.CompilerServices;
+using Sparrow.Server;
+
+namespace Voron.Data.RoaringBitmaps;
+
+public unsafe struct ContainerEntry
+{
+    /// <summary>
+    /// Direct pointer to container data for Array, ArrayUnsorted, and Bitmap containers; for Range
+    /// containers it stores RangeStart encoded as (RangeStart + 1), keeping Range allocation-free.
+    /// Cached here (8 bytes/entry, negligible vs 64B–8KB of container data) to avoid the double
+    /// dereference through Storage.Ptr on every Contains/Add/iterator step, and a Range null check.
+    /// </summary>
+    public byte* Data;
+
+    /// <summary>Memory handle for disposal. Default for Range containers.</summary>
+    internal ByteString Storage;
+
+    public int Cardinality;
+
+    /// <summary>
+    /// Container key (value >> 16); lets us walk entries without index indirection.
+    /// Supports up to ~140T entries (2^47).
+    /// </summary>
+    public uint Key;
+
+    internal uint NextFreeSlot
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Key;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => Key = value;
+    }
+
+
+    public ushort* ArrayData
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (ushort*)Data;
+    }
+
+    /// <summary>Raw ulong pointer for SIMD operations and methods requiring pointers.</summary>
+    public ulong* BitmapPtr
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (ulong*)Data;
+    }
+
+    /// <summary>
+    /// Start offset (0..65535) for Range containers. Encoded in Data as (start + 1),
+    /// so start=0 remains representable.
+    /// </summary>
+    internal ushort RangeStart
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (ushort)((nuint)Data - 1);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => Data = (byte*)(nuint)(value + 1);
+    }
+}

--- a/src/Voron/Data/RoaringBitmaps/ContainerType.cs
+++ b/src/Voron/Data/RoaringBitmaps/ContainerType.cs
@@ -1,0 +1,22 @@
+﻿namespace Voron.Data.RoaringBitmaps;
+
+public enum ContainerType : byte
+{
+    /// <summary>Sorted ushort array. Binary search for Contains. Merge-based set ops.</summary>
+    Array = 0,
+    /// <summary>8KB bitmap (1024 longs). Direct bit access.</summary>
+    Bitmap = 1,
+    /// <summary>
+    /// Contiguous values RangeStart..RangeStart+Cardinality-1 are set. No data allocation needed.
+    /// Cardinality == BitsPerContainer means all 65,536 bits set (full container).
+    /// Sequential Add at either edge is an O(1) increment.
+    /// </summary>
+    Range = 2,
+    /// <summary>
+    /// Unsorted ushort array. Add is O(1) append. On the first read (Contains, set ops, iteration),
+    /// sorts and deduplicates, converting to Array. Avoids O(log n + shift) per Add.
+    /// </summary>
+    ArrayUnsorted = 3,
+    /// <summary>Tombstone marker for free-list entries in the entries array.</summary>
+    Free = 0xFF
+}

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.FreeListHeads.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.FreeListHeads.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Sparrow.Server;
+
+namespace Voron.Data.RoaringBitmaps;
+
+public unsafe partial struct RoaringBitmap
+{
+    /// <summary>
+    /// Segregated storage free list: one intrusive singly-linked list head per size class.
+    ///
+    /// Storage blocks are bucketed into <see cref="NumSizeClasses"/> size classes on a 32-byte
+    /// aligned x1.091 geometric ladder spanning <see cref="InitialArrayContainerSizeInBytes"/> (64)
+    /// .. <see cref="BitmapContainerSizeInBytes"/> (8192). Allocations round their requested byte
+    /// count up to the enclosing class size, so every block in a class is exactly
+    /// <see cref="ClassSize"/>[c] bytes: a recycled block always fits any request mapping to its class,
+    /// the class is recovered on free from its Length, and every Length stays a multiple of
+    /// <see cref="SimdAlignment"/> (32) as the array-container SIMD set ops require. Worst-case internal
+    /// fragmentation is the x1.091 step (~9%); measured waste is ~4%.
+    ///
+    /// Each free block's first <c>sizeof(ByteString)</c> bytes hold the next <see cref="ByteString"/> in
+    /// its class chain (a default head means the class is empty). <see cref="_classMask"/> bit <c>c</c> is
+    /// set iff class <c>c</c> is non-empty, so <see cref="Allocate"/> finds the smallest sufficient class
+    /// in O(1) via <see cref="BitOperations.TrailingZeroCount(ulong)"/> rather than a best-fit walk. The
+    /// struct lives inline in <see cref="RoaringBitmap"/> and is swapped wholesale by <see cref="SwapContents"/>.
+    /// </summary>
+    internal unsafe struct FreeListHeads
+    {
+        private const int NumSizeClasses = 42;
+
+        /// <summary>Byte size of each storage class (32-aligned, strictly increasing).</summary>
+        private static readonly int[] ClassSize =
+        [
+            64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 416, 480, 544, 608, 672, 736, 832, 928,
+            1024, 1120, 1248, 1376, 1504, 1664, 1824, 2016, 2208, 2432, 2656, 2912, 3200, 3520, 3872,
+            4256, 4672, 5120, 5600, 6112, 6688, 7328, 8000, 8192
+        ];
+
+        /// <summary>Maps a 32-byte quantum (<c>bytes / 32</c>) to the smallest class whose size covers it.
+        /// Indexed by <c>(neededBytes + 31) &gt;&gt; 5</c>; covers quanta 0..256 (0..8192 bytes).</summary>
+        private static ReadOnlySpan<byte> ClassOfQuantum =>
+        [
+            0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16,
+            16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 20, 20, 20, 20, 21, 21, 21, 21, 22, 22, 22,
+            22, 23, 23, 23, 23, 23, 24, 24, 24, 24, 24, 25, 25, 25, 25, 25, 25, 26, 26, 26, 26, 26,
+            26, 27, 27, 27, 27, 27, 27, 27, 28, 28, 28, 28, 28, 28, 28, 29, 29, 29, 29, 29, 29, 29,
+            29, 30, 30, 30, 30, 30, 30, 30, 30, 30, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 32, 32,
+            32, 32, 32, 32, 32, 32, 32, 32, 32, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 34,
+            34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 34, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+            35, 35, 35, 35, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 37, 37, 37,
+            37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 38, 38, 38, 38, 38, 38, 38, 38, 38,
+            38, 38, 38, 38, 38, 38, 38, 38, 38, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39,
+            39, 39, 39, 39, 39, 39, 39, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+            40, 40, 40, 40, 40, 40, 41, 41, 41, 41, 41, 41
+        ];
+
+        /// <summary>One free-list head per size class, stored inline (no extra allocation).</summary>
+        [InlineArray(NumSizeClasses)]
+        private struct Heads
+        {
+            private ByteString _head0;
+        }
+
+        private Heads _heads;
+
+        /// <summary>Bit <c>c</c> set iff <see cref="_heads"/>[c] is non-empty. 42 classes fit one ulong.</summary>
+        private ulong _classMask;
+
+        /// <summary>Smallest size class whose <see cref="ClassSize"/> is &gt;= <paramref name="bytes"/>.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int SizeClassFor(int bytes)
+        {
+            Debug.Assert(bytes is >= 0 and <= BitmapContainerSizeInBytes, "storage request out of size-class range");
+            return ClassOfQuantum[(bytes + SimdAlignment - 1) >> 5];
+        }
+
+        /// <summary>
+        /// Push <paramref name="bs"/> onto the head of its size class's free list. The first
+        /// <c>sizeof(ByteString)</c> bytes of <paramref name="bs"/>'s data are overwritten with the
+        /// current head, forming the intrusive next-pointer. The class is recovered from
+        /// <c>bs.Length</c>, which is always exactly a <see cref="ClassSize"/> value.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Return(ByteString bs)
+        {
+            int c = SizeClassFor(bs.Length);
+            *(ByteString*)bs.Ptr = _heads[c]; // chain: new node's next = old class head
+            _heads[c] = bs;                   // new class head = bs
+            _classMask |= 1UL << c;
+        }
+
+        /// <summary>
+        /// Acquire storage of at least <paramref name="neededBytes"/>. Pops the head of the smallest
+        /// non-empty size class that can satisfy the request (O(1) via the class mask), unlinking it
+        /// in-place. Falls back to a fresh <paramref name="ctx"/> allocation rounded up to the class
+        /// size when every sufficient class is empty.
+        /// </summary>
+        public void Allocate(ByteStringContext ctx, int neededBytes, out ByteString storage)
+        {
+            int c = SizeClassFor(neededBytes);
+
+            // Classes >= c hold blocks of ClassSize[>=c] >= neededBytes; pick the smallest non-empty one.
+            ulong avail = _classMask & (~0UL << c);
+            if (avail != 0)
+            {
+                int fc = BitOperations.TrailingZeroCount(avail);
+                storage = _heads[fc];                  // pop head
+                ByteString next = *(ByteString*)storage.Ptr;
+                _heads[fc] = next;
+                if (next.HasValue == false)
+                    _classMask &= ~(1UL << fc);        // class now empty
+                return;
+            }
+
+            ctx.Allocate(ClassSize[c], out storage);
+        }
+
+        /// <summary>
+        /// Release every storage parked on the segregated free lists back to <paramref name="ctx"/> —
+        /// these are storages that were recycled via FreeContainer/Clear but never re-used before
+        /// Dispose. Walks only the non-empty classes by consuming set bits of the class mask.
+        /// </summary>
+        public void ReleaseAll(ByteStringContext ctx)
+        {
+            ulong mask = _classMask;
+            while (mask != 0)
+            {
+                int c = BitOperations.TrailingZeroCount(mask);
+                mask &= mask - 1;
+
+                ByteString freeNode = _heads[c];
+                while (freeNode.HasValue)
+                {
+                    ByteString nextNode = *(ByteString*)freeNode.Ptr; // read next before releasing
+                    ctx.Release(ref freeNode);
+                    freeNode = nextNode;
+                }
+                _heads[c] = default;
+            }
+            _classMask = 0;
+        }
+    }
+}

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.FreeListHeads.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.FreeListHeads.cs
@@ -9,28 +9,17 @@ namespace Voron.Data.RoaringBitmaps;
 public unsafe partial struct RoaringBitmap
 {
     /// <summary>
-    /// Segregated storage free list: one intrusive singly-linked list head per size class.
+    /// Segregated storage-free list: one intrusive singly linked list head per size class.
     ///
     /// Storage blocks are bucketed into <see cref="NumSizeClasses"/> size classes on a 32-byte
-    /// aligned x1.091 geometric ladder spanning <see cref="InitialArrayContainerSizeInBytes"/> (64)
-    /// .. <see cref="BitmapContainerSizeInBytes"/> (8192). Allocations round their requested byte
-    /// count up to the enclosing class size, so every block in a class is exactly
-    /// <see cref="ClassSize"/>[c] bytes: a recycled block always fits any request mapping to its class,
-    /// the class is recovered on free from its Length, and every Length stays a multiple of
-    /// <see cref="SimdAlignment"/> (32) as the array-container SIMD set ops require. Worst-case internal
-    /// fragmentation is the x1.091 step (~9%); measured waste is ~4%.
-    ///
-    /// Each free block's first <c>sizeof(ByteString)</c> bytes hold the next <see cref="ByteString"/> in
-    /// its class chain (a default head means the class is empty). <see cref="_classMask"/> bit <c>c</c> is
-    /// set iff class <c>c</c> is non-empty, so <see cref="Allocate"/> finds the smallest sufficient class
-    /// in O(1) via <see cref="BitOperations.TrailingZeroCount(ulong)"/> rather than a best-fit walk. The
-    /// struct lives inline in <see cref="RoaringBitmap"/> and is swapped wholesale by <see cref="SwapContents"/>.
+    /// aligned x1.091 geometric ladder spanning 64 - 8,192. Allocations round their requested byte
+    /// count up to the enclosing class size. All matching required <see cref="SimdAlignment"/>
+    /// Worst-case internal fragmentation is the x1.091 step (~9%); measured waste is ~4%.
     /// </summary>
-    internal unsafe struct FreeListHeads
+    private struct FreeListHeads
     {
         private const int NumSizeClasses = 42;
 
-        /// <summary>Byte size of each storage class (32-aligned, strictly increasing).</summary>
         private static readonly int[] ClassSize =
         [
             64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 416, 480, 544, 608, 672, 736, 832, 928,
@@ -38,8 +27,7 @@ public unsafe partial struct RoaringBitmap
             4256, 4672, 5120, 5600, 6112, 6688, 7328, 8000, 8192
         ];
 
-        /// <summary>Maps a 32-byte quantum (<c>bytes / 32</c>) to the smallest class whose size covers it.
-        /// Indexed by <c>(neededBytes + 31) &gt;&gt; 5</c>; covers quanta 0..256 (0..8192 bytes).</summary>
+        /// <summary>Maps a 32-byte quantum to the smallest class whose size covers it. Indexed by <c>(neededBytes + 31) &gt;&gt; 5</c>.</summary>
         private static ReadOnlySpan<byte> ClassOfQuantum =>
         [
             0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16,
@@ -56,7 +44,6 @@ public unsafe partial struct RoaringBitmap
             40, 40, 40, 40, 40, 40, 41, 41, 41, 41, 41, 41
         ];
 
-        /// <summary>One free-list head per size class, stored inline (no extra allocation).</summary>
         [InlineArray(NumSizeClasses)]
         private struct Heads
         {
@@ -65,10 +52,8 @@ public unsafe partial struct RoaringBitmap
 
         private Heads _heads;
 
-        /// <summary>Bit <c>c</c> set iff <see cref="_heads"/>[c] is non-empty. 42 classes fit one ulong.</summary>
         private ulong _classMask;
 
-        /// <summary>Smallest size class whose <see cref="ClassSize"/> is &gt;= <paramref name="bytes"/>.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int SizeClassFor(int bytes)
         {
@@ -76,12 +61,6 @@ public unsafe partial struct RoaringBitmap
             return ClassOfQuantum[(bytes + SimdAlignment - 1) >> 5];
         }
 
-        /// <summary>
-        /// Push <paramref name="bs"/> onto the head of its size class's free list. The first
-        /// <c>sizeof(ByteString)</c> bytes of <paramref name="bs"/>'s data are overwritten with the
-        /// current head, forming the intrusive next-pointer. The class is recovered from
-        /// <c>bs.Length</c>, which is always exactly a <see cref="ClassSize"/> value.
-        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Return(ByteString bs)
         {
@@ -91,17 +70,11 @@ public unsafe partial struct RoaringBitmap
             _classMask |= 1UL << c;
         }
 
-        /// <summary>
-        /// Acquire storage of at least <paramref name="neededBytes"/>. Pops the head of the smallest
-        /// non-empty size class that can satisfy the request (O(1) via the class mask), unlinking it
-        /// in-place. Falls back to a fresh <paramref name="ctx"/> allocation rounded up to the class
-        /// size when every sufficient class is empty.
-        /// </summary>
         public void Allocate(ByteStringContext ctx, int neededBytes, out ByteString storage)
         {
             int c = SizeClassFor(neededBytes);
 
-            // Classes >= c hold blocks of ClassSize[>=c] >= neededBytes; pick the smallest non-empty one.
+            // we use best-fit here using single instruction with bit twiddling 
             ulong avail = _classMask & (~0UL << c);
             if (avail != 0)
             {
@@ -117,11 +90,6 @@ public unsafe partial struct RoaringBitmap
             ctx.Allocate(ClassSize[c], out storage);
         }
 
-        /// <summary>
-        /// Release every storage parked on the segregated free lists back to <paramref name="ctx"/> —
-        /// these are storages that were recycled via FreeContainer/Clear but never re-used before
-        /// Dispose. Walks only the non-empty classes by consuming set bits of the class mask.
-        /// </summary>
         public void ReleaseAll(ByteStringContext ctx)
         {
             ulong mask = _classMask;

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
@@ -12,8 +12,6 @@ namespace Voron.Data.RoaringBitmaps;
 
 public unsafe partial struct RoaringBitmap
 {
-    #region Bitmap Container
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool BitmapContains(ulong* bitmap, ushort val) =>
         (bitmap[val >> 6] & (1UL << (val & 63))) != 0;
@@ -36,7 +34,7 @@ public unsafe partial struct RoaringBitmap
                 acc = AdvSimd.Add(acc, AdvSimd.Add(lower, upper));
             }
 
-            // 65,536 bits max fits in 16 bits, so the ushort accumulator can't overflow.
+            // 65,536 bits max fit in 16 bits, so the ushort accumulator can't overflow.
             return Vector128.Sum(acc);
         }
 
@@ -95,10 +93,6 @@ public unsafe partial struct RoaringBitmap
 
     internal static void ClearArrayInBitmap(ushort* arr, int arrLen, ulong* bitmap)
         => ApplyArrayToBitmap<ArrayAndNotOp>(arr, arrLen, bitmap);
-
-    #endregion
-
-    #region SIMD Bitmap Operations
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void BitmapOrNoPop(ulong* a, ulong* b, ulong* dst) =>
@@ -165,15 +159,13 @@ public unsafe partial struct RoaringBitmap
         public static Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b) => Vector512.AndNot(a, b);
     }
 
-    /// <summary>Narrow long values to ushort (low 16 bits), using SIMD when available.</summary>
     internal static void CopyDenseBottom16BitsToUshortArray(ReadOnlySpan<long> source, ushort* destination)
     {
         int j = 0;
         int count = source.Length;
         ref long src = ref MemoryMarshal.GetReference(source);
 
-        // Chained Narrow (ulong→uint→ushort): truncation == masking 0xFFFF for non-negative values,
-        // so no explicit AND with ContainerValueMask.
+        // Chained Narrow (ulong→uint→ushort): truncation == masking 0xFFFF for non-negative values, so no explicit AND with ContainerValueMask.
         if (Vector256.IsHardwareAccelerated && count >= 16)
         {
             for (; j <= count - 16; j += 16)
@@ -297,10 +289,6 @@ public unsafe partial struct RoaringBitmap
                 return new ContainerEntry { Cardinality = entry.Cardinality, Data = storage.Ptr, Storage = storage };
         }
     }
-
-    #endregion
-
-    #region Array Container
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool ArrayContainerContains(ushort* data, int cardinality, ushort value)
@@ -620,25 +608,17 @@ public unsafe partial struct RoaringBitmap
 
         new Span<ushort>(arr, count).Sort();
 
-        if (count > 1)
+        int write = 1;
+        for (int read = 1; read < count; read++)
         {
-            int write = 1;
-            for (int read = 1; read < count; read++)
-            {
-                if (arr[read] != arr[write - 1])
-                    arr[write++] = arr[read];
-            }
-            count = write;
+            if (arr[read] != arr[write - 1])
+                arr[write++] = arr[read];
         }
+        count = write;
 
         entry.Cardinality = count;
         type = ContainerType.Array;
     }
-
-    #endregion
-    
-    
-    #region Range Container
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int RangeEndExclusive(ref ContainerEntry entry) => entry.RangeStart + entry.Cardinality;
@@ -713,13 +693,13 @@ public unsafe partial struct RoaringBitmap
     {
         Debug.Assert(type == ContainerType.Range);
 
-        _freeList.Allocate(_ctx, BitmapContainerSizeInBytes, out ByteString storage);
+        _buffersFreeListHeads.Allocate(ctx, BitmapContainerSizeInBytes, out ByteString storage);
         ulong* bitmap = (ulong*)storage.Ptr;
         ClearBitmap(bitmap);
         FillBitmapFromRange(bitmap, entry.RangeStart, entry.Cardinality);
 
         if (entry.Storage.HasValue)
-            _ctx.Release(ref entry.Storage);
+            ctx.Release(ref entry.Storage);
 
         entry.Storage = storage;
         entry.Data = storage.Ptr;
@@ -730,7 +710,7 @@ public unsafe partial struct RoaringBitmap
     {
         int totalCount = rangeCount + sortedValues.Length;
         int neededBytes = totalCount * sizeof(ushort);
-        _freeList.Allocate(_ctx, neededBytes, out ByteString storage);
+        _buffersFreeListHeads.Allocate(ctx, neededBytes, out ByteString storage);
         ushort* arr = (ushort*)storage.Ptr;
 
         FillSequentialUInt16(arr, rangeStart, rangeCount);
@@ -763,24 +743,21 @@ public unsafe partial struct RoaringBitmap
         int totalCount = leftCount + rightCount;
         if (totalCount > ArrayContainerMaxCardinality)
             return false;
+        Span<long> buffer = stackalloc long[ArrayContainerMaxCardinality];
 
         if (left.RangeStart < right.RangeStart)
         {
-            long* rightValues = stackalloc long[rightCount];
-            long rightCurrent = right.RangeStart;
+           long rightCurrent = right.RangeStart;
             for (int i = 0; i < rightCount; i++, rightCurrent++)
-                rightValues[i] = rightCurrent;
+                buffer[i] = rightCurrent;
 
-            return MaybeConvertRangeToArray(ref left, ref leftType, left.RangeStart, leftCount, new ReadOnlySpan<long>(rightValues, rightCount));
+            return MaybeConvertRangeToArray(ref left, ref leftType, left.RangeStart, leftCount, buffer[..rightCount]);
         }
 
-        long* leftValues = stackalloc long[leftCount];
         long leftCurrent = left.RangeStart;
         for (int i = 0; i < leftCount; i++, leftCurrent++)
-            leftValues[i] = leftCurrent;
+            buffer[i] = leftCurrent;
 
-        return MaybeConvertRangeToArray(ref left, ref leftType, right.RangeStart, rightCount, new ReadOnlySpan<long>(leftValues, leftCount));
+        return MaybeConvertRangeToArray(ref left, ref leftType, right.RangeStart, rightCount, buffer[..leftCount]);
     }
-
-    #endregion
 }

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
@@ -166,7 +166,21 @@ public unsafe partial struct RoaringBitmap
         ref long src = ref MemoryMarshal.GetReference(source);
 
         // Chained Narrow (ulong→uint→ushort): truncation == masking 0xFFFF for non-negative values, so no explicit AND with ContainerValueMask.
-        if (Vector256.IsHardwareAccelerated && count >= 16)
+        if (Vector512.IsHardwareAccelerated && count >= 32)
+        {
+            for (; j <= count - 32; j += 32)
+            {
+                var v0 = Vector512.LoadUnsafe(ref src, (nuint)j).AsUInt64();
+                var v1 = Vector512.LoadUnsafe(ref src, (nuint)(j + 8)).AsUInt64();
+                var v2 = Vector512.LoadUnsafe(ref src, (nuint)(j + 16)).AsUInt64();
+                var v3 = Vector512.LoadUnsafe(ref src, (nuint)(j + 24)).AsUInt64();
+
+                var u0 = Vector512.Narrow(v0, v1); // 16 uints
+                var u1 = Vector512.Narrow(v2, v3); // 16 uints
+                Vector512.Narrow(u0, u1).StoreUnsafe(ref *destination, (nuint)j); // 32 shorts
+            }
+        }
+        else if (Vector256.IsHardwareAccelerated && count >= 16)
         {
             for (; j <= count - 16; j += 16)
             {
@@ -312,7 +326,21 @@ public unsafe partial struct RoaringBitmap
         if (cardinality == 0)
             return false;
 
-        if (AdvInstructionSet.IsAcceleratedVector256)
+        if (AdvInstructionSet.IsAcceleratedVector512)
+        {
+            int vecCount = (cardinality + Vector512<ushort>.Count - 1) / Vector512<ushort>.Count;
+            Vector512<ushort> needle = Vector512.Create(value);
+            for (int v = 0; v < vecCount; v++)
+            {
+                var hasMatch = Vector512.Equals(Vector512.Load(arr + v * Vector512<ushort>.Count), needle).ExtractMostSignificantBits();
+                if (hasMatch == 0)
+                    continue;
+
+                int found = BitOperations.TrailingZeroCount(hasMatch) + v * Vector512<ushort>.Count;
+                return found < cardinality;
+            }
+        }
+        else if (AdvInstructionSet.IsAcceleratedVector256)
         {
             int vecCount = (cardinality + Vector256<ushort>.Count - 1) / Vector256<ushort>.Count;
             Vector256<ushort> needle = Vector256.Create(value);
@@ -320,9 +348,9 @@ public unsafe partial struct RoaringBitmap
             {
                 // Safe to over-read: allocation is SIMD-aligned with zeroed padding.
                 var hasMatch = Vector256.Equals(Vector256.Load(arr + v * Vector256<ushort>.Count), needle).ExtractMostSignificantBits();
-                if (hasMatch == 0) 
+                if (hasMatch == 0)
                     continue;
-                
+
                 int found = BitOperations.TrailingZeroCount(hasMatch) + v * Vector256<ushort>.Count;
                 return found < cardinality;
             }

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
@@ -180,7 +180,7 @@ public unsafe partial struct RoaringBitmap
                 Vector512.Narrow(u0, u1).StoreUnsafe(ref *destination, (nuint)j); // 32 shorts
             }
         }
-        else if (Vector256.IsHardwareAccelerated && count >= 16)
+        if (Vector256.IsHardwareAccelerated && count >= 16)
         {
             for (; j <= count - 16; j += 16)
             {
@@ -194,7 +194,7 @@ public unsafe partial struct RoaringBitmap
                 Vector256.Narrow(u0, u1).StoreUnsafe(ref *destination, (nuint)j); // 16 shorts
             }
         }
-        else if (Vector128.IsHardwareAccelerated && count >= 8)
+        if (Vector128.IsHardwareAccelerated && count >= 8)
         {
             for (; j <= count - 8; j += 8)
             {

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
@@ -1,0 +1,786 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using Sparrow;
+using Sparrow.Server;
+
+namespace Voron.Data.RoaringBitmaps;
+
+public unsafe partial struct RoaringBitmap
+{
+    #region Bitmap Container
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool BitmapContains(ulong* bitmap, ushort val) =>
+        (bitmap[val >> 6] & (1UL << (val & 63))) != 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapSet(ulong* bitmap, ushort val) =>
+        bitmap[val >> 6] |= 1UL << (val & 63);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int BitmapContainerCardinality(byte* data)
+    {
+        if (AdvInstructionSet.Arm.IsSupportedArm64)
+        {
+            Vector128<ulong>* bitmapVec = (Vector128<ulong>*)data;
+            Vector128<ushort> acc = Vector128<ushort>.Zero;
+            for (int i = 0; i < BitmapContainerSizeInUInt64 / Vector128<ulong>.Count; i++)
+            {
+                Vector128<byte> popCounts = AdvSimd.PopCount(bitmapVec[i].AsByte());
+                var (lower, upper) = Vector128.Widen(popCounts);
+                acc = AdvSimd.Add(acc, AdvSimd.Add(lower, upper));
+            }
+
+            // 65,536 bits max fits in 16 bits, so the ushort accumulator can't overflow.
+            return Vector128.Sum(acc);
+        }
+
+        // Scalar fallback: 4-way unrolled for ILP via independent accumulator chains.
+        // 1024 is divisible by 4 so no remainder handling is needed.
+        int c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+        ulong* bitmap = (ulong*)data;
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i += 4)
+        {
+            c0 += BitOperations.PopCount(bitmap[i]);
+            c1 += BitOperations.PopCount(bitmap[i + 1]);
+            c2 += BitOperations.PopCount(bitmap[i + 2]);
+            c3 += BitOperations.PopCount(bitmap[i + 3]);
+        }
+
+        return c0 + c1 + c2 + c3;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ClearBitmap(ulong* bitmap)
+    {
+        new Span<byte>(bitmap, BitmapContainerSizeInBytes).Clear();
+    }
+
+    private interface IArrayToBitmapOp
+    {
+        static abstract ulong Apply(ulong current, ulong mask);
+    }
+
+    private struct ArrayOrOp : IArrayToBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong current, ulong mask) => current | mask;
+    }
+
+    private struct ArrayAndNotOp : IArrayToBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong current, ulong mask) => current & ~mask;
+    }
+
+    private static void ApplyArrayToBitmap<TOp>(ushort* arr, int arrLen, ulong* bitmap)
+        where TOp : struct, IArrayToBitmapOp
+    {
+        for (int i = 0; i < arrLen; i++)
+        {
+            ushort val = arr[i];
+            int wordIdx = val >> 6;
+            ulong mask = 1UL << (val & 63);
+            bitmap[wordIdx] = TOp.Apply(bitmap[wordIdx], mask);
+        }
+    }
+
+    internal static void SetArrayInBitmap(ushort* arr, int arrLen, ulong* bitmap)
+        => ApplyArrayToBitmap<ArrayOrOp>(arr, arrLen, bitmap);
+
+    internal static void ClearArrayInBitmap(ushort* arr, int arrLen, ulong* bitmap)
+        => ApplyArrayToBitmap<ArrayAndNotOp>(arr, arrLen, bitmap);
+
+    #endregion
+
+    #region SIMD Bitmap Operations
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapOrNoPop(ulong* a, ulong* b, ulong* dst) =>
+        BitmapOpDispatch<OrOp>(a, b, dst);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapAndNoPop(ulong* a, ulong* b, ulong* dst) =>
+        BitmapOpDispatch<AndOp>(a, b, dst);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapAndNotNoPop(ulong* a, ulong* b, ulong* dst) =>
+        BitmapOpDispatch<AndNotOp>(a, b, dst);
+
+    private interface IBitmapOp
+    {
+        static abstract ulong Apply(ulong a, ulong b);
+        static abstract Vector128<ulong> Apply(Vector128<ulong> a, Vector128<ulong> b);
+        static abstract Vector256<ulong> Apply(Vector256<ulong> a, Vector256<ulong> b);
+        static abstract Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b);
+    }
+
+    private struct AndOp : IBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong a, ulong b) => a & b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> Apply(Vector128<ulong> a, Vector128<ulong> b) => a & b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<ulong> Apply(Vector256<ulong> a, Vector256<ulong> b) => a & b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b) => a & b;
+    }
+
+    private struct OrOp : IBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong a, ulong b) => a | b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> Apply(Vector128<ulong> a, Vector128<ulong> b) => a | b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<ulong> Apply(Vector256<ulong> a, Vector256<ulong> b) => a | b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b) => a | b;
+    }
+
+    private struct AndNotOp : IBitmapOp
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Apply(ulong a, ulong b) => a & ~b;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> Apply(Vector128<ulong> a, Vector128<ulong> b) => Vector128.AndNot(a, b);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<ulong> Apply(Vector256<ulong> a, Vector256<ulong> b) => Vector256.AndNot(a, b);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<ulong> Apply(Vector512<ulong> a, Vector512<ulong> b) => Vector512.AndNot(a, b);
+    }
+
+    /// <summary>Narrow long values to ushort (low 16 bits), using SIMD when available.</summary>
+    internal static void CopyDenseBottom16BitsToUshortArray(ReadOnlySpan<long> source, ushort* destination)
+    {
+        int j = 0;
+        int count = source.Length;
+        ref long src = ref MemoryMarshal.GetReference(source);
+
+        // Chained Narrow (ulong→uint→ushort): truncation == masking 0xFFFF for non-negative values,
+        // so no explicit AND with ContainerValueMask.
+        if (Vector256.IsHardwareAccelerated && count >= 16)
+        {
+            for (; j <= count - 16; j += 16)
+            {
+                var v0 = Vector256.LoadUnsafe(ref src, (nuint)j).AsUInt64();
+                var v1 = Vector256.LoadUnsafe(ref src, (nuint)(j + 4)).AsUInt64();
+                var v2 = Vector256.LoadUnsafe(ref src, (nuint)(j + 8)).AsUInt64();
+                var v3 = Vector256.LoadUnsafe(ref src, (nuint)(j + 12)).AsUInt64();
+
+                var u0 = Vector256.Narrow(v0, v1); // 8 uints
+                var u1 = Vector256.Narrow(v2, v3); // 8 uints
+                Vector256.Narrow(u0, u1).StoreUnsafe(ref *destination, (nuint)j); // 16 shorts
+            }
+        }
+        else if (Vector128.IsHardwareAccelerated && count >= 8)
+        {
+            for (; j <= count - 8; j += 8)
+            {
+                var v0 = Vector128.LoadUnsafe(ref src, (nuint)j).AsUInt64();
+                var v1 = Vector128.LoadUnsafe(ref src, (nuint)(j + 2)).AsUInt64();
+                var v2 = Vector128.LoadUnsafe(ref src, (nuint)(j + 4)).AsUInt64();
+                var v3 = Vector128.LoadUnsafe(ref src, (nuint)(j + 6)).AsUInt64();
+
+                var u0 = Vector128.Narrow(v0, v1); // 4 uints
+                var u1 = Vector128.Narrow(v2, v3); // 4 uints
+                Vector128.Narrow(u0, u1).StoreUnsafe(ref *destination, (nuint)j); // 8 shorts
+            }
+        }
+
+        for (; j < count; j++)
+            destination[j] = (ushort)(source[j] & ContainerValueMask);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void FillSequentialUInt16(ushort* destination, int startValue, int count)
+    {
+        int i = 0;
+        if (AdvInstructionSet.IsAcceleratedVector256 && count >= Vector256<ushort>.Count)
+        {
+            Vector256<ushort> offsets = Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, (ushort)15);
+            Vector256<ushort> valueVec = Vector256.Create((ushort)startValue);
+            Vector256<ushort> stride = Vector256.Create((ushort)Vector256<ushort>.Count);
+
+            for (; i + Vector256<ushort>.Count <= count; i += Vector256<ushort>.Count)
+            {
+                (valueVec + offsets).Store(destination + i);
+                valueVec = valueVec + stride;
+            }
+        }
+
+        if (AdvInstructionSet.IsAcceleratedVector128 && count - i >= Vector128<ushort>.Count)
+        {
+            Vector128<ushort> offsets = Vector128.Create(0, 1, 2, 3, 4, 5, 6, (ushort)7);
+            Vector128<ushort> valueVec = Vector128.Create((ushort)(startValue + i));
+            Vector128<ushort> stride = Vector128.Create((ushort)Vector128<ushort>.Count);
+
+            for (; i + Vector128<ushort>.Count <= count; i += Vector128<ushort>.Count)
+            {
+                (valueVec + offsets).Store(destination + i);
+                valueVec = valueVec + stride;
+            }
+        }
+
+        for (; i < count; i++)
+            destination[i] = (ushort)(startValue + i);
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void BitmapOpDispatch<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        if (AdvInstructionSet.IsAcceleratedVector512)
+            BitmapOpVector512NoPop<TOp>(a, b, dst);
+        else if (AdvInstructionSet.IsAcceleratedVector256)
+            BitmapOpVector256NoPop<TOp>(a, b, dst);
+        else if (AdvInstructionSet.IsAcceleratedVector128)
+            BitmapOpVector128NoPop<TOp>(a, b, dst);
+        else
+            BitmapOpScalarNoPop<TOp>(a, b, dst);
+    }
+
+    private static void BitmapOpVector512NoPop<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        int N = Vector512<ulong>.Count;
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i += N)
+            TOp.Apply(Vector512.Load(a + i), Vector512.Load(b + i)).Store(dst + i);
+    }
+
+    private static void BitmapOpVector256NoPop<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        int N = Vector256<ulong>.Count;
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i += N)
+            TOp.Apply(Vector256.Load(a + i), Vector256.Load(b + i)).Store(dst + i);
+    }
+
+    private static void BitmapOpVector128NoPop<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        int N = Vector128<ulong>.Count;
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i += N)
+            TOp.Apply(Vector128.Load(a + i), Vector128.Load(b + i)).Store(dst + i);
+    }
+
+    private static void BitmapOpScalarNoPop<TOp>(ulong* a, ulong* b, ulong* dst) where TOp : struct, IBitmapOp
+    {
+        for (int i = 0; i < BitmapContainerSizeInUInt64; i++)
+            dst[i] = TOp.Apply(a[i], b[i]);
+    }
+
+    internal static ContainerEntry CloneContainer(ByteStringContext ctx, ref ContainerEntry entry, ContainerType type)
+    {
+        switch (type)
+        {
+            case ContainerType.Range:
+                return new ContainerEntry { Cardinality = entry.Cardinality, RangeStart = entry.RangeStart, Storage = default };
+            case ContainerType.Free:
+                return entry;
+            default:
+                int dataSize = entry.Storage.Length;
+                ctx.Allocate(dataSize, out ByteString storage);
+                Unsafe.CopyBlockUnaligned(storage.Ptr, entry.Data, (uint)dataSize);
+                return new ContainerEntry { Cardinality = entry.Cardinality, Data = storage.Ptr, Storage = storage };
+        }
+    }
+
+    #endregion
+
+    #region Array Container
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool ArrayContainerContains(ushort* data, int cardinality, ushort value)
+    {
+        return AdvInstructionSet.IsAcceleratedVector128 switch
+        {
+            // small arrays: SIMD linear scan is more efficient than the quad search
+            true when cardinality <= SimdLinearScanThreshold => SimdLinearContains(data, cardinality, value),
+            true => SimdQuadContains(data, cardinality, value),
+            _ => ArrayContainerFind(data, cardinality, value) >= 0
+        };
+    }
+
+    /// <summary>
+    /// SIMD linear scan for small arrays (&lt; 64 values), sorted or not. The last chunk may over-read into
+    /// zeroed padding; the found &lt; cardinality check excludes a false match from that padding.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool SimdLinearContains(ushort* arr, int cardinality, ushort value)
+    {
+        if (cardinality == 0)
+            return false;
+
+        if (AdvInstructionSet.IsAcceleratedVector256)
+        {
+            int vecCount = (cardinality + Vector256<ushort>.Count - 1) / Vector256<ushort>.Count;
+            Vector256<ushort> needle = Vector256.Create(value);
+            for (int v = 0; v < vecCount; v++)
+            {
+                // Safe to over-read: allocation is SIMD-aligned with zeroed padding.
+                var hasMatch = Vector256.Equals(Vector256.Load(arr + v * Vector256<ushort>.Count), needle).ExtractMostSignificantBits();
+                if (hasMatch == 0) 
+                    continue;
+                
+                int found = BitOperations.TrailingZeroCount(hasMatch) + v * Vector256<ushort>.Count;
+                return found < cardinality;
+            }
+        }
+        else if (AdvInstructionSet.IsAcceleratedVector128)
+        {
+            int vecCount = (cardinality + Vector128<ushort>.Count - 1) / Vector128<ushort>.Count;
+            Vector128<ushort> needle = Vector128.Create(value);
+            for (int v = 0; v < vecCount; v++)
+            {
+                var hasMatch = Vector128.Equals(Vector128.Load(arr + v * Vector128<ushort>.Count), needle).ExtractMostSignificantBits();
+                if (hasMatch == 0) 
+                    continue;
+                
+                int found = BitOperations.TrailingZeroCount(hasMatch) + v * Vector128<ushort>.Count;
+                return found < cardinality;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < cardinality; i++)
+            {
+                if (arr[i] == value)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Search for larger sorted arrays (&gt; 64 values): quaternary search over 8-element (Vector128)
+    /// block boundaries, then a single SIMD compare on the final block.
+    /// Based on Daniel Lemire's algorithm (https://lemire.me/blog/2026/04/27/you-can-beat-the-binary-search/)
+    /// </summary>
+    internal static bool SimdQuadContains(ushort* arr, int cardinality, ushort value)
+    {
+        int gap = Vector128<ushort>.Count; // 8
+        int numBlocks = cardinality / gap;
+        int @base = 0;
+        int n = numBlocks;
+
+        // Quaternary search on block boundaries
+        while (n > 3)
+        {
+            int quarter = n >> 2;
+            int k1 = arr[(@base + quarter + 1) * gap - 1];
+            int k2 = arr[(@base + 2 * quarter + 1) * gap - 1];
+            int k3 = arr[(@base + 3 * quarter + 1) * gap - 1];
+            @base += ((k1 < value ? 1 : 0) + (k2 < value ? 1 : 0) + (k3 < value ? 1 : 0)) * quarter;
+            n -= 3 * quarter;
+        }
+
+        while (n > 1)
+        {
+            int half = n >> 1;
+            @base = arr[(@base + half + 1) * gap - 1] < value ? @base + half : @base;
+            n -= half;
+        }
+
+        int lo = arr[(@base + 1) * gap - 1] < value ? @base + 1 : @base;
+
+        // lo in [0, numBlocks]: candidate block, or one past the last (value exceeds all maxima) where
+        // lo*gap is the tail start. Over-read into zeroed padding is safe; the cardinality check below
+        // excludes a padding match.
+        int startIdx = lo * gap;
+        var tailMatch = Vector128.Equals(Vector128.Load(arr + startIdx), Vector128.Create(value)).ExtractMostSignificantBits();
+        return tailMatch is not 0 && startIdx + BitOperations.TrailingZeroCount(tailMatch) < cardinality;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int ArrayContainerFind(ushort* arr, int count, ushort value)
+    {
+        int lo = 0;
+        int hi = count - 1;
+
+        while (lo <= hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            ushort midVal = arr[mid];
+
+            if (midVal == value)
+                return mid;
+            if (midVal < value)
+                lo = mid + 1;
+            else
+                hi = mid - 1;
+        }
+
+        return ~lo;
+    }
+
+    /// <summary>
+    /// Cross-compare AND on unsorted data: broadcast each A[i] across Vector256 and compare against all chunks of B.
+    /// Both arrays must be ≤ SimdLinearScanThreshold with buffers padded to 64 bytes.
+    /// </summary>
+    private static int SimdCrossAnd(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+    {
+        int di = 0;
+        int bVecCount = (bLen + Vector256<ushort>.Count - 1) / Vector256<ushort>.Count;
+
+        for (int i = 0; i < aLen; i++)
+        {
+            Vector256<ushort> needle = Vector256.Create(a[i]);
+            int found = int.MaxValue;
+
+            for (int bv = 0; bv < bVecCount; bv++)
+            {
+                // Safe to over-read: bLen ≤ 64 ushort elements (128 bytes total)
+                Vector256<ushort> bChunk = Vector256.Load(b + bv * Vector256<ushort>.Count);
+
+                var hasMatch = Vector256.Equals(needle, bChunk).ExtractMostSignificantBits();
+                if (hasMatch == 0) 
+                    continue;
+                
+                found = BitOperations.TrailingZeroCount(hasMatch) + bv * Vector256<ushort>.Count;
+                break;
+            }
+
+            // found >= bLen: either no match (int.MaxValue) or a match in padding past the live count.
+            if (found >= bLen)
+                continue;
+            dst[di++] = a[i];
+        }
+
+        return di;
+    }
+
+    /// <summary>
+    /// SIMD cross-compare ANDNOT: keep elements in A that do NOT exist in B.
+    /// Same cross-compare pattern, inverted match logic.
+    /// </summary>
+    private static int SimdCrossAndNot(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+    {
+        // Same over-read guarantee and found-index pattern as SimdCrossAnd — see comment there.
+        int di = 0;
+        int bVecCount = (bLen + Vector256<ushort>.Count - 1) / Vector256<ushort>.Count;
+
+        for (int i = 0; i < aLen; i++)
+        {
+            Vector256<ushort> needle = Vector256.Create(a[i]);
+            int found = int.MaxValue;
+
+            for (int bv = 0; bv < bVecCount; bv++)
+            {
+                // Safe to over-read: buffer guaranteed ≥ 64 bytes (minimum SIMD-aligned allocation), and bLen ≤ 64
+                Vector256<ushort> bChunk = Vector256.Load(b + bv * Vector256<ushort>.Count);
+
+                var hasMatch = Vector256.Equals(needle, bChunk).ExtractMostSignificantBits();
+                if (hasMatch == 0) 
+                    continue;
+                
+                found = BitOperations.TrailingZeroCount(hasMatch) + bv * Vector256<ushort>.Count;
+                break;
+            }
+
+            // found >= bLen: no match in B (int.MaxValue or padding), so keep for ANDNOT.
+            if (found >= bLen)
+                dst[di++] = a[i];
+        }
+
+        return di;
+    }
+
+    /// <summary>
+    /// AND / ANDNOT share the same SIMD galloping structure; only the keep/discard logic differs.
+    /// </summary>
+    private interface IArrayMatchStrategy
+    {
+        /// <summary>true for AND (keep matches), false for AND NOT (discard matches).</summary>
+        static abstract bool KeepOnMatch { get; }
+
+        /// <summary>false for AND (skip A values not in B), true for AND NOT (keep A values not in B).</summary>
+        static abstract bool KeepOnMissInSmaller { get; }
+    }
+
+    private struct AndStrategy : IArrayMatchStrategy
+    {
+        public static bool KeepOnMatch => true;
+        public static bool KeepOnMissInSmaller => false;
+    }
+
+    private struct AndNotStrategy : IArrayMatchStrategy
+    {
+        public static bool KeepOnMatch => false;
+        public static bool KeepOnMissInSmaller => true;
+    }
+
+    /// <summary>Intersection of two array containers into dst (SIMD galloping, scalar merge fallback).</summary>
+    internal static int ArrayContainerAnd(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+        => ArrayContainerMatch<AndStrategy>(a, aLen, b, bLen, dst);
+
+    /// <summary>A AND NOT B for two array containers (SIMD galloping, scalar merge fallback).</summary>
+    internal static int ArrayContainerAndNot(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+        => ArrayContainerMatch<AndNotStrategy>(a, aLen, b, bLen, dst);
+
+    private static int ArrayContainerMatch<TStrategy>(ushort* a, int aLen, ushort* b, int bLen, ushort* dst)
+        where TStrategy : struct, IArrayMatchStrategy
+    {
+        uint N = (uint)Vector256<ushort>.Count; // 16
+        int ai = 0, bi = 0, di = 0;
+
+        if (AdvInstructionSet.IsAcceleratedVector256)
+        {
+            while (ai < aLen && bi + (int)N <= bLen)
+            {
+                ushort val = a[ai];
+
+                // If val is past the current block of B, advance B
+                if (val > b[bi + N - 1])
+                {
+                    bi += (int)N;
+                    continue;
+                }
+
+                // If val is before the current block of B, it's not in B
+                if (val < b[bi])
+                {
+                    if (TStrategy.KeepOnMissInSmaller)
+                        dst[di++] = val;
+                    ai++;
+                    continue;
+                }
+
+                // Check if val exists in this block of B
+                Vector256<ushort> vVal = Vector256.Create(val);
+                Vector256<ushort> vBlock = Vector256.Load(b + bi);
+                bool found = Vector256.EqualsAny(vVal, vBlock);
+                if (found == TStrategy.KeepOnMatch)
+                    dst[di++] = val;
+
+                ai++;
+            }
+        }
+
+        // Scalar tail — also handles the full input when SIMD is not available
+        while (ai < aLen && bi < bLen)
+        {
+            if (a[ai] < b[bi])
+            {
+                if (TStrategy.KeepOnMissInSmaller)
+                    dst[di++] = a[ai];
+                ai++;
+            }
+            else if (a[ai] > b[bi])
+                bi++;
+            else
+            {
+                if (TStrategy.KeepOnMatch)
+                    dst[di++] = a[ai];
+                ai++;
+                bi++;
+            }
+        }
+
+        if (TStrategy.KeepOnMissInSmaller)
+        {
+            while (ai < aLen)
+                dst[di++] = a[ai++];
+        }
+
+        return di;
+    }
+
+    
+    [Conditional("DEBUG")]
+    private static void AssertSorted(ReadOnlySpan<long> values)
+    {
+        for (int i = 1; i < values.Length; i++)
+        {
+            Debug.Assert(values[i] > values[i - 1],
+                $"AddRange requires strictly sorted (unique) input: values[{i - 1}]={values[i - 1]} >= values[{i}]={values[i]}");
+        }
+    }
+
+    /// <summary>
+    /// Comparison sort + dedup for small arrays below the bitmap radix sort threshold.
+    /// </summary>
+    private static void SortAndDedupSmallArray(ref ContainerEntry entry, out ContainerType type)
+    {
+        var arr = entry.ArrayData;
+        int count = entry.Cardinality;
+
+        new Span<ushort>(arr, count).Sort();
+
+        if (count > 1)
+        {
+            int write = 1;
+            for (int read = 1; read < count; read++)
+            {
+                if (arr[read] != arr[write - 1])
+                    arr[write++] = arr[read];
+            }
+            count = write;
+        }
+
+        entry.Cardinality = count;
+        type = ContainerType.Array;
+    }
+
+    #endregion
+    
+    
+    #region Range Container
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int RangeEndExclusive(ref ContainerEntry entry) => entry.RangeStart + entry.Cardinality;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryMergeRangeInPlace(ref ContainerEntry entry, int otherStart, int otherEndExclusive)
+    {
+        int rangeStart = entry.RangeStart;
+        int rangeEnd = rangeStart + entry.Cardinality;
+
+        // Half-open interval merge: [rangeStart, rangeEnd) with [otherStart, otherEndExclusive).
+        // Merge on overlap or exact touch; fail only when there is an actual gap.
+        if (otherStart > rangeEnd || otherEndExclusive < rangeStart)
+            return false;
+
+        int mergedStart = Math.Min(rangeStart, otherStart);
+        int mergedEnd = Math.Max(rangeEnd, otherEndExclusive);
+        entry.RangeStart = (ushort)mergedStart;
+        entry.Cardinality = mergedEnd - mergedStart;
+        return true;
+    }
+
+    /// <summary>
+    /// Convert a Range container to Bitmap or Array to handle an Add outside the contiguous range.
+    /// </summary>
+    private void ConvertRangeForAdd(ref ContainerEntry entry, ref ContainerType type, ushort value)
+    {
+        Debug.Assert(type == ContainerType.Range);
+        int rangeStart = entry.RangeStart;
+        int rangeCount = entry.Cardinality;
+
+        Span<long> extraValuesSpan = stackalloc long[1];
+        extraValuesSpan[0] = value;
+        
+        if (MaybeConvertRangeToArray(ref entry, ref type, rangeStart, rangeCount, extraValuesSpan))
+            return;
+        
+        ConvertRangeToBitmap(ref entry, ref type);
+        BitmapSet(entry.BitmapPtr, value);
+        entry.Cardinality = LazyCardinality;
+    }
+
+    /// <summary>
+    /// Fill a cleared bitmap buffer with bits rangeStart ... (rangeStart+rangeCount-1) set.
+    /// </summary>
+    internal static void FillBitmapFromRange(ulong* bitmap, int rangeStart, int rangeCount)
+    {
+        if (rangeCount <= 0)
+            return;
+
+        int firstWord = rangeStart >> 6;
+        int firstBit = rangeStart & 63;
+        int lastValue = rangeStart + rangeCount - 1;
+        int lastWord = lastValue >> 6;
+        int lastBit = lastValue & 63;
+
+        if (firstWord == lastWord)
+        {
+            ulong startMask = ulong.MaxValue << firstBit;
+            ulong endMask = lastBit == 63 ? ulong.MaxValue : (1UL << (lastBit + 1)) - 1;
+            bitmap[firstWord] = startMask & endMask;
+            return;
+        }
+
+        bitmap[firstWord] = ulong.MaxValue << firstBit;
+        if (lastWord > firstWord + 1)
+            new Span<ulong>(bitmap + firstWord + 1, lastWord - firstWord - 1).Fill(ulong.MaxValue);
+        bitmap[lastWord] = lastBit == 63 ? ulong.MaxValue : (1UL << (lastBit + 1)) - 1;
+    }
+
+    private void ConvertRangeToBitmap(ref ContainerEntry entry, ref ContainerType type)
+    {
+        Debug.Assert(type == ContainerType.Range);
+
+        _freeList.Allocate(_ctx, BitmapContainerSizeInBytes, out ByteString storage);
+        ulong* bitmap = (ulong*)storage.Ptr;
+        ClearBitmap(bitmap);
+        FillBitmapFromRange(bitmap, entry.RangeStart, entry.Cardinality);
+
+        if (entry.Storage.HasValue)
+            _ctx.Release(ref entry.Storage);
+
+        entry.Storage = storage;
+        entry.Data = storage.Ptr;
+        type = ContainerType.Bitmap;
+    }
+
+    private void ConvertRangeToArray(ref ContainerEntry entry, ref ContainerType type, int rangeStart, int rangeCount, ReadOnlySpan<long> sortedValues)
+    {
+        int totalCount = rangeCount + sortedValues.Length;
+        int neededBytes = AlignForSimd(totalCount * sizeof(ushort));
+        _freeList.Allocate(_ctx, neededBytes, out ByteString storage);
+        ushort* arr = (ushort*)storage.Ptr;
+
+        FillSequentialUInt16(arr, rangeStart, rangeCount);
+        CopyDenseBottom16BitsToUshortArray(sortedValues, arr + rangeCount);
+
+        Debug.Assert(entry.Storage.HasValue is false, "Range containers should not have Storage");
+
+        entry.Storage = storage;
+        entry.Data = storage.Ptr;
+        entry.Cardinality = totalCount;
+        type = ContainerType.ArrayUnsorted;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool MaybeConvertRangeToArray(ref ContainerEntry entry, ref ContainerType type, int rangeStart, int rangeCount, scoped ReadOnlySpan<long> sortedValues)
+    {
+        int totalCount = rangeCount + sortedValues.Length;
+        if (totalCount > ArrayContainerMaxCardinality)
+            return false;
+
+        ConvertRangeToArray(ref entry, ref type, rangeStart, rangeCount, sortedValues);
+        return true;
+    }
+
+    [SkipLocalsInit]
+    private bool TryConvertRangeRangeToBestContainer(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right)
+    {
+        int leftCount = left.Cardinality;
+        int rightCount = right.Cardinality;
+        int totalCount = leftCount + rightCount;
+        if (totalCount > ArrayContainerMaxCardinality)
+            return false;
+
+        if (left.RangeStart < right.RangeStart)
+        {
+            long* rightValues = stackalloc long[rightCount];
+            long rightCurrent = right.RangeStart;
+            for (int i = 0; i < rightCount; i++, rightCurrent++)
+                rightValues[i] = rightCurrent;
+
+            return MaybeConvertRangeToArray(ref left, ref leftType, left.RangeStart, leftCount, new ReadOnlySpan<long>(rightValues, rightCount));
+        }
+
+        long* leftValues = stackalloc long[leftCount];
+        long leftCurrent = left.RangeStart;
+        for (int i = 0; i < leftCount; i++, leftCurrent++)
+            leftValues[i] = leftCurrent;
+
+        return MaybeConvertRangeToArray(ref left, ref leftType, right.RangeStart, rightCount, new ReadOnlySpan<long>(leftValues, leftCount));
+    }
+
+    #endregion
+}

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.Primitives.cs
@@ -729,7 +729,7 @@ public unsafe partial struct RoaringBitmap
     private void ConvertRangeToArray(ref ContainerEntry entry, ref ContainerType type, int rangeStart, int rangeCount, ReadOnlySpan<long> sortedValues)
     {
         int totalCount = rangeCount + sortedValues.Length;
-        int neededBytes = AlignForSimd(totalCount * sizeof(ushort));
+        int neededBytes = totalCount * sizeof(ushort);
         _freeList.Allocate(_ctx, neededBytes, out ByteString storage);
         ushort* arr = (ushort*)storage.Ptr;
 

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -9,6 +9,7 @@ using System.Runtime.Intrinsics.X86;
 using Sparrow;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
+using Sparrow.Server.Utils.VxSort;
 using Voron.Util;
 
 namespace Voron.Data.RoaringBitmaps;
@@ -34,27 +35,19 @@ namespace Voron.Data.RoaringBitmaps;
 ///   read or used again until <see cref="Clear"/>'d — which also recycles its storage for reuse as scratch.
 /// </summary>
 [StructLayout(LayoutKind.Auto)]
-public unsafe partial struct RoaringBitmap : IDisposable
+public unsafe partial struct RoaringBitmap(ByteStringContext ctx) : IDisposable
 {
     internal NativeList<ContainerEntry> _entries;
     internal NativeList<ContainerType> _types;
     internal NativeList<int> _index;
     internal int _containerCount;
     /// <summary>
-    /// Head of the entry free list, 1-based: 0 = empty, n = real slot index (n-1).
-    /// Zero-init (default struct) is therefore a valid empty state.
-    /// <see cref="ContainerEntry.NextFreeSlot"/> uses the same encoding for chaining.
+    /// Head of the entry-free list, 1-based: 0 = empty (ensure zero-init is default state), n = real slot index (n-1).
     /// </summary>
-    internal int _freeListHead;
-    /// <summary>Segregated storage free list (heads + class mask + size-class tables).
-    /// See <see cref="FreeListHeads"/> in RoaringBitmap.FreeListHeads.cs.</summary>
-    private FreeListHeads _freeList;
+    internal int _containersFreeListHead;
+    private FreeListHeads _buffersFreeListHeads;
 
-    private readonly ByteStringContext _ctx;
-
-    // Guards Dispose so it is idempotent — the same bitmap can be reached through two owners (e.g. a sorted
-    // CompiledQuery stores the top SortingMatch under both QueryMatch and SortingWrapper), so Dispose may be
-    // called more than once and must not double-release its storage.
+    
     private bool _disposed;
 
 #if DEBUG
@@ -80,17 +73,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
 #endif
     }
 
-    /// <summary>
-    /// Construct a RoaringBitmap backed by the given allocator.
-    /// All operations on this bitmap MUST use the same ByteStringContext instance that was
-    /// passed to the constructor. Mixing allocators will corrupt the storage free list.
-    /// </summary>
-    public RoaringBitmap(ByteStringContext ctx)
-    {
-        _ctx = ctx;
-        // _freeListHead == 0 is the terminator; default fields are already zero.
-    }
-
     private const int BitmapContainerSizeInBytes = 8192; // 8KB
     public const int BitmapContainerSizeInUInt64 = BitmapContainerSizeInBytes / sizeof(ulong);
     private const int ArrayContainerMaxCardinality = BitmapContainerSizeInBytes / sizeof(ushort); // crossover: array at max costs same as bitmap
@@ -111,23 +93,18 @@ public unsafe partial struct RoaringBitmap : IDisposable
         return card;
     }
 
-    private const int InitialArrayContainerSizeInBytes = 64; // 32 shorts — minimum for SIMD linear scan without scalar tail
     private const int SimdAlignment = 32; // Vector256 width in bytes
     private const int SimdLinearScanThreshold = 64; // below this, SIMD linear scan beats binary/quad search
 
     private const int IndexAbsent = -1;        // key is not present in index
 
     [DoesNotReturn]
-    private static void ThrowNegativeNotSupported(long value)
-    {
-        throw new ArgumentOutOfRangeException(nameof(value), value, "RoaringBitmap only supports non-negative values.");
-    }
+
+    private static void ThrowNegativeNotSupported(long value) => throw new ArgumentOutOfRangeException(nameof(value), value, "RoaringBitmap only supports non-negative values.");
 
     public readonly int ContainerCount => _containerCount;
 
-    /// <summary>Total cardinality across all containers. Not cached: O(container count) and repairs any
-    /// lazy bitmap popcounts (Cardinality == -1) found along the way. A method, not a property, so the
-    /// cost is visible at the call site — cache the result or gate on a cheaper bound in hot loops.</summary>
+   /// <summary>Total cardinality across ALL containers. Not cached, computed each time, avoid calling in hot loops:repairs any lazy bitmap (Cardinality == -1) along the way.</summary>
     public long ComputeCount()
     {
         AssertNotConsumed();
@@ -141,11 +118,9 @@ public unsafe partial struct RoaringBitmap : IDisposable
                 continue;
 
             int card = entries[i].Cardinality;
-            if (card is LazyCardinality)
+
+            if (card is LazyCardinality) // LazyCardinality: bitmap container was updated without recomputing the popcount.
             {
-                // LazyCardinality: bitmap container was updated without recomputing the popcount.
-                // Count bits directly so callers (e.g. ShouldSwitchToEntryScan) see a correct value
-                // rather than the sentinel -1, which would incorrectly trigger early entry scan.
                 Debug.Assert(types[i] is ContainerType.Bitmap, "only bitmaps can have lazy cardinality");
                 entries[i].Cardinality = card = BitmapContainerCardinality(entries[i].Data);
                 if (card is 0)
@@ -171,12 +146,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
         return ContainsAtSlot(slot, (ushort)(value & ContainerValueMask));
     }
 
-    /// <summary>
-    /// Container-internal membership test after the caller has already resolved the slot via
-    /// <see cref="GetSlotForKey"/>. Lets callers hoist the slot-resolution binary search out of
-    /// a hot loop when consecutive lookups share the same high-bits (e.g. BitmapMatch.AndWith
-    /// processing a batch with high entry-ID locality).
-    /// </summary>
+
     private readonly bool ContainsAtSlot(int slot, ushort low)
     {
         ref ContainerEntry entry = ref _entries[slot];
@@ -187,14 +157,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
             ContainerType.ArrayUnsorted => SimdLinearContains(entry.ArrayData, entry.Cardinality, low),
             ContainerType.Bitmap => BitmapContains((ulong*)entry.Data, low),
             ContainerType.Range => low >= entry.RangeStart && low < entry.RangeStart + entry.Cardinality,
-            _ => ThrowUnexpectedContainerType(type)
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type")
         };
-
-    [DoesNotReturn]
-    static bool ThrowUnexpectedContainerType(ContainerType type)
-    {
-        throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type");
-    }
     }
 
     public readonly long MinContainerKey
@@ -235,9 +199,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
     }
 
     /// <summary>
-    /// Reset all containers without releasing memory. Container storages are pushed onto
-    /// the dedicated free list and made available for reuse on the next allocation,
-    /// avoiding the round-trip through the ByteStringContext free pool.
+    /// Reset all containers, memory goes into _bitmap_ free list, not the allocator
     /// </summary>
     public void Clear()
     {
@@ -251,41 +213,24 @@ public unsafe partial struct RoaringBitmap : IDisposable
         ContainerEntry* entries = _entries.RawItems;
         ContainerType* types = _types.RawItems;
 
-        // Recover every storage and park it on the storage free list.
-        for (int i = 0; i < count; i++)
+       for (int i = 0; i < count; i++)
         {
             if (types[i] != ContainerType.Free && entries[i].Storage.HasValue)
-                _freeList.Return(entries[i].Storage);
+                _buffersFreeListHeads.Return(entries[i].Storage);
         }
 
         _entries.Clear();
         _types.Clear();
         _containerCount = 0;
-        _freeListHead = 0; // 0 = empty (entries are gone, free list is empty too)
+
+        _containersFreeListHead = 0; // 0 = empty (entries are gone, free list is empty too)
 
         int* indexRaw = _index.RawItems;
         int indexLen = _index.Count;
         new Span<int>(indexRaw, indexLen).Fill(IndexAbsent);
     }
 
-    /// <summary>
-    /// Swap the internal state of two bitmaps. O(1) — swaps all fields.
-    /// Used after entry scan to swap the filtered results into the main bitmap.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void SwapContents(ref RoaringBitmap other)
-    {
-        // Both bitmaps must share an allocator — swapping the whole struct also swaps the _ctx reference, which
-        // would only be safe (and only happens) when both were created from the same ByteStringContext.
-        Debug.Assert(ReferenceEquals(_ctx, other._ctx), "SwapContents requires both bitmaps to share an allocator");
-        (other, this) = (this, other);
-    }
-
-    /// <summary>Batch-add strictly sorted, unique values, grouped by container key. Large per-container
-    /// runs (&gt;4096) go straight to bitmap; contiguous runs extend/create Range containers. The Array
-    /// append fast-path and bitmap creation rely on input length equaling the unique-value count.
-    /// Bitmap updates are lazy (cardinality left as LazyCardinality); <see cref="PrepareForReading"/>
-    /// repairs it via <see cref="RepairAfterLazy"/> before reads.</summary>
+    /// <summary>Optimal bulk insert for known sorted data</summary>
     public void AddRange(ReadOnlySpan<long> sortedValues)
     {
         AssertNotConsumed();
@@ -294,12 +239,13 @@ public unsafe partial struct RoaringBitmap : IDisposable
 
         AssertSorted(sortedValues);
 
+        if (sortedValues[0] < 0)
+            ThrowNegativeNotSupported(sortedValues[0]);
+
         int index = 0;
         while (index < sortedValues.Length)
         {
             long value = sortedValues[index];
-                if (value < 0)
-                ThrowNegativeNotSupported(value);
             long key = value >> ContainerKeyShift;
 
             int start = index;
@@ -346,9 +292,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
     private static int SearchForContainerRangeEnd(ReadOnlySpan<long> sortedValues, long nextKeyStart, int start)
     {
         int jump = 1;
-        // Start with exponential jumps, then binary search within the last interval.
         while (start + jump < sortedValues.Length && sortedValues[start + jump] < nextKeyStart)
-            jump <<= 1;
+            jump <<= 1; // Start with exponential jumps, then binary search within the last interval.
         int lo = start + (jump >> 1);
         int hi = Math.Min(start + jump, sortedValues.Length);
         while (lo < hi)
@@ -364,7 +309,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
 
     private void CreateBitmapContainerFromSorted(long key, ReadOnlySpan<long> sortedValues)
     {
-        _freeList.Allocate(_ctx, BitmapContainerSizeInBytes, out ByteString storage);
+        _buffersFreeListHeads.Allocate(ctx, BitmapContainerSizeInBytes, out ByteString storage);
         new Span<byte>(storage.Ptr, BitmapContainerSizeInBytes).Clear();
 
         OrSortedIntoBitmap((ulong*)storage.Ptr, sortedValues);
@@ -378,9 +323,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
     }
 
     /// <summary>
-    /// OR sorted values into a bitmap, accumulating per word and writing once per word boundary so
-    /// consecutive values sharing a word collapse into ~N/64 writes. Idempotent, so safe for fresh and
-    /// existing bitmaps. Caller tracks cardinality.
+    /// Idempotent, Caller tracks cardinality.
     /// </summary>
     private static void OrSortedIntoBitmap(ulong* bitmapPtr, ReadOnlySpan<long> sortedValues)
     {
@@ -407,14 +350,11 @@ public unsafe partial struct RoaringBitmap : IDisposable
         bitmapPtr[currentWordIndex] |= currentMask;
     }
 
-    /// <summary>Create a new array container from sorted values with SIMD-friendly allocation.
-    /// Tagged <see cref="ContainerType.Array"/> (not ArrayUnsorted): AddRange contractually requires
-    /// strictly sorted, unique input (see AssertSorted), so the data is already in read order and the
-    /// lazy sort pass in PrepareForReading/AndContainerInPlace would be wasted work.</summary>
+
     private void CreateArrayContainerFromSorted(long key, ReadOnlySpan<long> sortedValues)
     {
         int neededBytes = sortedValues.Length * sizeof(ushort);
-        _freeList.Allocate(_ctx, neededBytes, out ByteString storage);
+        _buffersFreeListHeads.Allocate(ctx, neededBytes, out ByteString storage);
 
         CopyDenseBottom16BitsToUshortArray(sortedValues, (ushort*)storage.Ptr);
 
@@ -436,8 +376,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
         {
             case ContainerType.Bitmap:
             {
-                // Lazy: bits are OR'd in; cardinality is marked dirty, so RepairAfterLazy
-                // (called by PrepareForReading) recomputes it via popcount.
+                // Lazy: bits are OR'd in; cardinality is marked dirty, so RepairAfterLazy or PrepareForReading recomputes it via popcount.
                 OrSortedIntoBitmap((ulong*)entry.Data, sortedValues);
                 entry.Cardinality = LazyCardinality;
                 break;
@@ -454,9 +393,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
 
                 // Fully contained in existing range - noop.
                 if (firstLow >= rangeStart && lastLow < rangeEnd)
-                {
                     break;
-                }
 
                 bool contiguousBatch = lastLow - firstLow == sortedValues.Length - 1;
                 if (contiguousBatch && TryMergeRangeInPlace(ref entry, firstLow, lastLow + 1))
@@ -479,27 +416,22 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     goto case ContainerType.Bitmap; // Convert to bitmap and add
                 }
 
-                // If existing data was sorted and the new batch starts strictly after the last
-                // existing value, the appended result stays sorted — no need to degrade to
-                // ArrayUnsorted (which would force a sort pass in PrepareForReading).
+                // Array is sorted & new data is directly following last value, can just append
                 ushort firstNew = (ushort)(sortedValues[0] & ContainerValueMask);
                 bool stillSorted = type == ContainerType.Array
                     && (entry.Cardinality == 0 || firstNew > entry.ArrayData[entry.Cardinality - 1]);
 
-                // Ensure enough space (the free list rounds every block up to a 32-byte-aligned size class,
-                // and entry.Storage.Length is always such a class size, so this comparison is SIMD-exact).
                 int neededBytes = newTotal * sizeof(ushort);
                 if (entry.Storage.Length < neededBytes)
                 {
-                    _freeList.Allocate(_ctx, neededBytes, out ByteString newStorage);
+                    _buffersFreeListHeads.Allocate(ctx, neededBytes, out ByteString newStorage);
                     new Span<byte>(entry.Data, entry.Cardinality * sizeof(ushort))
                         .CopyTo(new Span<byte>(newStorage.Ptr, newStorage.Length));
-                    _freeList.Return(entry.Storage); // recycle old; new is larger
+                    _buffersFreeListHeads.Return(entry.Storage); // recycle old; new is larger
                     entry.Data = newStorage.Ptr;
                     entry.Storage = newStorage;
                 }
 
-                // Append new values
                 CopyDenseBottom16BitsToUshortArray(sortedValues, entry.ArrayData + entry.Cardinality);
                 entry.Cardinality = newTotal;
                 _types.RawItems[slot] = stillSorted ? ContainerType.Array : ContainerType.ArrayUnsorted;
@@ -512,11 +444,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
 
     /// <summary>
     /// Lazy OR skips per-container cardinality tracking: bitmap containers get Cardinality = -1 (dirty).
-    /// Call RepairAfterLazy() once afterwards to recompute cardinality in a single popcount pass.
-    ///
-    /// Unlike standard roaring bitmaps, we deliberately skip Bitmap→Array conversion of sparse results:
-    /// Corax bitmaps are built during query evaluation and discarded immediately, so re-allocating an
-    /// array buffer and scanning 1024 words costs more than the memory it would save.
+    /// Call RepairAfterLazy() once afterward to recompute cardinality in a single popcount pass.
     /// </summary>
     public void LazyOrWith(scoped ref RoaringBitmap other)
     {
@@ -528,8 +456,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
         if (otherLen > 0)
             EnsureIndexCoversKey(otherLen - 1);
 
-        _entries.EnsureCapacityFor(_ctx, other.ContainerCount);
-        _types.EnsureCapacityFor(_ctx, other.ContainerCount);
+        _entries.EnsureCapacityFor(ctx, other.ContainerCount);
+        _types.EnsureCapacityFor(ctx, other.ContainerCount);
 
         for (int key = 0; key < otherLen; key++)
         {
@@ -551,36 +479,26 @@ public unsafe partial struct RoaringBitmap : IDisposable
             ContainerType otherType = other._types.RawItems[otherSlot];
             ContainerEntry stolen = otherEntry;
             otherEntry = default; // Clear the entry
-            // Detach the stolen slot from `other`: otherwise it stays indexed and a later
-            // Contains/AndWith on `other` would NRE on the now-empty entry.Data. Hit by
-            // SortingMatch.SortInMemory → Score reading a bitmap absorbed by a prior OrWith.
+            // Detach the stolen slot from the other
             other._types.RawItems[otherSlot] = ContainerType.Free;
             other._index.RawItems[key] = IndexAbsent;
             other._containerCount--;
             AddNewContainer(key, otherType, stolen);
         }
 
-        // Destructive on `other` (containers stolen) — mark it consumed so a later use is caught in DEBUG,
-        // matching OrWith/AndWith/AndNotWith. (OrWith also marks it; MarkConsumed is idempotent.)
-        MarkConsumed(ref other);
+        MarkConsumed(ref other); // debug only - so we won't try to use it
     }
 
-    /// <summary>
-    /// OR this bitmap with another. Calls LazyOrWith then RepairAfterLazy.
-    /// </summary>
     public void OrWith(ref RoaringBitmap other)
     {
         AssertNotConsumed();
         LazyOrWith(ref other);
         RepairAfterLazy();
-        MarkConsumed(ref other);
     }
 
-    /// <summary>Lazy OR for a single container pair. Skips popcount — marks bitmap
-    /// containers with Cardinality = -1.</summary>
+    /// <summary>Lazy OR for a single container pair. Skips popcount — marks bitmap containers with Cardinality = -1.</summary>
     [SkipLocalsInit]
-    private void LazyOrContainerInPlace(ref ContainerEntry left, ref ContainerType leftType,
-        ref ContainerEntry right, ContainerType rightType)
+    private void LazyOrContainerInPlace(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right, ContainerType rightType)
     {
         switch (leftType, rightType)
         {
@@ -606,18 +524,13 @@ public unsafe partial struct RoaringBitmap : IDisposable
             }
             case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Range):
             {
-                // Convert to a heap bitmap first: we can't materialize the range into a stack
-                // buffer and recurse, because the (Array, Bitmap) case steals the right-hand
-                // buffer — a stack pointer that dangles once this frame returns.
-                ConvertArrayToBitmap(ref left, ref leftType);
+                ConvertArrayToBitmap(ref left, ref leftType); // allocate bitmap, will be "stoken" by the lazy or call 
                 LazyOrContainerInPlace(ref left, ref leftType, ref right, rightType);
                 break;
             }
             case (ContainerType.Bitmap, ContainerType.Range):
             {
-                // Materialize the range into a stack buffer and bitwise-OR in place — safe because
-                // (Bitmap, Bitmap) does not steal the right-hand buffer.
-                ulong* stackBitmap = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ulong* stackBitmap = stackalloc ulong[BitmapContainerSizeInUInt64]; // safe to use stack buffer, bitmap | bitmap won't steal the right-hand buffer
                 ContainerEntry temp2 = MaterializeRangeIntoBuffer(ref right, stackBitmap);
                 LazyOrContainerInPlace(ref left, ref leftType, ref temp2, ContainerType.Bitmap);
                 break;
@@ -647,7 +560,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     return;
                 }
                 // Append values left & right — duplicates are harmless, deduped on PrepareForReading.
-                AppendArrayContainers(ref left, ref right, maxResult);
+                ConcatArrayContainers(ref left, ref right, maxResult);
                 leftType = ContainerType.ArrayUnsorted;
                 break;
             }
@@ -658,7 +571,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
                 // OR left's array values into right's bitmap, then take ownership of the buffer.
                 SetArrayInBitmap(left.ArrayData, left.Cardinality, right.BitmapPtr);
                 if (left.Storage.HasValue)
-                    _ctx.Release(ref left.Storage);
+                    _buffersFreeListHeads.Return(left.Storage);
                 left.Storage = right.Storage;
                 left.Data = right.Data;
                 left.Cardinality = LazyCardinality;
@@ -671,23 +584,17 @@ public unsafe partial struct RoaringBitmap : IDisposable
         }
     }
 
-    /// <summary>Recompute cardinality for all containers marked dirty (Cardinality == -1)
-    /// after a sequence of lazy bitmap ops (AddRange, LazyOrWith, AndWith, OrWith on
-    /// bitmap containers, etc.). Single popcount passes. Containers that pop to zero
-    /// (e.g., AND/ANDNOT removed all bits) are freed here.</summary>
+    /// <summary>Recompute cardinality for all containers with Cardinality == -1). Allow to reduce popcount costs by batching them</summary>
     public void RepairAfterLazy()
     {
         for (int i = 0; i < _entries.Count; i++)
         {
-            if (// _types is a dense array, so cheaper to scan through it first
-                _types.RawItems[i] != ContainerType.Bitmap ||
+            if (_types.RawItems[i] != ContainerType.Bitmap || // _types is a dense array, so cheaper to scan through it first
                 _entries[i].Cardinality != LazyCardinality)
                 continue;
 
             ref ContainerEntry entry = ref _entries[i];
-
              entry.Cardinality  = BitmapContainerCardinality(entry.Data);
-
             if (entry.Cardinality is 0)
                 FreeContainer(entry.Key, i);
         }
@@ -719,10 +626,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
         }
     }
 
-    /// <summary>
-    /// Fill the buffer with values from the bitmap, starting from the current iteration state.
-    /// Returns the number of values written. Compatible with Corax's streaming evaluation.
-    /// </summary>
     public int Fill(Span<long> buffer, ref RoaringBitmapIterator iterator)
     {
         AssertNotConsumed();
@@ -732,25 +635,11 @@ public unsafe partial struct RoaringBitmap : IDisposable
     public RoaringBitmapIterator GetIterator()
     {
         AssertNotConsumed();
-        return new RoaringBitmapIterator(ref this, _ctx);
+        return new RoaringBitmapIterator(ref this, ctx);
     }
 
     /// <summary>
-    /// Filter a buffer in-place, keeping only values present in this bitmap. Buffer order is
-    /// preserved; callers may pass entry IDs in any order (e.g. sort-field order from
-    /// <c>IndexOrderStreaming</c>).
-    ///
-    /// Algorithm: a straight order-preserving per-element membership test. Each entry resolves its
-    /// container via the O(1) <c>_index[key]</c> lookup and probes that container directly. A prior
-    /// design sorted the buffer to entry-ID order, walked container groups, then restored order — the
-    /// idea being to amortise slot resolution across a container group. But the slot lookup is a single
-    /// array index (~1 ns), so the two <c>Span.Sort</c> passes it paid for dwarfed what they saved: a
-    /// benchmark across container shapes / selectivities / orderings showed per-element 3–30× faster on
-    /// the realistic scattered (sort-field-order) input and never slower, only tying on already-sorted
-    /// input with a dense Array container.
-    ///
-    /// ArrayUnsorted containers are sorted in-place and upgraded to Array on first touch, so repeated
-    /// calls on the same bitmap binary-search instead of re-running O(k) SIMD linear scans.
+    /// Filter a buffer in-place, keeping only values present in this bitmap. Buffer order is preserved; callers may pass entry IDs in any order.
     /// </summary>
     public int AndWith(Span<long> buffer, int count)
     {
@@ -805,44 +694,30 @@ public unsafe partial struct RoaringBitmap : IDisposable
         return kept;
     }
 
-    /// <summary>Batch scoring helper: for each entry in <paramref name="matches"/> that is present in this bitmap,
-    /// add <paramref name="boostFactor"/> to <paramref name="scores"/> at the same index. <paramref name="matches"/>
-    /// MUST be sorted ascending (and is, in the in-memory score sort, where it comes straight off the candidate
-    /// bitmap iterator) — see <see cref="VisitPresentSorted{TVisitor}"/> for the container-group sweep this shares
-    /// with <see cref="DedupAddNew"/>.</summary>
-    public void ScorePresentSorted(Span<long> matches, Span<float> scores, float boostFactor)
+    /// <summary>Batch scoring helper: for each entry in matches that is present in this bitmap, add boostFactor to scores at that index.</summary>
+    public void ScorePresentSorted(Span<long> sortedMatches, Span<float> scores, float boostFactor)
     {
         AssertNotConsumed();
         if (boostFactor == 0f)
             return;
-
         var visitor = new ScoreVisitor(scores, boostFactor);
-        VisitPresentSorted(matches, matches.Length, ref visitor);
+        VisitPresentSorted(sortedMatches, sortedMatches.Length, ref visitor);
     }
 
-    /// <summary>What to do with each element of a sorted batch as the container-group sweep classifies it as
-    /// present (<see cref="OnHit"/>) or absent (<see cref="OnMiss"/> / <see cref="OnAbsentRun"/>). A struct type
-    /// parameter so <see cref="VisitPresentSorted{TVisitor}"/> specializes and inlines every callback (same idiom
-    /// as the sort comparers).</summary>
     private interface IPresenceVisitor
     {
-        /// <summary>When false, the Array forward-sweep may stop the moment the container is exhausted, since every
-        /// remaining element in the run is a guaranteed miss the visitor doesn't care about.</summary>
         bool VisitsMisses { get; }
         void OnHit(int index);
         void OnMiss(int index);
-        /// <summary>An entire run <c>[from, to)</c> whose container is absent or tombstoned: no element is present.</summary>
+
         void OnAbsentRun(int from, int to);
     }
 
-    /// <summary>Walk a sorted batch grouped by container key. <paramref name="values"/> MUST be sorted ascending,
-    /// so each container's run is contiguous: one slot resolution per run, absent containers skipped wholesale, and
-    /// a sorted Array container swept with a single forward cursor instead of an independent search per probe —
-    /// turning N×O(scan) into O(N + cardinality). The <typeparamref name="TVisitor"/> decides what a hit/miss does
-    /// (score it, keep it, ...). Shared by <see cref="ScorePresentSorted"/> and <see cref="DedupAddNew"/>.</summary>
-    private void VisitPresentSorted<TVisitor>(Span<long> values, int count, scoped ref TVisitor visitor)
+    private void VisitPresentSorted<TVisitor>(Span<long> sortedMatches, int count, scoped ref TVisitor visitor)
         where TVisitor : struct, IPresenceVisitor, allows ref struct
     {
+        AssertSorted(sortedMatches);
+        
         int* idx = _index.RawItems;
         int idxLen = _index.Count;
         ContainerEntry* entries = _entries.RawItems;
@@ -852,8 +727,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
         int i = 0;
         while (i < count)
         {
-            long containerKey = values[i] >> ContainerKeyShift;
-            int groupEnd = Sorting.GallopLowerBound(values, i, count, (containerKey + 1) << ContainerKeyShift);
+            long containerKey = sortedMatches[i] >> ContainerKeyShift;
+            int groupEnd = Sorting.GallopLowerBound(sortedMatches, i, count, (containerKey + 1) << ContainerKeyShift);
 
             if (containerKey < 0 || containerKey >= idxLen || idx[containerKey] < 0)
             {
@@ -873,9 +748,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     ulong* bmp = (ulong*)entry.Data;
                     for (int gi = i; gi < groupEnd; gi++)
                     {
-                        ushort low = (ushort)(values[gi] & ContainerValueMask);
-                        if (BitmapContains(bmp, low)) visitor.OnHit(gi);
-                        else visitor.OnMiss(gi);
+                        ushort low = (ushort)(sortedMatches[gi] & ContainerValueMask);
+                        HandleVisitorHitMiss(ref visitor, BitmapContains(bmp, low), gi);
                     }
                     break;
                 }
@@ -886,9 +760,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     int rangeEnd = rangeStart + entry.Cardinality;
                     for (int gi = i; gi < groupEnd; gi++)
                     {
-                        ushort low = (ushort)(values[gi] & ContainerValueMask);
-                        if (low >= rangeStart && low < rangeEnd) visitor.OnHit(gi);
-                        else visitor.OnMiss(gi);
+                        ushort low = (ushort)(sortedMatches[gi] & ContainerValueMask);
+                        HandleVisitorHitMiss(ref visitor, low >= rangeStart && low < rangeEnd, gi);
                     }
                     break;
                 }
@@ -901,30 +774,26 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     int ai = 0;
                     for (int gi = i; gi < groupEnd; gi++)
                     {
-                        ushort low = (ushort)(values[gi] & ContainerValueMask);
+                        ushort low = (ushort)(sortedMatches[gi] & ContainerValueMask);
                         while (ai < arrLen && arr[ai] < low) ai++;
                         if (ai >= arrLen)
                         {
-                            // Container exhausted: every remaining element in this run is a miss.
                             if (visitsMisses == false)
-                                break;
+                                break; // Container exhausted: every remaining element in this run is a miss.
                             visitor.OnMiss(gi);
                             continue;
                         }
-                        if (arr[ai] == low) { visitor.OnHit(gi); ai++; }
-                        else visitor.OnMiss(gi);
+                        HandleVisitorHitMiss(ref visitor, arr[ai] == low, gi);
                     }
                     break;
                 }
-
                 case ContainerType.ArrayUnsorted:
                 {
                     if (groupEnd - i == 1)
                     {
                         // Single probe: a SIMD linear scan is cheaper than sorting the whole container for it.
-                        ushort low = (ushort)(values[i] & ContainerValueMask);
-                        if (SimdLinearContains(entry.ArrayData, entry.Cardinality, low)) visitor.OnHit(i);
-                        else visitor.OnMiss(i);
+                        ushort low = (ushort)(sortedMatches[i] & ContainerValueMask);
+                        HandleVisitorHitMiss(ref visitor, SimdLinearContains(entry.ArrayData, entry.Cardinality, low), i);
                     }
                     else
                     {
@@ -934,8 +803,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     break;
                 }
 
-                case ContainerType.Free:
-                    // Tombstone — nothing present here.
+                case ContainerType.Free: // Tombstone — nothing present here.
                     visitor.OnAbsentRun(i, groupEnd);
                     break;
 
@@ -944,6 +812,15 @@ public unsafe partial struct RoaringBitmap : IDisposable
             }
 
             i = groupEnd;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void HandleVisitorHitMiss(scoped ref TVisitor visitor, bool isHit, int index)
+        {
+            if (isHit) 
+                visitor.OnHit(index);
+            else 
+                visitor.OnMiss(index);
         }
     }
 
@@ -959,9 +836,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
         public void OnAbsentRun(int from, int to) { }
     }
 
-    /// <summary>The dedup half of <see cref="DedupAddNew"/>: KEEPS entries that are ABSENT from the bitmap
-    /// (compacting <see cref="_buffer"/> + <see cref="_indices"/> in place) and discards present ones. The kept
-    /// prefix never overtakes the sweep's read cursor, so the in-place compaction is safe.</summary>
+    /// <summary>KEEPS entries that are ABSENT from the bitmap  (compacting <see cref="_buffer"/> + <see cref="_indices"/> in place) and discards present ones.</summary>
     private ref struct DedupVisitor(Span<long> buffer, Span<int> indices) : IPresenceVisitor
     {
         private readonly Span<long> _buffer = buffer;
@@ -989,40 +864,30 @@ public unsafe partial struct RoaringBitmap : IDisposable
         }
     }
 
-    /// <summary>Dedup + add in a single pass: for each entry in <paramref name="buffer"/>,
-    /// if it is NOT already in the bitmap, keep it in the buffer and add it to the bitmap.
-    /// If it IS already present, discard it. Returns the count of new (non-duplicate) entries.
-    /// Buffer order is preserved (via the same index-tracking approach as <see cref="AndWith"/>).
-    /// Uses the same container-group batching as <see cref="AndWith"/> but with inverted logic:
-    /// entries absent from a container are kept; entries present are discarded.
-    /// Used by SortingMatch.StreamInIndexOrder to replace the per-entry Contains+Add loop.</summary>
+    /// <summary>Dedup + add in a single pass: for each entry in <paramref name="buffer"/>, if it is NOT already in the bitmap, keep it in the buffer and add it to the bitmap.
+    /// Returns the count of new (non-duplicate) entries. </summary>
     public int DedupAddNew(Span<long> buffer, int count)
     {
         if (count == 0) return 0;
 
-        using var _ = _ctx.Allocate(PadToVector256Width(count), out Span<int> indices);
+        using var _ = ctx.Allocate(PadToVector256Width(count), out Span<int> indices);
         InitializeIndices(indices, count);
         buffer[..count].Sort(indices[..count]);
         count = RemoveDuplicates(buffer, indices, count);
 
-        // Same sorted-container sweep as ScorePresentSorted, but the visitor KEEPS absent entries (compacting
-        // buffer + indices in place) and discards present ones.
         var visitor = new DedupVisitor(buffer, indices);
         VisitPresentSorted(buffer, count, ref visitor);
         int kept = visitor.Kept;
 
         // Add the new entries to the bitmap while they're still sorted.
         AddRange(buffer[..kept]);
-
-        // Restore original order.
-        indices[..kept].Sort(buffer[..kept]);
+        
+        indices[..kept].Sort(buffer[..kept]); // restore original order
         return kept;
     }
 
     private static int RemoveDuplicates(Span<long> buffer, Span<int> indices, int count)
     {
-        // Remove within-batch duplicates (buffer is sorted, so they're adjacent).
-        // Keep the first occurrence of each value, maintaining the indices in parallel.
         int unique = 1;
         for (int d = 1; d < count; d++)
         {
@@ -1038,14 +903,9 @@ public unsafe partial struct RoaringBitmap : IDisposable
     }
 
     /// <summary>
-    /// Bulk Select: for each rank in <paramref name="ranks"/>, write the corresponding
-    /// set-bit value into <paramref name="results"/> at the same index. Out-of-range
-    /// or negative ranks produce -1. <paramref name="ranks"/> is mutated (sorted in place).
-    /// <paramref name="ranks"/> and <paramref name="results"/> must NOT alias - we read
-    /// from ranks while writing to results in permuted order, so aliasing would corrupt input.
-    ///
-    /// Sorts ranks once, then walks containers a single time while accumulating
-    /// cardinality — O(C + N log N) instead of O(C * N) for repeated single-rank Select.
+    /// Bulk Select: for each rank in <paramref name="ranks"/>, write the corresponding set-bit value into <paramref name="results"/> at the same index.
+    /// Out-of-range or negative ranks produce -1. <paramref name="ranks"/> is mutated (sorted in place).
+    /// <paramref name="ranks"/> and <paramref name="results"/> must NOT alias - so aliasing would corrupt input.
     /// </summary>
     public void Select(ByteStringContext allocator, Span<long> ranks, Span<long> results)
     {
@@ -1055,32 +915,21 @@ public unsafe partial struct RoaringBitmap : IDisposable
         if (n == 0)
             return;
 
-        // Track each rank's original position so we can scatter results back in input order
-        // after sorting ranks ascending for the single-pass container walk.
-        // Pad the allocation up to a multiple of 8 ints so the AVX2 init loop below can
-        // store full Vector256<int> chunks without a scalar tail. Only indexes[0..n) is
-        // ever read after init; we slice back to n for Sort (parallel-keys API requires
-        // matching lengths) and subsequent reads.
         int paddedLen = PadToVector256Width(n);
-        using var _ = allocator.Allocate(paddedLen * sizeof(int), out ByteString work);
-        InitializeIndices(new Span<int>(work.Ptr, paddedLen), n);
-        var indexes = new Span<int>(work.Ptr, n);
+        using var _ = allocator.Allocate(paddedLen * sizeof(int), out Span<int> indexes);
+        InitializeIndices(indexes, n);
 
-        // Parallel sort: ranks ascending; indexes follow the same permutation so
-        // indexes[i] is the original position of the rank now at ranks[i].
-        ranks.Sort(indexes);
+        ranks.Sort(indexes.Slice(0, n)); // indexes is padded to a Vector256 width for the SIMD fill; Sort requires equal-length spans.
 
         int rankIdx = 0;
 
-        // Negative ranks sort to the front - emit -1 for each.
         while (rankIdx < n && ranks[rankIdx] < 0)
         {
             results[indexes[rankIdx]] = -1;
             rankIdx++;
         }
 
-        // Walk containers in key order, accumulating cardinality. Each rank lands
-        // inside the first container whose accumulated cardinality exceeds it.
+        // Walk containers in key order, accumulating cardinality. Each rank lands inside the first container whose accumulated cardinality exceeds it.
         int* idx = _index.RawItems;
         int idxLen = _index.Count;
         ContainerEntry* entries = _entries.RawItems;
@@ -1098,47 +947,39 @@ public unsafe partial struct RoaringBitmap : IDisposable
             if (type == ContainerType.Free)
                 continue;
 
-            Debug.Assert(type is not ContainerType.Free);
             int card = ResolveCardinality(ref entry);
-
             if (type == ContainerType.ArrayUnsorted)
             {
                 SortAndDedupSmallArray(ref entry, out type);
                 card = entry.Cardinality; // dedup may have shrunk the container
-
             }
 
             long containerEnd = accCard + card;
             long baseValue = (long)key << ContainerKeyShift;
+            int selWord = 0; // allows skipping repeated work when selecting multiple words on the same bitmap container
+            int selPopBefore = 0;
             while (rankIdx < n && ranks[rankIdx] < containerEnd)
             {
                 int localRank = (int)(ranks[rankIdx] - accCard);
-                results[indexes[rankIdx]] = baseValue + SelectInContainer(ref entry, type, localRank);
+                results[indexes[rankIdx]] = baseValue + SelectInContainer(ref entry, type, localRank, ref selWord, ref selPopBefore);
                 rankIdx++;
             }
             accCard = containerEnd;
         }
-
-        // Anything still unprocessed is past the end of the bitmap.
-        while (rankIdx < n)
+        
+        while (rankIdx < n) // Anything still unprocessed is past the end of the bitmap.
         {
             results[indexes[rankIdx]] = -1;
             rankIdx++;
         }
     }
 
-    /// <summary>Round <paramref name="n"/> up to the next multiple of 8 (the AVX2 Vector256&lt;int&gt;
-    /// lane width). Use this whenever allocating an int buffer that will be passed to
-    /// <see cref="InitializeIndices"/> so the SIMD loop can store full 256-bit chunks
-    /// without a scalar tail.</summary>
+    /// <summary>Round <paramref name="n"/> up to the next multiple of 8 (the AVX2 Vector256&lt;int&gt; lane width). Use this whenever allocating an int buffer that will be passed to
+    /// <see cref="InitializeIndices"/> so the SIMD loop can store full 256-bit chunks without a scalar tail.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int PadToVector256Width(int n) => (n + 7) & ~7;
 
-    /// <summary>Fill <paramref name="indices"/> with 0..read-1 using AVX2 256-bit stores.
-    /// <paramref name="indices"/> must be padded to a multiple of 8 — i.e.
-    /// <c>indices.Length &gt;= PadToVector256Width(read)</c> — so the unrolled SIMD loop can store
-    /// full Vector256&lt;int&gt; chunks without a scalar tail. Used by RoaringBitmap.Select
-    /// here and by Corax's DirectScanMatch via InternalsVisibleTo.</summary>
+    /// <summary>Fill <paramref name="indices"/> with 0..read-1 using AVX2 256-bit stores (requires padding to allow proper SIMD write past indices span).</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void InitializeIndices(Span<int> indices, int read)
     {
@@ -1157,9 +998,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
         }
     }
 
-    /// <summary>Find the nth set value inside a single container (0-based).
-    /// Caller is responsible for upgrading ArrayUnsorted to Array first.</summary>
-    private static int SelectInContainer(ref ContainerEntry entry, ContainerType type, int rank)
+    /// <summary>Find the nth set value inside a single container (0-based). Caller is responsible for upgrading ArrayUnsorted to Array first.</summary>
+    private static int SelectInContainer(ref ContainerEntry entry, ContainerType type, int rank, ref int word, ref int popBefore)
     {
         switch (type)
         {
@@ -1172,13 +1012,12 @@ public unsafe partial struct RoaringBitmap : IDisposable
             case ContainerType.Bitmap:
             {
                 ulong* bmp = (ulong*)entry.Data;
-                int word = 0;
+                int remaining = rank - popBefore; // index of the target among the set bits in bmp[word..)
 
-                // scan 8 ulongs at a time. popcnt is a 1-cycle instruction with
-                // four-way ILP on modern x86, so an unrolled batch of 8 retires in ~3 cycles.
+                // scan 8 ulongs at a time. popcnt is a 1-cycle instruction with four-way ILP on modern x86, so an unrolled batch of 8 retires in ~3 cycles.
                 // The JIT may also fuse this into AVX-512 VPOPCNTQ when supported.
-                const int Unroll = 8;
-                while (word + Unroll <= BitmapContainerSizeInUInt64)
+                const int unroll = 8;
+                while (word + unroll <= BitmapContainerSizeInUInt64)
                 {
                     int blockBits =   BitOperations.PopCount(bmp[word])
                                     + BitOperations.PopCount(bmp[word + 1])
@@ -1188,35 +1027,37 @@ public unsafe partial struct RoaringBitmap : IDisposable
                                     + BitOperations.PopCount(bmp[word + 5])
                                     + BitOperations.PopCount(bmp[word + 6])
                                     + BitOperations.PopCount(bmp[word + 7]);
-                    if (rank < blockBits)
+                    if (remaining < blockBits)
                         break;
-                    rank -= blockBits;
-                    word += Unroll;
+                    remaining -= blockBits;
+                    popBefore += blockBits;
+                    word += unroll;
                 }
 
                 for (; word < BitmapContainerSizeInUInt64; word++)
                 {
                     ulong w = bmp[word];
                     int bits = BitOperations.PopCount(w);
-                    if (rank < bits)
+                    if (remaining < bits)
                     {
-                        // Win 1: BMI2 PDEP deposits a single 1-bit at the rank-th set
-                        // position in w; trailing-zeros gives its bit index. One instruction.
+                        // BMI2 PDEP deposits a single 1-bit at the remaining-th set position in w; trailing-zeros gives its bit index. One instruction.
+                        // Note: word/popBefore are left at this word (not advanced) so the next, larger rank resumes here.
                         if (Bmi2.X64.IsSupported)
                         {
-                            ulong target = Bmi2.X64.ParallelBitDeposit(1UL << rank, w);
+                            ulong target = Bmi2.X64.ParallelBitDeposit(1UL << remaining, w);
                             return word * 64 + BitOperations.TrailingZeroCount(target);
                         }
 
-                        // Fallback: clear the lowest set bit `rank` times.
-                        while (rank > 0)
+                        // Fallback: clear the lowest set bit `remaining` times.
+                        while (remaining > 0)
                         {
                             w &= w - 1;
-                            rank--;
+                            remaining--;
                         }
                         return word * 64 + BitOperations.TrailingZeroCount(w);
                     }
-                    rank -= bits;
+                    remaining -= bits;
+                    popBefore += bits;
                 }
                 return -1; // shouldn't reach here if rank was valid
             }
@@ -1234,7 +1075,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
     /// </summary>
     public RoaringBitmap Clone()
     {
-        RoaringBitmap copy = new(_ctx);
+        RoaringBitmap copy = new(ctx);
 
         // Walk entries directly using the Key field - no index indirection needed
         ContainerEntry* entries = _entries.RawItems;
@@ -1242,33 +1083,24 @@ public unsafe partial struct RoaringBitmap : IDisposable
         int entryCount = _entries.Count;
         for (int i = 0; i < entryCount; i++)
         {
-            if (types[i] != ContainerType.Free)
-                copy.AddContainer(entries[i].Key, types[i], CloneContainer(_ctx, ref entries[i], types[i]));
+            if (types[i] is ContainerType.Free) continue;
+            ContainerEntry entry = CloneContainer(ctx, ref entries[i], types[i]);
+            if (entry.Cardinality != 0) 
+                copy.AddNewContainer(entries[i].Key, types[i], entry);
         }
         return copy;
     }
 
-    // Threshold: below this count, comparison sort on a small array
-    // is cheaper than the bitmap radix sort path.
+    // Threshold: below this count, comparison sort on a small array is cheaper than the bitmap radix sort path.
     private const int BitmapSortThreshold = 128;
 
     /// <summary>
-    /// Prepare for reading: sort and deduplicate all unsorted array containers,
-    /// and repair lazy bitmap cardinalities left dirty by <see cref="AddRange"/>
-    /// or <see cref="LazyOrWith"/>. Call this after all writes and before any
-    /// read operations (Contains, Fill, set ops, Count). Separates the sort
-    /// + popcount cost from the first query, making performance more predictable.
-    ///
-    /// For sorted input (e.g., Corax posting lists), the array sort step is
-    /// nearly free since the arrays are already in order.
+    /// Prepare for reading: sort and deduplicate all unsorted array containers, and repair lazy bitmap cardinalities.
     /// </summary>
     [SkipLocalsInit]
     public void PrepareForReading()
     {
         AssertNotConsumed();
-        // 8KB scratch bitmap for radix sort: explode unsorted values into bits,
-        // extract back as sorted array. O(n) bit-sets + O(1024) word scan vs O(n log n).
-        // Dedup is free. Scratch reused across all containers (one clear per chunk touched).
         ulong* scratch = stackalloc ulong[BitmapContainerSizeInUInt64];
 
         ContainerEntry* entries = _entries.RawItems;
@@ -1280,9 +1112,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
             {
                 case ContainerType.ArrayUnsorted:
                 {
-                    // All unsorted containers must be sorted for correct iteration order.
-                    // Contains() can use SIMD linear scan on unsorted data, but
-                    // Fill() (iteration) must emit entry IDs in ascending order.
                     ref ContainerEntry entry = ref entries[i];
                     if (entry.Cardinality >= BitmapSortThreshold)
                         SortViaBitmapScratch(ref entry, ref types[i], scratch);
@@ -1311,10 +1140,9 @@ public unsafe partial struct RoaringBitmap : IDisposable
     }
 
     /// <summary>
-    /// Radix sort using 8KB bitmap scratch space.
-    /// O(n) bit-sets and O(n) word scan. Dedup is free (a duplicate bit-set is noop).
-    /// dirtyMap tracks which 4-ulong chunks have been written so extraction only
-    /// visits touched chunks, skipping clean regions entirely.
+    /// Radix sort using 8KB bitmap scratch space. O(n) bit-sets and O(n) word scan. Dedup is free (a duplicate bit-set is noop).
+    /// IMPORTANT: we don't need to clear the whole bitmap, only the touched chunks.
+    /// dirtyMap tracks which 4-ulong chunks have been written so extraction only visits touched chunks, skipping clean regions entirely.
     /// </summary>
     private static void SortViaBitmapScratch(ref ContainerEntry entry, ref ContainerType type, ulong* scratch)
     {
@@ -1371,11 +1199,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
         type = ContainerType.Array;
     }
 
-    #region In-place Set Operations
-
     /// <summary>
-    /// In-place AND: retain only values that also exist in others.
-    /// Walks both index arrays; containers in this bitmap with no match in other are freed.
+    /// In-place AND: retain only values that also exist in others. Walks both index arrays; containers in this bitmap with no match in other are freed.
     /// </summary>
     public void AndWith(scoped ref RoaringBitmap other)
     {
@@ -1392,10 +1217,8 @@ public unsafe partial struct RoaringBitmap : IDisposable
             int otherSlot = other.GetSlotForKey(key);
             if (otherSlot < 0)
             {
-                // Not in other - remove; donate storage to other's free list so any
-                // remaining container conversions on that side can reuse it without
-                // round-tripping through ctx.Allocate.
-                DonateStorageThenFreeContainer(key, mySlot, ref other);
+                // Not in other - remove; donate storage to other's free list so remaining container conversions on that side can reuse it
+                FreeContainer(key, mySlot);
             }
             else
             {
@@ -1404,20 +1227,16 @@ public unsafe partial struct RoaringBitmap : IDisposable
                 AndContainerInPlace(ref myEntry, ref _types.RawItems[mySlot], ref otherEntry, other._types.RawItems[otherSlot]);
                 int card = ResolveCardinality(ref myEntry);
                 if (card == 0)
-                    DonateStorageThenFreeContainer(key, mySlot, ref other);
+                    FreeContainer(key, mySlot);
             }
         }
         MarkConsumed(ref other);
     }
 
     /// <summary>
-    /// Streaming AND for the limit-aware posting-list path: intersects in place only this bitmap's
-    /// containers with key in [<paramref name="fromKeyInclusive"/>, <paramref name="toKeyExclusive"/>)
-    /// against <paramref name="other"/>, returning the surviving cardinality in that range; containers
-    /// outside it are untouched. Unlike <see cref="AndWith"/> it does NOT consume <paramref name="other"/>:
-    /// the caller grows <paramref name="other"/> across batches and processes only the "settled" key
-    /// prefix (all term entries read, since the posting list is scanned ascending), leaving the growing
-    /// tail for a later call.
+    /// Streaming AND for the limit-aware posting-list path: intersects in place only this bitmap's containers with key in [<paramref name="fromKeyInclusive"/>, <paramref name="toKeyExclusive"/>).
+    /// Unlike <see cref="AndWith"/> it does NOT consume <paramref name="other"/>:  the caller grows <paramref name="other"/> across batches and can call AND on the same bitmap multiple times.
+    /// Each time, we'll only work on the containers in the specified range.
     /// </summary>
     public long AndWithRange(scoped ref RoaringBitmap other, int fromKeyInclusive, int toKeyExclusive)
     {
@@ -1454,9 +1273,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
         return survivors;
     }
 
-    /// <summary>Drop every container whose key is ≥ <paramref name="fromKeyInclusive"/>. Used by the
-    /// limit-aware streaming AND to discard the still-unintersected tail once enough survivors were
-    /// already found in the settled prefix.</summary>
+    /// <summary>Drop every container whose key is ≥ <paramref name="fromKeyInclusive"/>. Used by the limit-aware streaming AND to discard the still-unintersected tail once enough survivors were found.</summary>
     public void RemoveContainersFrom(int fromKeyInclusive)
     {
         AssertNotConsumed();
@@ -1468,21 +1285,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
             if (mySlot >= 0)
                 FreeContainer(key, mySlot);
         }
-    }
-
-    /// <summary>Donate this slot's storage to <paramref name="recipient"/>'s free pool
-    /// before freeing the entry. Used during AndWith / AndNotWith to arm the consumed
-    /// right-side bitmap with buffers that this side would otherwise have stranded on
-    /// its own pool.</summary>
-    private void DonateStorageThenFreeContainer(long key, int slot, scoped ref RoaringBitmap recipient)
-    {
-        ref ContainerEntry entry = ref _entries[slot];
-        if (entry.Storage.HasValue)
-        {
-            recipient._freeList.Return(entry.Storage);
-            entry.Storage = default;
-        }
-        FreeContainer(key, slot);
     }
 
     /// <summary>
@@ -1507,7 +1309,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
             ref ContainerEntry otherEntry = ref other._entries[otherSlot];
             AndNotContainerInPlace(ref _entries[mySlot], ref _types.RawItems[mySlot], ref otherEntry, other._types.RawItems[otherSlot]);
             if (_entries[mySlot].Cardinality == 0)
-                DonateStorageThenFreeContainer(key, mySlot, ref other);
+                FreeContainer(key, mySlot);
         }
         MarkConsumed(ref other);
     }
@@ -1555,7 +1357,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
             }
             case (ContainerType.Bitmap, ContainerType.Array or ContainerType.ArrayUnsorted):
             {
-                // AND bitmap with array: build the intersection in a stack scratch by
+                // AND bitmap with an array: build the intersection in a stack scratch by
                 // OR'ing only values that are set in left; then copy back. Lazy cardinality.
                 ushort* arr = right.ArrayData;
                 var bmp = left.BitmapPtr;
@@ -1739,8 +1541,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
     }
 
     /// <summary>
-    /// Materialize a Range container into the given stackalloc bitmap buffer. The returned entry points
-    /// at that buffer with Storage=default, so the caller must NOT release it.
+    /// Materialize a Range container into the given stackalloc bitmap buffer. The returned entry points at that buffer with Storage=default, so the caller must NOT release it.
     /// </summary>
     [SkipLocalsInit]
     private static ContainerEntry MaterializeRangeIntoBuffer(ref ContainerEntry entry, ulong* stackBitmap)
@@ -1756,14 +1557,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
         };
     }
 
-
-    #endregion
-
-    #region Index Operations
-
-    /// <summary>
-    /// Ensure the index array covers the given key, filling new slots with -1.
-    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureIndexCoversKey(long key)
     {
@@ -1773,7 +1566,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
         IncreaseIndexCapacity(key);
     }
 
-
     private void IncreaseIndexCapacity(long key)
     {
         if (key is < 0 or >= int.MaxValue - 16)
@@ -1781,7 +1573,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
 
         int needed = checked((int)(key + 1));
         int oldCount = _index.Count;
-        _index.EnsureCapacityFor(_ctx, needed - oldCount);
+        _index.EnsureCapacityFor(ctx, needed - oldCount);
         _index.Count = needed;
 
         // Fill new slots with -1 (absent)
@@ -1789,75 +1581,49 @@ public unsafe partial struct RoaringBitmap : IDisposable
         new Span<int>(ptr + oldCount, needed - oldCount).Fill(IndexAbsent);
     }
 
-    /// <summary>
-    /// Add a new container entry and register it in the index. Returns the entry slot.
-    /// </summary>
     private int AddNewContainer(long key, ContainerType type, in ContainerEntry entry)
     {
         EnsureIndexCoversKey(key);
 
         int slot;
-        if (_freeListHead != 0) // 0 = empty; non-zero = slot+1 (1-based)
+        if (_containersFreeListHead != 0) // 0 = empty; non-zero = slot+1 (1-based)
         {
-            slot = _freeListHead - 1; // decode: real index = stored - 1
+            slot = _containersFreeListHead - 1; // decode: real index = stored - 1
             Debug.Assert(_types.RawItems[slot] == ContainerType.Free, "Expected free entry");
-            _freeListHead = (int)_entries[slot].NextFreeSlot; // next encoded value (0 or slot+1)
+            _containersFreeListHead = (int)_entries[slot].NextFreeSlot; // next encoded value (0 or slot+1)
             _entries[slot] = entry;
             _types.RawItems[slot] = type;
         }
         else
         {
             slot = _entries.Count;
-            _entries.Add(_ctx, entry);
-            _types.Add(_ctx, type);
+            _entries.Add(ctx, entry);
+            _types.Add(ctx, type);
         }
 
-        // we checked size of key in EnsureIndexCoversKey, so this cast is safe
-        _entries[slot].Key = (uint)key;
+        _entries[slot].Key = (uint)key; // we checked size of key in EnsureIndexCoversKey, so this cast is safe
 
         _index.RawItems[key] = slot;
         _containerCount++;
         return slot;
     }
 
-    /// <summary>
-    /// Remove a container: detach its storage onto the free list for reuse,
-    /// mark the index as absent, and chain the slot onto the entry free list.
-    /// </summary>
     private void FreeContainer(long key, int slot)
     {
         ref ContainerEntry entry = ref _entries[slot];
         if (entry.Storage.HasValue)
-            _freeList.Return(entry.Storage);
+            _buffersFreeListHeads.Return(entry.Storage);
 
         entry = default;
         _types.RawItems[slot] = ContainerType.Free;
-        entry.NextFreeSlot = (uint)_freeListHead; // current head (0 or prev_slot+1)
-        _freeListHead = slot + 1;                 // encode: store as real_index + 1
+        entry.NextFreeSlot = (uint)_containersFreeListHead; // current head (0 or prev_slot+1)
+        _containersFreeListHead = slot + 1;                 // encode: store as real_index + 1
 
         _index.RawItems[key] = IndexAbsent;
         _containerCount--;
     }
 
-    /// <summary>Add a container entry while building a result bitmap from scratch (keys added in order).</summary>
-    private void AddContainer(long key, ContainerType type, in ContainerEntry entry)
-    {
-        if (entry.Cardinality == 0)
-            return;
-
-        AddNewContainer(key, type, entry);
-    }
-
-    #endregion
-
-    #region Container Management
-
-    /// <summary>
-    /// Append <paramref name="right"/>'s values into <paramref name="left"/> (<paramref name="totalCount"/>
-    /// entries total). Reuses left's buffer if it has room, else steals right's (swapping ownership) if it
-    /// fits, else allocates. Result is always <see cref="ContainerType.ArrayUnsorted"/>.
-    /// </summary>
-    private void AppendArrayContainers(ref ContainerEntry left, ref ContainerEntry right, int totalCount)
+    private void ConcatArrayContainers(ref ContainerEntry left, ref ContainerEntry right, int totalCount)
     {
         int neededBytes = totalCount * sizeof(ushort);
         Debug.Assert(neededBytes <= BitmapContainerSizeInBytes, "Total count exceeds maximum for array container");
@@ -1872,7 +1638,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
         // Right buffer fits both — append left's values after right, then take ownership (order is irrelevant for ArrayUnsorted).
         Unsafe.CopyBlockUnaligned(right.ArrayData + right.Cardinality, left.ArrayData, (uint)(leftCardinality * sizeof(ushort)));
         if (left.Storage.HasValue)
-            _ctx.Release(ref left.Storage);
+            ctx.Release(ref left.Storage);
         left.Storage = right.Storage;
         left.Data = right.Data;
         left.Cardinality = totalCount;
@@ -1898,20 +1664,17 @@ public unsafe partial struct RoaringBitmap : IDisposable
         int newSize = Math.Max(entry.Storage.Length * 2, requiredBytes);
         newSize = Math.Min(newSize, BitmapContainerSizeInBytes);
 
-        _freeList.Allocate(_ctx, newSize, out ByteString newStorage);
+        _buffersFreeListHeads.Allocate(ctx, newSize, out ByteString newStorage);
         int copyBytes = entry.Cardinality * sizeof(ushort);
         if (copyBytes > 0)
             Unsafe.CopyBlockUnaligned(newStorage.Ptr, entry.Data, (uint)copyBytes);
 
         if (entry.Storage.HasValue)
-            _freeList.Return(entry.Storage);
+            _buffersFreeListHeads.Return(entry.Storage);
         entry.Storage = newStorage;
         entry.Data = newStorage.Ptr;
     }
 
-    #endregion
-
-    #region Container Operations
 
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1974,40 +1737,26 @@ public unsafe partial struct RoaringBitmap : IDisposable
         }
     }
 
-    #endregion
-
-    #region Container Conversions
-
-    /// <summary>
-    /// Convert an array container (sorted or unsorted) to bitmap.
-    /// For unsorted arrays with possible duplicates, cardinality is recounted via popcount.
-    /// </summary>
+    /// <summary>Convert an array container (sorted or unsorted) to bitmap. The resulting bitmap is marked dirty  (Cardinality = LazyCardinality)</summary>
     private void ConvertArrayToBitmap(ref ContainerEntry entry, ref ContainerType type)
     {
         Debug.Assert(type is ContainerType.Array or ContainerType.ArrayUnsorted);
 
-        bool unsorted = type == ContainerType.ArrayUnsorted;
         ushort* arr = entry.ArrayData;
         int count = entry.Cardinality;
 
-        _freeList.Allocate(_ctx, BitmapContainerSizeInBytes, out ByteString newStorage);
+        _buffersFreeListHeads.Allocate(ctx, BitmapContainerSizeInBytes, out ByteString newStorage);
         ClearBitmap((ulong*)newStorage.Ptr);
         SetArrayInBitmap(arr, count, (ulong*)newStorage.Ptr);
 
-        if (unsorted)
-        {
-            var updatedCount = BitmapContainerCardinality(newStorage.Ptr);
-            entry.Cardinality = updatedCount;
-        }
         if (entry.Storage.HasValue)
-            _freeList.Return(entry.Storage);
+            _buffersFreeListHeads.Return(entry.Storage);
 
+        entry.Cardinality = LazyCardinality;
         entry.Storage = newStorage;
         entry.Data = newStorage.Ptr;
         type = ContainerType.Bitmap;
     }
-
-    #endregion
 
     public void Dispose()
     {
@@ -2022,18 +1771,19 @@ public unsafe partial struct RoaringBitmap : IDisposable
             for (int i = 0; i < count; i++)
             {
                 if (entries[i].Storage.HasValue)
-                    _ctx.Release(ref entries[i].Storage);
+                    ctx.Release(ref entries[i].Storage);
             }
 
-            _entries.Dispose(_ctx);
+            _entries.Dispose(ctx);
         }
 
-        _freeList.ReleaseAll(_ctx);
+
+        _buffersFreeListHeads.ReleaseAll(ctx);
 
         if (_types.IsValid)
-            _types.Dispose(_ctx);
+            _types.Dispose(ctx);
 
         if (_index.IsValid)
-            _index.Dispose(_ctx);
+            _index.Dispose(ctx);
     }
 }

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -412,7 +412,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
     /// lazy sort pass in PrepareForReading/AndContainerInPlace would be wasted work.</summary>
     private void CreateArrayContainerFromSorted(long key, ReadOnlySpan<long> sortedValues)
     {
-        int neededBytes = AlignForSimd(sortedValues.Length * sizeof(ushort));
+        int neededBytes = sortedValues.Length * sizeof(ushort);
         _freeList.Allocate(_ctx, neededBytes, out ByteString storage);
 
         CopyDenseBottom16BitsToUshortArray(sortedValues, (ushort*)storage.Ptr);
@@ -485,8 +485,9 @@ public unsafe partial struct RoaringBitmap : IDisposable
                 bool stillSorted = type == ContainerType.Array
                     && (entry.Cardinality == 0 || firstNew > entry.ArrayData[entry.Cardinality - 1]);
 
-                // Ensure enough space
-                int neededBytes = AlignForSimd(newTotal * sizeof(ushort));
+                // Ensure enough space (the free list rounds every block up to a 32-byte-aligned size class,
+                // and entry.Storage.Length is always such a class size, so this comparison is SIMD-exact).
+                int neededBytes = newTotal * sizeof(ushort);
                 if (entry.Storage.Length < neededBytes)
                 {
                     _freeList.Allocate(_ctx, neededBytes, out ByteString newStorage);
@@ -1871,13 +1872,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
     #endregion
 
     #region Container Management
-
-    /// <summary>Round allocation size up to a multiple of 32 bytes so Vector256 ops need no bounds checking.</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int AlignForSimd(int bytes)
-    {
-        return Math.Max(InitialArrayContainerSizeInBytes, (bytes + SimdAlignment - 1) & ~(SimdAlignment - 1));
-    }
 
     /// <summary>
     /// Append <paramref name="right"/>'s values into <paramref name="left"/> (<paramref name="totalCount"/>

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -513,6 +513,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
     /// </summary>
     public void LazyOrWith(scoped ref RoaringBitmap other)
     {
+        AssertNotConsumed();
         if (other.IsEmpty)
             return;
 
@@ -551,6 +552,10 @@ public unsafe partial struct RoaringBitmap : IDisposable
             other._containerCount--;
             AddNewContainer(key, otherType, stolen);
         }
+
+        // Destructive on `other` (containers stolen) — mark it consumed so a later use is caught in DEBUG,
+        // matching OrWith/AndWith/AndNotWith. (OrWith also marks it; MarkConsumed is idempotent.)
+        MarkConsumed(ref other);
     }
 
     /// <summary>
@@ -1889,7 +1894,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
             left.Cardinality = totalCount;
             return;
         }
-        // Right buffer fits both — prepend left's values into right, then take ownership.
+        // Right buffer fits both — append left's values after right, then take ownership (order is irrelevant for ArrayUnsorted).
         Unsafe.CopyBlockUnaligned(right.ArrayData + right.Cardinality, left.ArrayData, (uint)(leftCardinality * sizeof(ushort)));
         if (left.Storage.HasValue)
             _ctx.Release(ref left.Storage);

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -784,9 +784,10 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     break;
 
                 case ContainerType.ArrayUnsorted:
-                    // Normalize once: sort + upgrade so later probes of this container binary-search.
-                    new Span<ushort>(entry.ArrayData, entry.Cardinality).Sort();
-                    type = ContainerType.Array;
+                    // Normalize once: sort + dedup + upgrade so later probes of this container binary-search.
+                    // Dedup is required because append-only writes can leave duplicates, and the Array
+                    // container invariant is sorted AND unique (bare .Sort() would make dups permanent).
+                    SortAndDedupSmallArray(ref entry, out type);
                     if (ArrayContainerContains(entry.ArrayData, entry.Cardinality, low) == false) continue;
                     break;
 
@@ -923,9 +924,10 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     }
                     else
                     {
-                        // Normalize once: sort + upgrade so this and later probes of this container merge/binary-search.
-                        new Span<ushort>(entry.ArrayData, entry.Cardinality).Sort();
-                        type = ContainerType.Array;
+                        // Normalize once: sort + dedup + upgrade so this and later probes of this container
+                        // merge/binary-search. Dedup keeps the Array invariant (sorted AND unique) — without it,
+                        // duplicates left by append-only writes would survive the type flip permanently.
+                        SortAndDedupSmallArray(ref entry, out type);
                         goto case ContainerType.Array;
                     }
                     break;
@@ -1121,9 +1123,10 @@ public unsafe partial struct RoaringBitmap : IDisposable
             int card = ResolveCardinality(ref entry);
 
             if (type == ContainerType.ArrayUnsorted)
-            {   // Sort-on-first-select for ArrayUnsorted
-                new Span<ushort>(entry.ArrayData, card).Sort();
-                type = ContainerType.Array;
+            {   // Sort + dedup on first select; the Array invariant is sorted AND unique. Dedup can shrink
+                // the container, so refresh card afterward to keep containerEnd / SelectInContainer correct.
+                SortAndDedupSmallArray(ref entry, out type);
+                card = entry.Cardinality;
             }
 
             long containerEnd = accCard + card;

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -51,6 +51,11 @@ public unsafe partial struct RoaringBitmap : IDisposable
 
     private readonly ByteStringContext _ctx;
 
+    // Guards Dispose so it is idempotent — the same bitmap can be reached through two owners (e.g. a sorted
+    // CompiledQuery stores the top SortingMatch under both QueryMatch and SortingWrapper), so Dispose may be
+    // called more than once and must not double-release its storage.
+    private bool _disposed;
+
 #if DEBUG
     /// <summary>Set after this bitmap is passed as the right-hand side of a destructive
     /// set operation (OrWith, AndWith, AndNotWith). Any subsequent access asserts.
@@ -784,9 +789,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     break;
 
                 case ContainerType.ArrayUnsorted:
-                    // Normalize once: sort + dedup + upgrade so later probes of this container binary-search.
-                    // Dedup is required because append-only writes can leave duplicates, and the Array
-                    // container invariant is sorted AND unique (bare .Sort() would make dups permanent).
                     SortAndDedupSmallArray(ref entry, out type);
                     if (ArrayContainerContains(entry.ArrayData, entry.Cardinality, low) == false) continue;
                     break;
@@ -924,9 +926,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
                     }
                     else
                     {
-                        // Normalize once: sort + dedup + upgrade so this and later probes of this container
-                        // merge/binary-search. Dedup keeps the Array invariant (sorted AND unique) — without it,
-                        // duplicates left by append-only writes would survive the type flip permanently.
                         SortAndDedupSmallArray(ref entry, out type);
                         goto case ContainerType.Array;
                     }
@@ -1123,10 +1122,10 @@ public unsafe partial struct RoaringBitmap : IDisposable
             int card = ResolveCardinality(ref entry);
 
             if (type == ContainerType.ArrayUnsorted)
-            {   // Sort + dedup on first select; the Array invariant is sorted AND unique. Dedup can shrink
-                // the container, so refresh card afterward to keep containerEnd / SelectInContainer correct.
+            {
                 SortAndDedupSmallArray(ref entry, out type);
-                card = entry.Cardinality;
+                card = entry.Cardinality; // dedup may have shrunk the container
+
             }
 
             long containerEnd = accCard + card;
@@ -2039,6 +2038,10 @@ public unsafe partial struct RoaringBitmap : IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+            return;
+        _disposed = true;
+
         if (_entries.IsValid)
         {
             ContainerEntry* entries = _entries.RawItems;

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -9,7 +9,6 @@ using System.Runtime.Intrinsics.X86;
 using Sparrow;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
-using Sparrow.Server.Utils.VxSort;
 using Voron.Util;
 
 namespace Voron.Data.RoaringBitmaps;
@@ -704,6 +703,29 @@ public unsafe partial struct RoaringBitmap(ByteStringContext ctx) : IDisposable
         VisitPresentSorted(sortedMatches, sortedMatches.Length, ref visitor);
     }
 
+    /// <summary>Count how many of <paramref name="sortedMatches"/> (ascending) are present in this bitmap, via a
+    /// single grouped forward-cursor merge per container — O(matches + containers) instead of a point lookup per
+    /// element.</summary>
+    public int CountPresentSorted(Span<long> sortedMatches)
+    {
+        AssertNotConsumed();
+        var visitor = new CountVisitor();
+        VisitPresentSorted(sortedMatches, sortedMatches.Length, ref visitor);
+        return visitor.Count;
+    }
+
+    /// <summary>Retain only the entries of <paramref name="sortedMatches"/> (ascending) that are present in this
+    /// bitmap, compacting them to the front of the span in place; returns the retained count. One grouped
+    /// forward-cursor merge per container, vs a point lookup per element. The inverse of the filtering that
+    /// <see cref="DedupAddNew"/>'s visitor does (it keeps the absent; this keeps the present).</summary>
+    public int RetainPresentSorted(Span<long> sortedMatches)
+    {
+        AssertNotConsumed();
+        var visitor = new RetainVisitor(sortedMatches);
+        VisitPresentSorted(sortedMatches, sortedMatches.Length, ref visitor);
+        return visitor.Kept;
+    }
+
     private interface IPresenceVisitor
     {
         bool VisitsMisses { get; }
@@ -711,6 +733,29 @@ public unsafe partial struct RoaringBitmap(ByteStringContext ctx) : IDisposable
         void OnMiss(int index);
 
         void OnAbsentRun(int from, int to);
+    }
+
+    private struct CountVisitor : IPresenceVisitor
+    {
+        public int Count;
+        public readonly bool VisitsMisses => false;
+        public void OnHit(int index) => Count++;
+        public readonly void OnMiss(int index) { }
+        public readonly void OnAbsentRun(int from, int to) { }
+    }
+
+    // Keeps the present entries (the inverse of DedupVisitor): compacts each hit to the front in place. Hits are
+    // visited in ascending index order and Kept <= index throughout, so the in-place write never clobbers an
+    // unread element. VisitsMisses is false — absent entries (OnMiss / whole OnAbsentRun runs) are simply dropped.
+    private ref struct RetainVisitor(Span<long> buffer) : IPresenceVisitor
+    {
+        private readonly Span<long> _buffer = buffer;
+        public int Kept;
+
+        public readonly bool VisitsMisses => false;
+        public void OnHit(int index) => _buffer[Kept++] = _buffer[index];
+        public readonly void OnMiss(int index) { }
+        public readonly void OnAbsentRun(int from, int to) { }
     }
 
     private void VisitPresentSorted<TVisitor>(Span<long> sortedMatches, int count, scoped ref TVisitor visitor)
@@ -865,12 +910,27 @@ public unsafe partial struct RoaringBitmap(ByteStringContext ctx) : IDisposable
     }
 
     /// <summary>Dedup + add in a single pass: for each entry in <paramref name="buffer"/>, if it is NOT already in the bitmap, keep it in the buffer and add it to the bitmap.
-    /// Returns the count of new (non-duplicate) entries. </summary>
+    /// Returns the count of new (non-duplicate) entries. The kept entries are restored to their original (input) order.</summary>
+    [SkipLocalsInit]
     public int DedupAddNew(Span<long> buffer, int count)
     {
         if (count == 0) return 0;
 
+        if(count <= 4096)
+        {
+            Span<int> temp = stackalloc int[4096];
+            return DedupAddNew(buffer, count, temp);
+        }
+        
         using var _ = ctx.Allocate(PadToVector256Width(count), out Span<int> indices);
+        return DedupAddNew(buffer, count, indices);
+    }
+    
+
+    private int DedupAddNew(Span<long> buffer, int count, Span<int> indices)
+    {
+        if (count == 0) return 0;
+
         InitializeIndices(indices, count);
         buffer[..count].Sort(indices[..count]);
         count = RemoveDuplicates(buffer, indices, count);
@@ -881,7 +941,7 @@ public unsafe partial struct RoaringBitmap(ByteStringContext ctx) : IDisposable
 
         // Add the new entries to the bitmap while they're still sorted.
         AddRange(buffer[..kept]);
-        
+
         indices[..kept].Sort(buffer[..kept]); // restore original order
         return kept;
     }

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -1,0 +1,2052 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Sparrow;
+using Sparrow.Server;
+using Voron.Util;
+
+namespace Voron.Data.RoaringBitmaps;
+
+/// <summary>
+/// A roaring bitmap implementation optimized for Corax's native memory model.
+/// All memory is allocated through ByteStringContext, ensuring zero-managed heap allocations
+/// for the bitmap data. Non-negative values are split into container key (value &gt;&gt; 16)
+/// and low 16 bits. Container lookup is O(1) via a flat index array sized to the max key.
+///
+/// Container types:
+/// - Range: contiguous values start..start+count-1 (no data allocation). count=65536 means full.
+///   Sequential Add at either range edge is O(1). Created automatically for contiguous inserts.
+/// - ArrayUnsorted: append-only ushort[]. Add is O(1). Sorted lazily on first read.
+/// - Array: sorted ushort[] for sparse data (cardinality &lt;= 4096, up to 8KB)
+/// - Bitmap: 8KB fixed bitmap (1024 longs) for dense data (&gt; 4096 values)
+///
+/// Threading and consumption model:
+/// - Single-threaded by design: no locking, no atomic state. Callers must not share a bitmap across threads.
+/// - Set operations (<see cref="AndWith"/>, <see cref="AndNotWith"/>, <see cref="LazyOrWith"/>) are
+///   intentionally destructive on their right-hand argument (containers stolen/sorted/mutated in place) to
+///   skip a copy in hot paths. After being passed as the right side, a bitmap is consumed and must not be
+///   read or used again until <see cref="Clear"/>'d — which also recycles its storage for reuse as scratch.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+public unsafe partial struct RoaringBitmap : IDisposable
+{
+    internal NativeList<ContainerEntry> _entries;
+    internal NativeList<ContainerType> _types;
+    internal NativeList<int> _index;
+    internal int _containerCount;
+    /// <summary>
+    /// Head of the entry free list, 1-based: 0 = empty, n = real slot index (n-1).
+    /// Zero-init (default struct) is therefore a valid empty state.
+    /// <see cref="ContainerEntry.NextFreeSlot"/> uses the same encoding for chaining.
+    /// </summary>
+    internal int _freeListHead;
+    /// <summary>Segregated storage free list (heads + class mask + size-class tables).
+    /// See <see cref="FreeListHeads"/> in RoaringBitmap.FreeListHeads.cs.</summary>
+    private FreeListHeads _freeList;
+
+    private readonly ByteStringContext _ctx;
+
+#if DEBUG
+    /// <summary>Set after this bitmap is passed as the right-hand side of a destructive
+    /// set operation (OrWith, AndWith, AndNotWith). Any subsequent access asserts.
+    /// Reset by <see cref="Clear"/>.</summary>
+    private bool _consumed;
+#endif
+
+    [Conditional("DEBUG")]
+    private readonly void AssertNotConsumed()
+    {
+#if DEBUG
+        Debug.Assert(!_consumed, "Bitmap was consumed by a prior set operation. Call Clear() to reuse.");
+#endif
+    }
+
+    [Conditional("DEBUG")]
+    private static void MarkConsumed(ref RoaringBitmap bitmap)
+    {
+#if DEBUG
+        bitmap._consumed = true;
+#endif
+    }
+
+    /// <summary>
+    /// Construct a RoaringBitmap backed by the given allocator.
+    /// All operations on this bitmap MUST use the same ByteStringContext instance that was
+    /// passed to the constructor. Mixing allocators will corrupt the storage free list.
+    /// </summary>
+    public RoaringBitmap(ByteStringContext ctx)
+    {
+        _ctx = ctx;
+        // _freeListHead == 0 is the terminator; default fields are already zero.
+    }
+
+    private const int BitmapContainerSizeInBytes = 8192; // 8KB
+    public const int BitmapContainerSizeInUInt64 = BitmapContainerSizeInBytes / sizeof(ulong);
+    private const int ArrayContainerMaxCardinality = BitmapContainerSizeInBytes / sizeof(ushort); // crossover: array at max costs same as bitmap
+    public const int ContainerKeyShift = 16;
+    public const int ContainerSize = 1 << ContainerKeyShift; // 65,536 entry IDs per container
+    private const int ContainerValueMask = 0xFFFF;
+    private const int LazyCardinality = -1;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ResolveCardinality(ref ContainerEntry entry)
+    {
+        int card = entry.Cardinality;
+        if (card == LazyCardinality)
+        {
+            card = BitmapContainerCardinality(entry.Data);
+            entry.Cardinality = card;
+        }
+        return card;
+    }
+
+    private const int InitialArrayContainerSizeInBytes = 64; // 32 shorts — minimum for SIMD linear scan without scalar tail
+    private const int SimdAlignment = 32; // Vector256 width in bytes
+    private const int SimdLinearScanThreshold = 64; // below this, SIMD linear scan beats binary/quad search
+
+    private const int IndexAbsent = -1;        // key is not present in index
+
+    [DoesNotReturn]
+    private static void ThrowNegativeNotSupported(long value)
+    {
+        throw new ArgumentOutOfRangeException(nameof(value), value, "RoaringBitmap only supports non-negative values.");
+    }
+
+    public readonly int ContainerCount => _containerCount;
+
+    /// <summary>Total cardinality across all containers. Not cached: O(container count) and repairs any
+    /// lazy bitmap popcounts (Cardinality == -1) found along the way. A method, not a property, so the
+    /// cost is visible at the call site — cache the result or gate on a cheaper bound in hot loops.</summary>
+    public long ComputeCount()
+    {
+        AssertNotConsumed();
+        long total = 0;
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+        int count = _entries.Count;
+        for (int i = 0; i < count; i++)
+        {
+            if (types[i] == ContainerType.Free)
+                continue;
+
+            int card = entries[i].Cardinality;
+            if (card is LazyCardinality)
+            {
+                // LazyCardinality: bitmap container was updated without recomputing the popcount.
+                // Count bits directly so callers (e.g. ShouldSwitchToEntryScan) see a correct value
+                // rather than the sentinel -1, which would incorrectly trigger early entry scan.
+                Debug.Assert(types[i] is ContainerType.Bitmap, "only bitmaps can have lazy cardinality");
+                entries[i].Cardinality = card = BitmapContainerCardinality(entries[i].Data);
+                if (card is 0)
+                {
+                    FreeContainer(entries[i].Key, i);
+                    continue;
+                }
+            }
+            total += card;
+        }
+        return total;
+    }
+
+    public readonly bool IsEmpty => _containerCount == 0;
+
+    public readonly bool Contains(long value)
+    {
+        AssertNotConsumed();
+        long key = value >> ContainerKeyShift;
+        int slot = GetSlotForKey(key);
+        if (slot < 0)
+            return false;
+        return ContainsAtSlot(slot, (ushort)(value & ContainerValueMask));
+    }
+
+    /// <summary>
+    /// Container-internal membership test after the caller has already resolved the slot via
+    /// <see cref="GetSlotForKey"/>. Lets callers hoist the slot-resolution binary search out of
+    /// a hot loop when consecutive lookups share the same high-bits (e.g. BitmapMatch.AndWith
+    /// processing a batch with high entry-ID locality).
+    /// </summary>
+    private readonly bool ContainsAtSlot(int slot, ushort low)
+    {
+        ref ContainerEntry entry = ref _entries[slot];
+        ContainerType type = _types.RawItems[slot];
+        return type switch
+        {
+            ContainerType.Array => ArrayContainerContains(entry.ArrayData, entry.Cardinality, low),
+            ContainerType.ArrayUnsorted => SimdLinearContains(entry.ArrayData, entry.Cardinality, low),
+            ContainerType.Bitmap => BitmapContains((ulong*)entry.Data, low),
+            ContainerType.Range => low >= entry.RangeStart && low < entry.RangeStart + entry.Cardinality,
+            _ => ThrowUnexpectedContainerType(type)
+        };
+
+    [DoesNotReturn]
+    static bool ThrowUnexpectedContainerType(ContainerType type)
+    {
+        throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type");
+    }
+    }
+
+    public readonly long MinContainerKey
+    {
+        get
+        {
+            if (_containerCount == 0)
+                return -1;
+            for (int i = 0; i < _index.Count; i++)
+            {
+                if (_index[i] != IndexAbsent)
+                    return i;
+            }
+            return -1;
+        }
+    }
+
+    public readonly long MaxContainerKey
+    {
+        get
+        {
+            if (_containerCount == 0)
+                return -1;
+            for (int i = _index.Count - 1; i >= 0; i--)
+            {
+                if (_index[i] != IndexAbsent)
+                    return i;
+            }
+            return -1;
+        }
+    }
+
+    private readonly int GetSlotForKey(long key)
+    {
+        if (key < 0 || key >= _index.Count)
+            return IndexAbsent;
+        return _index.RawItems[key];
+    }
+
+    /// <summary>
+    /// Reset all containers without releasing memory. Container storages are pushed onto
+    /// the dedicated free list and made available for reuse on the next allocation,
+    /// avoiding the round-trip through the ByteStringContext free pool.
+    /// </summary>
+    public void Clear()
+    {
+#if DEBUG
+        _consumed = false;
+#endif
+        int count = _entries.Count;
+        if (count == 0 && _index.Count == 0)
+            return;
+
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+
+        // Recover every storage and park it on the storage free list.
+        for (int i = 0; i < count; i++)
+        {
+            if (types[i] != ContainerType.Free && entries[i].Storage.HasValue)
+                _freeList.Return(entries[i].Storage);
+        }
+
+        _entries.Clear();
+        _types.Clear();
+        _containerCount = 0;
+        _freeListHead = 0; // 0 = empty (entries are gone, free list is empty too)
+
+        int* indexRaw = _index.RawItems;
+        int indexLen = _index.Count;
+        new Span<int>(indexRaw, indexLen).Fill(IndexAbsent);
+    }
+
+    /// <summary>
+    /// Swap the internal state of two bitmaps. O(1) — swaps all fields.
+    /// Used after entry scan to swap the filtered results into the main bitmap.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SwapContents(ref RoaringBitmap other)
+    {
+        (other, this) = (this, other);
+    }
+
+    /// <summary>Batch-add strictly sorted, unique values, grouped by container key. Large per-container
+    /// runs (&gt;4096) go straight to bitmap; contiguous runs extend/create Range containers. The Array
+    /// append fast-path and bitmap creation rely on input length equaling the unique-value count.
+    /// Bitmap updates are lazy (cardinality left as LazyCardinality); <see cref="PrepareForReading"/>
+    /// repairs it via <see cref="RepairAfterLazy"/> before reads.</summary>
+    public void AddRange(ReadOnlySpan<long> sortedValues)
+    {
+        AssertNotConsumed();
+        if (sortedValues.IsEmpty)
+            return;
+
+        AssertSorted(sortedValues);
+
+        int index = 0;
+        while (index < sortedValues.Length)
+        {
+            long value = sortedValues[index];
+                if (value < 0)
+                ThrowNegativeNotSupported(value);
+            long key = value >> ContainerKeyShift;
+
+            int start = index;
+            // here we search for the index on the value in sortedValues that is the last that match
+            // the current container, so we can bulk insert it
+            index = SearchForContainerRangeEnd(sortedValues, (key + 1) << ContainerKeyShift, index + 1);
+            ReadOnlySpan<long> containerValues = sortedValues.Slice(start, index - start);
+
+            int slot = GetSlotForKey(key);
+            if (slot >= 0)
+            {
+                // Existing container — batch add via AddRangeToContainer
+                AddRangeToContainer(slot, containerValues);
+                continue;
+            }
+
+            // New container — keep contiguous runs as a range (any start offset)
+            ushort firstLow = (ushort)(containerValues[0] & ContainerValueMask);
+            ushort lastLow = (ushort)(containerValues[^1] & ContainerValueMask);
+            bool isRange = lastLow - firstLow == containerValues.Length - 1;
+
+            if (isRange)
+            {
+                AddNewContainer(key, ContainerType.Range, new ContainerEntry
+                {
+                    Cardinality = containerValues.Length,
+                    RangeStart = firstLow,
+                    Storage = default
+                });
+                continue;
+            }
+
+            if (containerValues.Length > ArrayContainerMaxCardinality)
+            {
+                CreateBitmapContainerFromSorted(key, containerValues);
+            }
+            else
+            {
+                CreateArrayContainerFromSorted(key, containerValues);
+            }
+        }
+    }
+
+    private static int SearchForContainerRangeEnd(ReadOnlySpan<long> sortedValues, long nextKeyStart, int start)
+    {
+        int jump = 1;
+        // Start with exponential jumps, then binary search within the last interval.
+        while (start + jump < sortedValues.Length && sortedValues[start + jump] < nextKeyStart)
+            jump <<= 1;
+        int lo = start + (jump >> 1);
+        int hi = Math.Min(start + jump, sortedValues.Length);
+        while (lo < hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            if (sortedValues[mid] < nextKeyStart)
+                lo = mid + 1;
+            else
+                hi = mid;
+        }
+        return lo;
+    }
+
+    private void CreateBitmapContainerFromSorted(long key, ReadOnlySpan<long> sortedValues)
+    {
+        _freeList.Allocate(_ctx, BitmapContainerSizeInBytes, out ByteString storage);
+        new Span<byte>(storage.Ptr, BitmapContainerSizeInBytes).Clear();
+
+        OrSortedIntoBitmap((ulong*)storage.Ptr, sortedValues);
+
+        AddNewContainer(key, ContainerType.Bitmap, new ContainerEntry
+        {
+            Cardinality = sortedValues.Length,
+            Data = storage.Ptr,
+            Storage = storage
+        });
+    }
+
+    /// <summary>
+    /// OR sorted values into a bitmap, accumulating per word and writing once per word boundary so
+    /// consecutive values sharing a word collapse into ~N/64 writes. Idempotent, so safe for fresh and
+    /// existing bitmaps. Caller tracks cardinality.
+    /// </summary>
+    private static void OrSortedIntoBitmap(ulong* bitmapPtr, ReadOnlySpan<long> sortedValues)
+    {
+        ushort firstLow = (ushort)(sortedValues[0] & ContainerValueMask);
+        int currentWordIndex = firstLow >> 6;
+        ulong currentMask = 1UL << (firstLow & 63);
+
+        for (int j = 1; j < sortedValues.Length; j++)
+        {
+            ushort low = (ushort)(sortedValues[j] & ContainerValueMask);
+            int wordIndex = low >> 6;
+
+            if (wordIndex == currentWordIndex)
+            {
+                currentMask |= 1UL << (low & 63);
+            }
+            else
+            {
+                bitmapPtr[currentWordIndex] |= currentMask;
+                currentWordIndex = wordIndex;
+                currentMask = 1UL << (low & 63);
+            }
+        }
+        bitmapPtr[currentWordIndex] |= currentMask;
+    }
+
+    /// <summary>Create a new array container from sorted values with SIMD-friendly allocation.
+    /// Tagged <see cref="ContainerType.Array"/> (not ArrayUnsorted): AddRange contractually requires
+    /// strictly sorted, unique input (see AssertSorted), so the data is already in read order and the
+    /// lazy sort pass in PrepareForReading/AndContainerInPlace would be wasted work.</summary>
+    private void CreateArrayContainerFromSorted(long key, ReadOnlySpan<long> sortedValues)
+    {
+        int neededBytes = AlignForSimd(sortedValues.Length * sizeof(ushort));
+        _freeList.Allocate(_ctx, neededBytes, out ByteString storage);
+
+        CopyDenseBottom16BitsToUshortArray(sortedValues, (ushort*)storage.Ptr);
+
+        AddNewContainer(key, ContainerType.Array, new ContainerEntry
+        {
+            Cardinality = sortedValues.Length,
+            Data = storage.Ptr,
+            Storage = storage
+        });
+    }
+
+    /// <summary>Batch-add sorted values into an existing container.</summary>
+    private void AddRangeToContainer(int slot, ReadOnlySpan<long> sortedValues)
+    {
+        ref ContainerEntry entry = ref _entries[slot];
+        ref ContainerType type = ref _types.RawItems[slot];
+
+        switch (type)
+        {
+            case ContainerType.Bitmap:
+            {
+                // Lazy: bits are OR'd in; cardinality is marked dirty, so RepairAfterLazy
+                // (called by PrepareForReading) recomputes it via popcount.
+                OrSortedIntoBitmap((ulong*)entry.Data, sortedValues);
+                entry.Cardinality = LazyCardinality;
+                break;
+            }
+
+            case ContainerType.Range:
+            {
+                int rangeStart = entry.RangeStart;
+                int rangeEnd = rangeStart + entry.Cardinality;
+
+                // Check if all new values are contiguous and can extend one edge.
+                ushort firstLow = (ushort)(sortedValues[0] & ContainerValueMask);
+                ushort lastLow = (ushort)(sortedValues[^1] & ContainerValueMask);
+
+                // Fully contained in existing range - noop.
+                if (firstLow >= rangeStart && lastLow < rangeEnd)
+                {
+                    break;
+                }
+
+                bool contiguousBatch = lastLow - firstLow == sortedValues.Length - 1;
+                if (contiguousBatch && TryMergeRangeInPlace(ref entry, firstLow, lastLow + 1))
+                    break;
+
+                // Non-contiguous batch (or disjoint contiguous batch) cannot stay as Range.
+                if (MaybeConvertRangeToArray(ref entry, ref type, rangeStart, entry.Cardinality, sortedValues))
+                    break;
+
+                ConvertRangeToBitmap(ref entry, ref type);
+                goto case ContainerType.Bitmap; // Convert to bitmap and add
+            }
+
+            case ContainerType.Array or ContainerType.ArrayUnsorted:
+            {
+                int newTotal = entry.Cardinality + sortedValues.Length;
+                if (newTotal > ArrayContainerMaxCardinality)
+                {
+                    ConvertArrayToBitmap(ref entry, ref _types.RawItems[slot]);
+                    goto case ContainerType.Bitmap; // Convert to bitmap and add
+                }
+
+                // If existing data was sorted and the new batch starts strictly after the last
+                // existing value, the appended result stays sorted — no need to degrade to
+                // ArrayUnsorted (which would force a sort pass in PrepareForReading).
+                ushort firstNew = (ushort)(sortedValues[0] & ContainerValueMask);
+                bool stillSorted = type == ContainerType.Array
+                    && (entry.Cardinality == 0 || firstNew > entry.ArrayData[entry.Cardinality - 1]);
+
+                // Ensure enough space
+                int neededBytes = AlignForSimd(newTotal * sizeof(ushort));
+                if (entry.Storage.Length < neededBytes)
+                {
+                    _freeList.Allocate(_ctx, neededBytes, out ByteString newStorage);
+                    new Span<byte>(entry.Data, entry.Cardinality * sizeof(ushort))
+                        .CopyTo(new Span<byte>(newStorage.Ptr, newStorage.Length));
+                    _freeList.Return(entry.Storage); // recycle old; new is larger
+                    entry.Data = newStorage.Ptr;
+                    entry.Storage = newStorage;
+                }
+
+                // Append new values
+                CopyDenseBottom16BitsToUshortArray(sortedValues, entry.ArrayData + entry.Cardinality);
+                entry.Cardinality = newTotal;
+                _types.RawItems[slot] = stillSorted ? ContainerType.Array : ContainerType.ArrayUnsorted;
+                break;
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type in AddRange");
+        }
+    }
+
+    /// <summary>
+    /// Lazy OR skips per-container cardinality tracking: bitmap containers get Cardinality = -1 (dirty).
+    /// Call RepairAfterLazy() once afterwards to recompute cardinality in a single popcount pass.
+    ///
+    /// Unlike standard roaring bitmaps, we deliberately skip Bitmap→Array conversion of sparse results:
+    /// Corax bitmaps are built during query evaluation and discarded immediately, so re-allocating an
+    /// array buffer and scanning 1024 words costs more than the memory it would save.
+    /// </summary>
+    public void LazyOrWith(scoped ref RoaringBitmap other)
+    {
+        if (other.IsEmpty)
+            return;
+
+        int otherLen = other._index.Count;
+        if (otherLen > 0)
+            EnsureIndexCoversKey(otherLen - 1);
+
+        _entries.EnsureCapacityFor(_ctx, other.ContainerCount);
+        _types.EnsureCapacityFor(_ctx, other.ContainerCount);
+
+        for (int key = 0; key < otherLen; key++)
+        {
+            int otherSlot = other.GetSlotForKey(key);
+            if (otherSlot < 0)
+                continue;
+
+            ref ContainerEntry otherEntry = ref other._entries[otherSlot];
+            int mySlot = GetSlotForKey(key);
+
+            if (mySlot >= 0)
+            {
+                LazyOrContainerInPlace(ref _entries[mySlot], ref _types.RawItems[mySlot],
+                    ref otherEntry, other._types.RawItems[otherSlot]);
+                continue;
+            }
+
+            // Steal container from other (zero-copy).
+            ContainerType otherType = other._types.RawItems[otherSlot];
+            ContainerEntry stolen = otherEntry;
+            otherEntry = default; // Clear the entry
+            // Detach the stolen slot from `other`: otherwise it stays indexed and a later
+            // Contains/AndWith on `other` would NRE on the now-empty entry.Data. Hit by
+            // SortingMatch.SortInMemory → Score reading a bitmap absorbed by a prior OrWith.
+            other._types.RawItems[otherSlot] = ContainerType.Free;
+            other._index.RawItems[key] = IndexAbsent;
+            other._containerCount--;
+            AddNewContainer(key, otherType, stolen);
+        }
+    }
+
+    /// <summary>
+    /// OR this bitmap with another. Calls LazyOrWith then RepairAfterLazy.
+    /// </summary>
+    public void OrWith(ref RoaringBitmap other)
+    {
+        AssertNotConsumed();
+        LazyOrWith(ref other);
+        RepairAfterLazy();
+        MarkConsumed(ref other);
+    }
+
+    /// <summary>Lazy OR for a single container pair. Skips popcount — marks bitmap
+    /// containers with Cardinality = -1.</summary>
+    [SkipLocalsInit]
+    private void LazyOrContainerInPlace(ref ContainerEntry left, ref ContainerType leftType,
+        ref ContainerEntry right, ContainerType rightType)
+    {
+        switch (leftType, rightType)
+        {
+            case (ContainerType.Range, ContainerType.Range):
+            {
+                if (TryMergeRangeInPlace(ref left, right.RangeStart, RangeEndExclusive(ref right)))
+                    return;
+
+                if (TryConvertRangeRangeToBestContainer(ref left, ref leftType, ref right))
+                    return;
+
+                // Disjoint ranges: materialize the other range and keep lazy OR semantics.
+                ulong* stackBmp = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ContainerEntry temp = MaterializeRangeIntoBuffer(ref right, stackBmp);
+                LazyOrContainerInPlace(ref left, ref leftType, ref temp, ContainerType.Bitmap);
+                break;
+            }
+            case (ContainerType.Range, _):
+            {
+                ConvertRangeToBitmap(ref left, ref leftType);
+                LazyOrContainerInPlace(ref left, ref leftType, ref right, rightType);
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Range):
+            {
+                // Convert to a heap bitmap first: we can't materialize the range into a stack
+                // buffer and recurse, because the (Array, Bitmap) case steals the right-hand
+                // buffer — a stack pointer that dangles once this frame returns.
+                ConvertArrayToBitmap(ref left, ref leftType);
+                LazyOrContainerInPlace(ref left, ref leftType, ref right, rightType);
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Range):
+            {
+                // Materialize the range into a stack buffer and bitwise-OR in place — safe because
+                // (Bitmap, Bitmap) does not steal the right-hand buffer.
+                ulong* stackBitmap = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ContainerEntry temp2 = MaterializeRangeIntoBuffer(ref right, stackBitmap);
+                LazyOrContainerInPlace(ref left, ref leftType, ref temp2, ContainerType.Bitmap);
+                break;
+            }
+            // From here, we no longer have ranges to worry about
+            case (ContainerType.Bitmap, ContainerType.Bitmap):
+            {
+                // OR bitmaps without popcount — just bitwise OR
+                BitmapOrNoPop(left.BitmapPtr, right.BitmapPtr, left.BitmapPtr);
+                left.Cardinality = LazyCardinality; // mark dirty
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                // Set bits unconditionally — no per-bit cardinality check
+                SetArrayInBitmap(right.ArrayData, right.Cardinality, left.BitmapPtr);
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                int maxResult = left.Cardinality + right.Cardinality;
+                if (maxResult > ArrayContainerMaxCardinality)
+                {
+                    ConvertArrayToBitmap(ref left, ref leftType);
+                    LazyOrContainerInPlace(ref left, ref leftType, ref right, rightType);
+                    return;
+                }
+                // Append values left & right — duplicates are harmless, deduped on PrepareForReading.
+                AppendArrayContainers(ref left, ref right, maxResult);
+                leftType = ContainerType.ArrayUnsorted;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Bitmap):
+            {
+                // Steal right's 8KB buffer
+                Debug.Assert(right.Storage.Length is BitmapContainerSizeInBytes, "Right container bitmap buffer must be exactly 8KB");
+                // OR left's array values into right's bitmap, then take ownership of the buffer.
+                SetArrayInBitmap(left.ArrayData, left.Cardinality, right.BitmapPtr);
+                if (left.Storage.HasValue)
+                    _ctx.Release(ref left.Storage);
+                left.Storage = right.Storage;
+                left.Data = right.Data;
+                left.Cardinality = LazyCardinality;
+                leftType = ContainerType.Bitmap;
+                right = default;
+                break;
+            }
+            default: // should never reach here
+                throw new InvalidOperationException($"Unexpected container type pair: {leftType}, {rightType}");
+        }
+    }
+
+    /// <summary>Recompute cardinality for all containers marked dirty (Cardinality == -1)
+    /// after a sequence of lazy bitmap ops (AddRange, LazyOrWith, AndWith, OrWith on
+    /// bitmap containers, etc.). Single popcount passes. Containers that pop to zero
+    /// (e.g., AND/ANDNOT removed all bits) are freed here.</summary>
+    public void RepairAfterLazy()
+    {
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            if (// _types is a dense array, so cheaper to scan through it first
+                _types.RawItems[i] != ContainerType.Bitmap ||
+                _entries[i].Cardinality != LazyCardinality)
+                continue;
+
+            ref ContainerEntry entry = ref _entries[i];
+
+             entry.Cardinality  = BitmapContainerCardinality(entry.Data);
+
+            if (entry.Cardinality is 0)
+                FreeContainer(entry.Key, i);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(long value)
+    {
+        AssertNotConsumed();
+        if (value < 0)
+            ThrowNegativeNotSupported(value);
+        long key = value >> ContainerKeyShift;
+        ushort low = (ushort)(value & ContainerValueMask);
+
+        int slot = GetSlotForKey(key);
+        if (slot >= 0)
+        {
+            ref ContainerEntry entry = ref _entries[slot];
+            AddToContainer(ref entry, slot, low);
+        }
+        else
+        {
+            AddNewContainer(key, ContainerType.Range, new ContainerEntry
+            {
+                Cardinality = 1,
+                RangeStart = low,
+                Storage = default
+            });
+        }
+    }
+
+    /// <summary>
+    /// Fill the buffer with values from the bitmap, starting from the current iteration state.
+    /// Returns the number of values written. Compatible with Corax's streaming evaluation.
+    /// </summary>
+    public int Fill(Span<long> buffer, ref RoaringBitmapIterator iterator)
+    {
+        AssertNotConsumed();
+        return iterator.Fill(ref this, buffer);
+    }
+
+    public RoaringBitmapIterator GetIterator()
+    {
+        AssertNotConsumed();
+        return new RoaringBitmapIterator(ref this, _ctx);
+    }
+
+    /// <summary>
+    /// Filter a buffer in-place, keeping only values present in this bitmap. Buffer order is
+    /// preserved; callers may pass entry IDs in any order (e.g. sort-field order from
+    /// <c>IndexOrderStreaming</c>).
+    ///
+    /// Algorithm: a straight order-preserving per-element membership test. Each entry resolves its
+    /// container via the O(1) <c>_index[key]</c> lookup and probes that container directly. A prior
+    /// design sorted the buffer to entry-ID order, walked container groups, then restored order — the
+    /// idea being to amortise slot resolution across a container group. But the slot lookup is a single
+    /// array index (~1 ns), so the two <c>Span.Sort</c> passes it paid for dwarfed what they saved: a
+    /// benchmark across container shapes / selectivities / orderings showed per-element 3–30× faster on
+    /// the realistic scattered (sort-field-order) input and never slower, only tying on already-sorted
+    /// input with a dense Array container.
+    ///
+    /// ArrayUnsorted containers are sorted in-place and upgraded to Array on first touch, so repeated
+    /// calls on the same bitmap binary-search instead of re-running O(k) SIMD linear scans.
+    /// </summary>
+    public int AndWith(Span<long> buffer, int count)
+    {
+        if (count == 0) return 0;
+
+        int* idx = _index.RawItems;
+        int idxLen = _index.Count;
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+
+        int kept = 0;
+        for (int i = 0; i < count; i++)
+        {
+            long value = buffer[i];
+            long containerKey = value >> ContainerKeyShift;
+            if (containerKey < 0 || containerKey >= idxLen)
+                continue;
+
+            int slot = idx[containerKey];
+            if (slot < 0) // absent or freed (FreeContainer resets _index[key] to IndexAbsent)
+                continue;
+
+            ushort low = (ushort)(value & ContainerValueMask);
+            ref ContainerEntry entry = ref entries[slot];
+            ref ContainerType type = ref types[slot];
+            switch (type)
+            {
+                case ContainerType.Bitmap:
+                    if (BitmapContains((ulong*)entry.Data, low) == false) continue;
+                    break;
+
+                case ContainerType.Array:
+                    if (ArrayContainerContains(entry.ArrayData, entry.Cardinality, low) == false) continue;
+                    break;
+
+                case ContainerType.Range:
+                    if (low < entry.RangeStart || low >= entry.RangeStart + entry.Cardinality) continue;
+                    break;
+
+                case ContainerType.ArrayUnsorted:
+                    // Normalize once: sort + upgrade so later probes of this container binary-search.
+                    new Span<ushort>(entry.ArrayData, entry.Cardinality).Sort();
+                    type = ContainerType.Array;
+                    if (ArrayContainerContains(entry.ArrayData, entry.Cardinality, low) == false) continue;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type in AndWith");
+            }
+
+            buffer[kept++] = value;
+        }
+
+        return kept;
+    }
+
+    /// <summary>Batch scoring helper: for each entry in <paramref name="matches"/> that is present in this bitmap,
+    /// add <paramref name="boostFactor"/> to <paramref name="scores"/> at the same index. <paramref name="matches"/>
+    /// MUST be sorted ascending (and is, in the in-memory score sort, where it comes straight off the candidate
+    /// bitmap iterator) — see <see cref="VisitPresentSorted{TVisitor}"/> for the container-group sweep this shares
+    /// with <see cref="DedupAddNew"/>.</summary>
+    public void ScorePresentSorted(Span<long> matches, Span<float> scores, float boostFactor)
+    {
+        AssertNotConsumed();
+        if (boostFactor == 0f)
+            return;
+
+        var visitor = new ScoreVisitor(scores, boostFactor);
+        VisitPresentSorted(matches, matches.Length, ref visitor);
+    }
+
+    /// <summary>What to do with each element of a sorted batch as the container-group sweep classifies it as
+    /// present (<see cref="OnHit"/>) or absent (<see cref="OnMiss"/> / <see cref="OnAbsentRun"/>). A struct type
+    /// parameter so <see cref="VisitPresentSorted{TVisitor}"/> specializes and inlines every callback (same idiom
+    /// as the sort comparers).</summary>
+    private interface IPresenceVisitor
+    {
+        /// <summary>When false, the Array forward-sweep may stop the moment the container is exhausted, since every
+        /// remaining element in the run is a guaranteed miss the visitor doesn't care about.</summary>
+        bool VisitsMisses { get; }
+        void OnHit(int index);
+        void OnMiss(int index);
+        /// <summary>An entire run <c>[from, to)</c> whose container is absent or tombstoned: no element is present.</summary>
+        void OnAbsentRun(int from, int to);
+    }
+
+    /// <summary>Walk a sorted batch grouped by container key. <paramref name="values"/> MUST be sorted ascending,
+    /// so each container's run is contiguous: one slot resolution per run, absent containers skipped wholesale, and
+    /// a sorted Array container swept with a single forward cursor instead of an independent search per probe —
+    /// turning N×O(scan) into O(N + cardinality). The <typeparamref name="TVisitor"/> decides what a hit/miss does
+    /// (score it, keep it, ...). Shared by <see cref="ScorePresentSorted"/> and <see cref="DedupAddNew"/>.</summary>
+    private void VisitPresentSorted<TVisitor>(Span<long> values, int count, scoped ref TVisitor visitor)
+        where TVisitor : struct, IPresenceVisitor, allows ref struct
+    {
+        int* idx = _index.RawItems;
+        int idxLen = _index.Count;
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+        bool visitsMisses = visitor.VisitsMisses;
+
+        int i = 0;
+        while (i < count)
+        {
+            long containerKey = values[i] >> ContainerKeyShift;
+            int groupEnd = GallopRight(values, i, count, (containerKey + 1) << ContainerKeyShift);
+
+            if (containerKey < 0 || containerKey >= idxLen || idx[containerKey] < 0)
+            {
+                visitor.OnAbsentRun(i, groupEnd);
+                i = groupEnd;
+                continue;
+            }
+
+            int slot = idx[containerKey];
+            ref ContainerEntry entry = ref entries[slot];
+            ref ContainerType type = ref types[slot];
+
+            switch (type)
+            {
+                case ContainerType.Bitmap:
+                {
+                    ulong* bmp = (ulong*)entry.Data;
+                    for (int gi = i; gi < groupEnd; gi++)
+                    {
+                        ushort low = (ushort)(values[gi] & ContainerValueMask);
+                        if (BitmapContains(bmp, low)) visitor.OnHit(gi);
+                        else visitor.OnMiss(gi);
+                    }
+                    break;
+                }
+
+                case ContainerType.Range:
+                {
+                    int rangeStart = entry.RangeStart;
+                    int rangeEnd = rangeStart + entry.Cardinality;
+                    for (int gi = i; gi < groupEnd; gi++)
+                    {
+                        ushort low = (ushort)(values[gi] & ContainerValueMask);
+                        if (low >= rangeStart && low < rangeEnd) visitor.OnHit(gi);
+                        else visitor.OnMiss(gi);
+                    }
+                    break;
+                }
+
+                case ContainerType.Array:
+                {
+                    // Both sides ascending (values sorted, Array container sorted): one forward sweep.
+                    ushort* arr = entry.ArrayData;
+                    int arrLen = entry.Cardinality;
+                    int ai = 0;
+                    for (int gi = i; gi < groupEnd; gi++)
+                    {
+                        ushort low = (ushort)(values[gi] & ContainerValueMask);
+                        while (ai < arrLen && arr[ai] < low) ai++;
+                        if (ai >= arrLen)
+                        {
+                            // Container exhausted: every remaining element in this run is a miss.
+                            if (visitsMisses == false)
+                                break;
+                            visitor.OnMiss(gi);
+                            continue;
+                        }
+                        if (arr[ai] == low) { visitor.OnHit(gi); ai++; }
+                        else visitor.OnMiss(gi);
+                    }
+                    break;
+                }
+
+                case ContainerType.ArrayUnsorted:
+                {
+                    if (groupEnd - i == 1)
+                    {
+                        // Single probe: a SIMD linear scan is cheaper than sorting the whole container for it.
+                        ushort low = (ushort)(values[i] & ContainerValueMask);
+                        if (SimdLinearContains(entry.ArrayData, entry.Cardinality, low)) visitor.OnHit(i);
+                        else visitor.OnMiss(i);
+                    }
+                    else
+                    {
+                        // Normalize once: sort + upgrade so this and later probes of this container merge/binary-search.
+                        new Span<ushort>(entry.ArrayData, entry.Cardinality).Sort();
+                        type = ContainerType.Array;
+                        goto case ContainerType.Array;
+                    }
+                    break;
+                }
+
+                case ContainerType.Free:
+                    // Tombstone — nothing present here.
+                    visitor.OnAbsentRun(i, groupEnd);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type in VisitPresentSorted");
+            }
+
+            i = groupEnd;
+        }
+    }
+
+    /// <summary>Adds <see cref="_boost"/> to the score slot of every present entry; ignores misses.</summary>
+    private readonly ref struct ScoreVisitor(Span<float> scores, float boost) : IPresenceVisitor
+    {
+        private readonly Span<float> _scores = scores;
+        private readonly float _boost = boost;
+
+        public bool VisitsMisses => false;
+        public void OnHit(int index) => _scores[index] += _boost;
+        public void OnMiss(int index) { }
+        public void OnAbsentRun(int from, int to) { }
+    }
+
+    /// <summary>The dedup half of <see cref="DedupAddNew"/>: KEEPS entries that are ABSENT from the bitmap
+    /// (compacting <see cref="_buffer"/> + <see cref="_indices"/> in place) and discards present ones. The kept
+    /// prefix never overtakes the sweep's read cursor, so the in-place compaction is safe.</summary>
+    private ref struct DedupVisitor(Span<long> buffer, Span<int> indices) : IPresenceVisitor
+    {
+        private readonly Span<long> _buffer = buffer;
+        private readonly Span<int> _indices = indices;
+        public int Kept;
+
+        public bool VisitsMisses => true;
+        public void OnHit(int index) { } // present — discard
+
+        public void OnMiss(int index)
+        {
+            _buffer[Kept] = _buffer[index];
+            _indices[Kept] = _indices[index];
+            Kept++;
+        }
+
+        public void OnAbsentRun(int from, int to)
+        {
+            for (int gi = from; gi < to; gi++)
+            {
+                _buffer[Kept] = _buffer[gi];
+                _indices[Kept] = _indices[gi];
+                Kept++;
+            }
+        }
+    }
+
+    /// <summary>Dedup + add in a single pass: for each entry in <paramref name="buffer"/>,
+    /// if it is NOT already in the bitmap, keep it in the buffer and add it to the bitmap.
+    /// If it IS already present, discard it. Returns the count of new (non-duplicate) entries.
+    /// Buffer order is preserved (via the same index-tracking approach as <see cref="AndWith"/>).
+    /// Uses the same container-group batching as <see cref="AndWith"/> but with inverted logic:
+    /// entries absent from a container are kept; entries present are discarded.
+    /// Used by SortingMatch.StreamInIndexOrder to replace the per-entry Contains+Add loop.</summary>
+    public int DedupAddNew(Span<long> buffer, int count)
+    {
+        if (count == 0) return 0;
+
+        using var _ = _ctx.Allocate(PadToVector256Width(count), out Span<int> indices);
+        InitializeIndices(indices, count);
+        buffer[..count].Sort(indices[..count]);
+        count = RemoveDuplicates(buffer, indices, count);
+
+        // Same sorted-container sweep as ScorePresentSorted, but the visitor KEEPS absent entries (compacting
+        // buffer + indices in place) and discards present ones.
+        var visitor = new DedupVisitor(buffer, indices);
+        VisitPresentSorted(buffer, count, ref visitor);
+        int kept = visitor.Kept;
+
+        // Add the new entries to the bitmap while they're still sorted.
+        AddRange(buffer[..kept]);
+
+        // Restore original order.
+        indices[..kept].Sort(buffer[..kept]);
+        return kept;
+    }
+
+    private static int RemoveDuplicates(Span<long> buffer, Span<int> indices, int count)
+    {
+        // Remove within-batch duplicates (buffer is sorted, so they're adjacent).
+        // Keep the first occurrence of each value, maintaining the indices in parallel.
+        int unique = 1;
+        for (int d = 1; d < count; d++)
+        {
+            if (buffer[d] == buffer[d - 1]) 
+                continue;
+            
+            buffer[unique] = buffer[d];
+            indices[unique] = indices[d];
+            unique++;
+        }
+
+        return unique;
+    }
+
+    /// <summary>Returns the first index in <c>[lo, hi)</c> where <c>buffer[index] &gt;= sentinel</c>,
+    /// using exponential probing then binary search — O(log d) where d is the run length.</summary>
+    private static int GallopRight(Span<long> buffer, int lo, int hi, long sentinel)
+    {
+        int step = 1;
+        int probe = lo;
+        while (probe < hi && buffer[probe] < sentinel)
+        {
+            lo = probe + 1;
+            probe = lo + step;
+            step <<= 1;
+        }
+        int limit = probe < hi ? probe : hi;
+        while (lo < limit)
+        {
+            int mid = (lo + limit) >> 1;
+            if (buffer[mid] < sentinel) lo = mid + 1;
+            else limit = mid;
+        }
+        return lo;
+    }
+
+    /// <summary>
+    /// Bulk Select: for each rank in <paramref name="ranks"/>, write the corresponding
+    /// set-bit value into <paramref name="results"/> at the same index. Out-of-range
+    /// or negative ranks produce -1. <paramref name="ranks"/> is mutated (sorted in place).
+    /// <paramref name="ranks"/> and <paramref name="results"/> must NOT alias - we read
+    /// from ranks while writing to results in permuted order, so aliasing would corrupt input.
+    ///
+    /// Sorts ranks once, then walks containers a single time while accumulating
+    /// cardinality — O(C + N log N) instead of O(C * N) for repeated single-rank Select.
+    /// </summary>
+    public void Select(ByteStringContext allocator, Span<long> ranks, Span<long> results)
+    {
+        int n = ranks.Length;
+        Debug.Assert(results.Length >= n);
+        Debug.Assert(ranks.Overlaps(results) == false, "ranks and results must not alias");
+        if (n == 0)
+            return;
+
+        // Track each rank's original position so we can scatter results back in input order
+        // after sorting ranks ascending for the single-pass container walk.
+        // Pad the allocation up to a multiple of 8 ints so the AVX2 init loop below can
+        // store full Vector256<int> chunks without a scalar tail. Only indexes[0..n) is
+        // ever read after init; we slice back to n for Sort (parallel-keys API requires
+        // matching lengths) and subsequent reads.
+        int paddedLen = PadToVector256Width(n);
+        using var _ = allocator.Allocate(paddedLen * sizeof(int), out ByteString work);
+        InitializeIndices(new Span<int>(work.Ptr, paddedLen), n);
+        var indexes = new Span<int>(work.Ptr, n);
+
+        // Parallel sort: ranks ascending; indexes follow the same permutation so
+        // indexes[i] is the original position of the rank now at ranks[i].
+        ranks.Sort(indexes);
+
+        int rankIdx = 0;
+
+        // Negative ranks sort to the front - emit -1 for each.
+        while (rankIdx < n && ranks[rankIdx] < 0)
+        {
+            results[indexes[rankIdx]] = -1;
+            rankIdx++;
+        }
+
+        // Walk containers in key order, accumulating cardinality. Each rank lands
+        // inside the first container whose accumulated cardinality exceeds it.
+        int* idx = _index.RawItems;
+        int idxLen = _index.Count;
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+
+        long accCard = 0;
+        for (int key = 0; key < idxLen && rankIdx < n; key++)
+        {
+            int slot = idx[key];
+            if (slot < 0)
+                continue;
+
+            ref ContainerEntry entry = ref entries[slot];
+            ref ContainerType type = ref types[slot];
+            if (type == ContainerType.Free)
+                continue;
+
+            Debug.Assert(type is not ContainerType.Free);
+            int card = ResolveCardinality(ref entry);
+
+            if (type == ContainerType.ArrayUnsorted)
+            {   // Sort-on-first-select for ArrayUnsorted
+                new Span<ushort>(entry.ArrayData, card).Sort();
+                type = ContainerType.Array;
+            }
+
+            long containerEnd = accCard + card;
+            long baseValue = (long)key << ContainerKeyShift;
+            while (rankIdx < n && ranks[rankIdx] < containerEnd)
+            {
+                int localRank = (int)(ranks[rankIdx] - accCard);
+                results[indexes[rankIdx]] = baseValue + SelectInContainer(ref entry, type, localRank);
+                rankIdx++;
+            }
+            accCard = containerEnd;
+        }
+
+        // Anything still unprocessed is past the end of the bitmap.
+        while (rankIdx < n)
+        {
+            results[indexes[rankIdx]] = -1;
+            rankIdx++;
+        }
+    }
+
+    /// <summary>Round <paramref name="n"/> up to the next multiple of 8 (the AVX2 Vector256&lt;int&gt;
+    /// lane width). Use this whenever allocating an int buffer that will be passed to
+    /// <see cref="InitializeIndices"/> so the SIMD loop can store full 256-bit chunks
+    /// without a scalar tail.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int PadToVector256Width(int n) => (n + 7) & ~7;
+
+    /// <summary>Fill <paramref name="indices"/> with 0..read-1 using AVX2 256-bit stores.
+    /// <paramref name="indices"/> must be padded to a multiple of 8 — i.e.
+    /// <c>indices.Length &gt;= PadToVector256Width(read)</c> — so the unrolled SIMD loop can store
+    /// full Vector256&lt;int&gt; chunks without a scalar tail. Used by RoaringBitmap.Select
+    /// here and by Corax's DirectScanMatch via InternalsVisibleTo.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void InitializeIndices(Span<int> indices, int read)
+    {
+        Debug.Assert(PadToVector256Width(read) <= indices.Length, "SIMD write past indices span");
+        ref int ptr = ref MemoryMarshal.GetReference(indices);
+
+        var countVec = Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7);
+        var increment = Vector256.Create(8);
+
+        int j = 0;
+        while (j < read)
+        {
+            countVec.StoreUnsafe(ref Unsafe.Add(ref ptr, j));
+            countVec += increment;
+            j += 8;
+        }
+    }
+
+    /// <summary>Find the nth set value inside a single container (0-based).
+    /// Caller is responsible for upgrading ArrayUnsorted to Array first.</summary>
+    private static int SelectInContainer(ref ContainerEntry entry, ContainerType type, int rank)
+    {
+        switch (type)
+        {
+            case ContainerType.Array:
+                return entry.ArrayData[rank];
+
+            case ContainerType.Range:
+                return entry.RangeStart + rank;
+
+            case ContainerType.Bitmap:
+            {
+                ulong* bmp = (ulong*)entry.Data;
+                int word = 0;
+
+                // scan 8 ulongs at a time. popcnt is a 1-cycle instruction with
+                // four-way ILP on modern x86, so an unrolled batch of 8 retires in ~3 cycles.
+                // The JIT may also fuse this into AVX-512 VPOPCNTQ when supported.
+                const int Unroll = 8;
+                while (word + Unroll <= BitmapContainerSizeInUInt64)
+                {
+                    int blockBits =   BitOperations.PopCount(bmp[word])
+                                    + BitOperations.PopCount(bmp[word + 1])
+                                    + BitOperations.PopCount(bmp[word + 2])
+                                    + BitOperations.PopCount(bmp[word + 3])
+                                    + BitOperations.PopCount(bmp[word + 4])
+                                    + BitOperations.PopCount(bmp[word + 5])
+                                    + BitOperations.PopCount(bmp[word + 6])
+                                    + BitOperations.PopCount(bmp[word + 7]);
+                    if (rank < blockBits)
+                        break;
+                    rank -= blockBits;
+                    word += Unroll;
+                }
+
+                for (; word < BitmapContainerSizeInUInt64; word++)
+                {
+                    ulong w = bmp[word];
+                    int bits = BitOperations.PopCount(w);
+                    if (rank < bits)
+                    {
+                        // Win 1: BMI2 PDEP deposits a single 1-bit at the rank-th set
+                        // position in w; trailing-zeros gives its bit index. One instruction.
+                        if (Bmi2.X64.IsSupported)
+                        {
+                            ulong target = Bmi2.X64.ParallelBitDeposit(1UL << rank, w);
+                            return word * 64 + BitOperations.TrailingZeroCount(target);
+                        }
+
+                        // Fallback: clear the lowest set bit `rank` times.
+                        while (rank > 0)
+                        {
+                            w &= w - 1;
+                            rank--;
+                        }
+                        return word * 64 + BitOperations.TrailingZeroCount(w);
+                    }
+                    rank -= bits;
+                }
+                return -1; // shouldn't reach here if rank was valid
+            }
+
+            case ContainerType.ArrayUnsorted:
+            case ContainerType.Free:
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected container type in SelectInContainer");
+        }
+    }
+
+    /// <summary>
+    /// Create a deep copy of this bitmap. All container data is cloned into the same ByteStringContext.
+    /// The source bitmap is not modified. The clone preserves container types (Range, Array, Bitmap).
+    /// </summary>
+    public RoaringBitmap Clone()
+    {
+        RoaringBitmap copy = new(_ctx);
+
+        // Walk entries directly using the Key field - no index indirection needed
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+        int entryCount = _entries.Count;
+        for (int i = 0; i < entryCount; i++)
+        {
+            if (types[i] != ContainerType.Free)
+                copy.AddContainer(entries[i].Key, types[i], CloneContainer(_ctx, ref entries[i], types[i]));
+        }
+        return copy;
+    }
+
+    // Threshold: below this count, comparison sort on a small array
+    // is cheaper than the bitmap radix sort path.
+    private const int BitmapSortThreshold = 128;
+
+    /// <summary>
+    /// Prepare for reading: sort and deduplicate all unsorted array containers,
+    /// and repair lazy bitmap cardinalities left dirty by <see cref="AddRange"/>
+    /// or <see cref="LazyOrWith"/>. Call this after all writes and before any
+    /// read operations (Contains, Fill, set ops, Count). Separates the sort
+    /// + popcount cost from the first query, making performance more predictable.
+    ///
+    /// For sorted input (e.g., Corax posting lists), the array sort step is
+    /// nearly free since the arrays are already in order.
+    /// </summary>
+    [SkipLocalsInit]
+    public void PrepareForReading()
+    {
+        AssertNotConsumed();
+        // 8KB scratch bitmap for radix sort: explode unsorted values into bits,
+        // extract back as sorted array. O(n) bit-sets + O(1024) word scan vs O(n log n).
+        // Dedup is free. Scratch reused across all containers (one clear per chunk touched).
+        ulong* scratch = stackalloc ulong[BitmapContainerSizeInUInt64];
+
+        ContainerEntry* entries = _entries.RawItems;
+        ContainerType* types = _types.RawItems;
+        int entryCount = _entries.Count;
+        for (int i = 0; i < entryCount; i++)
+        {
+            switch (types[i])
+            {
+                case ContainerType.ArrayUnsorted:
+                {
+                    // All unsorted containers must be sorted for correct iteration order.
+                    // Contains() can use SIMD linear scan on unsorted data, but
+                    // Fill() (iteration) must emit entry IDs in ascending order.
+                    ref ContainerEntry entry = ref entries[i];
+                    if (entry.Cardinality >= BitmapSortThreshold)
+                        SortViaBitmapScratch(ref entry, ref types[i], scratch);
+                    else
+                        SortAndDedupSmallArray(ref entry, out types[i]);
+                    break;
+                }
+
+                case ContainerType.Bitmap when entries[i].Cardinality == LazyCardinality:
+                {
+                    ref ContainerEntry entry = ref entries[i];
+                    entry.Cardinality = BitmapContainerCardinality(entry.Data);
+                    if (entry.Cardinality == 0)
+                        FreeContainer(entry.Key, i);
+                    break;
+                }
+                case ContainerType.Array:
+                case ContainerType.Range:
+                case ContainerType.Bitmap:
+                case ContainerType.Free:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(ContainerType), types[i], "Unexpected container type in PrepareForReading");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Radix sort using 8KB bitmap scratch space.
+    /// O(n) bit-sets and O(n) word scan. Dedup is free (a duplicate bit-set is noop).
+    /// dirtyMap tracks which 4-ulong chunks have been written so extraction only
+    /// visits touched chunks, skipping clean regions entirely.
+    /// </summary>
+    private static void SortViaBitmapScratch(ref ContainerEntry entry, ref ContainerType type, ulong* scratch)
+    {
+        Debug.Assert(type == ContainerType.ArrayUnsorted);
+
+        var arr = entry.ArrayData;
+        int count = entry.Cardinality;
+
+        const int dirtyMapUlongLen = 4;
+        ulong* dirtyMap = stackalloc ulong[dirtyMapUlongLen];
+        Debug.Assert(dirtyMap[0] is 0 ,"This ensure that the stackalloc was cleared, *this* method should not have [SkipLocalsInit]");
+
+        // Explode: set bits for each value, mark the chunk dirty on first touch and clear it.
+        for (int i = 0; i < count; i++)
+        {
+            ushort val = arr[i];
+            int wordIdx = val >> 6;
+            int chunkIdx = wordIdx >> 2;
+            if (BitmapContains(dirtyMap, (ushort)chunkIdx) == false)
+            {
+                BitmapSet(dirtyMap, (ushort)chunkIdx);
+                new Span<byte>(scratch + chunkIdx * 4, 4 * sizeof(ulong)).Clear();
+            }
+
+            BitmapSet(scratch, val);
+        }
+
+        // Extract: only visit chunks marked dirty
+        int sorted = 0;
+        for (int i = 0; i < dirtyMapUlongLen; i++)
+        {
+            ulong currentWork = dirtyMap[i];
+            while (currentWork != 0)
+            {
+                int chunkBit = BitOperations.TrailingZeroCount(currentWork);
+                int wordBaseIdx = ((i << 6) + chunkBit) << 2;
+                const int bitmapWordsPerBit = 4;
+                for (int wordOffset = 0; wordOffset < bitmapWordsPerBit; wordOffset++)
+                {
+                    int wordIdx = wordBaseIdx + wordOffset;
+                    ulong currentWord = scratch[wordIdx];
+                    while (currentWord != 0)
+                    {
+                        int bit = BitOperations.TrailingZeroCount(currentWord);
+                        arr[sorted++] = (ushort)((wordIdx << 6) + bit);
+                        currentWord &= currentWord - 1;
+                    }
+                    scratch[wordIdx] = 0;
+                }
+                currentWork &= currentWork - 1;
+            }
+        }
+        entry.Cardinality = sorted;
+        type = ContainerType.Array;
+    }
+
+    #region In-place Set Operations
+
+    /// <summary>
+    /// In-place AND: retain only values that also exist in others.
+    /// Walks both index arrays; containers in this bitmap with no match in other are freed.
+    /// </summary>
+    public void AndWith(scoped ref RoaringBitmap other)
+    {
+        AssertNotConsumed();
+        int* myIdx = _index.RawItems;
+        int myLen = _index.Count;
+
+        for (int key = 0; key < myLen; key++)
+        {
+            int mySlot = myIdx[key];
+            if (mySlot < 0)
+                continue;
+
+            int otherSlot = other.GetSlotForKey(key);
+            if (otherSlot < 0)
+            {
+                // Not in other - remove; donate storage to other's free list so any
+                // remaining container conversions on that side can reuse it without
+                // round-tripping through ctx.Allocate.
+                DonateStorageThenFreeContainer(key, mySlot, ref other);
+            }
+            else
+            {
+                ref ContainerEntry myEntry = ref _entries[mySlot];
+                ref ContainerEntry otherEntry = ref other._entries[otherSlot];
+                AndContainerInPlace(ref myEntry, ref _types.RawItems[mySlot], ref otherEntry, other._types.RawItems[otherSlot]);
+                int card = ResolveCardinality(ref myEntry);
+                if (card == 0)
+                    DonateStorageThenFreeContainer(key, mySlot, ref other);
+            }
+        }
+        MarkConsumed(ref other);
+    }
+
+    /// <summary>
+    /// Streaming AND for the limit-aware posting-list path: intersects in place only this bitmap's
+    /// containers with key in [<paramref name="fromKeyInclusive"/>, <paramref name="toKeyExclusive"/>)
+    /// against <paramref name="other"/>, returning the surviving cardinality in that range; containers
+    /// outside it are untouched. Unlike <see cref="AndWith"/> it does NOT consume <paramref name="other"/>:
+    /// the caller grows <paramref name="other"/> across batches and processes only the "settled" key
+    /// prefix (all term entries read, since the posting list is scanned ascending), leaving the growing
+    /// tail for a later call.
+    /// </summary>
+    public long AndWithRange(scoped ref RoaringBitmap other, int fromKeyInclusive, int toKeyExclusive)
+    {
+        AssertNotConsumed();
+        int* myIdx = _index.RawItems;
+        int from = Math.Max(0, fromKeyInclusive);
+        int to = Math.Min(_index.Count, toKeyExclusive);
+        long survivors = 0;
+
+        for (int key = from; key < to; key++)
+        {
+            int mySlot = myIdx[key];
+            if (mySlot < 0)
+                continue;
+
+            int otherSlot = other.GetSlotForKey(key);
+            if (otherSlot < 0)
+            {
+                // Settled container has no term entries — it cannot survive the intersection.
+                FreeContainer(key, mySlot);
+            }
+            else
+            {
+                ref ContainerEntry myEntry = ref _entries[mySlot];
+                ref ContainerEntry otherEntry = ref other._entries[otherSlot];
+                AndContainerInPlace(ref myEntry, ref _types.RawItems[mySlot], ref otherEntry, other._types.RawItems[otherSlot]);
+                int card = ResolveCardinality(ref myEntry);
+                if (card == 0)
+                    FreeContainer(key, mySlot);
+                else
+                    survivors += card;
+            }
+        }
+        return survivors;
+    }
+
+    /// <summary>Drop every container whose key is ≥ <paramref name="fromKeyInclusive"/>. Used by the
+    /// limit-aware streaming AND to discard the still-unintersected tail once enough survivors were
+    /// already found in the settled prefix.</summary>
+    public void RemoveContainersFrom(int fromKeyInclusive)
+    {
+        AssertNotConsumed();
+        int* myIdx = _index.RawItems;
+        int myLen = _index.Count;
+        for (int key = Math.Max(0, fromKeyInclusive); key < myLen; key++)
+        {
+            int mySlot = myIdx[key];
+            if (mySlot >= 0)
+                FreeContainer(key, mySlot);
+        }
+    }
+
+    /// <summary>Donate this slot's storage to <paramref name="recipient"/>'s free pool
+    /// before freeing the entry. Used during AndWith / AndNotWith to arm the consumed
+    /// right-side bitmap with buffers that this side would otherwise have stranded on
+    /// its own pool.</summary>
+    private void DonateStorageThenFreeContainer(long key, int slot, scoped ref RoaringBitmap recipient)
+    {
+        ref ContainerEntry entry = ref _entries[slot];
+        if (entry.Storage.HasValue)
+        {
+            recipient._freeList.Return(entry.Storage);
+            entry.Storage = default;
+        }
+        FreeContainer(key, slot);
+    }
+
+    /// <summary>
+    /// In-place ANDNOT: remove all values that exist in other from this bitmap.
+    /// </summary>
+    public void AndNotWith(scoped ref RoaringBitmap other)
+    {
+        AssertNotConsumed();
+        int myLen = _index.Count;
+        int* myIdx = _index.RawItems;
+
+        for (int key = 0; key < myLen; key++)
+        {
+            int mySlot = myIdx[key];
+            if (mySlot < 0)
+                continue;
+
+            int otherSlot = other.GetSlotForKey(key);
+            if (otherSlot < 0)
+                continue; // nothing to subtract
+
+            ref ContainerEntry otherEntry = ref other._entries[otherSlot];
+            AndNotContainerInPlace(ref _entries[mySlot], ref _types.RawItems[mySlot], ref otherEntry, other._types.RawItems[otherSlot]);
+            if (_entries[mySlot].Cardinality == 0)
+                DonateStorageThenFreeContainer(key, mySlot, ref other);
+        }
+        MarkConsumed(ref other);
+    }
+
+    [SkipLocalsInit]
+    private void AndContainerInPlace(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right, ContainerType rightType)
+    {
+        switch (leftType, rightType)
+        {
+            // Range×Range fast paths - no allocation needed
+            case (ContainerType.Range, ContainerType.Range):
+            {
+                int intersectStart = Math.Max(left.RangeStart, right.RangeStart);
+                int intersectEnd = Math.Min(RangeEndExclusive(ref left), RangeEndExclusive(ref right));
+                if (intersectStart >= intersectEnd)
+                {
+                    left.Cardinality = 0;
+                }
+                else
+                {
+                    left.RangeStart = (ushort)intersectStart;
+                    left.Cardinality = intersectEnd - intersectStart;
+                }
+                return;
+            }
+            case (ContainerType.Range, _):
+            {
+                ConvertRangeToBitmap(ref left, ref leftType);
+                AndContainerInPlace(ref left, ref leftType, ref right, rightType);
+                return;
+            }
+            case (_, ContainerType.Range):
+            {
+                ulong* stackBmp = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ContainerEntry temp = MaterializeRangeIntoBuffer(ref right, stackBmp);
+                AndContainerInPlace(ref left, ref leftType, ref temp, ContainerType.Bitmap);
+                return;
+            }
+            case (ContainerType.Bitmap, ContainerType.Bitmap):
+            {
+                // Lazy: bitwise AND only; PreparForReading will popcount + free if empty.
+                BitmapAndNoPop(left.BitmapPtr, right.BitmapPtr, left.BitmapPtr);
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                // AND bitmap with array: build the intersection in a stack scratch by
+                // OR'ing only values that are set in left; then copy back. Lazy cardinality.
+                ushort* arr = right.ArrayData;
+                var bmp = left.BitmapPtr;
+                ulong* scratch = stackalloc ulong[BitmapContainerSizeInUInt64];
+                new Span<byte>(scratch, BitmapContainerSizeInBytes).Clear();
+
+                for (int i = 0; i < right.Cardinality; i++)
+                {
+                    ushort val = arr[i];
+                    if (BitmapContains(bmp, val))
+                        BitmapSet(scratch, val);
+                }
+
+                new Span<byte>(scratch, BitmapContainerSizeInBytes)
+                    .CopyTo(new Span<byte>(left.Data, BitmapContainerSizeInBytes));
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Bitmap):
+            {
+                // Filter left's values against right's bitmap, in-place. Order doesn't matter.
+                ushort* arr = left.ArrayData;
+                var bmp = right.BitmapPtr;
+                int count = 0;
+                for (int i = 0; i < left.Cardinality; i++)
+                {
+                    ushort val = arr[i];
+                    if (BitmapContains(bmp, val))
+                        arr[count++] = val;
+                }
+                left.Cardinality = count;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                if (AdvInstructionSet.IsAcceleratedVector256
+                    && left.Cardinality <= SimdLinearScanThreshold
+                    && right.Cardinality <= SimdLinearScanThreshold)
+                {
+                    Debug.Assert(left.Storage.Length % Vector256<ushort>.Count == 0 && right.Storage.Length % Vector256<ushort>.Count == 0,
+                            "array containers must be SIMD-aligned for SIMD AND, see SimdContains for details");
+
+                    left.Cardinality = SimdCrossAnd(left.ArrayData, left.Cardinality, right.ArrayData, right.Cardinality, left.ArrayData);
+                }
+                else
+                {
+                    // Need sorted arrays for galloping merge
+                    if (leftType == ContainerType.ArrayUnsorted)
+                        SortAndDedupSmallArray(ref left, out leftType);
+                    if (rightType == ContainerType.ArrayUnsorted)
+                        SortAndDedupSmallArray(ref right, out rightType);
+                    ushort* a = left.ArrayData;
+                    ushort* b = right.ArrayData;
+                    left.Cardinality = ArrayContainerAnd(a, left.Cardinality, b, right.Cardinality, a);
+                }
+                break;
+            }
+            default:
+                throw new InvalidOperationException($"Invalid container combination: {leftType} and {rightType}");
+        }
+    }
+
+    [SkipLocalsInit]
+    private void AndNotContainerInPlace(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right, ContainerType rightType)
+    {
+        switch (leftType, rightType)
+        {
+            case (ContainerType.Range, ContainerType.Range):
+            {
+                AndNotTwoRangesInPlace(ref left, ref leftType, ref right);
+                break;
+            }
+            case (ContainerType.Range, _):
+            {
+                ConvertRangeToBitmap(ref left, ref leftType);
+                AndNotContainerInPlace(ref left, ref leftType, ref right, rightType);
+                break;
+            }
+            case (_, ContainerType.Range):
+            {
+                ulong* stackBmp = stackalloc ulong[BitmapContainerSizeInUInt64];
+                ContainerEntry temp = MaterializeRangeIntoBuffer(ref right, stackBmp);
+                AndNotContainerInPlace(ref left, ref leftType, ref temp, ContainerType.Bitmap);
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Bitmap):
+            {
+                // Lazy: bitwise ANDNOT only.
+                BitmapAndNotNoPop(left.BitmapPtr, right.BitmapPtr, left.BitmapPtr);
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Bitmap, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                // Lazy: clear bits unconditionally — no per-bit cardinality check.
+                ClearArrayInBitmap(right.ArrayData, right.Cardinality, left.BitmapPtr);
+                left.Cardinality = LazyCardinality;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Bitmap):
+            {
+                // Keep left values NOT in the right's bitmap. Order doesn't matter.
+                ushort* arr = left.ArrayData;
+                var bmp = right.BitmapPtr;
+                int count = 0;
+                for (int i = 0; i < left.Cardinality; i++)
+                {
+                    ushort val = arr[i];
+                    if (BitmapContains(bmp, val) == false)
+                        arr[count++] = val;
+                }
+
+                left.Cardinality = count;
+                break;
+            }
+            case (ContainerType.Array or ContainerType.ArrayUnsorted, ContainerType.Array or ContainerType.ArrayUnsorted):
+            {
+                // merge small arrays using SIMD
+                if (AdvInstructionSet.IsAcceleratedVector256
+                    && left.Cardinality <= SimdLinearScanThreshold
+                    && right.Cardinality <= SimdLinearScanThreshold)
+                {
+                    Debug.Assert(left.Storage.Length % Vector256<ushort>.Count == 0 && right.Storage.Length % Vector256<ushort>.Count == 0,
+                        "array containers must be SIMD-aligned for SIMD ANDNOT, see SimdCrossAndNot for details");
+                    left.Cardinality = SimdCrossAndNot(left.ArrayData, left.Cardinality, right.ArrayData, right.Cardinality, left.ArrayData);
+                    break;
+                }
+
+                if (leftType == ContainerType.ArrayUnsorted)
+                    SortAndDedupSmallArray(ref left, out leftType);
+                if (rightType == ContainerType.ArrayUnsorted)
+                    SortAndDedupSmallArray(ref right, out rightType);
+                ushort* a = left.ArrayData;
+                ushort* b = right.ArrayData;
+                left.Cardinality = ArrayContainerAndNot(a, left.Cardinality, b, right.Cardinality, a);
+                break;
+            }
+            default:
+                throw new InvalidOperationException($"Invalid container combination: {leftType} and {rightType}");
+        }
+    }
+
+    private void AndNotTwoRangesInPlace(ref ContainerEntry left, ref ContainerType leftType, ref ContainerEntry right)
+    {
+        int leftStart = left.RangeStart;
+        int leftEnd = RangeEndExclusive(ref left);
+        int rightStart = right.RangeStart;
+        int rightEnd = RangeEndExclusive(ref right);
+
+        // No overlap.
+        if (rightEnd <= leftStart || rightStart >= leftEnd)
+            return;
+
+        // Right is covering all of left.
+        if (rightStart <= leftStart && rightEnd >= leftEnd)
+        {
+            left.Cardinality = 0;
+            return;
+        }
+
+        // Trim low edge.
+        if (rightStart <= leftStart)
+        {
+            left.RangeStart = (ushort)rightEnd;
+            left.Cardinality = leftEnd - rightEnd;
+            return;
+        }
+
+        // Trim high edge.
+        if (rightEnd >= leftEnd)
+        {
+            left.Cardinality = rightStart - leftStart;
+            return;
+        }
+
+        // Middle cut would split into two ranges - materialize.
+        ConvertRangeToBitmap(ref left, ref leftType);
+        ulong* stackBmp = stackalloc ulong[BitmapContainerSizeInUInt64];
+        ContainerEntry temp = MaterializeRangeIntoBuffer(ref right, stackBmp);
+        AndNotContainerInPlace(ref left, ref leftType, ref temp, ContainerType.Bitmap);
+    }
+
+    /// <summary>
+    /// Materialize a Range container into the given stackalloc bitmap buffer. The returned entry points
+    /// at that buffer with Storage=default, so the caller must NOT release it.
+    /// </summary>
+    [SkipLocalsInit]
+    private static ContainerEntry MaterializeRangeIntoBuffer(ref ContainerEntry entry, ulong* stackBitmap)
+    {
+        ClearBitmap(stackBitmap);
+        FillBitmapFromRange(stackBitmap, entry.RangeStart, entry.Cardinality);
+
+        return new ContainerEntry
+        {
+            Data = (byte*)stackBitmap,
+            Cardinality = entry.Cardinality,
+            Storage = default // no allocation to release
+        };
+    }
+
+
+    #endregion
+
+    #region Index Operations
+
+    /// <summary>
+    /// Ensure the index array covers the given key, filling new slots with -1.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureIndexCoversKey(long key)
+    {
+        if (key < _index.Count)
+            return;
+
+        IncreaseIndexCapacity(key);
+    }
+
+
+    private void IncreaseIndexCapacity(long key)
+    {
+        if (key is < 0 or >= int.MaxValue - 16)
+            throw new ArgumentOutOfRangeException(nameof(key), $"Container key {key} is out of the valid range (0..{int.MaxValue - 17}).");
+
+        int needed = checked((int)(key + 1));
+        int oldCount = _index.Count;
+        _index.EnsureCapacityFor(_ctx, needed - oldCount);
+        _index.Count = needed;
+
+        // Fill new slots with -1 (absent)
+        int* ptr = _index.RawItems;
+        new Span<int>(ptr + oldCount, needed - oldCount).Fill(IndexAbsent);
+    }
+
+    /// <summary>
+    /// Add a new container entry and register it in the index. Returns the entry slot.
+    /// </summary>
+    private int AddNewContainer(long key, ContainerType type, in ContainerEntry entry)
+    {
+        EnsureIndexCoversKey(key);
+
+        int slot;
+        if (_freeListHead != 0) // 0 = empty; non-zero = slot+1 (1-based)
+        {
+            slot = _freeListHead - 1; // decode: real index = stored - 1
+            Debug.Assert(_types.RawItems[slot] == ContainerType.Free, "Expected free entry");
+            _freeListHead = (int)_entries[slot].NextFreeSlot; // next encoded value (0 or slot+1)
+            _entries[slot] = entry;
+            _types.RawItems[slot] = type;
+        }
+        else
+        {
+            slot = _entries.Count;
+            _entries.Add(_ctx, entry);
+            _types.Add(_ctx, type);
+        }
+
+        // we checked size of key in EnsureIndexCoversKey, so this cast is safe
+        _entries[slot].Key = (uint)key;
+
+        _index.RawItems[key] = slot;
+        _containerCount++;
+        return slot;
+    }
+
+    /// <summary>
+    /// Remove a container: detach its storage onto the free list for reuse,
+    /// mark the index as absent, and chain the slot onto the entry free list.
+    /// </summary>
+    private void FreeContainer(long key, int slot)
+    {
+        ref ContainerEntry entry = ref _entries[slot];
+        if (entry.Storage.HasValue)
+            _freeList.Return(entry.Storage);
+
+        entry = default;
+        _types.RawItems[slot] = ContainerType.Free;
+        entry.NextFreeSlot = (uint)_freeListHead; // current head (0 or prev_slot+1)
+        _freeListHead = slot + 1;                 // encode: store as real_index + 1
+
+        _index.RawItems[key] = IndexAbsent;
+        _containerCount--;
+    }
+
+    /// <summary>Add a container entry while building a result bitmap from scratch (keys added in order).</summary>
+    private void AddContainer(long key, ContainerType type, in ContainerEntry entry)
+    {
+        if (entry.Cardinality == 0)
+            return;
+
+        AddNewContainer(key, type, entry);
+    }
+
+    #endregion
+
+    #region Container Management
+
+    /// <summary>Round allocation size up to a multiple of 32 bytes so Vector256 ops need no bounds checking.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int AlignForSimd(int bytes)
+    {
+        return Math.Max(InitialArrayContainerSizeInBytes, (bytes + SimdAlignment - 1) & ~(SimdAlignment - 1));
+    }
+
+    /// <summary>
+    /// Append <paramref name="right"/>'s values into <paramref name="left"/> (<paramref name="totalCount"/>
+    /// entries total). Reuses left's buffer if it has room, else steals right's (swapping ownership) if it
+    /// fits, else allocates. Result is always <see cref="ContainerType.ArrayUnsorted"/>.
+    /// </summary>
+    private void AppendArrayContainers(ref ContainerEntry left, ref ContainerEntry right, int totalCount)
+    {
+        int neededBytes = totalCount * sizeof(ushort);
+        Debug.Assert(neededBytes <= BitmapContainerSizeInBytes, "Total count exceeds maximum for array container");
+        int leftCardinality = left.Cardinality;
+        if (neededBytes > right.Storage.Length)
+        {
+            EnsureArrayCapacity(ref left, totalCount);
+            Unsafe.CopyBlockUnaligned(left.ArrayData + leftCardinality, right.ArrayData, (uint)(right.Cardinality * sizeof(ushort)));
+            left.Cardinality = totalCount;
+            return;
+        }
+        // Right buffer fits both — prepend left's values into right, then take ownership.
+        Unsafe.CopyBlockUnaligned(right.ArrayData + right.Cardinality, left.ArrayData, (uint)(leftCardinality * sizeof(ushort)));
+        if (left.Storage.HasValue)
+            _ctx.Release(ref left.Storage);
+        left.Storage = right.Storage;
+        left.Data = right.Data;
+        left.Cardinality = totalCount;
+        right = default;
+    }
+
+    /// <summary>
+    /// Ensure the array container has room for the given number of entries.
+    /// Doubles the buffer size up to BitmapContainerSizeInBytes (8KB).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureArrayCapacity(ref ContainerEntry entry, int requiredEntries)
+    {
+        int requiredBytes = requiredEntries * sizeof(ushort);
+        if (requiredBytes <= entry.Storage.Length)
+            return;
+
+        IncreaseArrayCapacity(ref entry, requiredBytes);
+    }
+
+    private void IncreaseArrayCapacity(ref ContainerEntry entry, int requiredBytes)
+    {
+        int newSize = Math.Max(entry.Storage.Length * 2, requiredBytes);
+        newSize = Math.Min(newSize, BitmapContainerSizeInBytes);
+
+        _freeList.Allocate(_ctx, newSize, out ByteString newStorage);
+        int copyBytes = entry.Cardinality * sizeof(ushort);
+        if (copyBytes > 0)
+            Unsafe.CopyBlockUnaligned(newStorage.Ptr, entry.Data, (uint)copyBytes);
+
+        if (entry.Storage.HasValue)
+            _freeList.Return(entry.Storage);
+        entry.Storage = newStorage;
+        entry.Data = newStorage.Ptr;
+    }
+
+    #endregion
+
+    #region Container Operations
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddToContainer(ref ContainerEntry entry, int slot, ushort value)
+    {
+        ref ContainerType type = ref _types.RawItems[slot];
+        switch (type)
+        {
+            case ContainerType.Array:
+                // If value is >= the last element, append (or noop for duplicate) and stay sorted
+                if (entry.Cardinality > 0 && value >= entry.ArrayData[entry.Cardinality - 1])
+                {
+                    if (value == entry.ArrayData[entry.Cardinality - 1])
+                        break; // duplicate of last element - noop
+                    if (entry.Cardinality >= ArrayContainerMaxCardinality)
+                    {
+                        ConvertArrayToBitmap(ref entry, ref type);
+                        BitmapSet(entry.BitmapPtr, value);
+                        entry.Cardinality = LazyCardinality;
+                        break;
+                    }
+                    EnsureArrayCapacity(ref entry, entry.Cardinality + 1);
+                    entry.ArrayData[entry.Cardinality++] = value;
+                    break;
+                }
+                // Would break sort order - switch to unsorted for O(1) appends
+                type = ContainerType.ArrayUnsorted;
+                goto case ContainerType.ArrayUnsorted;
+
+            case ContainerType.ArrayUnsorted:
+                if (entry.Cardinality >= ArrayContainerMaxCardinality)
+                {
+                    // At capacity: sort+dedup via bitmap scratch, then promote if still full
+                    ulong* scratch = stackalloc ulong[BitmapContainerSizeInUInt64];
+                    SortViaBitmapScratch(ref entry, ref type, scratch); // type → Array, deduped
+                    if (entry.Cardinality >= ArrayContainerMaxCardinality)
+                    {
+                        ConvertArrayToBitmap(ref entry, ref type);
+                        goto case ContainerType.Bitmap;
+                    }
+                    goto case ContainerType.Array;// we are now sorted (and not full), we'll let the array handler deal with it.
+                }
+                EnsureArrayCapacity(ref entry, entry.Cardinality + 1);
+                entry.ArrayData[entry.Cardinality++] = value;
+                break;
+
+            case ContainerType.Bitmap:
+                BitmapSet(entry.BitmapPtr, value);
+                entry.Cardinality = LazyCardinality;
+                break;
+
+            case ContainerType.Range:
+                if (TryMergeRangeInPlace(ref entry, value, value + 1) == false)
+                {
+                    ConvertRangeForAdd(ref entry, ref type, value);
+                }
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), $"Unexpected value to add: {type}");
+        }
+    }
+
+    #endregion
+
+    #region Container Conversions
+
+    /// <summary>
+    /// Convert an array container (sorted or unsorted) to bitmap.
+    /// For unsorted arrays with possible duplicates, cardinality is recounted via popcount.
+    /// </summary>
+    private void ConvertArrayToBitmap(ref ContainerEntry entry, ref ContainerType type)
+    {
+        Debug.Assert(type is ContainerType.Array or ContainerType.ArrayUnsorted);
+
+        bool unsorted = type == ContainerType.ArrayUnsorted;
+        ushort* arr = entry.ArrayData;
+        int count = entry.Cardinality;
+
+        _freeList.Allocate(_ctx, BitmapContainerSizeInBytes, out ByteString newStorage);
+        ClearBitmap((ulong*)newStorage.Ptr);
+        SetArrayInBitmap(arr, count, (ulong*)newStorage.Ptr);
+
+        if (unsorted)
+        {
+            var updatedCount = BitmapContainerCardinality(newStorage.Ptr);
+            entry.Cardinality = updatedCount;
+        }
+        if (entry.Storage.HasValue)
+            _freeList.Return(entry.Storage);
+
+        entry.Storage = newStorage;
+        entry.Data = newStorage.Ptr;
+        type = ContainerType.Bitmap;
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        if (_entries.IsValid)
+        {
+            ContainerEntry* entries = _entries.RawItems;
+            int count = _entries.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (entries[i].Storage.HasValue)
+                    _ctx.Release(ref entries[i].Storage);
+            }
+
+            _entries.Dispose(_ctx);
+        }
+
+        _freeList.ReleaseAll(_ctx);
+
+        if (_types.IsValid)
+            _types.Dispose(_ctx);
+
+        if (_index.IsValid)
+            _index.Dispose(_ctx);
+    }
+}

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -269,6 +269,9 @@ public unsafe partial struct RoaringBitmap : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SwapContents(ref RoaringBitmap other)
     {
+        // Both bitmaps must share an allocator — swapping the whole struct also swaps the _ctx reference, which
+        // would only be safe (and only happens) when both were created from the same ByteStringContext.
+        Debug.Assert(ReferenceEquals(_ctx, other._ctx), "SwapContents requires both bitmaps to share an allocator");
         (other, this) = (this, other);
     }
 
@@ -1558,7 +1561,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
             }
             case (ContainerType.Bitmap, ContainerType.Bitmap):
             {
-                // Lazy: bitwise AND only; PreparForReading will popcount + free if empty.
+                // Lazy: bitwise AND only; PrepareForReading will popcount + free if empty.
                 BitmapAndNoPop(left.BitmapPtr, right.BitmapPtr, left.BitmapPtr);
                 left.Cardinality = LazyCardinality;
                 break;

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmap.cs
@@ -8,6 +8,7 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Server.Utils;
 using Voron.Util;
 
 namespace Voron.Data.RoaringBitmaps;
@@ -852,7 +853,7 @@ public unsafe partial struct RoaringBitmap : IDisposable
         while (i < count)
         {
             long containerKey = values[i] >> ContainerKeyShift;
-            int groupEnd = GallopRight(values, i, count, (containerKey + 1) << ContainerKeyShift);
+            int groupEnd = Sorting.GallopLowerBound(values, i, count, (containerKey + 1) << ContainerKeyShift);
 
             if (containerKey < 0 || containerKey >= idxLen || idx[containerKey] < 0)
             {
@@ -1034,28 +1035,6 @@ public unsafe partial struct RoaringBitmap : IDisposable
         }
 
         return unique;
-    }
-
-    /// <summary>Returns the first index in <c>[lo, hi)</c> where <c>buffer[index] &gt;= sentinel</c>,
-    /// using exponential probing then binary search — O(log d) where d is the run length.</summary>
-    private static int GallopRight(Span<long> buffer, int lo, int hi, long sentinel)
-    {
-        int step = 1;
-        int probe = lo;
-        while (probe < hi && buffer[probe] < sentinel)
-        {
-            lo = probe + 1;
-            probe = lo + step;
-            step <<= 1;
-        }
-        int limit = probe < hi ? probe : hi;
-        while (lo < limit)
-        {
-            int mid = (lo + limit) >> 1;
-            if (buffer[mid] < sentinel) lo = mid + 1;
-            else limit = mid;
-        }
-        return lo;
     }
 
     /// <summary>

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
@@ -123,26 +123,26 @@ public unsafe struct RoaringBitmapIterator : IDisposable
         if (toCopy <= 0)
             return written;
 
-        long* dst = (long*)Unsafe.AsPointer(ref buffer[written]);
+        ref var dst = ref buffer[written];
         ushort* src = arr + _positionInContainer;
         int i = 0;
 
-        // SIMD: load 4 ushorts in one 64-bit read, widen to 4 longs, OR with baseValue.
         if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
         {
             Vector256<long> vBase = Vector256.Create(baseValue);
             for (; i + 4 <= toCopy; i += 4)
             {
-                var v4us = Vector128.CreateScalarUnsafe(*(ulong*)(src + i)).AsUInt16();
-                var (v4ui, _) = Vector128.Widen(v4us);
-                var (v4ul, _) = Vector256.Widen(v4ui.ToVector256Unsafe());
-                (v4ul.AsInt64() | vBase).Store(dst + i);
+                Vector64<ushort> shorts = Vector64.Load(src + i);
+                Vector128<uint> ints = Vector128.WidenLower(shorts.ToVector128Unsafe());
+                Vector256<long> longs = Vector256.WidenLower(ints.ToVector256Unsafe()).AsInt64();
+                (longs | vBase).StoreUnsafe(ref Unsafe.Add(ref dst, i));
             }
         }
 
-        // Scalar remainder (or all, if no SIMD)
         for (; i < toCopy; i++)
-            dst[i] = baseValue | src[i];
+        {
+            Unsafe.Add(ref dst, i) = baseValue | src[i];
+        }
 
         _positionInContainer += toCopy;
         return written + toCopy;
@@ -190,29 +190,25 @@ public unsafe struct RoaringBitmapIterator : IDisposable
         if (toCopy <= 0)
             return written;
 
-        long* dst = (long*)Unsafe.AsPointer(ref buffer[written]);
+        ref var dst = ref buffer[written];
         int i = 0;
 
-        // SIMD: generate 4 sequential values at a time using a fixed offset vector
         if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
         {
-            Vector256<long> vOffsets = Vector256.Create(0L, 1L, 2L, 3L);
-            Vector256<long> vCurrent = Vector256.Create(baseValue + rangeStart + _positionInContainer) + vOffsets;
+            Vector256<long> vCurrent = Vector256.Create(baseValue + rangeStart + _positionInContainer) + 
+                                       Vector256.Create(0L, 1L, 2L, 3L);
             Vector256<long> vStep = Vector256.Create(4L);
-
             for (; i + 4 <= toCopy; i += 4)
             {
-                vCurrent.Store(dst + i);
+                vCurrent.StoreUnsafe(ref Unsafe.Add(ref dst, i));
                 vCurrent += vStep;
             }
             _positionInContainer += i;
         }
 
-        // Scalar remainder (or all, if no SIMD)
         for (; i < toCopy; i++)
         {
-            dst[i] = baseValue | (uint)(rangeStart + _positionInContainer);
-            _positionInContainer++;
+            Unsafe.Add(ref dst, i) = baseValue | (uint)(rangeStart + _positionInContainer++);
         }
 
         return written + toCopy;

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
@@ -123,26 +123,26 @@ public unsafe struct RoaringBitmapIterator : IDisposable
         if (toCopy <= 0)
             return written;
 
-        fixed (long* dst = &buffer[written])
+        long* dst = (long*)Unsafe.AsPointer(ref buffer[written]);
+        ushort* src = arr + _positionInContainer;
+        int i = 0;
+
+        // SIMD: load 4 ushorts in one 64-bit read, widen to 4 longs, OR with baseValue.
+        if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
         {
-            ushort* src = arr + _positionInContainer;
-            int i = 0;
-
-            // SIMD: widen 4 ushorts → 4 longs, OR with baseValue, store 4 longs.
-            if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
+            Vector256<long> vBase = Vector256.Create(baseValue);
+            for (; i + 4 <= toCopy; i += 4)
             {
-                Vector256<long> vBase = Vector256.Create(baseValue);
-                for (; i + 4 <= toCopy; i += 4)
-                {
-                    Vector256<long> vals = Vector256.Create(src[i], src[i + 1], src[i + 2], src[i + 3]);
-                    (vals | vBase).Store(dst + i);
-                }
+                var v4us = Vector128.CreateScalarUnsafe(*(ulong*)(src + i)).AsUInt16();
+                var (v4ui, _) = Vector128.Widen(v4us);
+                var (v4ul, _) = Vector256.Widen(v4ui.ToVector256Unsafe());
+                (v4ul.AsInt64() | vBase).Store(dst + i);
             }
-
-            // Scalar remainder (or all, if no SIMD)
-            for (; i < toCopy; i++)
-                dst[i] = baseValue | src[i];
         }
+
+        // Scalar remainder (or all, if no SIMD)
+        for (; i < toCopy; i++)
+            dst[i] = baseValue | src[i];
 
         _positionInContainer += toCopy;
         return written + toCopy;
@@ -190,34 +190,29 @@ public unsafe struct RoaringBitmapIterator : IDisposable
         if (toCopy <= 0)
             return written;
 
-        fixed (long* dst = &buffer[written])
+        long* dst = (long*)Unsafe.AsPointer(ref buffer[written]);
+        int i = 0;
+
+        // SIMD: generate 4 sequential values at a time using a fixed offset vector
+        if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
         {
-            int i = 0;
+            Vector256<long> vOffsets = Vector256.Create(0L, 1L, 2L, 3L);
+            Vector256<long> vCurrent = Vector256.Create(baseValue + rangeStart + _positionInContainer) + vOffsets;
+            Vector256<long> vStep = Vector256.Create(4L);
 
-            // SIMD: generate 4 sequential values at a time
-            if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
+            for (; i + 4 <= toCopy; i += 4)
             {
-                Vector256<long> vCurrent = Vector256.Create(
-                    baseValue + rangeStart + _positionInContainer,
-                    baseValue + rangeStart + _positionInContainer + 1,
-                    baseValue + rangeStart + _positionInContainer + 2,
-                    baseValue + rangeStart + _positionInContainer + 3);
-                Vector256<long> vStep = Vector256.Create(4L);
-
-                for (; i + 4 <= toCopy; i += 4)
-                {
-                    vCurrent.Store(dst + i);
-                    vCurrent += vStep;
-                }
-                _positionInContainer += i;
+                vCurrent.Store(dst + i);
+                vCurrent += vStep;
             }
+            _positionInContainer += i;
+        }
 
-            // Scalar remainder (or all, if no SIMD)
-            for (; i < toCopy; i++)
-            {
-                dst[i] = baseValue | (uint)(rangeStart + _positionInContainer);
-                _positionInContainer++;
-            }
+        // Scalar remainder (or all, if no SIMD)
+        for (; i < toCopy; i++)
+        {
+            dst[i] = baseValue | (uint)(rangeStart + _positionInContainer);
+            _positionInContainer++;
         }
 
         return written + toCopy;

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Sparrow;
+using Sparrow.Server;
+using Sparrow.Server.Utils.VxSort;
+
+namespace Voron.Data.RoaringBitmaps;
+
+/// <summary>
+/// Forward iterator for RoaringBitmap supporting Fill(Span&lt;long&gt;) streaming. On construction it builds
+/// a sorted array of packed (key in upper 32 bits, slot in lower 32 bits) ulongs for deterministic traversal.
+/// </summary>
+public unsafe struct RoaringBitmapIterator : IDisposable
+{
+    private ByteStringContext _ctx;
+    private ByteString _packedEntries; // array of packed (key << 32) | slot
+    private int _entryCount;
+    private int _containerIndex; // index into _packedEntries
+    /// <summary>Array: index into sorted array. Range: offset from RangeStart. Bitmap: current ulong index (0..1023).</summary>
+    private int _positionInContainer;
+    private ulong _bitmapCurrentWord; // Bitmap only: remaining bits in current word
+
+    public RoaringBitmapIterator(ref RoaringBitmap data, ByteStringContext ctx)
+    {
+        _ctx = ctx;
+        _containerIndex = 0;
+        _positionInContainer = 0;
+        _bitmapCurrentWord = 0;
+
+        // Build sorted array of packed (key, slot) ulongs from active containers
+        int containerCount = data.ContainerCount;
+        if (containerCount is 0)
+        {
+            _packedEntries = default;
+            _entryCount = 0;
+            return;
+        }
+
+        int sizeNeeded = containerCount * sizeof(ulong);
+        ctx.Allocate(sizeNeeded, out _packedEntries);
+
+        var packedPtr = (ulong*)_packedEntries.Ptr;
+        _entryCount = 0;
+
+        // Pack all active entries: (key << 32) | slot
+        var entries = new ReadOnlySpan<ContainerEntry>(data._entries.RawItems, data._entries.Count);
+        var types = data._types.RawItems;
+        for (int i = 0; i < entries.Length; i++)
+        {
+            if (types[i] != ContainerType.Free)
+            {
+                packedPtr[_entryCount] = ((ulong)entries[i].Key << 32) | (uint)i;
+                _entryCount++;
+            }
+        }
+
+        // Sort by packed value (key is in upper bits, so sorts by key)
+        Sort.Run(packedPtr, _entryCount);
+    }
+
+    public int Fill(ref RoaringBitmap data, Span<long> buffer)
+    {
+        int written = 0;
+        if (_entryCount == 0)
+            return 0;
+
+        var packedPtr = (ulong*)_packedEntries.Ptr;
+
+        while (written < buffer.Length && _containerIndex < _entryCount)
+        {
+            ulong packed = packedPtr[_containerIndex];
+            int slot = (int)(packed & 0xFFFFFFFF);
+            uint key = (uint)(packed >> 32);
+
+            ref ContainerEntry entry = ref data._entries[slot];
+            ContainerType type = data._types.RawItems[slot];
+            long baseValue = (long)key << RoaringBitmap.ContainerKeyShift;
+
+            // callers MUST call RoaringBitmap.PrepareForReading() before the first
+            // Fill() call, which converts every ArrayUnsorted container to sorted. 
+            Debug.Assert(type != ContainerType.ArrayUnsorted,
+                "RoaringBitmapIterator: ArrayUnsorted container at iteration time. " +
+                "PrepareForReading() must be called before Fill().");
+
+            switch (type)
+            {
+                case ContainerType.Array:
+                case ContainerType.ArrayUnsorted: // accepted defensively in Release; PrepareForReading should have removed these
+                    written = FillFromArray(ref entry, baseValue, buffer, written);
+                    break;
+
+                case ContainerType.Bitmap:
+                    written = FillFromBitmap(ref entry, baseValue, buffer, written);
+                    break;
+
+                case ContainerType.Range:
+                    written = FillFromRange(ref entry, baseValue, buffer, written);
+                    break;
+            }
+
+            bool containerCompleted = type == ContainerType.Bitmap
+                ? _positionInContainer >= RoaringBitmap.BitmapContainerSizeInUInt64 && _bitmapCurrentWord == 0
+                : _positionInContainer >= entry.Cardinality;
+
+            if (containerCompleted)
+            {
+                _containerIndex++;
+                _positionInContainer = 0;
+                _bitmapCurrentWord = 0;
+            }
+        }
+
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int FillFromArray(ref ContainerEntry entry, long baseValue, Span<long> buffer, int written)
+    {
+        ushort* arr = (ushort*)entry.ArrayData;
+        int count = entry.Cardinality;
+        int remaining = count - _positionInContainer;
+        int space = buffer.Length - written;
+        int toCopy = Math.Min(remaining, space);
+
+        if (toCopy <= 0)
+            return written;
+
+        fixed (long* dst = &buffer[written])
+        {
+            ushort* src = arr + _positionInContainer;
+            int i = 0;
+
+            // SIMD: widen 4 ushorts → 4 longs, OR with baseValue, store 4 longs.
+            if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
+            {
+                Vector256<long> vBase = Vector256.Create(baseValue);
+                for (; i + 4 <= toCopy; i += 4)
+                {
+                    Vector256<long> vals = Vector256.Create(
+                        (long)src[i], (long)src[i + 1], (long)src[i + 2], (long)src[i + 3]);
+                    (vals | vBase).Store(dst + i);
+                }
+            }
+
+            // Scalar remainder (or all, if no SIMD)
+            for (; i < toCopy; i++)
+                dst[i] = baseValue | src[i];
+        }
+
+        _positionInContainer += toCopy;
+        return written + toCopy;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int FillFromBitmap(ref ContainerEntry entry, long baseValue, Span<long> buffer, int written)
+    {
+        var bitmap = entry.BitmapPtr;
+
+        while (written < buffer.Length && _positionInContainer < RoaringBitmap.BitmapContainerSizeInUInt64)
+        {
+            if (_bitmapCurrentWord == 0)
+            {
+                _bitmapCurrentWord = bitmap[_positionInContainer];
+                if (_bitmapCurrentWord == 0)
+                {
+                    _positionInContainer++;
+                    continue;
+                }
+            }
+
+            while (_bitmapCurrentWord != 0 && written < buffer.Length)
+            {
+                int bit = BitOperations.TrailingZeroCount(_bitmapCurrentWord);
+                buffer[written++] = baseValue | (uint)(_positionInContainer * 64 + bit);
+                _bitmapCurrentWord &= _bitmapCurrentWord - 1;
+            }
+
+            if (_bitmapCurrentWord == 0)
+                _positionInContainer++;
+        }
+
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int FillFromRange(ref ContainerEntry entry, long baseValue, Span<long> buffer, int written)
+    {
+        int rangeStart = entry.RangeStart;
+        int remaining = entry.Cardinality - _positionInContainer;
+        int space = buffer.Length - written;
+        int toCopy = Math.Min(remaining, space);
+
+        if (toCopy <= 0)
+            return written;
+
+        fixed (long* dst = &buffer[written])
+        {
+            int i = 0;
+
+            // SIMD: generate 4 sequential values at a time
+            if (AdvInstructionSet.IsAcceleratedVector256 && toCopy >= 4)
+            {
+                Vector256<long> vCurrent = Vector256.Create(
+                    baseValue + rangeStart + _positionInContainer,
+                    baseValue + rangeStart + _positionInContainer + 1,
+                    baseValue + rangeStart + _positionInContainer + 2,
+                    baseValue + rangeStart + _positionInContainer + 3);
+                Vector256<long> vStep = Vector256.Create(4L);
+
+                for (; i + 4 <= toCopy; i += 4)
+                {
+                    vCurrent.Store(dst + i);
+                    vCurrent += vStep;
+                }
+                _positionInContainer += i;
+            }
+
+            // Scalar remainder (or all, if no SIMD)
+            for (; i < toCopy; i++)
+            {
+                dst[i] = baseValue | (uint)(rangeStart + _positionInContainer);
+                _positionInContainer++;
+            }
+        }
+
+        return written + toCopy;
+    }
+
+    public void Dispose()
+    {
+        if (_packedEntries.HasValue)
+        {
+            _ctx.Release(ref _packedEntries);
+            _packedEntries = default; // make Dispose idempotent — repeated callers are common in finally chains
+        }
+    }
+}

--- a/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
+++ b/src/Voron/Data/RoaringBitmaps/RoaringBitmapIterator.cs
@@ -10,16 +10,16 @@ using Sparrow.Server.Utils.VxSort;
 namespace Voron.Data.RoaringBitmaps;
 
 /// <summary>
-/// Forward iterator for RoaringBitmap supporting Fill(Span&lt;long&gt;) streaming. On construction it builds
-/// a sorted array of packed (key in upper 32 bits, slot in lower 32 bits) ulongs for deterministic traversal.
+/// Forward iterator for RoaringBitmap supporting Fill(Span&lt;long&gt;) streaming. On construction, builds a sorted array of packed
+/// (key in upper 32 bits, slot in lower 32 bits) ulongs for deterministic traversal.
 /// </summary>
 public unsafe struct RoaringBitmapIterator : IDisposable
 {
-    private ByteStringContext _ctx;
+    private readonly ByteStringContext _ctx;
     private ByteString _packedEntries; // array of packed (key << 32) | slot
-    private int _entryCount;
+    private readonly int _entryCount;
     private int _containerIndex; // index into _packedEntries
-    /// <summary>Array: index into sorted array. Range: offset from RangeStart. Bitmap: current ulong index (0..1023).</summary>
+    /// <summary>Array: index into a sorted array. Range: offset from RangeStart. Bitmap: current ulong index (0..1023).</summary>
     private int _positionInContainer;
     private ulong _bitmapCurrentWord; // Bitmap only: remaining bits in current word
 
@@ -78,17 +78,10 @@ public unsafe struct RoaringBitmapIterator : IDisposable
             ref ContainerEntry entry = ref data._entries[slot];
             ContainerType type = data._types.RawItems[slot];
             long baseValue = (long)key << RoaringBitmap.ContainerKeyShift;
-
-            // callers MUST call RoaringBitmap.PrepareForReading() before the first
-            // Fill() call, which converts every ArrayUnsorted container to sorted. 
-            Debug.Assert(type != ContainerType.ArrayUnsorted,
-                "RoaringBitmapIterator: ArrayUnsorted container at iteration time. " +
-                "PrepareForReading() must be called before Fill().");
-
+            
             switch (type)
             {
                 case ContainerType.Array:
-                case ContainerType.ArrayUnsorted: // accepted defensively in Release; PrepareForReading should have removed these
                     written = FillFromArray(ref entry, baseValue, buffer, written);
                     break;
 
@@ -99,6 +92,8 @@ public unsafe struct RoaringBitmapIterator : IDisposable
                 case ContainerType.Range:
                     written = FillFromRange(ref entry, baseValue, buffer, written);
                     break;
+                case ContainerType.ArrayUnsorted:
+                    throw new InvalidOperationException("RoaringBitmapIterator: ArrayUnsorted container at iteration time");
             }
 
             bool containerCompleted = type == ContainerType.Bitmap
@@ -119,7 +114,7 @@ public unsafe struct RoaringBitmapIterator : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int FillFromArray(ref ContainerEntry entry, long baseValue, Span<long> buffer, int written)
     {
-        ushort* arr = (ushort*)entry.ArrayData;
+        ushort* arr = entry.ArrayData;
         int count = entry.Cardinality;
         int remaining = count - _positionInContainer;
         int space = buffer.Length - written;
@@ -139,8 +134,7 @@ public unsafe struct RoaringBitmapIterator : IDisposable
                 Vector256<long> vBase = Vector256.Create(baseValue);
                 for (; i + 4 <= toCopy; i += 4)
                 {
-                    Vector256<long> vals = Vector256.Create(
-                        (long)src[i], (long)src[i + 1], (long)src[i + 2], (long)src[i + 3]);
+                    Vector256<long> vals = Vector256.Create(src[i], src[i + 1], src[i + 2], src[i + 3]);
                     (vals | vBase).Store(dst + i);
                 }
             }


### PR DESCRIPTION
**Part 02 of 13 — Voron: RoaringBitmaps.**
Stacked migration of Corax 2.0 (RavenDB-25281) onto `v7.2`.

The RoaringBitmap container engine (array/bitmap/range containers, SIMD set ops, iterator) that underpins all Corax posting-set work.

### ⚠️ This PR is partial by design — read before reviewing
This is one slice of a **13-PR stack** that together reconstruct the `corax-2.0-june` branch **byte-for-byte**. Each PR carries whole files for a single layer, split for reviewability. Consequences:

- **Intermediate source PRs (04–10) do not compile on their own.** Types/members they use are defined in other PRs of the stack (see map below).
- **Cross-PR references are expected, not defects.** If a symbol looks undefined, unused, or unreferenced *in this PR*, it is defined/consumed in another stack PR. Automated reviewers (incl. **GitHub Copilot**) will flag such cases — for a partial PR these are **false positives**, and will be answered as such.
- Only the **full assembled stack** (through #4891) compiles green and passes FastTests; per-PR CI red on intermediate PRs is expected.

Please focus review on logic *within the changed files*, not on cross-file resolution.

### The stack (each PR is based on the one above it; base ← `v7.2`)
| # | PR | Layer |
|---|----|-------|
| 01 | #4879 | Foundation: Corax build deps, cross-cutting glue, Sparrow |
| 02 | #4880 | Voron: RoaringBitmaps |
| 03 | #4881 | Voron: lookups, compact trees, posting lists, graph/container deltas |
| 04 | #4882 | Corax: IndexSearcher + boolean/term/multi matches |
| 05 | #4883 | Corax: sorting & directed-scan matches + primitives |
| 06 | #4884 | Corax: term providers, memoization, vector & spatial matches |
| 07 | #4885 | Corax: query planning (PlanCache, cardinality, cost) |
| 08 | #4886 | Server: QueryPlanBuilder (resolution & plan model) |
| 09 | #4887 | Server: QueryPlanBuilder (construct/cost) + QueryOptimizer |
| 10 | #4888 | Server: CoraxQueryBuilder + read/persistence ops |
| 11a | #4889 | Tests: FastTests Corax engine + FastTests Voron |
| 11b | #4890 | Tests: FastTests Corax query/plan |
| 11c | #4891 | Tests + tooling: remaining Corax/Slow/Stress/Infra + bench |