### PR TITLE
RavenDB-27190 Fix Corax 2.0 driving a sorted scan from one branch of an OR, dropping the other branch

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
@@ -172,6 +172,11 @@ internal static partial class QueryPlanBuilder
         PlanOptimizationFlags flags = PlanOptimizationFlags.None;
         List<ClauseInfo> clauses = walkerCtx.Clauses;
 
+        // `where a OR b` cannot drive a sorted scan from one of its branches: the scan would only emit that
+        // branch's documents, and the residual predicate can only filter what it walks - never re-admit the rest.
+        if (walkerCtx.IsOr)
+            return flags;
+
         // Collect non-negated, non-boosted Equals clause indices for compound lookups.
         const int maxStackAllocSize = 128;
         Span<int> eqBuf = clauses.Count <= maxStackAllocSize ? stackalloc int[maxStackAllocSize] : new int[clauses.Count];
@@ -225,8 +230,7 @@ internal static partial class QueryPlanBuilder
             }
         }
 
-        if (walkerCtx.IsOr || // cannot optimize: `where a OR b`
-            p.Index is not { HasCompoundFields: true } ||
+        if (p.Index is not { HasCompoundFields: true } ||
             eqCount is 0)
         {
             return flags;

--- a/test/SlowTests.Issues/Issues/RavenDB_27190.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27190.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27190 : RavenTestBase
+    {
+        public RavenDB_27190(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Question
+        {
+            public string Tag { get; set; }
+        }
+
+        private class Questions_ByTag : AbstractIndexCreationTask<Question>
+        {
+            public Questions_ByTag()
+            {
+                Map = questions => from q in questions
+                                   select new
+                                   {
+                                       q.Tag
+                                   };
+            }
+        }
+
+        private const int TagCount = 2000;
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void OrOfEqualsAndExistsMustNotCollapseToTheEqualsBranchWhenOrdered(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            // Enough documents that scanning the sort field's terms looks cheaper than a bitmap - that is what
+            // makes the planner pick the direct scan, and only then does the OR degenerate.
+            using (var bulk = store.BulkInsert())
+            {
+                for (int i = 0; i < TagCount; i++)
+                    bulk.Store(new Question { Tag = $"tag-{i:D5}" });
+
+                bulk.Store(new Question { Tag = "rest" }); // the single document the equality branch matches
+            }
+
+            new Questions_ByTag().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            const int expected = TagCount + 1;
+
+            using (var session = store.OpenSession())
+            {
+                // `Tag = 'rest' or exists(Tag)` is satisfied by every document that has a Tag, so the ORDER BY
+                // must not shrink the result to the single document matching the equality branch.
+                var ordered = session.Advanced
+                    .RawQuery<Question>("from index \"Questions/ByTag\" where (Tag = $p0 or exists(Tag)) order by Tag")
+                    .AddParameter("p0", "rest")
+                    .ToList();
+
+                Assert.Equal(expected, ordered.Count);
+
+                // Control: the same query without ORDER BY, and the exists() branch on its own.
+                var unordered = session.Advanced
+                    .RawQuery<Question>("from index \"Questions/ByTag\" where (Tag = $p0 or exists(Tag))")
+                    .AddParameter("p0", "rest")
+                    .ToList();
+
+                Assert.Equal(expected, unordered.Count);
+
+                var existsOnly = session.Advanced
+                    .RawQuery<Question>("from index \"Questions/ByTag\" where exists(Tag) order by Tag")
+                    .ToList();
+
+                Assert.Equal(expected, existsOnly.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27190/

### Additional description

`where (a = $p or exists(a)) order by a` returned only the documents matched by the equality branch: the planner picked the sorted scan and drove it from the equality clause, which is one branch of the OR, so only that branch's documents were produced. The residual predicate can filter what the scan walks, but never re-admit the documents from the other branch.

The `IsOr` guard already existed — with the comment `cannot optimize: where a OR b` — but it sat *after* the loop that sets `sortDrivingIdx` and `DirectScanCandidate`, so it only protected the compound optimizations below it. This moves the guard to the top of `ComputeTemplateOptimizations` and drops the now-unreachable copy.

Nested ORs were already safe: for `A and (B or C)` the root is an AND and the OR arrives as an `OrGroup` clause with no `FieldName`, which the loop skips — so guarding on the root `IsOr` is sufficient.

Note the bug only reproduces once there are enough documents for the direct scan to be chosen over the bitmap path, which is why the test inserts 2001 documents.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
