### PR TITLE
RavenDB-25281 [stack 11b/13] Tests: FastTests Corax query/plan

### DIFF
--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -1,14 +1,13 @@
-﻿﻿﻿﻿﻿﻿using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Corax;
-using Corax.Querying;
 using Corax.Mappings;
-using Corax.Querying.Matches.Meta;
-using Corax.Querying.Matches.SortingMatches.Meta;
-using Corax.Utils;
 using FastTests.Voron;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
+using Raven.Server.Documents.Indexes.Persistence.Corax.QueryPlanBuilder;
+using Raven.Server.Documents.Queries;
 using Sparrow.Server;
 using Sparrow.Threading;
 using Tests.Infrastructure;
@@ -54,39 +53,36 @@ namespace FastTests.Corax
         [RavenFact(RavenTestCategory.Corax)]
         public void OrBoosting()
         {
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/1", Content1 = 1}); //  2 * 10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/11", Content1 = 0}); //  2 
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/111", Content1 = 0}); //  2
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/2", Content1 = 1}); //  10            
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/4", Content1 = 1}); //  10
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/1", Content1 = 1});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/11", Content1 = 0});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/111", Content1 = 0});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/2", Content1 = 1});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/4", Content1 = 1});
             longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/3", Content1 = 2});
 
             IndexEntries();
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
-            {
-                var startWithMatch = searcher.StartWithQuery(searcher.FieldMetadataBuilder("Id", hasBoost: true), "list/1");
-                var boostedStartWithMatch = searcher.Boost(startWithMatch, 2);
-                var contentMatch = searcher.TermQuery(searcher.FieldMetadataBuilder("Content1", hasBoost: true), "1");
-                var orMatch = searcher.Or(boostedStartWithMatch, contentMatch);
-                var boostedOrMatch = searcher.Boost(orMatch, 10);
-                var orderByScore = searcher.OrderBy(boostedOrMatch, new OrderMetadata(true, MatchCompareFieldType.Score), defaultNullsSortMode: NullsSortMode.NullsSmallest);
-                Span<long> ids = stackalloc long[2048];
-                int read = orderByScore.Fill(ids);
-                ids = ids.Slice(0, read);
 
-                List<string> idsName = new();
-                for (int i = 0; i < read; ++i)
-                {
-                    long id = ids[i];
-                    idsName.Add(searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id));
-                }
+            // list/1 matches both startsWith (boost 2x) and Content1='1' → highest score.
+            // list/11, list/111 match startsWith only (boost 2x) → second tier.
+            // list/2, list/4 match Content1='1' only (no extra boost) → third tier.
+            // list/3 (Content1=2) doesn't match either condition → excluded.
+            var idsName = ExecuteRQLQueryByScore(
+                "FROM TestIndex WHERE boost(startsWith(Id, 'list/1'), 2) OR Content1 = '1' ORDER BY score()");
 
-                Assert.Equal("list/1", idsName[0]); // most unique 
-                Assert.Equal("list/11", idsName[1]); // 2nd
-                Assert.Equal("list/111", idsName[2]); // 3th
-                Assert.Equal("list/2", idsName[3]); // those scoring has no impact
-                Assert.Equal("list/4", idsName[4]); //
-            }
+            Assert.Equal(5, idsName.Count);
+            Assert.Equal("list/1", idsName[0]);
+            Assert.True(new HashSet<string> {"list/11", "list/111"}.SetEquals(idsName.GetRange(1, 2)));
+            Assert.True(new HashSet<string> {"list/2", "list/4"}.SetEquals(idsName.GetRange(3, 2)));
+
+            // Also verify OR-wrapped boost: boost(A OR B, factor) applies the factor to all branches.
+            // Score order is the same as above; list/1 (matches both) remains first.
+            var idsWrappedBoost = ExecuteRQLQueryByScore(
+                "FROM TestIndex WHERE boost(startsWith(Id, 'list/1') OR Content1 = '1', 10) ORDER BY score()");
+
+            Assert.Equal(5, idsWrappedBoost.Count);
+            Assert.Equal("list/1", idsWrappedBoost[0]);
+            Assert.True(new HashSet<string> {"list/11", "list/111"}.SetEquals(idsWrappedBoost.GetRange(1, 2)));
+            Assert.True(new HashSet<string> {"list/2", "list/4"}.SetEquals(idsWrappedBoost.GetRange(3, 2)));
         }
 
         [RavenTheory(RavenTestCategory.Corax)]
@@ -99,109 +95,68 @@ namespace FastTests.Corax
         {
             longList = Enumerable.Range(0, amount).Select(i => new IndexSingleNumericalEntry<long, long> {Id = $"list/{i}", Content1 = i % mod}).ToList();
             IndexEntries();
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
-            var contentMetadata = searcher.FieldMetadataBuilder("Content1", hasBoost: true);
-            {
-                IQueryMatch match = searcher.Boost(
-                    searcher.InQuery(contentMetadata, new() {"1", "2", "3"})
-                    , 10);
 
-                match = searcher.OrderBy(match,new OrderMetadata(true, MatchCompareFieldType.Score), defaultNullsSortMode: NullsSortMode.NullsSmallest);
-                Span<long> ids = stackalloc long[amount];
-                var read = match.Fill(ids);
-                List<string> result = new();
-                for (int i = 0; i < read; ++i)
-                {
-                    long id = ids[i];
-                    result.Add(searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id));
-                }
+            // Wrap the IN clause in boost() to exercise score propagation through an IN match.
+            var result = ExecuteRQLQueryByScore("FROM TestIndex WHERE boost(Content1 IN ('1', '2', '3'), 2) ORDER BY score()");
 
-                Assert.Equal(result.Count, result.Distinct().Count());
+            Assert.Equal(result.Count, result.Distinct().Count());
 
-                var localResults = longList.Where(x => x.Content1 is 1 or 2 or 3).Select(y => y.Id).ToArray();
-                var highestScore = result.ToArray().AsSpan(0, localResults.Length).ToArray();
-                Array.Sort(localResults);
-                Array.Sort(highestScore);
-                Assert.True(localResults.SequenceEqual(highestScore));
-            }
+            var localResults = longList.Where(x => x.Content1 is 1 or 2 or 3).Select(y => y.Id).ToArray();
+            var highestScore = result.ToArray();
+            Array.Sort(localResults);
+            Array.Sort(highestScore);
+            Assert.True(localResults.SequenceEqual(highestScore));
         }
         
         [RavenFact(RavenTestCategory.Corax)]
         public void OrderByBoosting()
         {
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/1", Content1 = 1}); // 2 * 10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/11", Content1 = 0}); // 2 * 10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/111", Content1 = 0}); // 2 * 10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/2", Content1 = 1}); //     10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/4", Content1 = 1}); //     10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/3", Content1 = 2}); //      0
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/1", Content1 = 1});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/11", Content1 = 0});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/111", Content1 = 0});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/2", Content1 = 1});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/4", Content1 = 1});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/3", Content1 = 2});
 
             IndexEntries();
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
-            {
-                var startWithMatch = searcher.StartWithQuery("Id", "list/1", hasBoost: true);
-                var boostedStartWithMatch = searcher.Boost(startWithMatch, 2);
-                var contentMatch = searcher.TermQuery("Content1", "1", hasBoost: true);
-                var orMatch = searcher.Or(boostedStartWithMatch, contentMatch);
-                var boostedOrMatch = searcher.Boost(orMatch, 10);
-                var contentMatch2 = searcher.TermQuery("Content1", "2", hasBoost: true);
-                var orMatch2 = searcher.Or(contentMatch2, boostedOrMatch);
-                var sortedMatch = searcher.OrderBy(orMatch2, new OrderMetadata(true, MatchCompareFieldType.Score), defaultNullsSortMode: NullsSortMode.NullsSmallest);
 
-                Span<long> ids = stackalloc long[2048];
-                int read = sortedMatch.Fill(ids);
-                ids = ids.Slice(0, read);
+            // boost(startsWith, 20) = inner boost 2 * outer boost 10; boost(Content1='1', 10) = outer boost only.
+            // list/1 matches startsWith (boost 20) + Content1='1' (boost 10) → highest.
+            // list/11, list/111 match startsWith only (boost 20) → second tier.
+            // list/2, list/4 match Content1='1' only (boost 10) → third tier.
+            // list/3 matches Content1='2' (no extra boost) → lowest.
+            var sortedByCorax = ExecuteRQLQueryByScore(
+                "FROM TestIndex WHERE boost(startsWith(Id, 'list/1'), 20) OR boost(Content1 = '1', 10) OR Content1 = '2' ORDER BY score()");
 
-                List<string> sortedByCorax = new();
-                for (int i = 0; i < read; ++i)
-                {
-                    long id = ids[i];
-                    sortedByCorax.Add(searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id));
-                }
-
-                for (int i = 0; i < longList.Count; ++i)
-                    Assert.Equal(longList[i].Id, sortedByCorax[i]);
-            }
+            Assert.Equal(6, sortedByCorax.Count);
+            Assert.Equal("list/1", sortedByCorax[0]);
+            Assert.True(new HashSet<string> {"list/11", "list/111"}.SetEquals(sortedByCorax.GetRange(1, 2)));
+            Assert.True(new HashSet<string> {"list/2", "list/4"}.SetEquals(sortedByCorax.GetRange(3, 2)));
+            Assert.Equal("list/3", sortedByCorax[5]);
         }
 
 
         [RavenFact(RavenTestCategory.Corax)]
         public void OrderByBoostingTake4()
         {
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/1", Content1 = 1}); // 2 * 10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/11", Content1 = 0}); // 2 * 10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/111", Content1 = 0}); // 2 * 10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/2", Content1 = 1}); //     10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/4", Content1 = 1}); //     10
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/3", Content1 = 2}); //      0
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/1", Content1 = 1});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/11", Content1 = 0});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/111", Content1 = 0});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/2", Content1 = 1});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/4", Content1 = 1});
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/3", Content1 = 2});
 
             IndexEntries();
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
-            {
-                var startWithMatch = searcher.StartWithQuery("Id", "list/1", hasBoost: true);
-                var boostedStartWithMatch = searcher.Boost(startWithMatch, 2);
-                var contentMatch = searcher.TermQuery("Content1", "1", hasBoost: true);
-                var orMatch = searcher.Or(boostedStartWithMatch, contentMatch);
-                var boostedOrMatch = searcher.Boost(orMatch, 10);
-                var contentMatch2 = searcher.TermQuery("Content1", "2", hasBoost: true);
-                var orMatch2 = searcher.Or(contentMatch2, boostedOrMatch);
-                var sortedMatch = searcher.OrderBy(orMatch2, new OrderMetadata(true, MatchCompareFieldType.Score), defaultNullsSortMode: NullsSortMode.NullsSmallest, 4);
 
-                // TODO: Check what happens in OrderBy statements when the buffer is too small. 
-                Span<long> ids = stackalloc long[1024];
+            // Pass take=4 as a server-side sorter limit to exercise limit propagation through SortingMatch.
+            var sortedByCorax = ExecuteRQLQueryByScore(
+                "FROM TestIndex WHERE boost(startsWith(Id, 'list/1'), 20) OR boost(Content1 = '1', 10) OR Content1 = '2' ORDER BY score()",
+                take: 4);
 
-                var read = sortedMatch.Fill(ids);
-
-                List<string> sortedByCorax = new();
-                for (int i = 0; i < read; ++i)
-                {
-                    long id = ids[i];
-                    sortedByCorax.Add(searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id));
-                }
-
-                for (int i = 0; i < 4; ++i)
-                    Assert.Equal(longList[i].Id, sortedByCorax[i]);
-            }
+            Assert.Equal(4, sortedByCorax.Count);
+            Assert.Equal("list/1", sortedByCorax[0]);
+            Assert.True(new HashSet<string> {"list/11", "list/111"}.SetEquals(sortedByCorax.GetRange(1, 2)));
+            Assert.True(sortedByCorax[3] == "list/2" || sortedByCorax[3] == "list/4");
         }
 
         private static int CompareAscending(IndexSingleNumericalEntry<long, long> value1, IndexSingleNumericalEntry<long, long> value2)
@@ -217,47 +172,27 @@ namespace FastTests.Corax
             longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/3", Content1 = 1}); // 1/4
             longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/4", Content1 = 1}); // 1/4
             longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/5", Content1 = 1}); // 1/4
-            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/6", Content1 = 1}); // 1/4            
+            longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/6", Content1 = 1}); // 1/4
 
             IndexEntries();
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
+
+            // BM25 IDF: Content1=0 (2 entries) scores higher than Content1=1 (4 entries).
+            var sortedByCorax = ExecuteRQLQueryByScore(
+                "FROM TestIndex WHERE Content1 = '0' OR Content1 = '1' ORDER BY score()");
+
+            for (int i = 0; i < longList.Count; ++i)
             {
-                var content0Match = searcher.TermQuery("Content1", "0", hasBoost: true);
-                var boostedContent0 = searcher.Boost(content0Match, 1);
-
-                var content1Match = searcher.TermQuery("Content1", "1", hasBoost: true);
-                var boostedContent1 = searcher.Boost(content1Match, 1);
-
-                var orMatch = searcher.Or(boostedContent0, boostedContent1);
-                var boostedOrMatch = searcher.Boost(orMatch, 10);
-                var sortedMatch = searcher.OrderBy(boostedOrMatch,new OrderMetadata(true,MatchCompareFieldType.Score), defaultNullsSortMode: NullsSortMode.NullsSmallest);
-
-                Span<long> ids = stackalloc long[1024];
-                var read = sortedMatch.Fill(ids);
-
-                List<string> sortedByCorax = new();
-                for (int i = 0; i < read; ++i)
+                if (longList[i].Id != sortedByCorax[i])
                 {
-                    long id = ids[i];
-                    sortedByCorax.Add(searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id));
+                    // Since documents can change places (unstable sort), verify the Content1 group is correct.
+                    var originalEntry = longList.Single(isne => isne.Id == sortedByCorax[i]);
+                    Assert.Equal(longList[i].Content1, originalEntry.Content1);
                 }
-
-
-                for (int i = 0; i < longList.Count; ++i)
-                {
-                    if (longList[i].Id != sortedByCorax[i])
-                    {
-                        // Since documents can change places (we're using unstable sort), we can assert if the boosted value is exactly the same as in the asserted document.
-                        var originalEntry = longList.Single(isne => isne.Id == sortedByCorax[i]);
-                        Assert.Equal(longList[i].Content1, originalEntry.Content1);
-                    }
-                    else
-                        Assert.Equal(longList[i].Id, sortedByCorax[i]);
-                }
+                else
+                    Assert.Equal(longList[i].Id, sortedByCorax[i]);
             }
         }
 
-        //todo
         [RavenFact(RavenTestCategory.Corax)]
         public void OrderByBoostingOrBasedInQuery()
         {
@@ -268,35 +203,22 @@ namespace FastTests.Corax
             longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/5", Content1 = 1}); // 1/4
             longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/6", Content1 = 1}); // 1/4
 
-
             IndexEntries();
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
-            var contentMetadata = searcher.FieldMetadataBuilder("Content1", hasBoost: true);
+
+            // BM25 IDF: Content1=0 (2 entries) scores higher than Content1=1 (4 entries).
+            var sortedByCorax = ExecuteRQLQueryByScore(
+                "FROM TestIndex WHERE Content1 IN ('0', '1') ORDER BY score()");
+
+            for (int i = 0; i < longList.Count; ++i)
             {
-                var query = searcher.OrderBy(searcher.InQuery(contentMetadata, new List<string>() {"0", "1"})
-                    ,new OrderMetadata(true,MatchCompareFieldType.Score), defaultNullsSortMode: NullsSortMode.NullsSmallest);
-
-                Span<long> ids = stackalloc long[1024];
-                var read = query.Fill(ids);
-
-                List<string> sortedByCorax = new();
-                for (int i = 0; i < read; ++i)
+                if (longList[i].Id != sortedByCorax[i])
                 {
-                    long id = ids[i];
-                    sortedByCorax.Add(searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id));
+                    // Since documents can change places (unstable sort), verify the Content1 group is correct.
+                    var originalEntry = longList.Single(isne => isne.Id == sortedByCorax[i]);
+                    Assert.Equal(longList[i].Content1, originalEntry.Content1);
                 }
-
-                for (int i = 0; i < longList.Count; ++i)
-                {
-                    if (longList[i].Id != sortedByCorax[i])
-                    {
-                        // Since documents can change places (we're using unstable sort), we can assert if the boosted value is exactly the same as in the asserted document.
-                        var originalEntry = longList.Single(isne => isne.Id == sortedByCorax[i]);
-                        Assert.Equal(longList[i].Content1, originalEntry.Content1);
-                    }
-                    else
-                        Assert.Equal(longList[i].Id, sortedByCorax[i]);
-                }
+                else
+                    Assert.Equal(longList[i].Id, sortedByCorax[i]);
             }
         }
 
@@ -350,28 +272,83 @@ namespace FastTests.Corax
             longList.Add(new IndexSingleNumericalEntry<long, long> {Id = $"list/4444", Content1 = 3}); // 1/4
 
             IndexEntries();
-
             longList.Sort(CompareAscending);
-            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
-            var contentMetadata = searcher.FieldMetadataBuilder("Content1", Content1, hasBoost: true);
+
+            // BM25 IDF: Content1=0 (1 entry) > Content1=1 (2) > Content1=2 (3) > Content1=3 (4 entries).
+            // After sorting longList ascending by Content1, sortedByCorax[i].Content1 must equal longList[i].Content1.
+            var sortedByCorax = ExecuteRQLQueryByScoreReadContent1(
+                "FROM TestIndex WHERE Content1 IN ('0', '1', '2', '3') ORDER BY score()");
+
+            for (int i = 0; i < longList.Count; ++i)
+                Assert.Equal(longList[i].Content1, sortedByCorax[i]);
+        }
+
+        private List<string> ExecuteRQLQueryByScore(string rqlQuery, long take = long.MaxValue)
+        {
+            using var knownFields = CreateKnownFields(Allocator);
+            using var searcher = new IndexSearcher(Env, knownFields);
+            var queryMetadata = new QueryMetadata(rqlQuery, null, 0);
+            var planParams = new PlanParameters
             {
-                var query = searcher.InQuery(contentMetadata, new List<string>() {"0", "1", "2", "3"});
-                var sortedMatch = searcher.OrderBy(query,new OrderMetadata(true,MatchCompareFieldType.Score), defaultNullsSortMode: NullsSortMode.NullsSmallest);
+                IndexSearcher = searcher,
+                Metadata = queryMetadata,
+                HasBoost = true,
+                Allocator = Allocator
+            };
+            var match = QueryPlanBuilder.BuildFilterMatch(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields, hasBoost: true), out _, null, false, default);
+            match = ApplyScoreOrderingIfRequested(searcher, queryMetadata, match, take);
+            var list = new List<string>();
+            Span<long> ids = stackalloc long[256];
+            int count;
+            while ((count = match.Fill(ids)) > 0)
+                for (int i = 0; i < count; i++)
+                    list.Add(searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(ids[i]));
+            return list;
+        }
 
-                Span<long> ids = stackalloc long[1024];
-                var read = sortedMatch.Fill(ids);
+        private List<long> ExecuteRQLQueryByScoreReadContent1(string rqlQuery)
+        {
+            using var knownFields = CreateKnownFields(Allocator);
+            using var searcher = new IndexSearcher(Env, knownFields);
+            var queryMetadata = new QueryMetadata(rqlQuery, null, 0);
+            var planParams = new PlanParameters
+            {
+                IndexSearcher = searcher,
+                Metadata = queryMetadata,
+                HasBoost = true,
+                Allocator = Allocator
+            };
+            var match = QueryPlanBuilder.BuildFilterMatch(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields, hasBoost: true), out _, null, false, default);
+            match = ApplyScoreOrderingIfRequested(searcher, queryMetadata, match, long.MaxValue);
+            var list = new List<long>();
+            var termsReader = searcher.TermsReaderFor("Content1");
+            Span<long> ids = stackalloc long[256];
+            int count;
+            while ((count = match.Fill(ids)) > 0)
+                for (int i = 0; i < count; i++)
+                    list.Add(long.Parse(termsReader.GetTermFor(ids[i])));
+            return list;
+        }
 
-                List<long> sortedByCorax = new();
-                var termsReader = searcher.TermsReaderFor("Content1");
+        // Wraps the searcher's score-ordering primitive directly. Production OrderBy(QueryBuilderParameters, ...)
+        // needs the full server-side query pipeline that these direct-IndexSearcher tests bypass.
+        private static global::Corax.Querying.Matches.Meta.IQueryMatch ApplyScoreOrderingIfRequested(IndexSearcher searcher, QueryMetadata queryMetadata, global::Corax.Querying.Matches.Meta.IQueryMatch match, long take)
+        {
+            var orderByFields = queryMetadata.OrderBy;
+            if (orderByFields is null || orderByFields.Length == 0)
+                return match;
 
-                for (int i = 0; i < read; ++i)
+            int takeInt = take > int.MaxValue ? global::Corax.Constants.IndexSearcher.TakeAll : (int)take;
+            foreach (var field in orderByFields)
+            {
+                if (field.OrderingType == Raven.Server.Documents.Queries.AST.OrderByFieldType.Score)
                 {
-                    sortedByCorax.Add(long.Parse(termsReader.GetTermFor(ids[i])));
+                    var meta = new global::Corax.Utils.OrderMetadata(true, global::Corax.Querying.Matches.SortingMatches.Meta.MatchCompareFieldType.Score, field.Ascending);
+                    return searcher.OrderBy(match, meta, global::Corax.Utils.NullsSortMode.NullsLargest, take: takeInt);
                 }
-
-                for (int i = 0; i < longList.Count; ++i)
-                    Assert.Equal(longList[i].Content1, sortedByCorax[i]);
             }
+
+            return match;
         }
 
         private void PrepareData(bool inverse = false)

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -295,7 +295,7 @@ namespace FastTests.Corax
                 HasBoost = true,
                 Allocator = Allocator
             };
-            var match = QueryPlanBuilder.BuildFilterMatch(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields, hasBoost: true), out _, null, false, default);
+            var match = QueryPlanBuilder.BuildFilterMatch(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields, hasBoost: true), null, false, default);
             match = ApplyScoreOrderingIfRequested(searcher, queryMetadata, match, take);
             var list = new List<string>();
             Span<long> ids = stackalloc long[256];
@@ -318,7 +318,7 @@ namespace FastTests.Corax
                 HasBoost = true,
                 Allocator = Allocator
             };
-            var match = QueryPlanBuilder.BuildFilterMatch(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields, hasBoost: true), out _, null, false, default);
+            var match = QueryPlanBuilder.BuildFilterMatch(planParams, new QueryBuilderParameters(searcher, Allocator, queryMetadata, null, knownFields, hasBoost: true), null, false, default);
             match = ApplyScoreOrderingIfRequested(searcher, queryMetadata, match, long.MaxValue);
             var list = new List<long>();
             var termsReader = searcher.TermsReaderFor("Content1");

--- a/test/FastTests/Corax/Bugs/RavenDB_25281_GetForGallop.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB_25281_GetForGallop.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron.Data.Lookups;
+using Xunit;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_25281_GetForGallop : StorageTest
+{
+    public RavenDB_25281_GetForGallop(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // GetFor walks the lookup once for a sorted batch of keys, galloping forward from the previous
+    // position within each page. This differential test asserts the gallop returns exactly the same
+    // value (or the missing sentinel) as a ground-truth dictionary, across multi-page trees and the
+    // dense / sparse / boundary key distributions the gallop branches on.
+    [RavenTheory(RavenTestCategory.Voron)]
+    [InlineData(214)]
+    [InlineData(1337)]
+    [InlineDataWithRandomSeed]
+    public void GetForMatchesGroundTruthAcrossPages(int seed)
+    {
+        const long missing = long.MinValue;
+        var random = new Random(seed);
+
+        // Enough distinct keys to span many leaf pages so SearchNextPage and the in-page gallop both run.
+        var keys = new HashSet<long>();
+        while (keys.Count < 20_000)
+            keys.Add(random.NextInt64(0, 1_000_000));
+
+        var reference = new Dictionary<long, long>();
+        var sortedKeys = keys.OrderBy(x => x).ToArray();
+
+        using (var wtx = Env.WriteTransaction())
+        {
+            var lookup = wtx.LookupFor<Int64LookupKey>("test");
+            foreach (var k in sortedKeys)
+            {
+                long value = (k * 2) + 1; // any deterministic, recoverable value
+                var key = new Int64LookupKey(k);
+                lookup.Add(ref key, value);
+                reference[k] = value;
+            }
+            wtx.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var lookup = rtx.LookupFor<Int64LookupKey>("test");
+
+            // 1. All keys present, fully dense merge (every entry is wanted).
+            AssertGetFor(lookup, reference, sortedKeys, missing);
+
+            // 2. Sparse random subset of present keys.
+            var sparse = sortedKeys.Where(_ => random.Next(20) == 0).ToArray();
+            AssertGetFor(lookup, reference, sparse, missing);
+
+            // 3. A dense contiguous run from the middle of the key space.
+            var run = sortedKeys.Skip(sortedKeys.Length / 3).Take(500).ToArray();
+            AssertGetFor(lookup, reference, run, missing);
+
+            // 4. Mix of present and absent keys (forces the "should be here but isn't" path).
+            var mixed = new SortedSet<long>(sparse);
+            for (int i = 0; i < 2000; i++)
+                mixed.Add(random.NextInt64(0, 1_000_000)); // some land between/at existing keys, some absent
+            AssertGetFor(lookup, reference, mixed.ToArray(), missing);
+
+            // 5. Keys entirely below, between, and above the stored range (boundary / next-page exhaustion).
+            long min = sortedKeys[0], max = sortedKeys[^1];
+            var boundary = new long[] { min - 100, min - 1, min, max, max + 1, max + 100 }
+                .Distinct().OrderBy(x => x).ToArray();
+            AssertGetFor(lookup, reference, boundary, missing);
+
+            // 6. Single-key batches at the extremes.
+            AssertGetFor(lookup, reference, new[] { min }, missing);
+            AssertGetFor(lookup, reference, new[] { max }, missing);
+            AssertGetFor(lookup, reference, new[] { max + 1 }, missing);
+        }
+    }
+
+    private static void AssertGetFor(Lookup<Int64LookupKey> lookup, Dictionary<long, long> reference, long[] queryKeys, long missing)
+    {
+        if (queryKeys.Length == 0)
+            return;
+
+        var terms = new long[queryKeys.Length];
+        lookup.GetFor(queryKeys, terms, missing);
+
+        for (int i = 0; i < queryKeys.Length; i++)
+        {
+            long expected = reference.TryGetValue(queryKeys[i], out var v) ? v : missing;
+            Assert.Equal(expected, terms[i]);
+        }
+    }
+}

--- a/test/FastTests/Corax/CompiledQueryBenchmark.cs
+++ b/test/FastTests/Corax/CompiledQueryBenchmark.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// End-to-end comparison benchmark: old streaming path vs bitmap path.
+/// Runs the same queries through the full RavenDB server with and without
+/// the bitmap pipeline enabled. Outputs timing comparison.
+/// </summary>
+public class CompiledQueryBenchmark : RavenTestBase
+{
+    public CompiledQueryBenchmark(Xunit.ITestOutputHelper output) : base(output) { }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying, Skip = "Benchmark — too slow for CI. Run manually.")]
+    public async Task CompareStreamingVsBitmap()
+    {
+        const int docCount = 10_000;
+        const int warmup = 3;
+        const int iterations = 50;
+
+        var optionsOld = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var storeOld = GetDocumentStore(optionsOld);
+        await SeedData(storeOld, docCount);
+
+        // Same configuration; both use the bitmap pipeline.
+        var optionsNew = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var storeNew = GetDocumentStore(optionsNew);
+        await SeedData(storeNew, docCount);
+
+        var queries = new (string name, string rql)[]
+        {
+            ("Term: Status=active", "from BenchDocs where Status = 'active'"),
+            ("AND: Status∩Category", "from BenchDocs where Status = 'active' and Category = 'cat-0'"),
+            ("OR: Cat0∪Cat1", "from BenchDocs where Category = 'cat-0' or Category = 'cat-1'"),
+            ("3-way AND", "from BenchDocs where Status = 'active' and Category = 'cat-0' and Tag = 'tag-0'"),
+            ("AND+Range", "from BenchDocs where Category = 'cat-0' and Price > 500"),
+            ("Mixed (OR)∩AND", "from BenchDocs where (Category = 'cat-0' or Category = 'cat-1') and Status = 'active'"),
+            ("startsWith", "from BenchDocs where startsWith(Name, 'doc-000')"),
+            ("IN clause", "from BenchDocs where Category in ('cat-0', 'cat-1', 'cat-2')"),
+        };
+
+        Output.WriteLine($"{"Query",-35} {"Run 1 (ms)",-12} {"Run 2 (ms)",-12} {"Ratio",-10} {"Results",-10}");
+        Output.WriteLine(new string('-', 80));
+
+        foreach (var (name, rql) in queries)
+        {
+            var (ms1, count1) = await BenchQuery(storeOld, rql, warmup, iterations);
+            var (ms2, count2) = await BenchQuery(storeNew, rql, warmup, iterations);
+
+            double ratio = ms1 / Math.Max(ms2, 0.001);
+            Output.WriteLine($"{name,-35} {ms1,8:F2}ms {ms2,8:F2}ms {ratio,8:F2}x {count1,8}");
+
+            Assert.Equal(count1, count2);
+        }
+    }
+
+    private async Task<(double avgMs, int resultCount)> BenchQuery(IDocumentStore store, string rql, int warmup, int iterations)
+    {
+        for (int w = 0; w < warmup; w++)
+        {
+            using var session = store.OpenAsyncSession();
+            await session.Advanced.AsyncRawQuery<dynamic>(rql).ToListAsync();
+        }
+
+        var times = new double[iterations];
+        int count = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            using var session = store.OpenAsyncSession();
+            var results = await session.Advanced.AsyncRawQuery<dynamic>(rql).ToListAsync();
+            sw.Stop();
+            times[i] = sw.Elapsed.TotalMilliseconds;
+            count = results.Count;
+        }
+
+        Array.Sort(times);
+        return (times[times.Length / 2], count);  // median eliminates outliers
+    }
+
+    private async Task SeedData(IDocumentStore store, int count)
+    {
+        for (int batch = 0; batch < count; batch += 1000)
+        {
+            using var session = store.OpenAsyncSession();
+            int end = Math.Min(batch + 1000, count);
+            for (int i = batch; i < end; i++)
+            {
+                await session.StoreAsync(new BenchDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}",
+                    Price = i * 3
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+    }
+
+    private class BenchDoc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public string Status { get; set; }
+        public string Tag { get; set; }
+        public int Price { get; set; }
+    }
+}

--- a/test/FastTests/Corax/CompiledQueryBenchmark.cs
+++ b/test/FastTests/Corax/CompiledQueryBenchmark.cs
@@ -9,9 +9,10 @@ using Xunit;
 namespace FastTests.Corax;
 
 /// <summary>
-/// End-to-end comparison benchmark: old streaming path vs bitmap path.
-/// Runs the same queries through the full RavenDB server with and without
-/// the bitmap pipeline enabled. Outputs timing comparison.
+/// Same-pipeline repeatability benchmark: measures query latencies through
+/// the Corax bitmap pipeline with two independent store instances.
+/// All queries exercise the same CompiledQuery path — no path comparison.
+/// Outputs timing comparison between the two runs.
 /// </summary>
 public class CompiledQueryBenchmark : RavenTestBase
 {

--- a/test/FastTests/Corax/CompiledQueryNestedGroupTests.cs
+++ b/test/FastTests/Corax/CompiledQueryNestedGroupTests.cs
@@ -1,0 +1,339 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// Regression suite for nested boolean groups in the Corax query planner: queries where a sub-clause of an
+/// OrGroup or AndGroup is itself a group with non-leaf children — the path that falls through to
+/// <c>ResolveClause</c>'s recursive bitmap-collapse instead of staying in the IL slot pipeline.
+/// Each test asserts result correctness only.
+/// </summary>
+public class CompiledQueryNestedGroupTests : RavenTestBase
+{
+    public CompiledQueryNestedGroupTests(Xunit.ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedAndInsideOr_TwoConjuncts()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // Layout: 100 docs, Category cycles a/b/c/d, Priority 1..5
+            // - cat='a' AND pri=1 → docs at i % 4 == 0 AND i % 5 == 0 → i ∈ {0,20,40,60,80} = 5
+            // - cat='b' AND pri=2 → i % 4 == 1 AND i % 5 == 1 → i ∈ {1,21,41,61,81} = 5
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = "a b c d".Split(' ')[i % 4],
+                    Priority = (i % 5) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where (Category = 'a' and Priority = 1) or (Category = 'b' and Priority = 2)")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            Assert.All(results, r =>
+                Assert.True((r.Category == "a" && r.Priority == 1) || (r.Category == "b" && r.Priority == 2),
+                    $"Unexpected match: Category={r.Category}, Priority={r.Priority}"));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedAndInsideOr_ThreeConjuncts()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 120; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = "a b c d".Split(' ')[i % 4],
+                    Priority = (i % 5) + 1,
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where " +
+                "(Category = 'a' and Priority = 1) or " +
+                "(Category = 'b' and Priority = 2) or " +
+                "(Category = 'c' and Status = 'active')")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+                Assert.True(
+                    (r.Category == "a" && r.Priority == 1) ||
+                    (r.Category == "b" && r.Priority == 2) ||
+                    (r.Category == "c" && r.Status == "active"),
+                    $"Unexpected match: Category={r.Category}, Priority={r.Priority}, Status={r.Status}"));
+
+            // Verify count is non-zero and matches expected predicate over the fixture
+            var expected = 0;
+            for (int i = 0; i < 120; i++)
+            {
+                var cat = "a b c d".Split(' ')[i % 4];
+                var pri = (i % 5) + 1;
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                if ((cat == "a" && pri == 1) || (cat == "b" && pri == 2) || (cat == "c" && sta == "active"))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedOrInsideAnd_LeafAndAndGroups()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 200; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = "alpha beta gamma delta".Split(' ')[i % 4],
+                    Priority = (i % 6) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // Active items that are EITHER (alpha,pri=1) OR (beta,pri=2)
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and " +
+                "((Tag = 'alpha' and Priority = 1) or (Tag = 'beta' and Priority = 2))")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.True(
+                    (r.Tag == "alpha" && r.Priority == 1) ||
+                    (r.Tag == "beta" && r.Priority == 2),
+                    $"Unexpected match: Tag={r.Tag}, Priority={r.Priority}");
+            });
+
+            var expected = 0;
+            for (int i = 0; i < 200; i++)
+            {
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                var tag = "alpha beta gamma delta".Split(' ')[i % 4];
+                var pri = (i % 6) + 1;
+                if (sta == "active" && ((tag == "alpha" && pri == 1) || (tag == "beta" && pri == 2)))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedTripleDepth_AndWithOrWithAnd()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 150; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Category = "x y z".Split(' ')[i % 3],
+                    Tag = "hot cold warm".Split(' ')[i % 3],
+                    Priority = (i % 5) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // Three-level: active AND (cat=x OR (tag=hot AND priority=1))
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and " +
+                "(Category = 'x' or (Tag = 'hot' and Priority = 1))")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.True(
+                    r.Category == "x" || (r.Tag == "hot" && r.Priority == 1),
+                    $"Unexpected match: Category={r.Category}, Tag={r.Tag}, Priority={r.Priority}");
+            });
+
+            var expected = 0;
+            for (int i = 0; i < 150; i++)
+            {
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                var cat = "x y z".Split(' ')[i % 3];
+                var tag = "hot cold warm".Split(' ')[i % 3];
+                var pri = (i % 5) + 1;
+                if (sta == "active" && (cat == "x" || (tag == "hot" && pri == 1)))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedWithNegation_AndNotInsideOrGroup()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Category = "a b c d".Split(' ')[i % 4],
+                    Priority = (i % 5) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // active AND ((category=a AND priority != 1) OR (category=b AND priority = 2))
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and " +
+                "((Category = 'a' and Priority != 1) or (Category = 'b' and Priority = 2))")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.True(
+                    (r.Category == "a" && r.Priority != 1) ||
+                    (r.Category == "b" && r.Priority == 2),
+                    $"Unexpected match: Category={r.Category}, Priority={r.Priority}");
+            });
+
+            var expected = 0;
+            for (int i = 0; i < 100; i++)
+            {
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                var cat = "a b c d".Split(' ')[i % 4];
+                var pri = (i % 5) + 1;
+                if (sta == "active" && ((cat == "a" && pri != 1) || (cat == "b" && pri == 2)))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedWithNegation_NotEqualsDirectInsideOrGroup()
+    {
+        // Probe for an asymmetry: NotEquals as a DIRECT sub-clause of a nested OrGroup
+        // (not wrapped in an inner AndGroup). NotCanonicalize only marks top-level
+        // OR-chain clauses with IsOrChainNotEquals=true; nested OrGroup sub-clauses
+        // are not marked. If the OrGroup collapse path (or the IL pipeline's nested
+        // OrGroup case in EmitAndPlan) doesn't handle the negation, the positive form
+        // leaks through and the result set is wrong.
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Category = "a b c d".Split(' ')[i % 4],
+                    Priority = (i % 5) + 1
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // active AND (Priority != 1 OR Category = 'b')
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and " +
+                "(Priority != 1 or Category = 'b')")
+                .ToListAsync();
+
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.True(
+                    r.Priority != 1 || r.Category == "b",
+                    $"Unexpected match: Category={r.Category}, Priority={r.Priority}");
+            });
+
+            var expected = 0;
+            for (int i = 0; i < 100; i++)
+            {
+                var sta = i % 2 == 0 ? "active" : "inactive";
+                var cat = "a b c d".Split(' ')[i % 4];
+                var pri = (i % 5) + 1;
+                if (sta == "active" && (pri != 1 || cat == "b"))
+                    expected++;
+            }
+            Assert.Equal(expected, results.Count);
+        }
+    }
+
+    private class TestDoc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Status { get; set; }
+        public string Category { get; set; }
+        public string Tag { get; set; }
+        public int Priority { get; set; }
+    }
+}

--- a/test/FastTests/Corax/CompiledQueryTests.cs
+++ b/test/FastTests/Corax/CompiledQueryTests.cs
@@ -1,0 +1,1285 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+public class CompiledQueryTests : RavenTestBase
+{
+    public CompiledQueryTests(Xunit.ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task SimpleTermQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Single term query
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status == "active")
+                .ToListAsync();
+
+            Assert.Equal(50, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task AndQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // AND query: Status=active AND Category=cat-0
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status == "active" && x.Category == "cat-0")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.Equal("cat-0", r.Category);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // OR query: Category=cat-0 OR Category=cat-1
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0" || x.Category == "cat-1")
+                .ToListAsync();
+
+            Assert.Equal(40, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task ThreeWayAnd_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 200; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // 3-way AND: Status=active AND Category=cat-0 AND Tag=tag-0
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status == "active" && x.Category == "cat-0" && x.Tag == "tag-0")
+                .ToListAsync();
+
+            // active (100/200) ∩ cat-0 (40/200) ∩ tag-0 (20/200)
+            // Expected: docs where i%2==0 AND i%5==0 AND i%10==0 → i%10==0
+            Assert.Equal(20, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("active", r.Status);
+                Assert.Equal("cat-0", r.Category);
+                Assert.Equal("tag-0", r.Tag);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task AndWithRange_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = i * 10
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // AND with range: Category=cat-0 AND Price > 200
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0" && x.Price > 200)
+                .ToListAsync();
+
+            // cat-0: indices 0,5,10,15,20,...,95 (20 total)
+            // Price > 200: i*10 > 200 → i > 20
+            // cat-0 indices > 20: 25,30,35,40,45,50,55,60,65,70,75,80,85,90,95 → 15
+            Assert.Equal(15, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("cat-0", r.Category);
+                Assert.True(r.Price > 200);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task InClause_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // IN clause: Category in (cat-0, cat-1, cat-2)
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category in ('cat-0', 'cat-1', 'cat-2')")
+                .ToListAsync();
+
+            // 3 categories × 20 each = 60
+            Assert.Equal(60, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotEquals_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Status != "active" — should get inactive docs
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status != "active")
+                .ToListAsync();
+
+            Assert.Equal(25, results.Count);
+            Assert.All(results, r => Assert.Equal("inactive", r.Status));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task BetweenQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = i * 10
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // BETWEEN: Category=cat-0 AND Price between 100 and 500
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' and Price between 100 and 500")
+                .ToListAsync();
+
+            // cat-0: 0,5,10,15,20,25,30,35,40,45,50,...
+            // Price 100-500: i=10..50 → cat-0 in that range: 10,15,20,25,30,35,40,45,50 → 9
+            Assert.Equal(9, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task LargeResultSet_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 3}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Large AND: 500 active ∩ 334 cat-0 = ~167
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Status == "active" && x.Category == "cat-0")
+                .ToListAsync();
+
+            // active: even indices, cat-0: i%3==0
+            // Both: i%2==0 AND i%3==0 → i%6==0 → 0,6,12,...,996 → 167
+            Assert.Equal(167, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task StartsWith_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"alpha-{i}",
+                    Category = "cat-0",
+                    Status = "active"
+                });
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"beta-{i}",
+                    Category = "cat-1",
+                    Status = "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // startsWith
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where startsWith(Name, 'alpha')")
+                .ToListAsync();
+
+            Assert.Equal(50, results.Count);
+            Assert.All(results, r => Assert.StartsWith("alpha", r.Name));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task ExistsQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        // Store docs — all have Category, so exists(Category) should return all
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 3}",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // exists(Category) — all 30 docs have it
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where exists(Category)")
+                .ToListAsync();
+
+            Assert.Equal(30, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task AndWithStartsWith_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"item-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // AND with startsWith: Status=active AND startsWith(Name, 'item-0000')
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Status = 'active' and startsWith(Name, 'item-0000')")
+                .ToListAsync();
+
+            // item-00000 to item-00009, active (even): 00000,00002,00004,00006,00008 → 5
+            Assert.Equal(5, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrderByScore_BitmapPath()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestDoc { Name = "hello world foo", Category = "cat-0", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "hello", Category = "cat-0", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "world", Category = "cat-1", Status = "inactive" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // ORDER BY score() should fall back to old path and work correctly
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where search(Name, 'hello') order by score()")
+                .ToListAsync();
+
+            // Should find docs with 'hello' in Name, ordered by relevance
+            Assert.True(results.Count >= 1);
+        }
+    }
+
+    /// <summary>
+    /// Verifies score ordering direction contracts:
+    ///   ORDER BY score()     → highest scores first  (default, search-engine convention)
+    ///   ORDER BY score() ASC → highest scores first  (ASC is idiomatic for "most relevant" in RavenDB)
+    ///   ORDER BY score() DESC → lowest scores first  (explicit reversal)
+    /// </summary>
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrderByScore_DirectionSemantics()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        // Three docs with different boost factors in the query give reliably distinct scores.
+        // Name values are unique so each doc matches exactly one boost() clause.
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestDoc { Name = "doc-a", Category = "cat-x", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "doc-b", Category = "cat-x", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "doc-c", Category = "cat-x", Status = "active" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // boost() factors ensure doc-a > doc-b > doc-c in score.
+        const string where = "boost(Name = 'doc-a', 100) OR boost(Name = 'doc-b', 10) OR boost(Name = 'doc-c', 1)";
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // No direction / default: highest score first.
+            var defaultOrder = await session.Advanced.AsyncRawQuery<TestDoc>(
+                $"from TestDocs where {where} order by score()")
+                .ToListAsync();
+            Assert.Equal(3, defaultOrder.Count);
+            Assert.Equal("doc-a", defaultOrder[0].Name);
+            Assert.Equal("doc-b", defaultOrder[1].Name);
+            Assert.Equal("doc-c", defaultOrder[2].Name);
+
+            // ASC: same as default — highest score first.
+            var ascOrder = await session.Advanced.AsyncRawQuery<TestDoc>(
+                $"from TestDocs where {where} order by score() asc")
+                .ToListAsync();
+            Assert.Equal(3, ascOrder.Count);
+            Assert.Equal("doc-a", ascOrder[0].Name);
+            Assert.Equal("doc-b", ascOrder[1].Name);
+            Assert.Equal("doc-c", ascOrder[2].Name);
+
+            // DESC: lowest score first.
+            var descOrder = await session.Advanced.AsyncRawQuery<TestDoc>(
+                $"from TestDocs where {where} order by score() desc")
+                .ToListAsync();
+            Assert.Equal(3, descOrder.Count);
+            Assert.Equal("doc-c", descOrder[0].Name);
+            Assert.Equal("doc-b", descOrder[1].Name);
+            Assert.Equal("doc-a", descOrder[2].Name);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task RegexQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = i % 2 == 0 ? $"alpha-{i}" : $"beta-{i}",
+                    Category = "cat-0",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // regex query
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where regex(Name, '^alpha')")
+                .ToListAsync();
+
+            Assert.Equal(25, results.Count);
+            Assert.All(results, r => Assert.StartsWith("alpha", r.Name));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotEqualsInAndChain_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // AND with !=: Category=cat-0 AND Status != 'active'
+        // First verify old path returns correct results
+        using (var session = store.OpenAsyncSession())
+        {
+            var oldPathResults = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' and Status = 'inactive'")
+                .ToListAsync();
+            Assert.Equal(10, oldPathResults.Count);
+            Assert.All(oldPathResults, r => Assert.Equal("inactive", r.Status));
+        }
+
+        // Now test != through bitmap path
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' and Status != 'active'")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            foreach (var r in results)
+            {
+                Assert.Equal("cat-0", r.Category);
+                Assert.Equal("inactive", r.Status);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task MixedAndOr_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Mixed: (Category=cat-0 OR Category=cat-1) AND Status=active
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where (Category = 'cat-0' or Category = 'cat-1') and Status = 'active'")
+                .ToListAsync();
+
+            // (cat-0 ∪ cat-1) = 40, active = 50, intersection = 20
+            Assert.Equal(20, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.True(r.Category is "cat-0" or "cat-1");
+                Assert.Equal("active", r.Status);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrderBy_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = (99 - i) * 10 // reverse order
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // ORDER BY Name LIMIT 10
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' order by Name limit 10")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            // Should be sorted by Name ascending
+            for (int i = 1; i < results.Count; i++)
+            {
+                Assert.True(string.Compare(results[i - 1].Name, results[i].Name, System.StringComparison.Ordinal) <= 0,
+                    $"Results not sorted: {results[i - 1].Name} should be before {results[i].Name}");
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task ComplexAndOrWithSort_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 200; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"item-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}",
+                    Price = i * 5
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Complex: (cat-0 OR cat-1) AND active, ORDER BY Name LIMIT 10
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where (Category = 'cat-0' or Category = 'cat-1') and Status = 'active' order by Name limit 10")
+                .ToListAsync();
+
+            Assert.Equal(10, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.True(r.Category is "cat-0" or "cat-1");
+                Assert.Equal("active", r.Status);
+            });
+            // Verify sorting
+            for (int i = 1; i < results.Count; i++)
+            {
+                Assert.True(string.Compare(results[i - 1].Name, results[i].Name, System.StringComparison.Ordinal) <= 0);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EndsWith_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = i % 2 == 0 ? $"item-{i}-alpha" : $"item-{i}-beta",
+                    Category = $"cat-{i % 5}",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where endsWith(Name, 'alpha')")
+                .ToListAsync();
+
+            Assert.Equal(25, results.Count);
+            Assert.All(results, r => Assert.EndsWith("alpha", r.Name));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task FiveWayAnd_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 500; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}",
+                    Price = i * 3
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // 5-way AND: Category=cat-0 AND Status=active AND Tag=tag-0 AND Price>500 AND startsWith(Name, 'doc-0')
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' and Status = 'active' and Tag = 'tag-0' and Price > 500 and startsWith(Name, 'doc-0')")
+                .ToListAsync();
+
+            // cat-0: i%5==0, active: i%2==0, tag-0: i%10==0 → i%10==0 AND i%2==0 → i%10==0
+            // Price > 500: i*3 > 500 → i > 166
+            // startsWith doc-0: i < 100000 (all match with 5-digit padding)
+            // Combined: i%10==0 AND i>166 → 170,180,190,...,490 → 33 items
+            Assert.Equal(33, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("cat-0", r.Category);
+                Assert.Equal("active", r.Status);
+                Assert.Equal("tag-0", r.Tag);
+                Assert.True(r.Price > 500);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NestedOrWithAnd_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 5}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Tag = $"tag-{i % 10}"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // (cat-0 OR cat-1) AND (tag-0 OR tag-5)
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where (Category = 'cat-0' or Category = 'cat-1') and (Tag = 'tag-0' or Tag = 'tag-5')")
+                .ToListAsync();
+
+            // (cat-0∪cat-1) ∩ (tag-0∪tag-5): cat-1 (i%5==1) never overlaps tag-0/tag-5 (i%10==0 or 5, i.e. i%5==0),
+            // so only cat-0 ∩ tag-0 (10) and cat-0 ∩ tag-5 (10) survive → 20.
+            Assert.Equal(20, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EmptyResultSet_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = "cat-0",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // No matches — nonexistent term
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-999")
+                .ToListAsync();
+
+            Assert.Equal(0, results.Count);
+        }
+
+        // AND that produces empty result
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0" && x.Status == "inactive")
+                .ToListAsync();
+
+            Assert.Equal(0, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task Pagination_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = "cat-0",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Page 1: skip 0, take 10
+        using (var session = store.OpenAsyncSession())
+        {
+            var page1 = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0")
+                .Skip(0).Take(10)
+                .ToListAsync();
+            Assert.Equal(10, page1.Count);
+        }
+
+        // Page 2: skip 10, take 10 — verify no overlap with page 1
+        using (var session = store.OpenAsyncSession())
+        {
+            var allResults = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0")
+                .ToListAsync();
+
+            var page1 = allResults.Take(10).ToList();
+            var page2 = allResults.Skip(10).Take(10).ToList();
+            Assert.Equal(10, page1.Count);
+            Assert.Equal(10, page2.Count);
+            Assert.NotEqual(page1[0].Id, page2[0].Id);
+            Assert.All(page2, r => Assert.DoesNotContain(r.Name, page1.Select(p => p.Name)));
+        }
+
+        // Page 10: skip 90, take 10
+        using (var session = store.OpenAsyncSession())
+        {
+            var allResults = await session.Query<TestDoc>()
+                .Where(x => x.Category == "cat-0")
+                .OrderBy(r => r.Name)
+                .ToListAsync();
+
+            var page10 = allResults.Skip(90).Take(10).ToList();
+            Assert.Equal(10, page10.Count);
+            Assert.NotEqual(page10[0].Name, allResults[0].Name);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task TrueOrConstantFolding_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 3}",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // (true or Category='cat-0') → should return all 50 docs
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where true or Category = 'cat-0'")
+                .ToListAsync();
+
+            Assert.Equal(50, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task OrderByDesc_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D5}",
+                    Category = "cat-0",
+                    Status = "active",
+                    Price = i * 10
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // ORDER BY Price DESC LIMIT 5
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'cat-0' order by Price as long desc limit 5")
+                .ToListAsync();
+
+            Assert.Equal(5, results.Count);
+            // Should be highest prices first
+            Assert.True(results[0].Price >= results[1].Price);
+            Assert.True(results[0].Price >= results[4].Price);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task SingleDocResult_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestDoc { Name = "unique-doc", Category = "unique-cat", Status = "active" });
+            for (int i = 0; i < 99; i++)
+                await session.StoreAsync(new TestDoc { Name = $"doc-{i}", Category = "common-cat", Status = "active" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Single result — tests cardinality-1 path
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestDoc>()
+                .Where(x => x.Category == "unique-cat")
+                .ToListAsync();
+
+            Assert.Equal(1, results.Count);
+            Assert.Equal("unique-doc", results[0].Name);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task SearchQuery_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestDoc { Name = "hello world", Category = "cat-0", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "hello there", Category = "cat-0", Status = "active" });
+            await session.StoreAsync(new TestDoc { Name = "goodbye world", Category = "cat-1", Status = "inactive" });
+            await session.StoreAsync(new TestDoc { Name = "foo bar", Category = "cat-2", Status = "active" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // search() query without boost — should use bitmap path
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where search(Name, 'hello')")
+                .ToListAsync();
+
+            Assert.Equal(2, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NoWhereClause_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = $"cat-{i % 3}",
+                    Status = i % 2 == 0 ? "active" : "inactive"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // No WHERE clause — should return all documents
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs")
+                .ToListAsync();
+
+            Assert.Equal(30, results.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NoWhereClauseWithOrderBy_BitmapPipeline()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i:D2}",
+                    Category = $"cat-{i % 5}",
+                    Status = "active"
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // No WHERE clause with ORDER BY — bitmap path should handle sorting
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs order by Name")
+                .ToListAsync();
+
+            Assert.Equal(20, results.Count);
+            // Verify ordering
+            for (int i = 1; i < results.Count; i++)
+            {
+                Assert.True(string.Compare(results[i - 1].Name, results[i].Name, StringComparison.Ordinal) <= 0,
+                    $"Expected {results[i - 1].Name} <= {results[i].Name}");
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EntryScanWithSmallBitmapVsLargePostingList_Correctness()
+    {
+        // Verifies correctness of results when the entry-scan heuristic triggers.
+        // Entry scan fires when: bitmap.Count < 32K && bitmap.Count * 64 < nextMatch.Count.
+        // This test validates the result is correct under heuristic-triggering conditions
+        // (10 rare entries AND'd with ~2500 active entries).
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // 5000 docs, only 10 have Category='rare'
+            for (int i = 0; i < 5000; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = i < 10 ? "rare" : $"common-{i % 50}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = i
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Category='rare' produces ~10 entries, Status='active' has ~2500
+        // 10 * 64 = 640 < 2500 → entry scan should fire
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'rare' and Status = 'active'")
+                .ToListAsync();
+
+            Assert.Equal(5, results.Count); // indices 0,2,4,6,8
+            Assert.All(results, r =>
+            {
+                Assert.Equal("rare", r.Category);
+                Assert.Equal("active", r.Status);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EntryScanWithNotEquals_Correctness()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 5000; i++)
+            {
+                await session.StoreAsync(new TestDoc
+                {
+                    Name = $"doc-{i}",
+                    Category = i < 10 ? "rare" : $"common-{i % 50}",
+                    Status = i % 2 == 0 ? "active" : "inactive",
+                    Price = i
+                });
+            }
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // Category='rare' AND Status != 'active'
+        // 10 rare entries, 5 active, 5 inactive → expect 5 inactive
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced.AsyncRawQuery<TestDoc>(
+                "from TestDocs where Category = 'rare' and Status != 'active'")
+                .ToListAsync();
+
+            Assert.Equal(5, results.Count);
+            Assert.All(results, r =>
+            {
+                Assert.Equal("rare", r.Category);
+                Assert.Equal("inactive", r.Status);
+            });
+        }
+    }
+
+    private class TestDoc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public string Status { get; set; }
+        public string Tag { get; set; }
+        public int Price { get; set; }
+    }
+}

--- a/test/FastTests/Corax/DirectScanResidualTests.cs
+++ b/test/FastTests/Corax/DirectScanResidualTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// Regression guards for the direct-scan residual path (RavenDB-25281). A direct-scan plan is driven by an
+/// ORDER BY field that also carries a range/equals WHERE clause; the remaining WHERE clauses become per-entry
+/// residuals evaluated by <c>CompiledEntryPredicate</c>. Two historical bugs:
+///   1. residual string-equality terms were not analyzer-encoded, so a mixed-case value (e.g. <c>Name = 'BOB'</c>)
+///      never matched the stored, lower-cased term <c>bob</c>;
+///   2. an <c>(A or B)</c> group residual was not handled recursively, throwing/returning wrong rows.
+/// Both are fixed by routing entry-scan and direct-scan through one recursive core (ScanParamExtractor.
+/// ExtractFromPredicate, always analyzing via GetAnalyzedSlice). Results are checked against brute force and
+/// across engines (Lucene has no direct scan, so a match proves the rewrite is semantics-preserving).
+/// </summary>
+public class DirectScanResidualTests : RavenTestBase
+{
+    public DirectScanResidualTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public int Seq { get; set; }
+    }
+
+    private class Items_Index : AbstractIndexCreationTask<Item>
+    {
+        public Items_Index()
+        {
+            Map = items => from i in items
+                select new { i.Name, i.Category, i.Seq };
+        }
+    }
+
+    // Deterministic seed sized to make the direct-scan path cost-effective. DirectScan is a top-N
+    // streaming optimization, so it only wins with a small page AND a NON-selective residual (a high
+    // pass-rate keeps the scanned-entry estimate small). Name is heavily skewed to "Bob" (3 of 4) so a
+    // Name='BOB' residual is non-selective; Category cycles 3-way so an (red or blue) group residual is
+    // ~2/3 non-selective. Both keep the per-execution cost gate on the DirectScan side. Name is
+    // capitalised on purpose so the residual must lower-case it to match the stored term.
+    private static List<Item> BuildSeed(int count)
+    {
+        string[] names = { "Bob", "Bob", "Bob", "Alice" };
+        string[] cats = { "red", "green", "blue" };
+        var items = new List<Item>(count);
+        for (int i = 0; i < count; i++)
+        {
+            items.Add(new Item
+            {
+                Id = $"items/{i}",
+                Name = names[i % names.Length],
+                Category = cats[i % cats.Length],
+                Seq = i
+            });
+        }
+
+        return items;
+    }
+
+    private static async Task SeedAsync(IDocumentStore store, List<Item> items)
+    {
+        using var bulk = store.BulkInsert();
+        foreach (var it in items)
+            await bulk.StoreAsync(it, it.Id);
+    }
+
+    // Top-N expectation: the lowest-Seq matches, in Seq order, capped at limit (matches "order by Seq
+    // as long limit N"). The residual code path under test is only exercised when DirectScan is chosen,
+    // which requires the small page bound — so the correctness checks must use the same top-N shape.
+    private static List<string> ExpectedTopN(IEnumerable<Item> items, Func<Item, bool> predicate, int limit) =>
+        items.Where(predicate).OrderBy(i => i.Seq).Take(limit).Select(i => i.Id).ToList();
+
+    // Bug 1: a direct-scan residual string-equality with a mixed-case value. Stored term is lower-cased
+    // by the default analyzer ("Bob" -> "bob"); the residual must analyzer-encode 'BOB' the same way.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task DirectScanResidual_MixedCaseStringEquality_Matches(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and Name = 'BOB' order by Seq as long limit 25")
+            .ToListAsync();
+
+        var actual = results.Select(r => r.Id).ToList();
+        var expected = ExpectedTopN(items,
+            i => i.Seq >= 0 && i.Seq <= 3999 && string.Equals(i.Name, "BOB", StringComparison.OrdinalIgnoreCase), 25);
+
+        Assert.NotEmpty(expected);
+        Assert.Equal(expected, actual);
+    }
+
+    // Bug 2: a direct-scan plan with an (A or B) group residual must recurse into the group, returning
+    // correct rows without an IndexOutOfRangeException.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task DirectScanResidual_OrGroup_Matches(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and (Category = 'red' or Category = 'blue') order by Seq as long limit 25")
+            .ToListAsync();
+
+        var actual = results.Select(r => r.Id).ToList();
+        var expected = ExpectedTopN(items,
+            i => i.Seq >= 0 && i.Seq <= 3999 && (i.Category == "red" || i.Category == "blue"), 25);
+
+        Assert.NotEmpty(expected);
+        Assert.Equal(expected, actual);
+    }
+
+    // Proves the direct-scan path is actually exercised (not silently demoted to a bitmap sort) so the
+    // two correctness tests above are guarding the intended code. Corax-only: Lucene has no DirectScan.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task DirectScanResidual_PlanUsesDirectScan(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and Name = 'BOB' order by Seq as long limit 25 include timings()")
+            .Timings(out var timings)
+            .ToListAsync();
+
+        Assert.NotEmpty(results);
+        Assert.NotNull(timings);
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        var compiled = FindOperation(plan, "CompiledQuery");
+        Assert.True(compiled != null, "Expected a CompiledQuery node in the plan. Plan: " + Describe(plan));
+        Assert.True(compiled.Parameters.TryGetValue("OptimizationHint", out var hint) && hint == "FieldSortedScan",
+            "Expected the plan to use the FieldSortedScan strategy, but OptimizationHint was '" + (hint ?? "<missing>") + "'. Plan: " + Describe(plan));
+
+        // The executed scan match's own structure must be surfaced under the plan (the bitmap op template never
+        // ran for this query). The node carries the driving tree, residual predicates, and per-run scan counts,
+        // attached as a DIRECT child of CompiledQuery, keeping the match's own name "DirectScan" — distinct from
+        // the DecisionTrail's "FieldSortedScan" candidacy entry. Target the structural node by its child position.
+        var directScan = compiled.Children?.FirstOrDefault(c => c.Operation == "DirectScan");
+        Assert.True(directScan != null, "Expected a DirectScan node as a direct child of CompiledQuery. Plan: " + Describe(plan));
+        Assert.True(directScan.Parameters.ContainsKey("DrivingTree"),
+            "DirectScan params: " + string.Join(", ", directScan.Parameters.Select(kv => kv.Key + "=" + kv.Value)));
+        Assert.Equal("Seq", directScan.Parameters["DrivingTree"]);
+        Assert.True(directScan.Parameters.TryGetValue("ResidualPredicates", out var residuals) && residuals.Contains("Name"),
+            "Expected the surfaced DirectScan node to carry the 'Name' residual predicate. Plan: " + Describe(plan));
+        Assert.True(directScan.Parameters.ContainsKey("TreeEntriesScanned"));
+    }
+
+    // Cost-model regression (RavenDB-25281). A sorted residual scan only early-terminates at the page boundary
+    // when its take is page-bounded. Requesting statistics (or a count query, or a post-filter) forces the scan
+    // to TakeAll so it can report an exact TotalResults — it then reads every matching entry's stored fields.
+    // The DirectScan cost gate must therefore price the scan against the FULL matching set, not the limit-1 page.
+    // Before the fix the estimate always assumed the page bound, so a "ORDER BY non-selective-field DESC LIMIT 1
+    // + residual + statistics" query chose DirectScan and drained the whole driving tree (TreeExhausted, slow).
+    // This pins the contrast: the SAME query picks DirectScan without statistics (page-bounded, a few entries)
+    // and the bitmap pipeline with statistics (no stored-entry read per scanned entry), returning identical rows.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task DirectScanResidual_StatisticsRequested_RejectsFullTreeScan(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        string query = $"from index '{index.IndexName}' where Seq between 0 and 3999 and Name = 'BOB' " +
+                       "order by Seq as long desc limit 1 include timings()";
+
+        using var session = store.OpenAsyncSession();
+
+        // No statistics requested -> client sends SkipStatistics=true -> the sorted scan is page-bounded
+        // (take=1), so DirectScan wins the cost gate and the plan reports the FieldSortedScan strategy.
+        var noStatsResults = await session.Advanced
+            .AsyncRawQuery<Item>(query)
+            .Timings(out var noStatsTimings)
+            .ToListAsync();
+
+        var noStatsPlan = noStatsTimings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(noStatsPlan);
+        Assert.True(noStatsPlan.Parameters.TryGetValue("OptimizationHint", out var noStatsHint) && noStatsHint == "FieldSortedScan",
+            "Without statistics the page-bounded scan should pick FieldSortedScan, but OptimizationHint was '" +
+            (noStatsHint ?? "<missing>") + "'. Plan: " + Describe(noStatsPlan));
+
+        // Statistics requested -> SkipStatistics=false -> the read must drain the driving tree to count
+        // TotalResults, so DirectScan would do a stored-entry read per matching entry. The cost model now
+        // prices it against the full matching set and rejects it, falling back to the bitmap pipeline.
+        var statsResults = await session.Advanced
+            .AsyncRawQuery<Item>(query)
+            .Statistics(out var stats)
+            .Timings(out var statsTimings)
+            .ToListAsync();
+
+        var statsPlan = statsTimings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(statsPlan);
+        statsPlan.Parameters.TryGetValue("OptimizationHint", out var statsHint);
+        Assert.True(statsHint != "FieldSortedScan",
+            "With statistics the scan is TakeAll (full tree drain), so DirectScan must be rejected for the bitmap " +
+            "pipeline, but OptimizationHint was 'FieldSortedScan'. Plan: " + Describe(statsPlan));
+        var compiled = FindOperation(statsPlan, "CompiledQuery");
+        Assert.True(compiled?.Children?.FirstOrDefault(c => c.Operation == "DirectScan") == null,
+            "Expected NO DirectScan node when statistics are requested. Plan: " + Describe(statsPlan));
+
+        // Both shapes return the identical correct top-1 row, and statistics report the true total match count.
+        Assert.Equal(noStatsResults.Select(r => r.Id), statsResults.Select(r => r.Id));
+        long expectedTotal = items.Count(i => i.Seq >= 0 && i.Seq <= 3999 &&
+                                              string.Equals(i.Name, "BOB", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(expectedTotal, stats.TotalResults);
+    }
+
+    private static QueryInspectionNode FindOperation(QueryInspectionNode node, string operation)
+    {
+        if (node == null)
+            return null;
+        if (node.Operation == operation)
+            return node;
+        if (node.Children == null)
+            return null;
+        foreach (var child in node.Children)
+        {
+            var found = FindOperation(child, operation);
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+
+    private static string Describe(QueryInspectionNode node, int depth = 0)
+    {
+        if (node == null)
+            return "<null>";
+        var prefix = new string(' ', depth * 2);
+        var line = prefix + node.Operation;
+        if (node.Children == null || node.Children.Count == 0)
+            return line;
+        return line + Environment.NewLine + string.Join(Environment.NewLine, node.Children.Select(c => Describe(c, depth + 1)));
+    }
+}

--- a/test/FastTests/Corax/InEntryScanTests.cs
+++ b/test/FastTests/Corax/InEntryScanTests.cs
@@ -1,0 +1,367 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// Exercises the IN / ALL IN residual predicate on the entry-scan path. Each test shapes
+/// the data so the entry-scan heuristic fires: a highly selective seed clause (~10 docs)
+/// is AND'd with an IN clause whose value set has a large posting list (~3000 docs via
+/// filler), satisfying <c>seed.Count * 64 &lt; inMatch.Count</c>. The IN/AllIn clause then
+/// becomes a per-entry residual predicate rather than a bitmap posting-list union, which is
+/// the code path added for the entry-scan IN support.
+/// </summary>
+public class InEntryScanTests : RavenTestBase
+{
+    public InEntryScanTests(Xunit.ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private const int FillerCount = 3000;
+
+    private static async Task SeedAsync(Raven.Client.Documents.IDocumentStore store)
+    {
+        using var session = store.OpenAsyncSession();
+
+        // 10 selective "rare" seed docs with assorted attribute values.
+        for (int i = 0; i < 10; i++)
+        {
+            await session.StoreAsync(new Item
+            {
+                Seed = "rare",
+                Color = i % 2 == 0 ? null : (i % 3 == 0 ? "red" : ColorCycle(i)),
+                Code = i,
+                Score = i * 1.5,
+                Tags = i % 2 == 0 ? new[] { "x", "y", "z" } : new[] { "x", "z" }
+            });
+        }
+
+        // Filler docs that DO satisfy the IN value sets (Color=blue, Code=500, Score=999.5,
+        // Tags⊇{x,y}) so the IN/AllIn posting lists are large and entry scan wins the cost check —
+        // but they never satisfy Seed='rare', so they are excluded from results.
+        for (int i = 0; i < FillerCount; i++)
+        {
+            await session.StoreAsync(new Item
+            {
+                Seed = $"common-{i % 50}",
+                Color = "blue",
+                Code = 500,
+                Score = 999.5,
+                Tags = new[] { "x", "y", "common" }
+            });
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    // rare docs: i even -> null, i==3,9 -> "red", others -> green/blue cycle
+    private static string ColorCycle(int i) => (i % 3) switch { 1 => "green", _ => "blue" };
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task InString_MultiTerm_EntryScan_ReturnsCorrectResults()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // rare docs Colors: i0=null,i1=green,i2=null,i3=red,i4=null,i5=blue,i6=null,i7=green,i8=null,i9=red
+        // IN ('green','blue') over rare docs -> i1(green), i5(blue), i7(green) => 3
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and Color in ('green', 'blue')")
+            .ToListAsync();
+
+        Assert.Equal(3, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.True(r.Color is "green" or "blue");
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task InLong_EntryScan_ReturnsCorrectResults()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // rare docs Code = i (0..9). IN [2,5,7,500] -> rare matching 2,5,7 => 3 (no rare has 500).
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and Code in (2, 5, 7, 500)")
+            .ToListAsync();
+
+        Assert.Equal(3, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.Contains(r.Code, new long[] { 2, 5, 7 });
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task InDouble_EntryScan_ReturnsCorrectResults()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // rare docs Score = i*1.5. IN [3.0, 7.5, 12.0, 999.5] -> i2(3.0), i5(7.5), i8(12.0) => 3.
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and Score in (3.0, 7.5, 12.0, 999.5)")
+            .ToListAsync();
+
+        Assert.Equal(3, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.Contains(r.Score, new[] { 3.0, 7.5, 12.0 });
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task AllIn_MultiValue_EntryScan_ReturnsCorrectResults()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // rare docs: even i -> Tags=[x,y,z] (covers {x,y}); odd i -> Tags=[x,z] (missing y).
+        // ALL IN (x,y) over rare docs -> even i = 0,2,4,6,8 => 5.
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and Tags all in ('x', 'y')")
+            .ToListAsync();
+
+        Assert.Equal(5, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.Contains("x", r.Tags);
+            Assert.Contains("y", r.Tags);
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task InWithNull_EntryScan_MatchesNullField()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // 'blue' is included so the filler docs (all Color='blue') bloat the IN posting list and
+        // entry scan fires. rare docs: even i -> Color=null (5 docs); i5 -> Color=blue (1 doc).
+        // IN ('blue', null) over rare docs => 5 null + 1 blue = 6. The null match exercises the
+        // HasNull flag carried into the residual scan via ResidualInValues.HasNull.
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and Color in ('blue', null)")
+            .ToListAsync();
+
+        Assert.Equal(6, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.True(r.Color is null or "blue");
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task In_EntryScan_MatchesOrChain_Parity()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        // IN clause: entry-scan residual path (large filler posting list).
+        var inResults = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and Color in ('green', 'blue')")
+            .ToListAsync();
+
+        // Equivalent OR chain: bitmap pipeline. Result sets must be identical.
+        var orResults = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and (Color = 'green' or Color = 'blue')")
+            .ToListAsync();
+
+        var inIds = inResults.Select(r => r.Id).OrderBy(x => x).ToList();
+        var orIds = orResults.Select(r => r.Id).OrderBy(x => x).ToList();
+        Assert.Equal(orIds, inIds);
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task InString_MixedCase_EntryScan_AppliesAnalyzer()
+    {
+        // Regression guard: the residual IN value set must be analyzer-encoded with the FIELD's
+        // analyzer so it matches the entry's stored (analyzed) term. With mixed-case values the
+        // default analyzer lowercases both sides; if the IN value is built without the field
+        // analyzer it stays "Bravo" while the stored term is "bravo" and the match is lost.
+        // (Lowercase-only data masks this because lowercasing a lowercase value is a no-op.)
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // 1 selective seed doc; its Name matches only via the SECOND IN term.
+            await session.StoreAsync(new Item { Seed = "rare", Name = "Bravo" });
+
+            // Filler bloats the IN posting list (Name='Alpha') so entry scan wins the cost check.
+            for (int i = 0; i < FillerCount; i++)
+                await session.StoreAsync(new Item { Seed = $"common-{i % 50}", Name = "Alpha" });
+
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var read = store.OpenAsyncSession();
+        var results = await read.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and Name in ('Alpha', 'Bravo')")
+            .ToListAsync();
+
+        Assert.Equal(1, results.Count);
+        Assert.Equal("Bravo", results[0].Name);
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotInString_EntryScan_ReturnsComplementIncludingNull()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // rare docs Colors: i0=null,i1=green,i2=null,i3=red,i4=null,i5=blue,i6=null,i7=green,i8=null,i9=red
+        // NOT IN ('green','blue') over rare docs -> exclude i1,i7 (green) and i5 (blue) =>
+        // i0,i2,i4,i6,i8 (null) + i3,i9 (red) = 7. The null-field docs MUST appear (a doc lacking
+        // the value satisfies NOT IN, matching the bitmap AndNot complement).
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and not (Color in ('green', 'blue'))")
+            .ToListAsync();
+
+        Assert.Equal(7, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.True(r.Color is null or "red");
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotInLong_EntryScan_ReturnsComplement()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // rare docs Code = i (0..9). NOT IN [2,5,7,500] -> 0,1,3,4,6,8,9 => 7.
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and not (Code in (2, 5, 7, 500))")
+            .ToListAsync();
+
+        Assert.Equal(7, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.DoesNotContain(r.Code, new long[] { 2, 5, 7 });
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotInDouble_EntryScan_ReturnsComplement()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // rare docs Score = i*1.5. NOT IN [3.0,7.5,12.0,999.5] -> exclude i2(3.0),i5(7.5),i8(12.0) => 7.
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and not (Score in (3.0, 7.5, 12.0, 999.5))")
+            .ToListAsync();
+
+        Assert.Equal(7, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.DoesNotContain(r.Score, new[] { 3.0, 7.5, 12.0 });
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotAllIn_MultiValue_EntryScan_ReturnsComplement()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        // rare docs: even i -> Tags=[x,y,z] (contains {x,y} -> ALL IN true -> excluded);
+        // odd i -> Tags=[x,z] (missing y -> ALL IN false -> included). odd i = 1,3,5,7,9 => 5.
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and not (Tags all in ('x', 'y'))")
+            .ToListAsync();
+
+        Assert.Equal(5, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal("rare", r.Seed);
+            Assert.DoesNotContain("y", r.Tags);
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task NotIn_EntryScan_IsExactComplementOfIn_Parity()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        using var store = GetDocumentStore(options);
+        await SeedAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        var allRare = (await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare'").ToListAsync())
+            .Select(r => r.Id).OrderBy(x => x).ToList();
+
+        var inIds = (await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and Color in ('green', 'blue')").ToListAsync())
+            .Select(r => r.Id).ToHashSet();
+
+        var notInIds = (await session.Advanced.AsyncRawQuery<Item>(
+                "from Items where Seed = 'rare' and not (Color in ('green', 'blue'))").ToListAsync())
+            .Select(r => r.Id).OrderBy(x => x).ToList();
+
+        // Within the seed, NOT IN must be exactly the complement of IN: (all rare) \ (rare ∩ IN).
+        var expected = allRare.Where(id => inIds.Contains(id) == false).OrderBy(x => x).ToList();
+        Assert.Equal(expected, notInIds);
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+        public string Seed { get; set; }
+        public string Name { get; set; }
+        public string Color { get; set; }
+        public long Code { get; set; }
+        public double Score { get; set; }
+        public string[] Tags { get; set; }
+    }
+}

--- a/test/FastTests/Corax/LimitEarlyExitTests.cs
+++ b/test/FastTests/Corax/LimitEarlyExitTests.cs
@@ -1,0 +1,493 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+public class LimitEarlyExitTests(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void SingleClauseWithLimit(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenSession();
+        var results = session.Advanced.RawQuery<Doc>(
+                "from index 'DocIndex' where Tag = 'even' limit 10")
+            .ToList();
+
+        Assert.Equal(10, results.Count);
+        foreach (var r in results)
+            Assert.Equal("even", r.Tag);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task SingleClauseWithLimitReportsOutput(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .WhereEquals("Tag", "even")
+            .Take(10)
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(10, results.Count);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+        Assert.True(plan.Parameters.ContainsKey("Output"),
+            $"Output missing. Parameters: {string.Join(", ", plan.Parameters.Keys)}");
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void SingleClauseWithLimitAndOrderBy(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenSession();
+        var results = session.Advanced.RawQuery<Doc>(
+                "from index 'DocIndex' where Tag = 'even' order by Value limit 10")
+            .ToList();
+
+        Assert.Equal(10, results.Count);
+        for (int i = 1; i < results.Count; i++)
+            Assert.True(results[i].Value >= results[i - 1].Value);
+        foreach (var r in results)
+            Assert.Equal("even", r.Tag);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void OrChainWithLimit(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenSession();
+        var results = session.Advanced.RawQuery<Doc>(
+                "from index 'DocIndex' where Tag = 'even' or Tag = 'odd' limit 10")
+            .ToList();
+
+        Assert.Equal(10, results.Count);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task OrChainWithLimitDoesNotScanAll(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .WhereEquals("Tag", "even")
+            .OrElse()
+            .WhereEquals("Tag", "odd")
+            .Take(10)
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(10, results.Count);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+        var output = long.Parse(plan.Parameters["Output"]);
+        Assert.True(output < 500,
+            $"Expected early exit to produce fewer than 500 entries, but produced {output}");
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task OrChainWithLimitMarksEarlyExitInGraph(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500); // every doc is even or odd → the OR chain matches all 500, but the limit caps it
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .WhereEquals("Tag", "even")
+            .OrElse()
+            .WhereEquals("Tag", "odd")
+            .Take(10)
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(10, results.Count);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+
+        // The pushed-down page limit (10) capped the pipeline below the 500 actual matches, so the run
+        // early-exited. OverlayTimings records Limit + EarlyExit on the root, and the dataflow graph labels
+        // the slot-0 → result edge so a reader can see we did NOT scan the rest.
+        Assert.Equal("10", plan.Parameters["Limit"]);
+        Assert.Equal("true", plan.Parameters["EarlyExit"]);
+        Assert.Contains("limit=10 (early exit)", plan.Parameters["PlanGraphDot"]);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task NoLimitDoesNotMarkEarlyExit(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 100);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .WhereEquals("Tag", "even")
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(50, results.Count);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+
+        // No limit was pushed down, so nothing was skipped: neither the EarlyExit flag nor the edge label appears.
+        Assert.False(plan.Parameters.ContainsKey("EarlyExit"));
+        Assert.DoesNotContain("early exit", plan.Parameters["PlanGraphDot"]);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void AndChainWithLimit(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenSession();
+        var results = session.Advanced.RawQuery<Doc>(
+                "from index 'DocIndex' where Tag = 'even' and Value < 100 limit 10")
+            .ToList();
+
+        Assert.Equal(10, results.Count);
+        foreach (var r in results)
+        {
+            Assert.Equal("even", r.Tag);
+            Assert.True(r.Value < 100);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void LimitLargerThanResultSet(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 20);
+
+        using var session = store.OpenSession();
+        var results = session.Advanced.RawQuery<Doc>(
+                "from index 'DocIndex' where Tag = 'even' limit 100")
+            .ToList();
+
+        Assert.Equal(10, results.Count);
+        foreach (var r in results)
+            Assert.Equal("even", r.Tag);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void LimitOneReturnsExactlyOne(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenSession();
+        var results = session.Advanced.RawQuery<Doc>(
+                "from index 'DocIndex' where Tag = 'even' limit 1")
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("even", results[0].Tag);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void SkipAndTakeReturnsCorrectPage(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenSession();
+        // skip 5, take 10 → bitmap needs at least 15 entries
+        var results = session.Advanced.RawQuery<Doc>(
+                "from index 'DocIndex' where Tag = 'even' limit 5, 10")
+            .ToList();
+
+        Assert.Equal(10, results.Count);
+        foreach (var r in results)
+            Assert.Equal("even", r.Tag);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task SkipAndTakeReportsOutput(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .WhereEquals("Tag", "even")
+            .Skip(5)
+            .Take(10)
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(10, results.Count);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+        Assert.True(plan.Parameters.ContainsKey("Output"),
+            $"Output missing. Parameters: {string.Join(", ", plan.Parameters.Keys)}");
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void NoLimitReturnsAll(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 100);
+
+        using var session = store.OpenSession();
+        var results = session.Advanced.RawQuery<Doc>(
+                "from index 'DocIndex' where Tag = 'even'")
+            .ToList();
+
+        Assert.Equal(50, results.Count);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task NoLimitScansAll(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 100);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .WhereEquals("Tag", "even")
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(50, results.Count);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+        var output = long.Parse(plan.Parameters["Output"]);
+        Assert.Equal(50, output);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void NegatedEqualsReportsComplementTotal(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500); // Value 0..499 → exactly one doc has Value == 10
+
+        using var session = store.OpenSession();
+        // Explicit RQL: `not (Value = 10)` parses to ClauseType.Equals + IsNegated (a NegatedExpression
+        // wrapping an Equals), distinct from `Value != 10` (ClauseType.NotEquals) — only this shape stresses
+        // the IsNegated guard.
+        var results = session.Advanced
+            .RawQuery<Doc>("from index 'DocIndex' where true and not (Value = 10)")
+            .Statistics(out var stats)
+            .ToList();
+
+        // not (Value = 10) parses to ClauseType.Equals + IsNegated: the cardinality estimator keys on
+        // ClauseType and stores the term count (1), but the plan executes FillAllEntries AndNot and produces
+        // the complement (499). ComputeKnownExactTotal must reject this shape (the IsNegated guard on the
+        // Equals branch) and fall back to scanning, so the reported total is the true complement — not the
+        // term count. Drop that guard and TotalResults wrongly reports 1.
+        Assert.Equal(499, results.Count);
+        Assert.Equal(499, stats.TotalResults);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task WhenFalseGuardCollapsesToAllEntriesAndEarlyExits(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500); // when(false, ...) drops the predicate → the query matches every doc
+
+        using var session = store.OpenAsyncSession();
+        // when($flag = true, Tag = $t) with flag=false: the guard fails, so the Tag predicate is dropped and the
+        // top-level clause statically collapses to a lone MatchAll sentinel. That sentinel already carries its
+        // exact O(1) count (NumberOfEntries) in Cardinality, so ComputeKnownExactTotal must report it directly
+        // instead of draining the full index to count it. With the known total in hand the page limit (10) is
+        // pushed down → the pipeline early-exits and TotalResults is the exact whole-index count.
+        var results = await session.Advanced
+            .AsyncRawQuery<Doc>("from index 'DocIndex' where when($flag = true, Tag = $t) include timings() limit 10")
+            .AddParameter("flag", false)
+            .AddParameter("t", "even")
+            .Statistics(out var stats)
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(10, results.Count);
+        Assert.Equal(500, stats.TotalResults); // the lone sentinel's exact count, not a drained scan
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+        Assert.Equal("10", plan.Parameters["Limit"]);
+        Assert.Equal("true", plan.Parameters["EarlyExit"]);
+        Assert.Contains("limit=10 (early exit)", plan.Parameters["PlanGraphDot"]);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task FullScanOrderByReportsExactTotalFromPostingCount(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500); // Value 0..499, single-valued
+
+        using var session = store.OpenAsyncSession();
+        // No WHERE: the sorted scan drives off the full Value range (DirectScanSimpleMatch). For a single-valued
+        // field the exact TotalResults equals the driving provider's posting count (500), resolved up front from
+        // CountPostingsInRange instead of draining Fill to recount — see DirectScanMatchBase.KnownExactTotal.
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .OrderBy(x => x.Value)
+            .Take(10)
+            .Statistics(out var stats)
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(10, results.Count);
+        for (int i = 1; i < results.Count; i++)
+            Assert.True(results[i].Value >= results[i - 1].Value);
+        Assert.Equal(0, results[0].Value); // smallest Value first
+        Assert.Equal(500, stats.TotalResults);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.True(plan.Parameters.TryGetValue("PlanGraphDot", out var dot) && dot.Contains("data_knownexacttotal=\"500\""), dot);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task RangeDrivingOrderByReportsExactTotalFromPostingCount(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store, 500); // Value 0..499 → 399 docs have Value > 100
+
+        using var session = store.OpenAsyncSession();
+        // where Value > 100 order by Value: the range clause drives the sort with no residual (DirectScanSimpleMatch).
+        // Single-valued, so the exact TotalResults is the in-range posting count (399), read from the provider
+        // rather than draining Fill — the page (10) is returned without walking the remaining 389 matches to count.
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .WhereGreaterThan(x => x.Value, 100)
+            .OrderBy(x => x.Value)
+            .Take(10)
+            .Statistics(out var stats)
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(10, results.Count);
+        for (int i = 1; i < results.Count; i++)
+            Assert.True(results[i].Value >= results[i - 1].Value);
+        Assert.Equal(101, results[0].Value); // smallest Value strictly greater than 100
+        Assert.Equal(399, stats.TotalResults);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.True(plan.Parameters.TryGetValue("PlanGraphDot", out var dot) && dot.Contains("data_knownexacttotal=\"399\""), dot);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task FullScanOrderByStringWithNullsReportsExactTotalIncludingNulls(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        new DocIndex().Execute(store);
+
+        const int withTag = 300;
+        const int nullTag = 200;
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < withTag; i++)
+                bulk.Store(new Doc { Value = i, Tag = "t" + (i % 50) });
+            for (int i = 0; i < nullTag; i++)
+                bulk.Store(new Doc { Value = withTag + i, Tag = null });
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        // Full scan ORDER BY a string field drives off the exists provider, which is built skipNulls because
+        // SortedDrivingMatch emits the field's null (and non-existing) groups itself. The exact TotalResults must
+        // therefore include those null docs: it is the index entry count (500), NOT the exists provider's
+        // null-excluded posting sum (300). Asserting the known-total plan value pins the count to the
+        // page-bounded fast path rather than a Fill drain (which would also read 500 and hide a regression).
+        var results = await session.Advanced
+            .AsyncDocumentQuery<Doc, DocIndex>()
+            .OrderBy(x => x.Tag)
+            .Take(10)
+            .Statistics(out var stats)
+            .Timings(out QueryTimings timings)
+            .ToListAsync();
+
+        Assert.Equal(10, results.Count);
+        Assert.Equal(withTag + nullTag, stats.TotalResults);
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        Assert.True(plan.Parameters.TryGetValue("PlanGraphDot", out var dot) &&
+                    dot.Contains($"data_knownexacttotal=\"{withTag + nullTag}\""), dot);
+    }
+
+    private void InsertDocuments(IDocumentStore store, int count)
+    {
+        new DocIndex().Execute(store);
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < count; i++)
+                bulk.Store(new Doc { Value = i, Tag = i % 2 == 0 ? "even" : "odd" });
+        }
+
+        Indexes.WaitForIndexing(store);
+    }
+
+    private class DocIndex : AbstractIndexCreationTask<Doc>
+    {
+        public DocIndex()
+        {
+            Map = docs => from d in docs select new { d.Value, d.Tag };
+        }
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public int Value { get; set; }
+        public string Tag { get; set; }
+    }
+}

--- a/test/FastTests/Corax/PlanCacheCollapseTests.cs
+++ b/test/FastTests/Corax/PlanCacheCollapseTests.cs
@@ -1,0 +1,249 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
+using Tests.Infrastructure;
+using Xunit;
+using PlanCache = Corax.Querying.Planning.PlanCache;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// RavenDB-25281: the plan-cache structural key is a SHA over a canonical serialization of the query's
+/// WHERE + ORDER BY AST, with WHERE literal VALUES blanked (type kept) and parameter NAMES renumbered to
+/// first-occurrence ordinals. Two queries therefore share ONE bucket iff they are structurally identical up to
+/// literal values and parameter names. These tests pin that contract from the outside by counting the distinct
+/// buckets in the index's SharedPlanCache (Snapshot returns one PlanCacheEntry per structural key):
+///   - pure value variants and parameter-name variants collapse onto a single bucket;
+///   - a different literal TYPE, operator, field, or ORDER BY shape does NOT collapse (each gets its own bucket);
+/// and that the collapse is result-preserving — the one shared template resolves each query's own value through
+/// the per-query slot vector, so different bound values still return their own correct results.
+/// </summary>
+public class PlanCacheCollapseTests : RavenTestBase
+{
+    public PlanCacheCollapseTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public int Seq { get; set; }
+    }
+
+    private class Items_Index : AbstractIndexCreationTask<Item>
+    {
+        public Items_Index()
+        {
+            Map = items => from i in items
+                select new { i.Name, i.Category, i.Seq };
+        }
+    }
+
+    // Field names that are RQL reserved words, so referencing them must be quoted ('Order'). The parser then
+    // represents the quoted field as a string ValueExpression rather than a FieldExpression - the case the
+    // structural plan key has to keep distinct.
+    private class Reserved
+    {
+        public string Id { get; set; }
+        public string Order { get; set; }
+        public string Group { get; set; }
+    }
+
+    private class Reserved_Index : AbstractIndexCreationTask<Reserved>
+    {
+        public Reserved_Index()
+        {
+            Map = docs => from d in docs select new { d.Order, d.Group };
+            Index(x => x.Order, FieldIndexing.Search);
+            Index(x => x.Group, FieldIndexing.Search);
+        }
+    }
+
+    private static List<Item> BuildSeed(int count)
+    {
+        string[] names = { "Bob", "Alice" };
+        string[] cats = { "red", "green", "blue" };
+        var items = new List<Item>(count);
+        for (int i = 0; i < count; i++)
+            items.Add(new Item { Id = $"items/{i}", Name = names[i % names.Length], Category = cats[i % cats.Length], Seq = i });
+        return items;
+    }
+
+    private async Task<(IDocumentStore Store, string IndexName, List<Item> Items, PlanCache Cache)> SetupAsync(Options options)
+    {
+        var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(200);
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var it in items)
+                await bulk.StoreAsync(it, it.Id);
+        }
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        var serverIndex = database.IndexStore.GetIndex(index.IndexName);
+        var cache = ((CoraxIndexPersistence)serverIndex.IndexPersistence).SharedPlanCache;
+        return (store, index.IndexName, items, cache);
+    }
+
+    private static async Task RunAsync(IAsyncDocumentSession session, string rql, params (string Name, object Value)[] parameters)
+    {
+        var query = session.Advanced.AsyncRawQuery<Item>(rql);
+        foreach (var (name, value) in parameters)
+            query.AddParameter(name, value);
+        await query.ToListAsync();
+    }
+
+    // Bucket creation happens at query time (cache miss → ParseTemplate + GetOrAddBucket), so the distinct-bucket
+    // count after a batch of queries is the externally visible structural-key cardinality. We measure deltas
+    // around each batch so any one-off background query before the batch cannot perturb the assertion.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task ValueAndParameterNameVariantsShareBucket_TypeOperatorFieldAndOrderByDoNot(Options options)
+    {
+        var (store, idx, _, cache) = await SetupAsync(options);
+        using (store)
+        {
+            int Buckets() => cache.Snapshot().Count;
+            using var session = store.OpenAsyncSession();
+
+            // 1) Pure value variants: same shape, three distinct long literals → exactly ONE bucket.
+            int before = Buckets();
+            await RunAsync(session, $"from index '{idx}' where Seq > 5");
+            await RunAsync(session, $"from index '{idx}' where Seq > 10");
+            await RunAsync(session, $"from index '{idx}' where Seq > 150");
+            Assert.Equal(before + 1, Buckets());
+
+            // 2) Parameter-name variants: same shape, different parameter names → ONE more bucket. Distinct from
+            //    the literal bucket above because a parameter operand (P0) is not the same source as a literal (L).
+            before = Buckets();
+            await RunAsync(session, $"from index '{idx}' where Seq > $min", ("min", 5));
+            await RunAsync(session, $"from index '{idx}' where Seq > $threshold", ("threshold", 20));
+            Assert.Equal(before + 1, Buckets());
+
+            // 3) Literal TYPE variant: a double literal (5.5) is L{Double}, not L{Long}. The per-variant
+            //    CacheKeyHash does not see literals, so the structural key MUST keep the type → a new bucket.
+            before = Buckets();
+            await RunAsync(session, $"from index '{idx}' where Seq > 5.5");
+            Assert.Equal(before + 1, Buckets());
+
+            // 4) Operator variant: < vs > is a different template → a new bucket.
+            before = Buckets();
+            await RunAsync(session, $"from index '{idx}' where Seq < 5");
+            Assert.Equal(before + 1, Buckets());
+
+            // 5) Field variant: a different field (and value type) → a new bucket.
+            before = Buckets();
+            await RunAsync(session, $"from index '{idx}' where Category = 'red'");
+            Assert.Equal(before + 1, Buckets());
+
+            // 6) ORDER BY variant: the same WHERE shape as (1) but with an ORDER BY changes the template (sort
+            //    metadata + sort-driven optimizations), so it must NOT collapse onto the un-ordered bucket.
+            before = Buckets();
+            await RunAsync(session, $"from index '{idx}' where Seq > 7 order by Seq as long");
+            Assert.Equal(before + 1, Buckets());
+        }
+    }
+
+    // The collapse is only safe if the single shared template resolves each query's OWN value at instantiation
+    // (via the per-query slot vector), never a value baked from whichever variant compiled the plan first. This
+    // runs four literal value variants and four parameter value variants through one shared bucket each, and
+    // asserts every one returns its own brute-force-correct result.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task CollapsedBucketIsResultPreserving_PerQueryValuesResolveIndependently(Options options)
+    {
+        var (store, idx, items, cache) = await SetupAsync(options);
+        using (store)
+        {
+            int Buckets() => cache.Snapshot().Count;
+            using var session = store.OpenAsyncSession();
+
+            int[] thresholds = { 5, 50, 150, 199 };
+
+            List<string> Expected(int t) =>
+                items.Where(i => i.Seq > t).OrderBy(i => i.Seq).Select(i => i.Id).ToList();
+
+            // Literal value variants — all share one bucket, each must return its own correct top set.
+            int before = Buckets();
+            foreach (var t in thresholds)
+            {
+                var results = await session.Advanced
+                    .AsyncRawQuery<Item>($"from index '{idx}' where Seq > {t} order by Seq as long")
+                    .ToListAsync();
+                Assert.Equal(Expected(t), results.Select(r => r.Id).ToList());
+            }
+            Assert.Equal(before + 1, Buckets()); // four distinct literals, one shared template
+
+            // Parameter value variants — also one shared bucket (distinct from the literal one), each correct.
+            before = Buckets();
+            foreach (var t in thresholds)
+            {
+                var results = await session.Advanced
+                    .AsyncRawQuery<Item>($"from index '{idx}' where Seq > $t order by Seq as long")
+                    .AddParameter("t", t)
+                    .ToListAsync();
+                Assert.Equal(Expected(t), results.Select(r => r.Id).ToList());
+            }
+            Assert.Equal(before + 1, Buckets()); // four distinct parameter values, one shared template
+        }
+    }
+
+    // A quoted field name (e.g. 'Order' for a reserved word) is parsed as a string ValueExpression, not a
+    // FieldExpression. The structural key must still keep the field NAME: collapsing it like a value operand let
+    // search('Order',$t) and search('Group',$t) share one bucket+template, so the second resolved against the
+    // wrong field. This pins both halves: search-TERM variants on one quoted field still collapse (the term is a
+    // slot), but a DIFFERENT quoted field does not - and each query returns its own correct, field-specific result.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task QuotedFieldName_SearchSegregatesByFieldButCollapsesTermVariants(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Reserved_Index();
+        index.Execute(store);
+        using (var bulk = store.BulkInsert())
+        {
+            await bulk.StoreAsync(new Reserved { Id = "r/1", Order = "alpha", Group = "zeta" });
+            await bulk.StoreAsync(new Reserved { Id = "r/2", Order = "zeta", Group = "alpha" });
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        var serverIndex = database.IndexStore.GetIndex(index.IndexName);
+        var cache = ((CoraxIndexPersistence)serverIndex.IndexPersistence).SharedPlanCache;
+
+        int Buckets() => cache.Snapshot().Count;
+        using var session = store.OpenAsyncSession();
+
+        async Task<string[]> Search(string field, object term)
+        {
+            var results = await session.Advanced
+                .AsyncRawQuery<Reserved>($"from index '{index.IndexName}' where search('{field}', $term)")
+                .AddParameter("term", term)
+                .ToListAsync();
+            return results.Select(r => r.Id).OrderBy(id => id).ToArray();
+        }
+
+        // Two search-TERM variants on the SAME quoted field collapse to one bucket (the term is a slot binding),
+        // and each still returns its own correct result.
+        int before = Buckets();
+        Assert.Equal(new[] { "r/1" }, await Search("Order", "alpha"));
+        Assert.Equal(new[] { "r/2" }, await Search("Order", "zeta"));
+        Assert.Equal(before + 1, Buckets());
+
+        // A DIFFERENT quoted field with the identical shape must NOT collapse onto the 'Order' bucket. Before the
+        // fix the key dropped the quoted field, so this collided and returned r/1 (the Order match) instead of r/2.
+        before = Buckets();
+        Assert.Equal(new[] { "r/2" }, await Search("Group", "alpha"));
+        Assert.Equal(before + 1, Buckets());
+    }
+}

--- a/test/FastTests/Corax/PlanCacheSpatialVectorCollapseTests.cs
+++ b/test/FastTests/Corax/PlanCacheSpatialVectorCollapseTests.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
+using Tests.Infrastructure;
+using Xunit;
+using PlanCache = Corax.Querying.Planning.PlanCache;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// RavenDB-25281 collapse coverage for the post-filter clause families — spatial and vector — that
+/// resolve their operands through a dedicated binding array rather than the ordinary scalar term path. The
+/// structural key blanks WHERE literal VALUES (keeping type) and renumbers parameter NAMES, so a spatial
+/// <c>spatial.circle(R, lat, lon, 'miles')</c> with different numeric R/lat/lon, or a parameterized
+/// <c>vector.search(Embedding, $vec, $sim)</c> with different bound vectors/thresholds, must share ONE plan
+/// bucket. The collapse is only safe because every spatial/vector operand is read through the per-query slot
+/// vector at instantiation (ResolveSpatialFromBindings / ResolveVectorFromBindings → ResolveBindingScalar/Raw →
+/// SlotBindingFor), never baked into the shared template. These tests pin both halves: the bucket count
+/// collapses, and each collapsed query still returns its own geometry-/direction-correct result.
+/// </summary>
+public class PlanCacheSpatialVectorCollapseTests : RavenTestBase
+{
+    public PlanCacheSpatialVectorCollapseTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Geo
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public double Lat { get; set; }
+        public double Lon { get; set; }
+        public float[] Embedding { get; set; }
+    }
+
+    private class Geo_Index : AbstractIndexCreationTask<Geo>
+    {
+        public Geo_Index()
+        {
+            Map = docs => from d in docs
+                select new
+                {
+                    d.Name,
+                    Coordinates = CreateSpatialField(d.Lat, d.Lon),
+                    Embedding = CreateVector(d.Embedding),
+                };
+        }
+    }
+
+    // east / north / north-east unit vectors. Cosine similarity is 1.0 against a same-direction query and
+    // 0.0 (east vs north) or ~0.707 (east vs NE) otherwise, so a 0.9 threshold selects exactly the doc whose
+    // embedding points the same way as the query vector — independent of the cosine→[0,1] scaling.
+    private static readonly float[] East = [1f, 0f];
+    private static readonly float[] North = [0f, 1f];
+    private static readonly float[] NorthEast = [0.70710677f, 0.70710677f];
+
+    // Three docs strung out east along the equator from the origin. At the equator one degree of longitude is
+    // ~69 miles, so the longitudes below sit at ~0 / ~20.7 / ~62.2 miles from (0,0): a circle of 10 mi holds
+    // only "Origin", 40 mi adds "Near", 100 mi adds "Far". Each doc also carries a distinct embedding direction.
+    private static List<Geo> BuildSeed() =>
+    [
+        new Geo { Id = "geo/origin", Name = "Origin", Lat = 0, Lon = 0.0, Embedding = East },
+        new Geo { Id = "geo/near", Name = "Near", Lat = 0, Lon = 0.3, Embedding = North },
+        new Geo { Id = "geo/far", Name = "Far", Lat = 0, Lon = 0.9, Embedding = NorthEast },
+    ];
+
+    private async Task<(IDocumentStore Store, string IndexName, PlanCache Cache)> SetupAsync(Options options)
+    {
+        var store = GetDocumentStore(options);
+        var index = new Geo_Index();
+        index.Execute(store);
+        using (var session = store.OpenSession())
+        {
+            foreach (var d in BuildSeed())
+                session.Store(d, d.Id);
+            session.SaveChanges();
+        }
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        var serverIndex = database.IndexStore.GetIndex(index.IndexName);
+        var cache = ((CoraxIndexPersistence)serverIndex.IndexPersistence).SharedPlanCache;
+        return (store, index.IndexName, cache);
+    }
+
+    private static async Task<List<string>> NamesAsync(IAsyncDocumentSession session, string rql, params (string Name, object Value)[] parameters)
+    {
+        var query = session.Advanced.AsyncRawQuery<Geo>(rql);
+        foreach (var (name, value) in parameters)
+            query.AddParameter(name, value);
+        var results = await query.ToListAsync();
+        return results.Select(r => r.Name).OrderBy(n => n).ToList();
+    }
+
+    // spatial.circle(R, lat, lon, 'miles') variants differ only in numeric literal/parameter values, so all the
+    // literal variants collapse onto one bucket and all the parameter variants onto a second (distinct because a
+    // parameter operand is a different source than a literal). Each variant still resolves its own circle through
+    // the slot vector, so a wider radius selects strictly more docs.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Spatial)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task SpatialCircleValueAndParameterVariantsShareBucket_AndResolveOwnRadius(Options options)
+    {
+        var (store, idx, cache) = await SetupAsync(options);
+        using (store)
+        {
+            int Buckets() => cache.Snapshot().Count;
+            using var session = store.OpenAsyncSession();
+
+            string Spatial(string circle) => $"from index '{idx}' where spatial.within(Coordinates, {circle})";
+
+            // Literal radius variants — one shared bucket; each radius selects its own correct set.
+            int before = Buckets();
+            Assert.Equal(new[] { "Origin" },
+                await NamesAsync(session, Spatial("spatial.circle(10, 0, 0, 'miles')")));
+            Assert.Equal(new[] { "Near", "Origin" },
+                await NamesAsync(session, Spatial("spatial.circle(40, 0, 0, 'miles')")));
+            Assert.Equal(new[] { "Far", "Near", "Origin" },
+                await NamesAsync(session, Spatial("spatial.circle(100, 0, 0, 'miles')")));
+            Assert.Equal(before + 1, Buckets());
+
+            // Parameter radius variants — a second shared bucket (parameter source ≠ literal source).
+            before = Buckets();
+            string ParamCircle = "spatial.circle($r, $lat, $lon, 'miles')";
+            Assert.Equal(new[] { "Origin" },
+                await NamesAsync(session, Spatial(ParamCircle), ("r", 10.0), ("lat", 0.0), ("lon", 0.0)));
+            Assert.Equal(new[] { "Near", "Origin" },
+                await NamesAsync(session, Spatial(ParamCircle), ("r", 40.0), ("lat", 0.0), ("lon", 0.0)));
+            Assert.Equal(new[] { "Far", "Near", "Origin" },
+                await NamesAsync(session, Spatial(ParamCircle), ("r", 100.0), ("lat", 0.0), ("lon", 0.0)));
+            Assert.Equal(before + 1, Buckets());
+        }
+    }
+
+    // vector.search(Embedding, $vec, $sim) variants differ only in their bound query vector and threshold, so all
+    // three collapse onto one bucket. The query vector lives in the slot vector, so each variant matches the doc
+    // pointing in its own direction — proving the shared template never bakes the first query's vector.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Vector)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task VectorSearchParameterVariantsShareBucket_AndResolveOwnVector(Options options)
+    {
+        var (store, idx, cache) = await SetupAsync(options);
+        using (store)
+        {
+            int Buckets() => cache.Snapshot().Count;
+            using var session = store.OpenAsyncSession();
+
+            string Rql = $"from index '{idx}' where vector.search(Embedding, $vec, $sim)";
+
+            int before = Buckets();
+            Assert.Equal(new[] { "Origin" },
+                await NamesAsync(session, Rql, ("vec", East), ("sim", 0.9f)));
+            Assert.Equal(new[] { "Near" },
+                await NamesAsync(session, Rql, ("vec", North), ("sim", 0.9f)));
+            Assert.Equal(new[] { "Far" },
+                await NamesAsync(session, Rql, ("vec", NorthEast), ("sim", 0.9f)));
+            Assert.Equal(before + 1, Buckets());
+        }
+    }
+}

--- a/test/FastTests/Corax/PlanCacheStrategyTests.cs
+++ b/test/FastTests/Corax/PlanCacheStrategyTests.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// Guards the plan-cache cardinality hazard (RavenDB-25281). The bitmap-vs-direct-scan choice must NOT be
+/// frozen into the cached plan: <c>CompiledPlan.Strategy</c> records only the parameter-independent
+/// <em>structural</em> candidacy, while the actual strategy is re-decided on every execution by the cost gate
+/// (<c>DirectScanCostEffective</c> / <c>CompoundFieldCostEffective</c>) against the current parameters, falling
+/// back to the bitmap pipeline when a scan would not pay off. The instance-time choice is surfaced as
+/// <c>OptimizationHint</c> and the cached candidacy as <c>StrategyCandidate</c>, so a cost-gate flip is observable.
+/// Correctness is checked against brute force and across engines (Lucene never direct-scans).
+/// </summary>
+public class PlanCacheStrategyTests : RavenTestBase
+{
+    public PlanCacheStrategyTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public int Seq { get; set; }
+    }
+
+    private class Items_Index : AbstractIndexCreationTask<Item>
+    {
+        public Items_Index()
+        {
+            Map = items => from i in items
+                select new { i.Name, i.Category, i.Seq };
+        }
+    }
+
+    // Seq == index (so ORDER BY Seq == document order). Name is 1-in-10 Alice, rest Bob, so Name='Bob' is
+    // NON-selective (~90%, ~3600 of 4000 — direct-scan wins for top-N) while Name='Alice' is selective
+    // (~10%, ~400 — below the survivor-aware cost gate's ~565-survivor crossover for a 25-row page, so
+    // direct-scan over-scans the sorted stream and loses to a cheaper bitmap sort). Names are capitalised
+    // so a residual must analyzer-lowercase to match the stored term.
+    private static List<Item> BuildSeed(int count)
+    {
+        string[] cats = { "red", "green", "blue" };
+        var items = new List<Item>(count);
+        for (int i = 0; i < count; i++)
+            items.Add(new Item { Id = $"items/{i}", Name = (i % 10 == 0) ? "Alice" : "Bob", Category = cats[i % cats.Length], Seq = i });
+        return items;
+    }
+
+    private static async Task SeedAsync(IDocumentStore store, List<Item> items)
+    {
+        using var bulk = store.BulkInsert();
+        foreach (var it in items)
+            await bulk.StoreAsync(it, it.Id);
+    }
+
+    // Top-N expectation: the lowest-Seq matches, in Seq order, capped at limit.
+    private static List<string> ExpectedTopN(IEnumerable<Item> items, Func<Item, bool> predicate, int limit) =>
+        items.Where(predicate).OrderBy(i => i.Seq).Take(limit).Select(i => i.Id).ToList();
+
+    private static QueryInspectionNode Find(QueryInspectionNode node, string op)
+    {
+        if (node == null)
+            return null;
+        if (node.Operation == op)
+            return node;
+        if (node.Children == null)
+            return null;
+        foreach (var c in node.Children)
+        {
+            var f = Find(c, op);
+            if (f != null)
+                return f;
+        }
+
+        return null;
+    }
+
+    private static (string hint, string candidate) StrategyOf(QueryTimings timings)
+    {
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        var compiled = Find(plan, "CompiledQuery");
+        Assert.True(compiled != null, "Expected a CompiledQuery node. Plan: " + Describe(plan));
+        compiled.Parameters.TryGetValue("OptimizationHint", out var hint);
+        compiled.Parameters.TryGetValue("StrategyCandidate", out var candidate);
+        return (hint, candidate);
+    }
+
+    private static string Describe(QueryInspectionNode node, int depth = 0)
+    {
+        if (node == null)
+            return "<null>";
+        var prefix = new string(' ', depth * 2);
+        var line = prefix + node.Operation;
+        if (node.Children == null || node.Children.Count == 0)
+            return line;
+        return line + Environment.NewLine + string.Join(Environment.NewLine, node.Children.Select(c => Describe(c, depth + 1)));
+    }
+
+    // The cost gate must run PER EXECUTION: two queries with the identical direct-scan-candidate shape
+    // (range on the sort field + a residual + ORDER BY sort field + a small page) resolve to different
+    // ACTUAL strategies based purely on the residual's selectivity. The non-selective one streams via
+    // FieldSortedScan; the selective one is demoted to a (cheaper) bitmap sort. The demotion is observable:
+    // the cached structural candidacy (FieldSortedScan) is surfaced as StrategyCandidate while the executed
+    // strategy is BitmapPipeline. Corax-only: Lucene has no FieldSortedScan and never emits these hints.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task PerExecutionCostGate_FlipsStrategy_AndIsObservable(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        // Non-selective residual (Name='BOB' matches ~90%) over a wide range, top-25 -> FieldSortedScan wins.
+        await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and Name = 'BOB' order by Seq as long limit 25 include timings()")
+            .Timings(out var directScanTimings)
+            .ToListAsync();
+        var (directHint, directCandidate) = StrategyOf(directScanTimings);
+        Assert.Equal("FieldSortedScan", directHint);
+        Assert.Equal("FieldSortedScan", directCandidate); // both planned & actual strategies are always surfaced
+
+        // Selective residual (Name='Alice' matches ~25%, ~1000 of 4000 — below the ~1225 cost-gate
+        // boundary) over the same wide range and page: a bitmap is cheaper, so the per-execution gate
+        // demotes the FieldSortedScan candidate to BitmapPipeline.
+        await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and Name = 'Alice' order by Seq as long limit 25 include timings()")
+            .Timings(out var bitmapTimings)
+            .ToListAsync();
+        var (bitmapHint, bitmapCandidate) = StrategyOf(bitmapTimings);
+        Assert.Equal("BitmapPipeline", bitmapHint);
+        Assert.Equal("FieldSortedScan", bitmapCandidate); // candidacy preserved, but not chosen for these params
+    }
+
+    // The SAME query, run with no page bound (huge page) instead of a small limit, must also demote: a
+    // full materialization can't benefit from streaming top-N, so the gate falls back to bitmap. Proves
+    // the decision tracks the live page size / cardinality, not a frozen verdict from a prior execution.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task PageSizeDrivesStrategy_NotFrozen(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        const string body = "where Seq between 0 and 3999 and Name = 'BOB' order by Seq as long";
+
+        // Small page -> FieldSortedScan.
+        await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' {body} limit 25 include timings()")
+            .Timings(out var paged)
+            .ToListAsync();
+        Assert.Equal("FieldSortedScan", StrategyOf(paged).hint);
+
+        // No page bound -> demoted to BitmapPipeline, candidacy preserved.
+        await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' {body} include timings()")
+            .Timings(out var unpaged)
+            .ToListAsync();
+        var (hint, candidate) = StrategyOf(unpaged);
+        Assert.Equal("BitmapPipeline", hint);
+        Assert.Equal("FieldSortedScan", candidate);
+    }
+
+    // A bare sort with no WHERE clause is a full index scan, and that is the textbook direct-scan case:
+    // walk the sort field's term tree in order and stop at the page, instead of filling every entry into a
+    // bitmap and sorting it. A full scan has no residual that could be selective and no bitmap that could be
+    // cheaper, so the cost gate is unconditional — UNLIKE a residual scan, which demotes to bitmap when
+    // unpaged (see PageSizeDrivesStrategy_NotFrozen). Both the limited and the unlimited bare sort must
+    // therefore execute FieldSortedScan. Corax-only: Lucene has no FieldSortedScan.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task BareSort_NoWhere_DirectScans_PagedAndUnpaged(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        // Limited bare sort -> FieldSortedScan.
+        await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' order by Seq as long limit 25 include timings()")
+            .Timings(out var paged)
+            .ToListAsync();
+        var pagedStrategy = StrategyOf(paged);
+        Assert.Equal("FieldSortedScan", pagedStrategy.hint);
+        Assert.Equal("FieldSortedScan", pagedStrategy.candidate);
+
+        // Unlimited bare sort -> STILL FieldSortedScan. The full-scan cost gate is unconditional, so unlike a
+        // residual scan this does not demote when unpaged.
+        await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' order by Seq as long include timings()")
+            .Timings(out var unpaged)
+            .ToListAsync();
+        var unpagedStrategy = StrategyOf(unpaged);
+        Assert.Equal("FieldSortedScan", unpagedStrategy.hint);
+        Assert.Equal("FieldSortedScan", unpagedStrategy.candidate);
+    }
+
+    // Correctness for the bare-sort direct scan: the paged top-N and the full unpaged result must each be the
+    // complete set in sort order, matching brute force and Lucene.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task BareSort_NoWhere_IsResultPreserving(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        var paged = await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' order by Seq as long limit 25")
+            .ToListAsync();
+        Assert.Equal(
+            ExpectedTopN(items, _ => true, 25),
+            paged.Select(r => r.Id).ToList());
+
+        var full = await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' order by Seq as long")
+            .ToListAsync();
+        Assert.Equal(
+            ExpectedTopN(items, _ => true, int.MaxValue),
+            full.Select(r => r.Id).ToList());
+    }
+
+    // Correctness across both strategies and both engines. Whatever the per-execution gate picks, the
+    // top-N answer must equal the brute-force expectation, and Corax must match Lucene.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task StrategyChoiceIsResultPreserving(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Items_Index();
+        index.Execute(store);
+        var items = BuildSeed(4000);
+        await SeedAsync(store, items);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        // Direct-scan-favoured (non-selective residual + small page).
+        var directScanResults = await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and Name = 'BOB' order by Seq as long limit 25")
+            .ToListAsync();
+        Assert.Equal(
+            ExpectedTopN(items, i => i.Seq is >= 0 and <= 3999 && string.Equals(i.Name, "BOB", StringComparison.OrdinalIgnoreCase), 25),
+            directScanResults.Select(r => r.Id).ToList());
+
+        // Bitmap-favoured (selective residual + small page).
+        var bitmapResults = await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and Category = 'red' order by Seq as long limit 25")
+            .ToListAsync();
+        Assert.Equal(
+            ExpectedTopN(items, i => i.Seq is >= 0 and <= 3999 && i.Category == "red", 25),
+            bitmapResults.Select(r => r.Id).ToList());
+
+        // Unpaged full result of the direct-scan-candidate query (demotes to bitmap) — must be complete.
+        var fullResults = await session.Advanced
+            .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and Name = 'BOB' order by Seq as long")
+            .ToListAsync();
+        Assert.Equal(
+            ExpectedTopN(items, i => i.Seq is >= 0 and <= 3999 && string.Equals(i.Name, "BOB", StringComparison.OrdinalIgnoreCase), int.MaxValue),
+            fullResults.Select(r => r.Id).ToList());
+    }
+}

--- a/test/FastTests/Corax/PlanCacheStrategyTests.cs
+++ b/test/FastTests/Corax/PlanCacheStrategyTests.cs
@@ -135,9 +135,9 @@ public class PlanCacheStrategyTests : RavenTestBase
         Assert.Equal("FieldSortedScan", directHint);
         Assert.Equal("FieldSortedScan", directCandidate); // both planned & actual strategies are always surfaced
 
-        // Selective residual (Name='Alice' matches ~25%, ~1000 of 4000 — below the ~1225 cost-gate
-        // boundary) over the same wide range and page: a bitmap is cheaper, so the per-execution gate
-        // demotes the FieldSortedScan candidate to BitmapPipeline.
+        // Selective residual (Name='Alice' matches ~10%, ~400 of 4000 — below the survivor-aware cost gate's
+        // ~565-survivor crossover for a 25-row page) over the same wide range and page: a bitmap is cheaper, so
+        // the per-execution gate demotes the FieldSortedScan candidate to BitmapPipeline.
         await session.Advanced
             .AsyncRawQuery<Item>($"from index '{index.IndexName}' where Seq between 0 and 3999 and Name = 'Alice' order by Seq as long limit 25 include timings()")
             .Timings(out var bitmapTimings)

--- a/test/FastTests/Corax/QueryPlanGraphMatchCoverageTests.cs
+++ b/test/FastTests/Corax/QueryPlanGraphMatchCoverageTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Corax.Querying.Matches.Meta;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// Tripwire for the query-plan graph (<c>QueryPlanGraph</c>). The graph renders a compiled query as a
+/// dataflow diagram by switching on the <em>kind</em> of every <see cref="IQueryMatch"/> that can appear in a
+/// plan: bitmap-pipeline leaves, slot producers (direct/compound scans), result wrappers (sort/boost), and the
+/// per-entry POST-FILTERS (spatial / vector). The post-filter recognition in particular is string-based
+/// (<c>operation.Contains("Spatial") || operation.Contains("VectorSearch")</c>), so a newly-added match type
+/// that does not fit one of these buckets — or a new post-filter whose name does not contain those tokens —
+/// would be silently dropped from the graph with no compile-time signal.
+///
+/// This test reflects over every concrete <see cref="IQueryMatch"/> implementation in the Corax assembly and
+/// asserts each is accounted for in the maintained classification below. Adding a new match type breaks this
+/// test until the author classifies it here AND confirms <c>QueryPlanGraph</c> renders it (the failure message
+/// says exactly that). Post-filter matches additionally must satisfy the graph's Contains-based predicate, so a
+/// post-filter named without "Spatial"/"VectorSearch" is caught here rather than vanishing from the diagram.
+/// </summary>
+public class QueryPlanGraphMatchCoverageTests : RavenTestBase
+{
+    public QueryPlanGraphMatchCoverageTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // Per-entry post-filters: rendered as the green PostFilter chain that consumes the candidate bitmap.
+    // QueryPlanGraph.IsPostFilterOp matches these by name Contains("Spatial") || Contains("VectorSearch"),
+    // mirrored by PostFilterPredicate below — every name here MUST satisfy that predicate.
+    private static readonly HashSet<string> PostFilterMatches = new()
+    {
+        "SpatialMatch",
+        "VectorSearchMatch",
+        "MultiVectorSearchMatch",
+    };
+
+    // Result-shaping wrappers that sit above the bitmap pipeline (QueryPlanGraph.ResultWrapperOps): peeled off
+    // and rendered as the dataflow tail (sort strategy / boost factor → Result).
+    private static readonly HashSet<string> ResultWrapperMatches = new()
+    {
+        "SortingMatch",
+        "SortingMultiMatch",
+        "BoostingMatch",
+    };
+
+    // Slot producers / streaming-scan drivers: surfaced as the producer node feeding the pipeline.
+    private static readonly HashSet<string> ProducerMatches = new()
+    {
+        "DirectScanSimpleMatch",
+        "DirectScanFilteredMatch",
+        "SortedDrivingMatch",
+        "SortedDrivingWithTieBreakMatch",
+    };
+
+    // Bitmap-pipeline leaves / accumulators: rendered as op-template nodes writing their DestSlot.
+    private static readonly HashSet<string> PipelineMatches = new()
+    {
+        "TermMatch",
+        "TermsProviderMatch",
+        "BitmapMatch",
+        "LazyOrMatch",
+        "PhraseMatch",
+        "AllEntriesMatch",
+    };
+
+    // Plan roots: CompiledQueryMatch is the bitmap pipeline root; PostFilterMatch is the all-entries bypass root.
+    private static readonly HashSet<string> RootMatches = new()
+    {
+        "CompiledQueryMatch",
+        "PostFilterMatch",
+    };
+
+    private static bool PostFilterPredicate(string name)
+        => name.Contains("Spatial") || name.Contains("VectorSearch");
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void EveryQueryMatchTypeIsClassifiedForThePlanGraph()
+    {
+        HashSet<string> classified = new();
+        classified.UnionWith(PostFilterMatches);
+        classified.UnionWith(ResultWrapperMatches);
+        classified.UnionWith(ProducerMatches);
+        classified.UnionWith(PipelineMatches);
+        classified.UnionWith(RootMatches);
+
+        List<string> discovered = typeof(IQueryMatch).Assembly
+            .GetTypes()
+            .Where(t => t.IsAbstract == false
+                        && t.IsInterface == false
+                        && typeof(IQueryMatch).IsAssignableFrom(t))
+            .Select(SimpleName)
+            .Distinct()
+            .ToList();
+
+        List<string> unclassified = discovered.Where(name => classified.Contains(name) == false).OrderBy(n => n).ToList();
+        Assert.True(unclassified.Count == 0,
+            "New IQueryMatch type(s) not classified for QueryPlanGraph: " + string.Join(", ", unclassified) + ". " +
+            "Add each to the appropriate set in this test AND make sure QueryPlanGraph renders it " +
+            "(IsPostFilterOp for spatial/vector post-filters, ResultWrapperOps for sort/boost wrappers, " +
+            "a producer node for scans, or the op-template for pipeline leaves).");
+
+        // The classification must not rot: a removed/renamed match type leaves a stale entry here.
+        List<string> stale = classified.Where(name => discovered.Contains(name) == false).OrderBy(n => n).ToList();
+        Assert.True(stale.Count == 0,
+            "Classification lists a match type that no longer exists in Corax: " + string.Join(", ", stale) + ". Remove the stale entry.");
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void EveryPostFilterMatchIsRecognizedByTheGraphsNamePredicate()
+    {
+        // The graph recognises post-filters by name token, not type identity. Any match we declare a post-filter
+        // must satisfy that predicate, otherwise QueryPlanGraph would drop it from the post-filter chain.
+        List<string> notRecognized = PostFilterMatches.Where(name => PostFilterPredicate(name) == false).OrderBy(n => n).ToList();
+        Assert.True(notRecognized.Count == 0,
+            "Post-filter match type(s) whose name is not matched by QueryPlanGraph.IsPostFilterOp " +
+            "(Contains \"Spatial\"/\"VectorSearch\"): " + string.Join(", ", notRecognized) + ". " +
+            "Either rename to include the token or broaden IsPostFilterOp.");
+    }
+
+    private static string SimpleName(Type type)
+    {
+        string name = type.Name;
+        int tick = name.IndexOf('`');
+        return tick < 0 ? name : name.Substring(0, tick);
+    }
+}

--- a/test/FastTests/Corax/QueryPlanGraphMatchCoverageTests.cs
+++ b/test/FastTests/Corax/QueryPlanGraphMatchCoverageTests.cs
@@ -67,11 +67,15 @@ public class QueryPlanGraphMatchCoverageTests : RavenTestBase
         "AllEntriesMatch",
     };
 
-    // Plan roots: CompiledQueryMatch is the bitmap pipeline root; PostFilterMatch is the all-entries bypass root.
+    // Plan roots: CompiledQueryMatch is the bitmap pipeline root; PostFilterMatch is the all-entries bypass root;
+    // EmptyQueryMatch is the degenerate empty-result plan (missing field/term) returned directly to the caller.
+    // ToGraphviz receives it at the top level, finds no CompiledQuery/PostFilterMatch, and renders the valid
+    // "no compiled op stream" fallback — it carries no DestSlot ops, so there is nothing else to draw.
     private static readonly HashSet<string> RootMatches = new()
     {
         "CompiledQueryMatch",
         "PostFilterMatch",
+        "EmptyQueryMatch",
     };
 
     private static bool PostFilterPredicate(string name)

--- a/test/FastTests/Corax/QueryPlanGraphTooltipTests.cs
+++ b/test/FastTests/Corax/QueryPlanGraphTooltipTests.cs
@@ -36,6 +36,7 @@ public class QueryPlanGraphTooltipTests : RavenTestBase
             var rql = "from Items where Name = $n include timings()";
             await session.Advanced.AsyncRawQuery<Item>(rql)
                 .AddParameter("n", "even")
+                .WaitForNonStaleResults()
                 .Timings(out var timings)
                 .ToListAsync();
 

--- a/test/FastTests/Corax/QueryPlanGraphTooltipTests.cs
+++ b/test/FastTests/Corax/QueryPlanGraphTooltipTests.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Queries.Timings;
+using Tests.Infrastructure;
+using Xunit;
+using ITestOutputHelper = Xunit.ITestOutputHelper;
+
+namespace FastTests.Corax;
+
+public class QueryPlanGraphTooltipTests : RavenTestBase
+{
+    public QueryPlanGraphTooltipTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task PlanGraphDot_ExposesDataPropertiesAsTooltip(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 20; i++)
+                await session.StoreAsync(new Item { Name = i % 2 == 0 ? "even" : "odd", Value = i });
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var rql = "from Items where Name = $n include timings()";
+            await session.Advanced.AsyncRawQuery<Item>(rql)
+                .AddParameter("n", "even")
+                .Timings(out var timings)
+                .ToListAsync();
+
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            var dot = root.Parameters["PlanGraphDot"];
+
+            // Every node/edge that carries data_* facts must also expose them as a single-line tooltip.
+            Assert.Contains("tooltip=\"", dot);
+
+            // The tooltip uses the original (readable) key names and the " | " one-line separator, and a node
+            // with more than one fact joins them — confirm a representative fact and the join are present.
+            Assert.Contains("FieldName: Name", dot);
+            Assert.Contains("  |  ", dot);
+
+            // One line: a tooltip value must not contain a raw newline (EscapeAttr collapses them to spaces).
+            foreach (var line in dot.Split('\n'))
+            {
+                int idx = line.IndexOf("tooltip=\"", System.StringComparison.Ordinal);
+                if (idx < 0)
+                    continue;
+                int end = line.IndexOf('"', idx + "tooltip=\"".Length);
+                Assert.True(end > idx, "tooltip attribute should be closed on the same line");
+            }
+        }
+    }
+}

--- a/test/FastTests/Corax/QueryPlanGraphTooltipTests.cs
+++ b/test/FastTests/Corax/QueryPlanGraphTooltipTests.cs
@@ -46,10 +46,11 @@ public class QueryPlanGraphTooltipTests : RavenTestBase
             // Every node/edge that carries data_* facts must also expose them as a single-line tooltip.
             Assert.Contains("tooltip=\"", dot);
 
-            // The tooltip uses the original (readable) key names and the " | " one-line separator, and a node
-            // with more than one fact joins them — confirm a representative fact and the join are present.
+            // The tooltip uses the original (readable) key names; a node with more than one fact joins them
+            // with the Graphviz line-break separator (an escaped "\\" left after EscapeAttr collapses the
+            // newline to a space) — confirm a representative fact and the join are present.
             Assert.Contains("FieldName: Name", dot);
-            Assert.Contains("  |  ", dot);
+            Assert.Contains("\\\\ ", dot);
 
             // One line: a tooltip value must not contain a raw newline (EscapeAttr collapses them to spaces).
             foreach (var line in dot.Split('\n'))

--- a/test/FastTests/Corax/QueryPlanTests.cs
+++ b/test/FastTests/Corax/QueryPlanTests.cs
@@ -170,8 +170,9 @@ public class QueryPlanTests(ITestOutputHelper output) : RavenTestBase(output)
         // uniform op tree
         Assert.Contains(compiledRoot.Children, c => c.Operation == "FillFromMatch");
         Assert.Contains(compiledRoot.Children, c => c.Operation.Contains("Spatial"));
-        // no timing telemetry overlaid (no CompiledQueryMatch ran)
-        Assert.False(compiledRoot.Parameters.ContainsKey("Output"));
+        // The post-filter match surfaces its final survivor count as the Result output (1 stored doc),
+        // even though no CompiledQueryMatch ran. But per-op timing telemetry is still NOT overlaid:
+        Assert.Equal("1", compiledRoot.Parameters["Output"]);
         var fill = compiledRoot.Children.First(c => c.Operation == "FillFromMatch");
         Assert.False(fill.Parameters.ContainsKey("Ms"));
         Assert.False(fill.Parameters.ContainsKey("Output"));

--- a/test/FastTests/Corax/QueryPlanTests.cs
+++ b/test/FastTests/Corax/QueryPlanTests.cs
@@ -41,5 +41,207 @@ public class QueryPlanTests(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
+    
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void DecisionTrailSurfacedInTimings_NoOrderBy(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        new Index().Execute(store);
+        using var session = store.OpenSession();
+        session.Store(new Dto("maciej", new DateTime(2024, 8, 22)));
+        session.SaveChanges();
+        Indexes.WaitForIndexing(store);
+
+        var result = session.Advanced.DocumentQuery<Dto, Index>()
+            .WhereEquals(d => d.Name, "maciej")
+            .Timings(out var timings)
+            .ToList();
+
+        Assert.NotNull(result);
+        Assert.NotNull(timings);
+        var plan = timings.QueryPlan as Raven.Client.Documents.Queries.Timings.QueryInspectionNode;
+        Assert.NotNull(plan);
+        Assert.NotNull(plan.Parameters);
+        // A plain equals query with no ORDER BY makes no cost-gated strategy decision: the absence of
+        // ORDER BY is a precondition, not a decision, so the DecisionTrail records nothing and no
+        // DecisionTrail node is emitted. The chosen strategy is still surfaced via OptimizationHint.
+        Assert.True(plan.Parameters.ContainsKey("OptimizationHint"));
+        var trailNode = plan.Children?.FirstOrDefault(c => c.Operation == "DecisionTrail");
+        Assert.Null(trailNode);
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void DecisionTrailSurfacedInTimings_WithOrderBy(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        new Index().Execute(store);
+        using var session = store.OpenSession();
+        session.Store(new Dto("maciej", new DateTime(2024, 8, 22)));
+        session.SaveChanges();
+        Indexes.WaitForIndexing(store);
+
+        var result = session.Advanced.DocumentQuery<Dto, Index>()
+            .WhereEquals(d => d.Name, "maciej")
+            .AndAlso()
+            .WhereBetween(x => x.Date, new DateTime(2024, 8, 21), new DateTime(2024, 8, 23))
+            .OrderBy(x => x.Date)
+            .Timings(out var timings)
+            .ToList();
+
+        Assert.NotNull(result);
+        Assert.NotNull(timings);
+        var plan = timings.QueryPlan as Raven.Client.Documents.Queries.Timings.QueryInspectionNode;
+        Assert.NotNull(plan);
+        // With ORDER BY, the plan root is the SortingMatch wrapper, and the compiled-query
+        // inspection (which carries the DecisionTrail) is its single child.
+        var compiledRoot = plan.Operation == "CompiledQuery"
+            ? plan
+            : plan.Children?.FirstOrDefault(c => c.Operation == "CompiledQuery");
+        Assert.NotNull(compiledRoot);
+        var trailNode = compiledRoot.Children?.FirstOrDefault(c => c.Operation == "DecisionTrail");
+        Assert.NotNull(trailNode);
+        Assert.True(trailNode.Children.Count >= 2);
+        foreach (var child in trailNode.Children)
+        {
+            Assert.True(child.Parameters.ContainsKey("Accepted"));
+            Assert.True(child.Parameters.ContainsKey("Reason"));
+        }
+        var acceptedEntries = trailNode.Children.Where(c => c.Parameters["Accepted"] == "True").ToList();
+        Assert.True(acceptedEntries.Count >= 1);
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TimingIsOverlaidOnStructuralPlan_ForCompiledMatch(Options options)
+    {
+        // A term query runs through CompiledQueryMatch, so OverlayTimings annotates the structural plan
+        // with the run's telemetry: Output on the CompiledQuery node, and OutputWithDups/Ms on the executed op.
+        using var store = GetDocumentStore(options);
+        new Index().Execute(store);
+        using var session = store.OpenSession();
+        session.Store(new Dto("maciej", new DateTime(2024, 8, 22)));
+        session.SaveChanges();
+        Indexes.WaitForIndexing(store);
+
+        var result = session.Advanced.DocumentQuery<Dto, Index>()
+            .WhereEquals(d => d.Name, "maciej")
+            .Timings(out var timings)
+            .ToList();
+
+        Assert.Equal(1, result.Count);
+        var compiledRoot = CompiledRoot(timings);
+        Assert.NotNull(compiledRoot);
+        // timing overlay
+        Assert.True(compiledRoot.Parameters.ContainsKey("Output"));
+        var fill = compiledRoot.Children.First(c => c.Operation == "Fill");
+        Assert.True(fill.Parameters.ContainsKey("Ms"));
+        Assert.True(fill.Parameters.ContainsKey("OutputWithDups"));
+        // structural data sits alongside it
+        Assert.Equal("Name", fill.Parameters["FieldName"]);
+        Assert.Equal("maciej", fill.Parameters["Term"]);
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void SpatialOnlyPlan_IsStructural_WithNoTimingTelemetry(Options options)
+    {
+        // A spatial-only query takes the all-entries post-filter bypass: its executed match is a
+        // PostFilterMatch (not a CompiledQueryMatch), so there is NO timing telemetry to overlay.
+        // The structural plan must still be fully formed — a uniform op tree (Fill + SpatialMatch),
+        // NOT a raw match dump — proving the plan is built independently of timing data.
+        using var store = GetDocumentStore(options);
+        new SpatialIndex().Execute(store);
+        using var session = store.OpenSession();
+        session.Store(new SpatialDto { Name = "alpha", Lat = 0, Lng = 0 });
+        session.SaveChanges();
+        Indexes.WaitForIndexing(store);
+
+        var spatial = session.Advanced
+            .DocumentQuery<SpatialDto>("SpatialIndex")
+            .Spatial("Coordinates", factory => factory.WithinRadius(60, 0, 0, Raven.Client.Documents.Indexes.Spatial.SpatialUnits.Miles))
+            .Timings(out var timings)
+            .ToList();
+
+        Assert.Equal(1, spatial.Count);
+        var compiledRoot = CompiledRoot(timings);
+        Assert.NotNull(compiledRoot);
+        // uniform op tree
+        Assert.Contains(compiledRoot.Children, c => c.Operation == "Fill");
+        Assert.Contains(compiledRoot.Children, c => c.Operation.Contains("Spatial"));
+        // no timing telemetry overlaid (no CompiledQueryMatch ran)
+        Assert.False(compiledRoot.Parameters.ContainsKey("Output"));
+        var fill = compiledRoot.Children.First(c => c.Operation == "Fill");
+        Assert.False(fill.Parameters.ContainsKey("Ms"));
+        Assert.False(fill.Parameters.ContainsKey("Output"));
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void PlanBuildSpanSurfacedUnderCoraxScope(Options options)
+    {
+        // The plan-build / IL-compile work composes as an "Optimizer" span under the "Corax" timing scope.
+        using var store = GetDocumentStore(options);
+        new Index().Execute(store);
+        using var session = store.OpenSession();
+        session.Store(new Dto("maciej", new DateTime(2024, 8, 22)));
+        session.SaveChanges();
+        Indexes.WaitForIndexing(store);
+
+        session.Advanced.DocumentQuery<Dto, Index>()
+            .WhereEquals(d => d.Name, "maciej")
+            .Timings(out var timings)
+            .ToList();
+
+        Assert.NotNull(timings.Timings);
+        var corax = FindTiming(timings, "Corax");
+        Assert.NotNull(corax);
+        Assert.NotNull(corax.Timings);
+        Assert.True(corax.Timings.ContainsKey("Optimizer"));
+    }
+
+    private static Raven.Client.Documents.Queries.Timings.QueryInspectionNode CompiledRoot(Raven.Client.Documents.Queries.Timings.QueryTimings timings)
+    {
+        var plan = timings.QueryPlan as Raven.Client.Documents.Queries.Timings.QueryInspectionNode;
+        if (plan == null)
+            return null;
+        return plan.Operation == "CompiledQuery"
+            ? plan
+            : plan.Children?.FirstOrDefault(c => c.Operation == "CompiledQuery");
+    }
+
+    private static Raven.Client.Documents.Queries.Timings.QueryTimings FindTiming(Raven.Client.Documents.Queries.Timings.QueryTimings node, string key)
+    {
+        if (node.Timings == null)
+            return null;
+        if (node.Timings.TryGetValue(key, out var found))
+            return found;
+        foreach (var child in node.Timings.Values)
+        {
+            var hit = FindTiming(child, key);
+            if (hit != null)
+                return hit;
+        }
+        return null;
+    }
+
+    private class SpatialIndex : AbstractIndexCreationTask<SpatialDto>
+    {
+        public SpatialIndex()
+        {
+            Map = docs => from d in docs
+                select new { d.Name, Coordinates = CreateSpatialField(d.Lat, d.Lng) };
+        }
+    }
+
+    private class SpatialDto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public double Lat { get; set; }
+        public double Lng { get; set; }
+    }
+
     private record Dto(string Name, DateTime Date, string Id = null);
 }

--- a/test/FastTests/Corax/QueryPlanTests.cs
+++ b/test/FastTests/Corax/QueryPlanTests.cs
@@ -135,7 +135,7 @@ public class QueryPlanTests(ITestOutputHelper output) : RavenTestBase(output)
         Assert.NotNull(compiledRoot);
         // timing overlay
         Assert.True(compiledRoot.Parameters.ContainsKey("Output"));
-        var fill = compiledRoot.Children.First(c => c.Operation == "Fill");
+        var fill = compiledRoot.Children.First(c => c.Operation == "FillFromPostingSource");
         Assert.True(fill.Parameters.ContainsKey("Ms"));
         Assert.True(fill.Parameters.ContainsKey("OutputWithDups"));
         // structural data sits alongside it
@@ -168,11 +168,11 @@ public class QueryPlanTests(ITestOutputHelper output) : RavenTestBase(output)
         var compiledRoot = CompiledRoot(timings);
         Assert.NotNull(compiledRoot);
         // uniform op tree
-        Assert.Contains(compiledRoot.Children, c => c.Operation == "Fill");
+        Assert.Contains(compiledRoot.Children, c => c.Operation == "FillFromMatch");
         Assert.Contains(compiledRoot.Children, c => c.Operation.Contains("Spatial"));
         // no timing telemetry overlaid (no CompiledQueryMatch ran)
         Assert.False(compiledRoot.Parameters.ContainsKey("Output"));
-        var fill = compiledRoot.Children.First(c => c.Operation == "Fill");
+        var fill = compiledRoot.Children.First(c => c.Operation == "FillFromMatch");
         Assert.False(fill.Parameters.ContainsKey("Ms"));
         Assert.False(fill.Parameters.ContainsKey("Output"));
     }

--- a/test/FastTests/Corax/RavenDB_25281_KnownTotalAndMultiValuedSortTests.cs
+++ b/test/FastTests/Corax/RavenDB_25281_KnownTotalAndMultiValuedSortTests.cs
@@ -1,0 +1,854 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// RavenDB-25281 regression guards for two query-planner fixes:
+///   - exists() known-total: a single non-boosted exists() reports its exact TotalResults from O(1) metadata
+///     (entry count minus the field's non-existing posting list) instead of draining the posting set, so the
+///     read stays page-bounded (EarlyExit) even under statistics.
+///   - multi-valued sort guard: an equals/range clause on a MULTI-VALUED sort field must not drive a DirectScan.
+///     SortedDrivingMatch walks every posting of a multi-valued field, so docs matching the term under one value
+///     but a different value elsewhere leaked through unfiltered. The guard falls back to the bitmap pipeline +
+///     SortingMatch, which applies the clause as a real filter.
+/// </summary>
+public class RavenDB_25281_KnownTotalAndMultiValuedSortTests : RavenTestBase
+{
+    public RavenDB_25281_KnownTotalAndMultiValuedSortTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // Base doc has no Tagline property at all -> the index records it under the field's NON-EXISTING
+    // posting list, so exists(Tagline) must exclude it.
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class TaggedDoc : Doc
+    {
+        public string Tagline { get; set; }
+    }
+
+    private class Docs_ByTagline : AbstractIndexCreationTask<TaggedDoc>
+    {
+        public Docs_ByTagline()
+        {
+            // Map Name (present on every doc) AND Tagline: the base Doc entries are indexed via Name, but
+            // lack Tagline entirely -> they land in Tagline's NON-EXISTING posting list, so exists(Tagline)
+            // must exclude them. (Mapping Tagline alone would index the absent value as a null term = exists.)
+            Map = docs => from d in docs
+                select new { d.Name, d.Tagline };
+        }
+    }
+
+    // exists(Tagline) reports the exact total from metadata and early-exits at the page even under
+    // statistics (which would otherwise force a full count-draining scan).
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task Exists_KnownTotal_ReportsExactTotalAndEarlyExitsWithStatistics(Options options)
+    {
+        const int withTag = 800;
+        const int withoutTag = 400;
+
+        options.ModifyDocumentStore = s => s.Conventions = new DocumentConventions { FindCollectionName = _ => "Docs" };
+        using var store = GetDocumentStore(options);
+        var index = new Docs_ByTagline();
+        index.Execute(store);
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < withTag; i++)
+                await bulk.StoreAsync(new TaggedDoc { Name = $"name/{i}", Tagline = $"line {i}" }, $"docs/tag/{i}");
+            for (int i = 0; i < withoutTag; i++)
+                await bulk.StoreAsync(new Doc { Name = $"name/{i}" }, $"docs/plain/{i}");
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        // Ground truth: the actual matching rows come from the bitmap, independent of the known-total that
+        // only sources TotalResults. If the metadata count over/under-reports, it will diverge from this.
+        var allMatches = await session.Advanced
+            .AsyncRawQuery<TaggedDoc>($"from index '{index.IndexName}' where exists(Tagline)")
+            .ToListAsync();
+        int actualExists = allMatches.Count;
+        Assert.True(actualExists > 25, $"Test needs more than a page of matches, but only {actualExists} exist.");
+
+        var results = await session.Advanced
+            .AsyncRawQuery<TaggedDoc>($"from index '{index.IndexName}' where exists(Tagline) limit 25 include timings()")
+            .Statistics(out var stats)
+            .Timings(out var timings)
+            .ToListAsync();
+
+        Assert.Equal(25, results.Count);
+        // The metadata-resolved total must match the real matching-document count exactly.
+        Assert.Equal(actualExists, (int)stats.TotalResults);
+        // And the data setup must actually exercise the "minus non-existing" arithmetic (some docs lack Tagline).
+        Assert.Equal(withTag, actualExists);
+
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        var compiled = FindOperation(plan, "CompiledQuery");
+        Assert.True(compiled != null, "Expected a CompiledQuery node. Plan: " + Describe(plan));
+        // The read must NOT have drained the full posting set: the known total let the bitmap pipeline keep
+        // its page limit even under statistics, so it stopped at the page (EarlyExit).
+        Assert.True(compiled.Parameters.TryGetValue("EarlyExit", out var earlyExit) && earlyExit == "true",
+            "Expected EarlyExit=true (known total skips the count drain), but plan was: " + Describe(plan) +
+            " params: " + string.Join(", ", compiled.Parameters.Select(kv => kv.Key + "=" + kv.Value)));
+    }
+
+    private class Movie
+    {
+        public string Id { get; set; }
+        public string[] Genres { get; set; }
+        public int Seq { get; set; }
+    }
+
+    private class Movies_ByGenres : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_ByGenres()
+        {
+            Map = movies => from m in movies
+                select new { m.Genres, m.Seq };
+        }
+    }
+
+    // Deterministic seed: every movie has Drama plus one rotating extra genre, so Genres is multi-valued
+    // (some docs hold 2 terms) and "Drama" is non-selective. This is exactly the shape that historically
+    // drove an (incorrect) DirectScan on the multi-valued sort field.
+    private static List<Movie> BuildMovies(int count)
+    {
+        string[] extra = { "Action", "Comedy", "Horror", "SciFi" };
+        var movies = new List<Movie>(count);
+        for (int i = 0; i < count; i++)
+        {
+            // 1 in 4 movies is Drama-only; the rest are Drama + one extra (multi-valued).
+            var genres = i % 4 == 0
+                ? new[] { "Drama" }
+                : new[] { "Drama", extra[i % extra.Length] };
+            movies.Add(new Movie { Id = $"movies/{i}", Genres = genres, Seq = i });
+        }
+
+        return movies;
+    }
+
+    // A Genres='Drama' filter that also drives ORDER BY Genres must return ONLY docs containing "Drama".
+    // Cross-engine: Lucene has no DirectScan, so a match proves the Corax fallback is semantics-preserving
+    // (the bug leaked non-matching documents).
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task MultiValuedSortField_EqualsDriven_ReturnsOnlyMatchingDocs(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Movies_ByGenres();
+        index.Execute(store);
+        var movies = BuildMovies(800);
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var m in movies)
+                await bulk.StoreAsync(m, m.Id);
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<Movie>($"from index '{index.IndexName}' where Genres = 'Drama' order by Genres limit 25")
+            .ToListAsync();
+
+        Assert.Equal(25, results.Count);
+        foreach (var r in results)
+        {
+            Assert.True(r.Genres != null && r.Genres.Any(g => string.Equals(g, "Drama", StringComparison.OrdinalIgnoreCase)),
+                $"Document {r.Id} was returned but its Genres [{string.Join(", ", r.Genres ?? Array.Empty<string>())}] do not contain 'Drama'.");
+        }
+    }
+
+    // Plan guard: the same query must NOT pick FieldSortedScan (DirectScan) on Corax — the multi-valued
+    // sort field forces the bitmap pipeline + SortingMatch fallback.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task MultiValuedSortField_EqualsDriven_DoesNotUseDirectScan(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Movies_ByGenres();
+        index.Execute(store);
+        var movies = BuildMovies(800);
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var m in movies)
+                await bulk.StoreAsync(m, m.Id);
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<Movie>($"from index '{index.IndexName}' where Genres = 'Drama' order by Genres limit 25 include timings()")
+            .Timings(out var timings)
+            .ToListAsync();
+
+        Assert.NotEmpty(results);
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        plan.Parameters.TryGetValue("OptimizationHint", out var hint);
+        Assert.True(hint != "FieldSortedScan",
+            "A multi-valued sort field must not drive a DirectScan, but OptimizationHint was 'FieldSortedScan'. Plan: " + Describe(plan));
+        var compiled = FindOperation(plan, "CompiledQuery");
+        Assert.True(compiled?.Children?.FirstOrDefault(c => c.Operation == "DirectScan") == null,
+            "Expected NO DirectScan node for a multi-valued sort field. Plan: " + Describe(plan));
+    }
+
+    // A query shaped `where f1 = $x order by f2` over a compound(f1, f2) field has no WHERE clause on the sort
+    // field f2, yet the compound tree already stores f1's entries in f2 order. DirectScanCandidate is set for
+    // this shape so the planner walks the compound subtree in f2 order and skips the SortingMatch heap.
+    private class Film
+    {
+        public string Id { get; set; }
+        public string Category { get; set; }
+        public int Year { get; set; }
+    }
+
+    private class Films_ByCategoryAndYear : AbstractIndexCreationTask<Film>
+    {
+        public Films_ByCategoryAndYear()
+        {
+            Map = films => from f in films
+                select new { f.Category, f.Year };
+            CompoundField("Category", "Year");
+        }
+    }
+
+    // Single-valued Category (equality driver) and Year (sort key), cycled so neither is pre-sorted by
+    // insertion order. 1 in 3 films is "Action" -> well above a 25-row page and below the scan cost cap.
+    private static List<Film> BuildFilms(int count)
+    {
+        string[] categories = { "Action", "Comedy", "Drama" };
+        var films = new List<Film>(count);
+        for (int i = 0; i < count; i++)
+            films.Add(new Film { Id = $"films/{i}", Category = categories[i % categories.Length], Year = 1980 + (i * 7) % 45 });
+
+        return films;
+    }
+
+    // Plan guard: equality on the compound leading key + ORDER BY the second key (no filter on the sort field)
+    // must drive the compound tree walk (CompoundSortedScan / DirectScan), NOT bitmap pipeline + SortingMatch.
+    // Also checks the rows are correct, in ascending sort order.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task EqualityDrivenCompoundSort_UsesCompoundSortedScan(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Films_ByCategoryAndYear();
+        index.Execute(store);
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var f in BuildFilms(300))
+                await bulk.StoreAsync(f, f.Id);
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        // No filter on the sort field: equality on the compound leading key + ORDER BY the compound second key.
+        // Engages DirectScanCandidate (the no-filter optimization) and must walk the compound tree in Year order.
+        await AssertCompoundSortedScanInOrder(session, index.IndexName,
+            $"from index '{index.IndexName}' where Category = 'Action' order by Year as long limit 25 include timings()");
+
+        // Range on the sort field (the existing composite-range path): must ALSO come back in Year order, not
+        // entry-id order. This is the shape that exposed the missing SortedDrivingMatch wrapper.
+        await AssertCompoundSortedScanInOrder(session, index.IndexName,
+            $"from index '{index.IndexName}' where Category = 'Action' and Year > 1990 order by Year as long limit 25 include timings()");
+    }
+
+    private async Task AssertCompoundSortedScanInOrder(IAsyncDocumentSession session, string indexName, string rql)
+    {
+        var results = await session.Advanced
+            .AsyncRawQuery<Film>(rql)
+            .Timings(out var timings)
+            .ToListAsync();
+
+        Assert.Equal(25, results.Count);
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        var compiled = FindOperation(plan, "CompiledQuery");
+        Assert.True(compiled != null, "Expected a CompiledQuery node. Plan: " + Describe(plan));
+        compiled.Parameters.TryGetValue("OptimizationHint", out var hint);
+        Assert.True(hint == "CompoundSortedScan",
+            "Expected the compound tree walk to drive equality+ORDER BY on compound(Category, Year), but " +
+            "OptimizationHint was '" + hint + "' for [" + rql + "]. Plan: " + Describe(plan) + " params: " +
+            string.Join(", ", compiled.Parameters.Select(kv => kv.Key + "=" + kv.Value)));
+        Assert.True(compiled.Children?.FirstOrDefault(c => c.Operation == "DirectScan") != null,
+            "Expected a DirectScan node (compound sorted walk) for [" + rql + "]. Plan: " + Describe(plan));
+
+        int prev = int.MinValue;
+        foreach (var r in results)
+        {
+            Assert.Equal("Action", r.Category);
+            Assert.True(r.Year >= prev, $"Results are not ascending by Year for [{rql}]: saw {prev} then {r.Year}.");
+            prev = r.Year;
+        }
+    }
+
+    // Descending plan guard: equality on the compound leading key + ORDER BY the second key DESC with no filter
+    // on the sort field must stream via the compound tree walk DESCENDING (CompoundSortedScan, TreeDirection=
+    // Backward), not the bitmap pipeline. The backward StartsWith provider seeks to successor(prefix) (end of the
+    // field1 block) and walks down. Verifies plan, descending order, and paging.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task DescendingEqualityDrivenCompoundSort_UsesBackwardCompoundSortedScan(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Films_ByCategoryAndYear();
+        index.Execute(store);
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var f in BuildFilms(300))
+                await bulk.StoreAsync(f, f.Id);
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        var page1 = await session.Advanced
+            .AsyncRawQuery<Film>($"from index '{index.IndexName}' where Category = 'Action' order by Year as long desc limit 25 include timings()")
+            .Timings(out var timings)
+            .ToListAsync();
+
+        Assert.Equal(25, page1.Count);
+
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        var compiled = FindOperation(plan, "CompiledQuery");
+        Assert.True(compiled != null, "Expected a CompiledQuery node. Plan: " + Describe(plan));
+        compiled.Parameters.TryGetValue("OptimizationHint", out var hint);
+        Assert.True(hint == "CompoundSortedScan",
+            "Descending equality+ORDER BY on compound(Category, Year) must stream via the compound tree walk, but " +
+            "OptimizationHint was '" + hint + "'. Plan: " + Describe(plan));
+        var directScan = FindOperation(plan, "DirectScan");
+        Assert.True(directScan != null, "Expected a DirectScan node (compound sorted walk). Plan: " + Describe(plan));
+        directScan.Parameters.TryGetValue("TreeDirection", out var direction);
+        Assert.True(direction == "Backward",
+            "Expected the compound scan to walk Backward for a descending ORDER BY, but TreeDirection was '" + direction +
+            "'. Params: " + string.Join(", ", directScan.Parameters.Select(kv => kv.Key + "=" + kv.Value)));
+
+        // Page 1 is descending by Year and all rows are the driving 'Action' value.
+        int prev = int.MaxValue;
+        foreach (var r in page1)
+        {
+            Assert.Equal("Action", r.Category);
+            Assert.True(r.Year <= prev, $"Results are not descending by Year: saw {prev} then {r.Year}.");
+            prev = r.Year;
+        }
+
+        // Paging: the second page continues the same descending stream (no overlap/gap at the boundary).
+        var page2 = await session.Advanced
+            .AsyncRawQuery<Film>($"from index '{index.IndexName}' where Category = 'Action' order by Year as long desc limit 25, 25")
+            .ToListAsync();
+
+        Assert.Equal(25, page2.Count);
+        Assert.True(page2[0].Year <= page1[^1].Year,
+            $"Page 2 must continue the descending order: page1 ended at {page1[^1].Year}, page2 started at {page2[0].Year}.");
+        foreach (var r in page2)
+        {
+            Assert.Equal("Action", r.Category);
+            Assert.True(r.Year <= prev, $"Results are not descending across pages by Year: saw {prev} then {r.Year}.");
+            prev = r.Year;
+        }
+
+        // The descending stream must start at the largest Year among the 'Action' films.
+        var maxActionYear = BuildFilms(300).Where(f => f.Category == "Action").Max(f => f.Year);
+        Assert.Equal(maxActionYear, page1[0].Year);
+    }
+
+    // Known-total / early-exit: the bare compound shape (equality on field1, ORDER BY field2, no field2 filter)
+    // must resolve TotalResults from the driving term's cardinality and stop at the page, not drain the whole
+    // driving set to count it, even under statistics.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task EqualityDrivenCompoundSort_ResolvesKnownTotalAndEarlyExitsUnderStatistics(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Films_ByCategoryAndYear();
+        index.Execute(store);
+        var films = BuildFilms(300);
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var f in films)
+                await bulk.StoreAsync(f, f.Id);
+        }
+
+        Indexes.WaitForIndexing(store);
+        int actionCount = films.Count(f => f.Category == "Action");
+        Assert.True(actionCount > 25, "Test needs more than a page of Action films.");
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<Film>($"from index '{index.IndexName}' where Category = 'Action' order by Year as long limit 25 include timings()")
+            .Statistics(out var stats)
+            .Timings(out var timings)
+            .ToListAsync();
+
+        Assert.Equal(25, results.Count);
+        // The exact total is reported from the term cardinality, not from draining the scan.
+        Assert.Equal(actionCount, (int)stats.TotalResults);
+
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        var directScan = FindOperation(plan, "DirectScan");
+        Assert.True(directScan != null, "Expected a DirectScan node. Plan: " + Describe(plan));
+
+        // Known total resolved up front (equals the driving 'Action' cardinality).
+        Assert.True(directScan.Parameters.TryGetValue("KnownExactTotal", out var knownTotal),
+            "Expected KnownExactTotal on the DirectScan. Params: " + string.Join(", ", directScan.Parameters.Select(kv => kv.Key + "=" + kv.Value)));
+        Assert.Equal(actionCount, ParseCount(knownTotal));
+
+        // The scan stopped at the page instead of draining the whole 'Action' set.
+        directScan.Parameters.TryGetValue("StoppedAt", out var stoppedAt);
+        Assert.True(stoppedAt != null && stoppedAt != "TreeExhausted",
+            "Expected the scan to stop at the page (not TreeExhausted), but StoppedAt=" + (stoppedAt ?? "<null>"));
+        Assert.True(directScan.Parameters.TryGetValue("TreeEntriesScanned", out var scanned) && ParseCount(scanned) < actionCount,
+            "Expected fewer than the whole 'Action' set to be scanned, but TreeEntriesScanned=" + (scanned ?? "<null>") + " of " + actionCount);
+    }
+
+    private static int ParseCount(string n) => int.Parse(n, System.Globalization.NumberStyles.AllowThousands, System.Globalization.CultureInfo.InvariantCulture);
+
+    // A single-field ORDER BY served by a CompoundSortedScan already emits in order, so the sort is elided into
+    // the scan regardless of an $rvn_corax_sort hint. Pinning IndexOrderStreaming must not de-elide it (which
+    // would wrap the scan in a SortingMatch that drains and re-sorts already-ordered output). On a sorted scan
+    // the hint is a no-op; it only matters where a real SortingMatch exists (bitmap pipeline).
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task EqualityDrivenCompoundSort_WithIndexOrderStreamingHint_StillElidesAndEarlyExits(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Films_ByCategoryAndYear();
+        index.Execute(store);
+        var films = BuildFilms(300);
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var f in films)
+                await bulk.StoreAsync(f, f.Id);
+        }
+
+        Indexes.WaitForIndexing(store);
+        int actionCount = films.Count(f => f.Category == "Action");
+        Assert.True(actionCount > 25, "Test needs more than a page of Action films.");
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<Film>($"from index '{index.IndexName}' where Category = 'Action' order by Year as long limit 25 include timings()")
+            .AddParameter("rvn_corax_sort", "IndexOrderStreaming")
+            .Timings(out var timings)
+            .ToListAsync();
+
+        Assert.Equal(25, results.Count);
+        int prev = int.MinValue;
+        foreach (var r in results)
+        {
+            Assert.Equal("Action", r.Category);
+            Assert.True(r.Year >= prev, $"Results are not ascending by Year: saw {prev} then {r.Year}.");
+            prev = r.Year;
+        }
+
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+
+        var compiled = FindOperation(plan, "CompiledQuery");
+        compiled.Parameters.TryGetValue("OptimizationHint", out var hint);
+        Assert.True(hint == "CompoundSortedScan",
+            "Expected CompoundSortedScan even with the IndexOrderStreaming hint, but OptimizationHint was '" + hint + "'. Plan: " + Describe(plan));
+
+        // The sort must be elided into the scan: no SortingMatch wrapper re-sorting the already-ordered output.
+        Assert.True(FindOperation(plan, "SortingMatch") == null,
+            "The IndexOrderStreaming hint de-elided the sort: a SortingMatch is wrapping the compound sorted scan. Plan: " + Describe(plan));
+
+        // And the scan must stop at the page, not drain the whole 'Action' set.
+        var directScan = FindOperation(plan, "DirectScan");
+        Assert.True(directScan != null, "Expected a DirectScan node. Plan: " + Describe(plan));
+        directScan.Parameters.TryGetValue("StoppedAt", out var stoppedAt);
+        Assert.True(stoppedAt != null && stoppedAt != "TreeExhausted",
+            "Expected the scan to stop at the page (not TreeExhausted), but StoppedAt=" + (stoppedAt ?? "<null>") + ". Plan: " + Describe(plan));
+        Assert.True(directScan.Parameters.TryGetValue("TreeEntriesScanned", out var scanned) && ParseCount(scanned) < actionCount,
+            "Expected fewer than the whole 'Action' set to be scanned, but TreeEntriesScanned=" + (scanned ?? "<null>") + " of " + actionCount);
+    }
+
+    // Cross-engine: the same shape must return exactly the matching rows in sort order on both engines.
+    // Lucene has no compound/DirectScan, so a match proves the Corax compound-scan path is semantics-preserving.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task EqualityDrivenCompoundSort_ReturnsCorrectlyOrderedMatches(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Films_ByCategoryAndYear();
+        index.Execute(store);
+        var films = BuildFilms(300);
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var f in films)
+                await bulk.StoreAsync(f, f.Id);
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        int expectedActionCount = films.Count(f => f.Category == "Action");
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<Film>($"from index '{index.IndexName}' where Category = 'Action' order by Year as long")
+            .ToListAsync();
+
+        Assert.Equal(expectedActionCount, results.Count);
+        int prev = int.MinValue;
+        foreach (var r in results)
+        {
+            Assert.Equal("Action", r.Category);
+            Assert.True(r.Year >= prev, $"Results are not ascending by Year: saw {prev} then {r.Year}.");
+            prev = r.Year;
+        }
+    }
+
+    private class FilmNullable
+    {
+        public string Id { get; set; }
+        public string Category { get; set; }
+        public int? Year { get; set; }
+    }
+
+    private class FilmsNullable_ByCategoryAndYear : AbstractIndexCreationTask<FilmNullable>
+    {
+        public FilmsNullable_ByCategoryAndYear()
+        {
+            Map = films => from f in films
+                select new { f.Category, f.Year };
+            CompoundField("Category", "Year");
+        }
+    }
+
+    // Every null-Year film is an "Action" film (i % 9 == 0 is a subset of i % 3 == 0), so the "Action"
+    // result set mixes ~1/3 null years with real years — exactly the case where the compound scan's
+    // null handling matters.
+    private static List<FilmNullable> BuildFilmsWithNulls(int count)
+    {
+        string[] categories = { "Action", "Comedy", "Drama" };
+        var films = new List<FilmNullable>(count);
+        for (int i = 0; i < count; i++)
+        {
+            int? year = i % 9 == 0 ? null : 1980 + (i * 7) % 45;
+            films.Add(new FilmNullable { Id = $"films/{i}", Category = categories[i % categories.Length], Year = year });
+        }
+
+        return films;
+    }
+
+    // Null behavior: `where Category = 'Action' order by Year` with some Action docs having a NULL sort value.
+    // The compound walk would emit nulls at the wrong end (its null marker sorts after the real values),
+    // contradicting NullsSortMode, so the bare shape with null sort values must fall back to the bitmap pipeline.
+    // Pins (a) Corax matches Lucene's ordered sequence exactly, and (b) the plan fell back (OptimizationHint=BitmapPipeline).
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public async Task EqualityDrivenCompoundSort_WithNullSortValues_FallsBackAndMatchesLucene()
+    {
+        var films = BuildFilmsWithNulls(300);
+
+        var (luceneOrder, _) = await RunOrdered(RavenSearchEngineMode.Lucene);
+        var (coraxOrder, coraxHint) = await RunOrdered(RavenSearchEngineMode.Corax);
+
+        Assert.NotEmpty(coraxOrder);
+        Assert.Contains((int?)null, coraxOrder); // the data must actually exercise null sort values
+
+        string Shape(List<int?> o) =>
+            $"count={o.Count}, nulls={o.Count(x => x == null)}, " +
+            $"firstNullAt={o.FindIndex(x => x == null)}, lastNullAt={o.FindLastIndex(x => x == null)}, " +
+            $"nonNullAscending={IsAscending(o.Where(x => x != null).Select(x => x.Value))}";
+
+        Assert.True(luceneOrder.SequenceEqual(coraxOrder),
+            $"Corax order diverges from Lucene.\n  Lucene: {Shape(luceneOrder)}\n  Corax:  {Shape(coraxOrder)}");
+
+        // The guard must have demoted the bare compound shape to the bitmap pipeline (the only path that places
+        // nulls per NullsSortMode). If this ever reports CompoundSortedScan, the null placement above is luck.
+        Assert.Equal("BitmapPipeline", coraxHint);
+
+        static bool IsAscending(IEnumerable<int> xs)
+        {
+            int prev = int.MinValue;
+            foreach (var x in xs) { if (x < prev) return false; prev = x; }
+            return true;
+        }
+
+        async Task<(List<int?> order, string hint)> RunOrdered(RavenSearchEngineMode mode)
+        {
+            using var store = GetDocumentStore(Options.ForSearchEngine(mode));
+            var index = new FilmsNullable_ByCategoryAndYear();
+            await index.ExecuteAsync(store);
+            using (var bulk = store.BulkInsert())
+            {
+                foreach (var f in films)
+                    await bulk.StoreAsync(f, f.Id);
+            }
+
+            Indexes.WaitForIndexing(store);
+
+            using var session = store.OpenAsyncSession();
+            var results = await session.Advanced
+                .AsyncRawQuery<FilmNullable>($"from index '{index.IndexName}' where Category = 'Action' order by Year as long include timings()")
+                .Timings(out var timings)
+                .ToListAsync();
+
+            string hint = null;
+            if (timings.QueryPlan is QueryInspectionNode plan && FindOperation(plan, "CompiledQuery") is { } compiled)
+                compiled.Parameters.TryGetValue("OptimizationHint", out hint);
+
+            return (results.Select(r => r.Year).ToList(), hint);
+        }
+    }
+
+    private class TieDoc
+    {
+        public string Id { get; set; }
+        public long P { get; set; }
+        public long S { get; set; }
+    }
+
+    private class TieDocs_Index : AbstractIndexCreationTask<TieDoc>
+    {
+        public TieDocs_Index()
+        {
+            Map = docs => from d in docs
+                select new { d.P, d.S };
+        }
+    }
+
+    // Two-field sort tie-break: ORDER BY P desc, S desc on a large single primary group must apply the secondary
+    // (S) ordering. The tie-break path truncates to the top-`take` by S when the group exceeds the page cap, so a
+    // 2000-doc group with a 25-row page must keep the 25 LARGEST S, not the smallest. Cross-engine pins the answer.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task TwoFieldSort_LargePrimaryGroup_AppliesSecondaryTieBreakDescending(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new TieDocs_Index();
+        index.Execute(store);
+
+        // Mirror the Movies/Showcase shape that exposed the bug: a huge primary group whose secondary is
+        // mostly a common small value (0/1), with a few RARE large values scattered through the group. A
+        // correct top-K truncation must surface those rare large values; a broken one keeps the common small ones.
+        const int n = 40000;
+        var bigS = new Dictionary<int, long>();
+        for (int k = 0; k < 30; k++)
+            bigS[k * 1300] = 1000 - k; // 30 docs with distinct large S (1000..971), scattered across the group
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < n; i++)
+            {
+                long s = bigS.TryGetValue(i, out var big) ? big : i % 2; // everyone else is 0 or 1
+                await bulk.StoreAsync(new TieDoc { P = 1, S = s }, $"tie/{i}");
+            }
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<TieDoc>($"from index '{index.IndexName}' order by P as long desc, S as long desc limit 25")
+            .ToListAsync();
+
+        Assert.Equal(25, results.Count);
+        // P is constant, so this is purely S descending: the 25 largest S = 1000, 999, ..., 976.
+        var actual = results.Select(r => r.S).ToList();
+        var expected = Enumerable.Range(0, 25).Select(i => (long)(1000 - i)).ToList();
+        Assert.Equal(expected, actual);
+    }
+
+    private class CatDoc
+    {
+        public string Id { get; set; }
+        public string Category { get; set; }
+        public int UnitsInStock { get; set; }
+    }
+
+    private class CatDocs_ByCategoryUnits : AbstractIndexCreationTask<CatDoc>
+    {
+        public CatDocs_ByCategoryUnits()
+        {
+            Map = docs => from d in docs
+                select new { d.Category, d.UnitsInStock };
+            CompoundField("Category", "UnitsInStock");
+        }
+    }
+
+    // Descending compound-prefix scan: `where Category = X order by Category, UnitsInStock desc` collapses to a
+    // single DESCENDING sort over compound(Category, UnitsInStock). The compound walk must run the prefix BACKWARD
+    // (a null seek term to the backward StartsWith provider crashed with NullReferenceException). Must return the
+    // matching docs in descending UnitsInStock order.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task DescendingCompoundSort_DoesNotCrashAndOrdersCorrectly(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new CatDocs_ByCategoryUnits();
+        index.Execute(store);
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < 200; i++)
+                await bulk.StoreAsync(new CatDoc { Category = "categories/1-A", UnitsInStock = i }, $"cat/{i}");
+            for (int i = 0; i < 50; i++)
+                await bulk.StoreAsync(new CatDoc { Category = "categories/2-A", UnitsInStock = 1000 + i }, $"other/{i}");
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<CatDoc>($"from index '{index.IndexName}' where Category = 'categories/1-A' order by Category, UnitsInStock as long desc limit 25")
+            .ToListAsync();
+
+        Assert.Equal(25, results.Count);
+        int prev = int.MaxValue;
+        foreach (var r in results)
+        {
+            Assert.Equal("categories/1-A", r.Category);
+            Assert.True(r.UnitsInStock <= prev, $"Results not descending by UnitsInStock: {prev} then {r.UnitsInStock}");
+            prev = r.UnitsInStock;
+        }
+        // The largest UnitsInStock among the 200 'categories/1-A' docs is 199.
+        Assert.Equal(199, results[0].UnitsInStock);
+    }
+
+    // RavenDB-26831: a compound numeric member must sort negatives correctly. New indexes (built at
+    // OrderPreservingCompoundNumericEncoding or higher) encode signed longs order-preserving, so the
+    // CompoundSortedScan walk/range over a field with negative values is correct. Cross-engine pins it to Lucene.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task CompoundSort_NegativeNumericValues_OrderedCorrectly(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new CatDocs_ByCategoryUnits();
+        index.Execute(store);
+
+        var values = new[] { -50, -16, -1, 0, 1, 7, 100 };
+        using (var bulk = store.BulkInsert())
+        {
+            int i = 0;
+            foreach (var u in values)
+                await bulk.StoreAsync(new CatDoc { Category = "categories/1-A", UnitsInStock = u }, $"cat/{i++}");
+        }
+
+        Indexes.WaitForIndexing(store);
+        using var session = store.OpenAsyncSession();
+
+        // Ascending: this pins Category and walks compound(Category, UnitsInStock) ascending — exercises the
+        // order-preserving encoding directly. Negatives must come first.
+        var asc = await session.Advanced
+            .AsyncRawQuery<CatDoc>($"from index '{index.IndexName}' where Category = 'categories/1-A' order by Category, UnitsInStock as long include timings()")
+            .Timings(out var ascTimings)
+            .ToListAsync();
+        Assert.Equal(new[] { -50, -16, -1, 0, 1, 7, 100 }, asc.Select(r => r.UnitsInStock).ToList());
+
+        if (options.SearchEngineMode == RavenSearchEngineMode.Corax)
+        {
+            // Make sure we actually exercised the compound walk (not a plain SortingMatch that would pass regardless).
+            var plan = ascTimings.QueryPlan as QueryInspectionNode;
+            var compiled = FindOperation(plan, "CompiledQuery");
+            compiled?.Parameters.TryGetValue("OptimizationHint", out var hint);
+            Assert.True(compiled?.Parameters.GetValueOrDefault("OptimizationHint") == "CompoundSortedScan",
+                "Expected CompoundSortedScan to exercise the compound numeric encoding. Plan: " + Describe(plan));
+        }
+
+        // Descending.
+        var desc = await session.Advanced
+            .AsyncRawQuery<CatDoc>($"from index '{index.IndexName}' where Category = 'categories/1-A' order by Category, UnitsInStock as long desc")
+            .ToListAsync();
+        Assert.Equal(new[] { 100, 7, 1, 0, -1, -16, -50 }, desc.Select(r => r.UnitsInStock).ToList());
+
+        // Range crossing zero: > -10 must include -1,0,1,… and exclude -16,-50 — both the rows AND the count.
+        var range = await session.Advanced
+            .AsyncRawQuery<CatDoc>($"from index '{index.IndexName}' where Category = 'categories/1-A' and UnitsInStock > -10 order by Category, UnitsInStock as long")
+            .Statistics(out var rangeStats)
+            .ToListAsync();
+        Assert.Equal(new[] { -1, 0, 1, 7, 100 }, range.Select(r => r.UnitsInStock).ToList());
+        Assert.Equal(5, (int)rangeStats.TotalResults);
+    }
+
+    // Descending sort over ONLY the second compound member (leading member pinned by WHERE but not in the ORDER
+    // BY): `where Category = X order by UnitsInStock desc`. The compound walk's `forward` is false with no field2
+    // range — the path that built a backward StartsWith provider with a null seek term and crashed. Must not
+    // crash and must return descending UnitsInStock.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task DescendingSortOnSecondCompoundMemberOnly_DoesNotCrashAndOrdersCorrectly(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new CatDocs_ByCategoryUnits();
+        index.Execute(store);
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < 200; i++)
+                await bulk.StoreAsync(new CatDoc { Category = "categories/1-A", UnitsInStock = i }, $"cat/{i}");
+            for (int i = 0; i < 50; i++)
+                await bulk.StoreAsync(new CatDoc { Category = "categories/2-A", UnitsInStock = 1000 + i }, $"other/{i}");
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session.Advanced
+            .AsyncRawQuery<CatDoc>($"from index '{index.IndexName}' where Category = 'categories/1-A' order by UnitsInStock as long desc limit 25")
+            .ToListAsync();
+
+        Assert.Equal(25, results.Count);
+        int prev = int.MaxValue;
+        foreach (var r in results)
+        {
+            Assert.Equal("categories/1-A", r.Category);
+            Assert.True(r.UnitsInStock <= prev, $"Results not descending by UnitsInStock: {prev} then {r.UnitsInStock}");
+            prev = r.UnitsInStock;
+        }
+        Assert.Equal(199, results[0].UnitsInStock);
+    }
+
+    private static QueryInspectionNode FindOperation(QueryInspectionNode node, string operation)
+    {
+        if (node == null)
+            return null;
+        if (node.Operation == operation)
+            return node;
+        if (node.Children == null)
+            return null;
+        foreach (var child in node.Children)
+        {
+            var found = FindOperation(child, operation);
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+
+    private static string Describe(QueryInspectionNode node, int depth = 0)
+    {
+        if (node == null)
+            return "<null>";
+        var prefix = new string(' ', depth * 2);
+        var line = prefix + node.Operation;
+        if (node.Children == null || node.Children.Count == 0)
+            return line;
+        return line + Environment.NewLine + string.Join(Environment.NewLine, node.Children.Select(c => Describe(c, depth + 1)));
+    }
+}

--- a/test/FastTests/Corax/RavenDB_25281_SearchPlanInspectionTests.cs
+++ b/test/FastTests/Corax/RavenDB_25281_SearchPlanInspectionTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+// RavenDB-25281: a search(field, "a b c") clause compiles to a SINGLE bitmap-pipeline leaf, but it executes as a
+// match over multiple analyzer-tokenized terms (OR/AND, or a phrase for a quoted group). These tests pin that the
+// query plan surfaces that multi-term reality — the tokenized terms, their count, and the operator — instead of
+// only the raw literal search string.
+public class RavenDB_25281_SearchPlanInspectionTests : RavenTestBase
+{
+    public RavenDB_25281_SearchPlanInspectionTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string Body { get; set; }
+    }
+
+    private class Docs_BySearchBody : AbstractIndexCreationTask<Doc>
+    {
+        public Docs_BySearchBody()
+        {
+            Map = docs => from d in docs
+                select new { d.Body };
+            Index(x => x.Body, FieldIndexing.Search);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task SearchClause_PlanSurfacesTokenizedTermsAndOperator(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new Docs_BySearchBody();
+        index.Execute(store);
+
+        using (var s = store.OpenAsyncSession())
+        {
+            await s.StoreAsync(new Doc { Body = "the love boat is sailing" });
+            await s.StoreAsync(new Doc { Body = "love is in the air" });
+            await s.StoreAsync(new Doc { Body = "a boat on the river" });
+            await s.StoreAsync(new Doc { Body = "nothing relevant here" });
+            await s.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenAsyncSession();
+
+        // Three whitespace-separated words, default operator -> a 3-term OR match.
+        var or = await SearchPlanParams(session, index.IndexName, "where search(Body, 'the love boat')");
+        Assert.Equal("the, love, boat", or["SearchTerms"]);
+        Assert.Equal("3", or["SearchTermCount"]);
+        Assert.Equal("Or", or["SearchOperator"]);
+
+        // Explicit AND operator is surfaced.
+        var and = await SearchPlanParams(session, index.IndexName, "where search(Body, 'love boat', and)");
+        Assert.Equal("love, boat", and["SearchTerms"]);
+        Assert.Equal("2", and["SearchTermCount"]);
+        Assert.Equal("And", and["SearchOperator"]);
+
+        // A quoted group is a single phrase term, not three terms.
+        var phrase = await SearchPlanParams(session, index.IndexName, "where search(Body, '\"the love boat\"')");
+        Assert.Equal("the love boat", phrase["SearchTerms"]);
+        Assert.Equal("1", phrase["SearchTermCount"]);
+    }
+
+    private static async Task<Dictionary<string, string>> SearchPlanParams(IAsyncDocumentSession session, string indexName, string whereClause)
+    {
+        await session.Advanced
+            .AsyncRawQuery<Doc>($"from index '{indexName}' {whereClause} include timings()")
+            .Timings(out var timings)
+            .ToListAsync();
+
+        var plan = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotNull(plan);
+        var search = FindNodeWithParam(plan, "SearchTerms");
+        Assert.True(search != null, "Expected a plan node carrying SearchTerms (a search() leaf). Plan: " + Describe(plan));
+        return search.Parameters;
+    }
+
+    private static QueryInspectionNode FindNodeWithParam(QueryInspectionNode node, string paramKey)
+    {
+        if (node == null)
+            return null;
+        if (node.Parameters != null && node.Parameters.ContainsKey(paramKey))
+            return node;
+        if (node.Children == null)
+            return null;
+        foreach (var child in node.Children)
+        {
+            var found = FindNodeWithParam(child, paramKey);
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+
+    private static string Describe(QueryInspectionNode node, int depth = 0)
+    {
+        if (node == null)
+            return "<null>";
+        var line = new string(' ', depth * 2) + node.Operation;
+        if (node.Children == null || node.Children.Count == 0)
+            return line;
+        return line + "\n" + string.Join("\n", node.Children.Select(c => Describe(c, depth + 1)));
+    }
+}

--- a/test/FastTests/Corax/StreamingOptimization_DataTests.cs
+++ b/test/FastTests/Corax/StreamingOptimization_DataTests.cs
@@ -37,7 +37,7 @@ public class StreamingOptimization_DataTests : RavenTestBase
 
     public static IEnumerable<object[]> UnboundedRange()
     {
-        foreach (var unaryOperation in new UnaryMatchOperation[] {UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThan, UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual})
+        foreach (var unaryOperation in new ComparisonOperator[] {ComparisonOperator.GreaterThan, ComparisonOperator.LessThan, ComparisonOperator.GreaterThanOrEqual, ComparisonOperator.LessThanOrEqual})
         foreach (var fieldType in new OrderingType[] {OrderingType.String, OrderingType.Long, OrderingType.Double})
         foreach (var isAscending in new bool[]{true, false})
         {
@@ -55,7 +55,7 @@ public class StreamingOptimization_DataTests : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [MemberData(nameof(UnboundedRange))]
-    public void UnboundedRangeQueries(UnaryMatchOperation unaryMatchOperation, OrderingType fieldType, bool ascending, object value)
+    public void UnboundedRangeQueries(ComparisonOperator unaryMatchOperation, OrderingType fieldType, bool ascending, object value)
     {
         using var store = CreateDatabase(out List<Dto> actualDocuments);
         using var session = store.OpenSession();
@@ -79,21 +79,21 @@ public class StreamingOptimization_DataTests : RavenTestBase
 
         query = unaryMatchOperation switch
         {
-            UnaryMatchOperation.LessThan when queriedValue is long l => query.WhereLessThan(fieldName, l),
-            UnaryMatchOperation.LessThan when queriedValue is double d => query.WhereLessThan(fieldName, d),
-            UnaryMatchOperation.LessThan when queriedValue is string s => query.WhereLessThan(fieldName, s),
+            ComparisonOperator.LessThan when queriedValue is long l => query.WhereLessThan(fieldName, l),
+            ComparisonOperator.LessThan when queriedValue is double d => query.WhereLessThan(fieldName, d),
+            ComparisonOperator.LessThan when queriedValue is string s => query.WhereLessThan(fieldName, s),
 
-            UnaryMatchOperation.LessThanOrEqual when queriedValue is long l => query.WhereLessThanOrEqual(fieldName, l),
-            UnaryMatchOperation.LessThanOrEqual when queriedValue is double d => query.WhereLessThanOrEqual(fieldName, d),
-            UnaryMatchOperation.LessThanOrEqual when queriedValue is string s => query.WhereLessThanOrEqual(fieldName, s),
+            ComparisonOperator.LessThanOrEqual when queriedValue is long l => query.WhereLessThanOrEqual(fieldName, l),
+            ComparisonOperator.LessThanOrEqual when queriedValue is double d => query.WhereLessThanOrEqual(fieldName, d),
+            ComparisonOperator.LessThanOrEqual when queriedValue is string s => query.WhereLessThanOrEqual(fieldName, s),
 
-            UnaryMatchOperation.GreaterThan when queriedValue is long l => query.WhereGreaterThan(fieldName, l),
-            UnaryMatchOperation.GreaterThan when queriedValue is double d => query.WhereGreaterThan(fieldName, d),
-            UnaryMatchOperation.GreaterThan when queriedValue is string s => query.WhereGreaterThan(fieldName, s),
+            ComparisonOperator.GreaterThan when queriedValue is long l => query.WhereGreaterThan(fieldName, l),
+            ComparisonOperator.GreaterThan when queriedValue is double d => query.WhereGreaterThan(fieldName, d),
+            ComparisonOperator.GreaterThan when queriedValue is string s => query.WhereGreaterThan(fieldName, s),
 
-            UnaryMatchOperation.GreaterThanOrEqual when queriedValue is long l => query.WhereGreaterThanOrEqual(fieldName, l),
-            UnaryMatchOperation.GreaterThanOrEqual when queriedValue is double d => query.WhereGreaterThanOrEqual(fieldName, d),
-            UnaryMatchOperation.GreaterThanOrEqual when queriedValue is string s => query.WhereGreaterThanOrEqual(fieldName, s),
+            ComparisonOperator.GreaterThanOrEqual when queriedValue is long l => query.WhereGreaterThanOrEqual(fieldName, l),
+            ComparisonOperator.GreaterThanOrEqual when queriedValue is double d => query.WhereGreaterThanOrEqual(fieldName, d),
+            ComparisonOperator.GreaterThanOrEqual when queriedValue is string s => query.WhereGreaterThanOrEqual(fieldName, s),
 
             _ => throw new InvalidDataException(unaryMatchOperation.ToString())
         };
@@ -106,21 +106,21 @@ public class StreamingOptimization_DataTests : RavenTestBase
 
         Func<Dto, bool> filter = unaryMatchOperation switch
         {
-            UnaryMatchOperation.LessThan when queriedValue is long l => dto => dto.LongValue < l,
-            UnaryMatchOperation.LessThan when queriedValue is double d => dto => dto.DoubleValue < d,
-            UnaryMatchOperation.LessThan when queriedValue is string s => dto => dto.Name.AsSpan().SequenceCompareTo(s) < 0,
+            ComparisonOperator.LessThan when queriedValue is long l => dto => dto.LongValue < l,
+            ComparisonOperator.LessThan when queriedValue is double d => dto => dto.DoubleValue < d,
+            ComparisonOperator.LessThan when queriedValue is string s => dto => dto.Name.AsSpan().SequenceCompareTo(s) < 0,
 
-            UnaryMatchOperation.LessThanOrEqual when queriedValue is long l => dto => dto.LongValue <= l,
-            UnaryMatchOperation.LessThanOrEqual when queriedValue is double d => dto => dto.DoubleValue <= d,
-            UnaryMatchOperation.LessThanOrEqual when queriedValue is string s => dto => dto.Name.AsSpan().SequenceCompareTo(s) <= 0,
+            ComparisonOperator.LessThanOrEqual when queriedValue is long l => dto => dto.LongValue <= l,
+            ComparisonOperator.LessThanOrEqual when queriedValue is double d => dto => dto.DoubleValue <= d,
+            ComparisonOperator.LessThanOrEqual when queriedValue is string s => dto => dto.Name.AsSpan().SequenceCompareTo(s) <= 0,
 
-            UnaryMatchOperation.GreaterThan when queriedValue is long l => dto => dto.LongValue > l,
-            UnaryMatchOperation.GreaterThan when queriedValue is double d => dto => dto.DoubleValue > d,
-            UnaryMatchOperation.GreaterThan when queriedValue is string s => dto => dto.Name.AsSpan().SequenceCompareTo(s) > 0,
+            ComparisonOperator.GreaterThan when queriedValue is long l => dto => dto.LongValue > l,
+            ComparisonOperator.GreaterThan when queriedValue is double d => dto => dto.DoubleValue > d,
+            ComparisonOperator.GreaterThan when queriedValue is string s => dto => dto.Name.AsSpan().SequenceCompareTo(s) > 0,
 
-            UnaryMatchOperation.GreaterThanOrEqual when queriedValue is long l => dto => dto.LongValue >= l,
-            UnaryMatchOperation.GreaterThanOrEqual when queriedValue is double d => dto => dto.DoubleValue >= d,
-            UnaryMatchOperation.GreaterThanOrEqual when queriedValue is string s => dto => dto.Name.AsSpan().SequenceCompareTo(s) >= 0,
+            ComparisonOperator.GreaterThanOrEqual when queriedValue is long l => dto => dto.LongValue >= l,
+            ComparisonOperator.GreaterThanOrEqual when queriedValue is double d => dto => dto.DoubleValue >= d,
+            ComparisonOperator.GreaterThanOrEqual when queriedValue is string s => dto => dto.Name.AsSpan().SequenceCompareTo(s) >= 0,
 
             _ => throw new InvalidDataException(unaryMatchOperation.ToString())
         };

--- a/test/FastTests/Corax/Vectors/RavenDB_25281_BinaryVectorDimensions.cs
+++ b/test/FastTests/Corax/Vectors/RavenDB_25281_BinaryVectorDimensions.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Tests.Infrastructure;
+using Xunit;
+using ITestOutputHelper = Xunit.ITestOutputHelper;
+
+namespace FastTests.Corax.Vectors;
+
+// Verifies the dimension-unit contract for BINARY (int1) vector fields (RavenDB-25281 / #4887).
+//
+// The query-time guard (QueryPlanBuilder.Vector.AssertDimensions) compares the field's persisted
+// `numberOfDimensions` against the query vector's byte length (VectorValue.Length). For Single/Int8,
+// IndexFieldsPersistence persists the BYTE length (dims*4, dims+4), so the raw comparison is correct. For
+// Binary it persists the RAW dimension count, while the runtime binary vector is bit-packed to ceil(dims/8)
+// bytes — so when the dimension comes from the field configuration (rather than from already-indexed data),
+// a valid same-dimension binary vector trips the guard and throws "different number of dimensions".
+//
+// This test pins down that contract: a binary vector field configured with explicit Dimensions, queried with
+// a correctly-sized binary vector, must NOT throw a dimensions mismatch.
+public class RavenDB_25281_BinaryVectorDimensions(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private const int Dimensions = 32;          // 32 bits ...
+    private const int PackedBytes = Dimensions / 8; // ... = 4 bytes once bit-packed (ceil(32/8))
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task BinaryVectorSearch_WithMatchingDimensions_DoesNotThrowDimensionMismatch(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // A document without the vector field, so the field's dimension is taken from the configured
+            // Dimensions (the seed path) rather than from indexed vector data.
+            await session.StoreAsync(new Doc { Text = "no vector here" });
+            await session.SaveChangesAsync();
+        }
+
+        await new BinaryVectorIndex().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // A correctly-sized binary query vector: PackedBytes bytes == Dimensions bits.
+            var query = session.Query<Doc, BinaryVectorIndex>()
+                .VectorSearch(x => x.WithField(f => f.Vector), f => f.ByEmbedding(new byte[PackedBytes]));
+
+            // Must not throw "Vector field ... has N dimensions, but the vector passed ... has M dimensions".
+            var results = await query.ToListAsync();
+            Assert.Empty(results); // no indexed vectors, but the dimension guard must have accepted the query
+        }
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public byte[] Embedding { get; set; }
+        public string Text { get; set; }
+        public object Vector { get; set; }
+    }
+
+    private class BinaryVectorIndex : AbstractIndexCreationTask<Doc>
+    {
+        public BinaryVectorIndex()
+        {
+            Map = docs => from doc in docs
+                select new { Vector = CreateVector(doc.Embedding) };
+
+            VectorIndexes.Add(x => x.Vector, new VectorOptions
+            {
+                SourceEmbeddingType = VectorEmbeddingType.Binary,
+                DestinationEmbeddingType = VectorEmbeddingType.Binary,
+                Dimensions = Dimensions
+            });
+        }
+    }
+}

--- a/test/FastTests/Corax/Vectors/RavenDB_25281_NestedOrSpatialVector.cs
+++ b/test/FastTests/Corax/Vectors/RavenDB_25281_NestedOrSpatialVector.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax.Vectors;
+
+public class RavenDB_25281_NestedOrSpatialVector(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private sealed class GeoVecDoc
+    {
+        public string Id { get; set; }
+        public string Tag { get; set; }
+        public double Lat { get; set; }
+        public double Lon { get; set; }
+        public float[] Embedding { get; set; }
+    }
+
+    private sealed class GeoVecIndex : AbstractIndexCreationTask<GeoVecDoc>
+    {
+        public GeoVecIndex()
+        {
+            Map = docs => from d in docs
+                          select new
+                          {
+                              d.Tag,
+                              Coordinates = CreateSpatialField(d.Lat, d.Lon),
+                              Embedding = CreateVector(d.Embedding),
+                          };
+        }
+    }
+
+    // east unit vector — cosine similarity 1.0 against a [1,0] query, 0.0 against [0,1].
+    private static readonly float[] East = [1f, 0f];
+
+    // north unit vector — cosine similarity 0.0 against a [1,0] query.
+    private static readonly float[] North = [0f, 1f];
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void NestedOrWithSpatialAndVectorLeavesReturnsUnionOfBothBranches()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        // Branch A := (Tag == "A" AND vector.search(Embedding, [1,0], 0.9))  -> tag A AND an east-pointing embedding
+        // Branch B := (Tag == "B" AND spatial.within(Coordinates, circle(60mi @ (0,0)))) -> tag B AND inside the circle
+        // The query is (Branch A) OR (Branch B). Inside an OR branch the spatial / vector clauses are ordinary
+        // pipeline leaves (the planner only lifts them to top-level post-filters in an AND context), so this shape
+        // exercises the nested-OR path that the IsPostFilter-by-type bug would have mishandled.
+        using (var session = store.OpenSession())
+        {
+            // Matches branch A: tag A, east embedding (far from the circle — irrelevant for branch A).
+            session.Store(new GeoVecDoc { Id = "docs/1", Tag = "A", Lat = 40, Lon = 40, Embedding = East });
+            // tag A but north embedding -> fails branch A's vector filter; tag != B -> not branch B.
+            session.Store(new GeoVecDoc { Id = "docs/2", Tag = "A", Lat = 40, Lon = 40, Embedding = North });
+            // Matches branch B: tag B, inside the circle (embedding direction irrelevant for branch B).
+            session.Store(new GeoVecDoc { Id = "docs/3", Tag = "B", Lat = 0, Lon = 0, Embedding = North });
+            // tag B but outside the circle -> fails branch B's spatial filter; tag != A -> not branch A.
+            session.Store(new GeoVecDoc { Id = "docs/4", Tag = "B", Lat = 40, Lon = 40, Embedding = East });
+            // tag A, inside the circle, north embedding -> branch A fails (vector), branch B fails (tag) -> neither.
+            session.Store(new GeoVecDoc { Id = "docs/5", Tag = "A", Lat = 0, Lon = 0, Embedding = North });
+            // Matches branch B: tag B, inside the circle, east embedding (the east embedding does not pull it into
+            // branch A because that branch also requires tag A).
+            session.Store(new GeoVecDoc { Id = "docs/6", Tag = "B", Lat = 0, Lon = 0, Embedding = East });
+            // Matches branch A: tag A, east embedding, also inside the circle (still only one branch — tag is A).
+            session.Store(new GeoVecDoc { Id = "docs/7", Tag = "A", Lat = 0, Lon = 0, Embedding = East });
+            // Unrelated tag -> neither branch regardless of geometry / embedding.
+            session.Store(new GeoVecDoc { Id = "docs/8", Tag = "C", Lat = 0, Lon = 0, Embedding = East });
+            session.SaveChanges();
+        }
+
+        new GeoVecIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var ids = session.Advanced
+                .RawQuery<GeoVecDoc>(
+                    @"from index 'GeoVecIndex'
+                      where (Tag = $tagA and vector.search(Embedding, $vec, $minSim))
+                         or (Tag = $tagB and spatial.within(Coordinates, spatial.circle($r, $lat, $lon, 'miles')))")
+                .AddParameter("tagA", "A")
+                .AddParameter("vec", East)
+                .AddParameter("minSim", 0.9f)
+                .AddParameter("tagB", "B")
+                .AddParameter("r", 60.0)
+                .AddParameter("lat", 0.0)
+                .AddParameter("lon", 0.0)
+                .WaitForNonStaleResults()
+                .ToList()
+                .Select(d => d.Id)
+                .OrderBy(id => id)
+                .ToArray();
+
+            Assert.Equal(new[] { "docs/1", "docs/3", "docs/6", "docs/7" }, ids);
+        }
+    }
+}

--- a/test/FastTests/Corax/Vectors/RavenDB_25281_VectorPostFilterNoSort.cs
+++ b/test/FastTests/Corax/Vectors/RavenDB_25281_VectorPostFilterNoSort.cs
@@ -1,0 +1,168 @@
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax.Vectors;
+
+public class RavenDB_25281_VectorPostFilterNoSort(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private sealed class CityVecDoc
+    {
+        public string Id { get; set; }
+        public string City { get; set; }
+        public float[] Embedding { get; set; }
+    }
+
+    private sealed class CityVecIndex : AbstractIndexCreationTask<CityVecDoc>
+    {
+        public CityVecIndex()
+        {
+            Map = docs => from d in docs
+                          select new
+                          {
+                              d.City,
+                              Embedding = CreateVector(d.Embedding),
+                          };
+        }
+    }
+
+    // Query vector points east ([1,0]). The seeded docs lie on a gradient of decreasing cosine similarity to it.
+    private static readonly float[] Query = [1f, 0f];
+
+    private static void Seed(IDocumentStore store)
+    {
+        using var session = store.OpenSession();
+        // NYC docs on a clearly-separated similarity gradient against [1,0] (all unit vectors): sim 1.0 > 0.8 > 0.6.
+        session.Store(new CityVecDoc { Id = "docs/nyc-1", City = "NYC", Embedding = [1.0f, 0.0f] });
+        session.Store(new CityVecDoc { Id = "docs/nyc-2", City = "NYC", Embedding = [0.8f, 0.6f] });
+        session.Store(new CityVecDoc { Id = "docs/nyc-3", City = "NYC", Embedding = [0.6f, 0.8f] });
+        // A different city with the MOST similar embedding of all — must be filtered out by the City clause,
+        // proving the vector runs as a genuine post-filter and not a global nearest-neighbour scan.
+        session.Store(new CityVecDoc { Id = "docs/par-1", City = "Paris", Embedding = [1.0f, 0.0f] });
+        session.SaveChanges();
+    }
+
+    private static QueryInspectionNode FindNode(QueryInspectionNode node, string operation)
+    {
+        if (node is null)
+            return null;
+        if (node.Operation == operation)
+            return node;
+        if (node.Children is null)
+            return null;
+        foreach (var child in node.Children)
+        {
+            var hit = FindNode(child, operation);
+            if (hit != null)
+                return hit;
+        }
+
+        return null;
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void AndFilteredVectorSearch_NoOrderBy_SkipsSortWrapper_AndStreamsScoreOrder()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        Seed(store);
+        new CityVecIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenSession();
+        var ids = session.Advanced
+            .RawQuery<CityVecDoc>(
+                @"from index 'CityVecIndex'
+                  where City = $c and vector.search(Embedding, $vec, $minSim)
+                  include timings()")
+            .AddParameter("c", "NYC")
+            .AddParameter("vec", Query)
+            .AddParameter("minSim", 0.5f)
+            .Timings(out var timings)
+            .WaitForNonStaleResults()
+            .ToList()
+            .Select(d => d.Id)
+            .ToList();
+
+        // Paris is excluded by the City post-filter even though it is the single most-similar doc.
+        Assert.Equal(new[] { "docs/nyc-1", "docs/nyc-2", "docs/nyc-3" }, ids);
+
+        // The single vector post-filter already streams its HNSW output in similarity-score order, so the
+        // implicit score SortingMatch wrapper must NOT be added: the plan root is the CompiledQuery, not a sort.
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+        Assert.Null(FindNode(plan, "SortingMatch"));
+        Assert.Null(FindNode(plan, "SortingMultiMatch"));
+        // The vector search is still present, as a post-filter hanging off the bitmap pipeline.
+        Assert.NotNull(FindNode(plan, "VectorSearchMatch"));
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void AndFilteredVectorSearch_ExplicitOrderByScore_SkipsSortWrapper()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        Seed(store);
+        new CityVecIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenSession();
+        var ids = session.Advanced
+            .RawQuery<CityVecDoc>(
+                @"from index 'CityVecIndex'
+                  where City = $c and vector.search(Embedding, $vec, $minSim)
+                  order by score()
+                  include timings()")
+            .AddParameter("c", "NYC")
+            .AddParameter("vec", Query)
+            .AddParameter("minSim", 0.5f)
+            .Timings(out var timings)
+            .WaitForNonStaleResults()
+            .ToList()
+            .Select(d => d.Id)
+            .ToList();
+
+        Assert.Equal(new[] { "docs/nyc-1", "docs/nyc-2", "docs/nyc-3" }, ids);
+
+        // `ORDER BY score()` asks for exactly the order the vector emits natively — the wrapper is still redundant.
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        Assert.Equal("CompiledQuery", plan.Operation);
+        Assert.Null(FindNode(plan, "SortingMatch"));
+        Assert.Null(FindNode(plan, "SortingMultiMatch"));
+        Assert.NotNull(FindNode(plan, "VectorSearchMatch"));
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void OrBranchVectorSearch_KeepsSortWrapper()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        Seed(store);
+        new CityVecIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenSession();
+        session.Advanced
+            .RawQuery<CityVecDoc>(
+                @"from index 'CityVecIndex'
+                  where vector.search(Embedding, $vec, $minSim) or City = $c
+                  include timings()")
+            .AddParameter("c", "Paris")
+            .AddParameter("vec", Query)
+            .AddParameter("minSim", 0.5f)
+            .Timings(out var timings)
+            .WaitForNonStaleResults()
+            .ToList();
+
+        // Inside an OR branch the vector is an ordinary pipeline leaf, not a post-filter, so it does NOT provide
+        // the result order on its own — the implicit score SortingMatch wrapper must be retained. The plan root is
+        // therefore the sort wrapper, with the CompiledQuery bitmap pipeline as a descendant.
+        var plan = timings.QueryPlan as QueryInspectionNode;
+        Assert.NotNull(plan);
+        Assert.NotEqual("CompiledQuery", plan.Operation);
+        Assert.NotNull(FindNode(plan, "SortingMatch"));
+        Assert.NotNull(FindNode(plan, "CompiledQuery"));
+    }
+}


### PR DESCRIPTION
**Part 11b of 13 — Tests: FastTests Corax query/plan.**
Stacked migration of Corax 2.0 (RavenDB-25281) onto `v7.2`.

Query/plan FastTests: compiled-query, RavenDB_25281_*, plan-cache, direct-scan residual, limit early-exit, in-entry-scan, query-plan graph. Trails all source PRs.

### ⚠️ This PR is partial by design — read before reviewing
This is one slice of a **13-PR stack** that together reconstruct the `corax-2.0-june` branch **byte-for-byte**. Each PR carries whole files for a single layer, split for reviewability. Consequences:

- **Intermediate source PRs (04–10) do not compile on their own.** Types/members they use are defined in other PRs of the stack (see map below).
- **Cross-PR references are expected, not defects.** If a symbol looks undefined, unused, or unreferenced *in this PR*, it is defined/consumed in another stack PR. Automated reviewers (incl. **GitHub Copilot**) will flag such cases — for a partial PR these are **false positives**, and will be answered as such.
- Only the **full assembled stack** (through #4891) compiles green and passes FastTests; per-PR CI red on intermediate PRs is expected.

Please focus review on logic *within the changed files*, not on cross-file resolution.

### The stack (each PR is based on the one above it; base ← `v7.2`)
| # | PR | Layer |
|---|----|-------|
| 01 | #4879 | Foundation: Corax build deps, cross-cutting glue, Sparrow |
| 02 | #4880 | Voron: RoaringBitmaps |
| 03 | #4881 | Voron: lookups, compact trees, posting lists, graph/container deltas |
| 04 | #4882 | Corax: IndexSearcher + boolean/term/multi matches |
| 05 | #4883 | Corax: sorting & directed-scan matches + primitives |
| 06 | #4884 | Corax: term providers, memoization, vector & spatial matches |
| 07 | #4885 | Corax: query planning (PlanCache, cardinality, cost) |
| 08 | #4886 | Server: QueryPlanBuilder (resolution & plan model) |
| 09 | #4887 | Server: QueryPlanBuilder (construct/cost) + QueryOptimizer |
| 10 | #4888 | Server: CoraxQueryBuilder + read/persistence ops |
| 11a | #4889 | Tests: FastTests Corax engine + FastTests Voron |
| 11b | #4890 | Tests: FastTests Corax query/plan |
| 11c | #4891 | Tests + tooling: remaining Corax/Slow/Stress/Infra + bench |